### PR TITLE
Extra fixes for Chapters 1 - 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Output directories
 images/
 output/
+webwork-extraction/
 #
 #
 ## Standard LaTeX files types

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ Calculus_Question_File.pdf
 Calculus_Question_File_Instructor.pdf
 jingreport.txt
 schema_check.txt
+merge.ptx

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -267,9 +267,9 @@
       </preface>
     </frontmatter>
 
-    <xi:include href="./chapter_limits.ptx" />
+    <!-- <xi:include href="./chapter_limits.ptx" /> -->
 
-    <!-- <xi:include href="./chapter_derivatives.ptx" /> -->
+    <xi:include href="./chapter_derivatives.ptx" />
 
     <!-- <xi:include href="./chapter_graphbehavior.ptx" /> -->
 

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -267,9 +267,9 @@
       </preface>
     </frontmatter>
 
-    <!-- <xi:include href="./chapter_limits.ptx" /> -->
+    <xi:include href="./chapter_limits.ptx" />
 
-    <xi:include href="./chapter_derivatives.ptx" />
+    <!-- <xi:include href="./chapter_derivatives.ptx" /> -->
 
     <!-- <xi:include href="./chapter_graphbehavior.ptx" /> -->
 

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -267,7 +267,7 @@
       </preface>
     </frontmatter>
 
-    <!-- <xi:include href="./chapter_limits.ptx" /> -->
+    <xi:include href="./chapter_limits.ptx" />
 
     <xi:include href="./chapter_derivatives.ptx" />
 

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -133,7 +133,7 @@
 \colorlet{firstcolor}{blue}
 \colorlet{secondcolor}{red}
 \colorlet{thirdcolor}{magenta}
-\pgfplotsset{firstcurvestyle/.style={color=firstcolor,mark=none,thick,{Kite}-{Kite},solid}}
+\pgfplotsset{firstcurvestyle/.style={color=firstcolor,mark=none,thick,{Kite}-{Kite},solid,fill=firstcolor!50,fill=none}}
 \pgfplotsset{secondcurvestyle/.style={color=secondcolor,mark=none,thick,{Kite}-{Kite},dashdotted}}
 \pgfplotsset{thirdcurvestyle/.style={color=thirdcolor,mark=none,thick,{Kite}-{Kite},dashdotdotted}}
 \pgfplotsset{tangentline/.style={color=black,mark=none,thick,{Kite}-{Kite},solid}}
@@ -271,7 +271,7 @@
 
     <xi:include href="./chapter_derivatives.ptx" />
 
-    <!-- <xi:include href="./chapter_graphbehavior.ptx" /> -->
+    <xi:include href="./chapter_graphbehavior.ptx" />
 
     <!-- <xi:include href="./chapter_deriv_apps.ptx" /> -->
 

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -68,7 +68,7 @@
 
               <p>
                 <m>\lzoo{x}{x^n}= nx^{n-1}</m>,
-                where <m>n</m> is an integer, <m>n&gt;0</m>.
+                where <m>n</m> is an integer, <m>n \gt 0</m>.
               </p>
             </li>
 
@@ -87,7 +87,7 @@
               </p>
 
               <p>
-                <m>\lzoo{x}{\ln(x)} = \frac{1}{x}</m>, for <m>x\gt 0</m>.
+                <m>\lzoo{x}{\ln(x)} = \frac{1}{x}</m>, for <m>x \gt  0</m>.
               </p>
             </li>
           </dl>
@@ -685,7 +685,7 @@
             <statement>
               <p>
                 What is the name of the rule which states that <m>\lzoo{x}{x^n} = nx^{n-1}</m>,
-                where <m>n&gt;0</m> is an integer?
+                where <m>n \gt 0</m> is an integer?
               </p>
 
               <p>
@@ -1370,7 +1370,7 @@
           <statement>
             <p>
               A property of logarithms is that <m>\log_a(x) = \frac{\log_b(x)}{\log_b(a)}</m>,
-              for all bases <m>a,b&gt;0,\neq 1</m>.
+              for all bases <m>a,b \gt 0,\neq 1</m>.
 
               <ol>
                 <li>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -220,7 +220,7 @@
           <image xml:id="img_xcubedwithderiv" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.1,xmax=2.1,
             ymin=-5.1,ymax=5.1,
@@ -231,7 +231,7 @@
             \addplot[soliddot] coordinates {(-1,-1) (-1,3)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
           <!-- figures/fig_xcubedwithderiv.tex END -->
@@ -388,7 +388,7 @@
             <image xml:id="img_sintangapprox">
               <description></description>
               <latex-image>
-              <![CDATA[
+
               \begin{tikzpicture}
               \begin{axis}[xmin=-1.1,xmax=5.1,
               ymin=-1,ymax=10,]
@@ -400,7 +400,7 @@
               \end{axis}
 
               \end{tikzpicture}
-              ]]>
+
               </latex-image>
             </image>
             <!-- figures/fig_xcubedwithderiv.tex END -->
@@ -411,7 +411,7 @@
             <image xml:id="img_sintangapproxzoom">
               <description></description>
               <latex-image>
-              <![CDATA[
+
               \begin{tikzpicture}
               \begin{axis}[ymin=6.7,ymax=7.4,
               xmin=2.5,xmax=3.5,
@@ -425,7 +425,7 @@
               \end{axis}
 
               \end{tikzpicture}
-              ]]>
+
               </latex-image>
             </image>
             <!-- figures/fig_xcubedwithderiv.tex END -->
@@ -669,10 +669,10 @@
             <pg-code>
               Context("ArbitraryString");
               $ans=Compute("Power Rule");
-              $ev=$ans-&gt;cmp(checker =&gt; sub {
+              $ev=$ans->cmp(checker => sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct-&gt;value;
-              $student = $student-&gt;value;
+              $correct = $correct->value;
+              $student = $student->value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/ /, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -719,10 +719,10 @@
             <setup>
             <pg-code>
               $ans=Compute("e^x");
-              $ev=$ans-&gt;cmp(checker=&gt;sub{my($correct,$student,$self )=@_;
-                my$context=Context()-&gt;copy;
-                $context-&gt;flags-&gt;set(no_parameters=&gt;0);
-                $context-&gt;variables-&gt;add('C0'=&gt;'Parameter');
+              $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
+                my$context=Context()->copy;
+                $context->flags->set(no_parameters=>0);
+                $context->variables->add('C0'=>'Parameter');
                 my$c0=Formula($context,'C0');
                 $student=Formula($context,$student);
                 $correct=Formula($context,"$c0 e^x");
@@ -752,10 +752,10 @@
         <webwork seed="1">
             <setup>            <pg-code>
               $ans=Formula("10");
-              $ev=$ans-&gt;cmp(checker=&gt;sub{my($correct,$student,$self )=@_;
-                my$context=Context()-&gt;copy;
-                $context-&gt;flags-&gt;set(no_parameters=&gt;0);
-                $context-&gt;variables-&gt;add('C0'=&gt;'Parameter');
+              $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
+                my$context=Context()->copy;
+                $context->flags->set(no_parameters=>0);
+                $context->variables->add('C0'=>'Parameter');
                 my$c0=Formula($context,'C0');
                 $student=Formula($context,$student);
                 $correct=Formula($context,"$c0");
@@ -887,12 +887,12 @@
             <setup>
             <pg-code>
               $ans=Compute("17x-205");
-              $ev=$ans-&gt;cmp(checker=&gt;sub{my($correct,$student,$self )=@_;
+              $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
                 return 0 if $student == Formula("0");
-                my$context=Context()-&gt;copy;
-                $context-&gt;flags-&gt;set(no_parameters=&gt;0);
-                $context-&gt;variables-&gt;add('C0'=&gt;'Parameter');
-                $context-&gt;variables-&gt;add('C1'=&gt;'Parameter');
+                my$context=Context()->copy;
+                $context->flags->set(no_parameters=>0);
+                $context->variables->add('C0'=>'Parameter');
+                $context->variables->add('C1'=>'Parameter');
                 my$c0=Formula($context,'C0');
                 my$c1=Formula($context,'C1');
                 $student=Formula($context,$student);
@@ -947,10 +947,10 @@
               Context("ArbitraryString");
               $ans[0]=Compute("a velocity function");
               $ans[1]=Compute("an acceleration function");
-              $ev[0]=$ans[0]-&gt;cmp(checker =&gt; sub {
+              $ev[0]=$ans[0]->cmp(checker => sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct-&gt;value;
-              $student = $student-&gt;value;
+              $correct = $correct->value;
+              $student = $student->value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/ /, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -958,10 +958,10 @@
               $words[2] =~ s/^~~W+|~~W+$//g;
               return ($#words &lt;= 2 and ((uc($words[0]) eq 'VELOCITY') or (uc($words[0]) eq 'VELOCITY' and uc($words[1]) eq 'FUNCTION') or (uc($words[0]) eq 'A' and uc($words[1]) eq 'VELOCITY' and uc($words[2]) eq 'FUNCTION')));
               });
-              $ev[1]=$ans[1]-&gt;cmp(checker =&gt; sub {
+              $ev[1]=$ans[1]->cmp(checker => sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct-&gt;value;
-              $student = $student-&gt;value;
+              $correct = $correct->value;
+              $student = $student->value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/ /, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -1005,19 +1005,19 @@
             <pg-code>
               Context("ArbitraryString");
               $ans=Compute("lb/ft^2");
-              $ev=$ans-&gt;cmp(checker =&gt; sub {
+              $ev=$ans->cmp(checker => sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct-&gt;value; # get perl string from String object
-              $student = $student-&gt;value; # ditto
+              $correct = $correct->value; # get perl string from String object
+              $student = $student->value; # ditto
               my $context = Context(); Context("Numeric");
-              my $check = NumberWithUnits("1 $correct")-&gt;cmp-&gt;evaluate("1 $student");
+              my $check = NumberWithUnits("1 $correct")->cmp->evaluate("1 $student");
               Context($context);
-              $ans-&gt;{correct_ans_latex_string} = substr($check-&gt;{correct_ans_latex_string},3);
-              if ($check-&gt;{score}) {
-                $ans-&gt;{preview_latex_string} = substr($check-&gt;{preview_latex_string},3);
-                $ans-&gt;{preview_text_string} = substr($check-&gt;{preview_text_string},3);
+              $ans->{correct_ans_latex_string} = substr($check->{correct_ans_latex_string},3);
+              if ($check->{score}) {
+                $ans->{preview_latex_string} = substr($check->{preview_latex_string},3);
+                $ans->{preview_text_string} = substr($check->{preview_text_string},3);
               }
-              return $check-&gt;{score};
+              return $check->{score};
               });
             </pg-code>
             </setup>
@@ -1089,8 +1089,8 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0);
               $f=Formula("9t^5-1/8t^3+3t-8");
               $fp=Formula("45t^4-3/8t^2+3");
             </pg-code>
@@ -1111,7 +1111,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
+              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $f=Formula("9sin(theta) +10cos(theta)");
               $fp=Formula("9cos(theta)-10sin(theta)");
             </pg-code>
@@ -1136,7 +1136,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(r=&gt;'Real');
+              Context()->variables->are(r=>'Real');
               $f=Formula("6e^r");
               $fp=Formula("6e^r");
             </pg-code>
@@ -1157,7 +1157,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $f=Formula("10t^4-cos(t) +7sin(t)");
               $fp=Formula("40t^3 + sin(t) + 7cos(t)");
             </pg-code>
@@ -1198,8 +1198,8 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(s=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->variables->are(s=>'Real');
+              Context()->flags->set(reduceConstants=>0);
               $f=Formula("1/4s^4+1/3s^3+1/2s^2+s+1");
               $fp=Formula("s^3+s^2+s+1");
             </pg-code>
@@ -1220,7 +1220,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $f=Formula("e^t-sin(t)-cos(t)");
               $fp=Formula("e^t-cos(t)+sin(t)");
             </pg-code>
@@ -1261,9 +1261,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstantFunctions=>0);
+              Context()->flags->set(reduceConstants=>0);
               $f=Formula("ln(17)+e^2+sin(pi)/2");
               $fp=Formula("0");
             </pg-code>
@@ -1284,7 +1284,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $f=Formula("(1+3t)^2");
               $fp=Formula("18t+6");
             </pg-code>
@@ -1478,7 +1478,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $f=Formula("t^2 - e^t");
               @d=(Formula("2t - e^t"), Formula("2 - e^t"), Formula("-e^t"), Formula("-e^t"));
             </pg-code>
@@ -1511,7 +1511,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
+              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $f=Formula("theta^4-theta^3");
               @d=(Formula("4theta^3-3theta^2"), Formula("12theta^2-6theta"), Formula("24theta-6"), Formula("24"));
             </pg-code>
@@ -1548,7 +1548,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
+              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $f=Formula("sin(theta)-cos(theta)");
               @d=(Formula("cos(theta)+sin(theta)"), Formula("-sin(theta)+cos(theta)"), Formula("-cos(theta)-sin(theta)"), Formula("sin(theta)-cos(theta)"));
             </pg-code>
@@ -1627,9 +1627,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=2(x-1)");
               $n=Formula("y=-(1/2)(x-1)");
             </pg-code>
@@ -1654,9 +1654,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;are(y=&gt;'Real',t=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->are(y=>'Real',t=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=t+4");
               $n=Formula("y=-t+4");
             </pg-code>
@@ -1681,9 +1681,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->are(y=>'Real',x=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=x-1");
               $n=Formula("y=-(x-1)");
             </pg-code>
@@ -1708,9 +1708,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->are(y=>'Real',x=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=4");
               $n=Formula("x=pi/2");
             </pg-code>
@@ -1735,10 +1735,10 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->flags->set(reduceConstantFunctions=>0);
+              Context()->variables->are(y=>'Real',x=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=sqrt(2)(x-pi/4)-sqrt(2)");
               $n=Formula("y=-(1/sqrt(2))(x-pi/4)-sqrt(2)");
             </pg-code>
@@ -1763,10 +1763,10 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->flags->set(reduceConstantFunctions=>0);
+              Context()->variables->are(y=>'Real',x=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=2(x-5)+13");
               $n=Formula("y=-(1/2)(x-5)+13");
             </pg-code>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_basic_diff_rules">
   <title>Basic Differentiation Rules</title>
   <introduction>
@@ -69,7 +68,7 @@
 
               <p>
                 <m>\lzoo{x}{x^n}= nx^{n-1}</m>,
-                where <m>n</m> is an integer, <m>n>0</m>.
+                where <m>n</m> is an integer, <m>n&gt;0</m>.
               </p>
             </li>
 
@@ -105,7 +104,7 @@
       Therefore their derivative is <m>0</m>
       (they change at the rate of <m>0</m>).
       The theorem then states some fairly amazing things.
-      The <xref ref="power-derivative-rule" text="title" /> states that the derivatives of Power Functions
+      The <xref ref="power-derivative-rule" text="title"/> states that the derivatives of Power Functions
       (of the form <m>y=x^n</m>)
       are very straightforward:
       multiply by the power, then subtract <m>1</m> from the power.
@@ -115,10 +114,10 @@
     </p>
 
     <p>
-      One special case of the <xref ref="power-derivative-rule" text="title" /> is when <m>n=1</m>,
+      One special case of the <xref ref="power-derivative-rule" text="title"/> is when <m>n=1</m>,
       i.e., when <m>f(x) = x</m>.
       What is <m>\fp(x)</m>?
-      According to the <xref ref="power-derivative-rule" text="title" />,
+      According to the <xref ref="power-derivative-rule" text="title"/>,
       <me>
         \fp(x) = \lzoo{x}{x} = \lzoo{x}{x^1} = 1\cdot x^0 = 1
       </me>.
@@ -168,7 +167,7 @@
             <li>
               <p>
                 Sketch <m>f</m>,
-                <m>\fp</m> and the tangent line from <xref ref="item-tangent-line" /> on the same axis.
+                <m>\fp</m> and the tangent line from <xref ref="item-tangent-line"/> on the same axis.
               </p>
             </li>
           </ol>
@@ -179,7 +178,7 @@
           <ol>
             <li>
               <p>
-                The <xref ref="power-derivative-rule" text="title" /> states that if <m>f(x) = x^3</m>,
+                The <xref ref="power-derivative-rule" text="title"/> states that if <m>f(x) = x^3</m>,
                 then <m>\fp(x) = 3x^2</m>.
               </p>
             </li>
@@ -294,7 +293,7 @@
     <p>
       <xref ref="thm_deriv_prop">Theorem</xref>
       allows us to find the derivatives of a wide variety of functions.
-      It can be used in conjunction with the <xref ref="power-derivative-rule" text="title" /> to find the derivatives of any polynomial.
+      It can be used in conjunction with the <xref ref="power-derivative-rule" text="title"/> to find the derivatives of any polynomial.
       Recall in <xref ref="ex_deriv1">Example</xref> that we found,
       using the limit definition, the derivative of <m>f(x) = 3x^2+5x-7</m>.
       We can now find its derivative without expressly using limits:
@@ -618,7 +617,7 @@
       We now consider <m>\fp'</m>, which describes the rate of velocity change.
       Sports car enthusiasts talk of how fast a car can go from <m>0</m> to
       <quantity>
-        <mag>60</mag><unit base="mileperhour" />
+        <mag>60</mag><unit base="mileperhour"/>
       </quantity>; they are bragging about the
       <em>acceleration</em> of the car.
     </p>
@@ -670,10 +669,10 @@
             <pg-code>
               Context("ArbitraryString");
               $ans=Compute("Power Rule");
-              $ev=$ans->cmp(checker => sub {
+              $ev=$ans-&gt;cmp(checker =&gt; sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct->value;
-              $student = $student->value;
+              $correct = $correct-&gt;value;
+              $student = $student-&gt;value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/ /, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -686,11 +685,11 @@
             <statement>
               <p>
                 What is the name of the rule which states that <m>\lzoo{x}{x^n} = nx^{n-1}</m>,
-                where <m>n>0</m> is an integer?
+                where <m>n&gt;0</m> is an integer?
               </p>
 
               <p>
-                <var name="$ans" width="20" evaluator="$ev" />
+                <var name="$ans" width="20" evaluator="$ev"/>
               </p>
             </statement>
         </webwork>
@@ -709,7 +708,7 @@
               </p>
 
               <p>
-                <var name="$ans" width="10" />
+                <var name="$ans" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -720,10 +719,10 @@
             <setup>
             <pg-code>
               $ans=Compute("e^x");
-              $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
-                my$context=Context()->copy;
-                $context->flags->set(no_parameters=>0);
-                $context->variables->add('C0'=>'Parameter');
+              $ev=$ans-&gt;cmp(checker=&gt;sub{my($correct,$student,$self )=@_;
+                my$context=Context()-&gt;copy;
+                $context-&gt;flags-&gt;set(no_parameters=&gt;0);
+                $context-&gt;variables-&gt;add('C0'=&gt;'Parameter');
                 my$c0=Formula($context,'C0');
                 $student=Formula($context,$student);
                 $correct=Formula($context,"$c0 e^x");
@@ -753,10 +752,10 @@
         <webwork seed="1">
             <setup>            <pg-code>
               $ans=Formula("10");
-              $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
-                my$context=Context()->copy;
-                $context->flags->set(no_parameters=>0);
-                $context->variables->add('C0'=>'Parameter');
+              $ev=$ans-&gt;cmp(checker=&gt;sub{my($correct,$student,$self )=@_;
+                my$context=Context()-&gt;copy;
+                $context-&gt;flags-&gt;set(no_parameters=&gt;0);
+                $context-&gt;variables-&gt;add('C0'=&gt;'Parameter');
                 my$c0=Formula($context,'C0');
                 $student=Formula($context,$student);
                 $correct=Formula($context,"$c0");
@@ -805,7 +804,7 @@
                     </p>
 
                     <p>
-                      <var name="$not" form="buttons" />
+                      <var name="$not" form="buttons"/>
                     </p>
                   </li>
 
@@ -815,7 +814,7 @@
                     </p>
 
                     <p>
-                      <var name="$covered" form="buttons" />
+                      <var name="$covered" form="buttons"/>
                     </p>
                   </li>
 
@@ -825,7 +824,7 @@
                     </p>
 
                     <p>
-                      <var name="$covered" form="buttons" />
+                      <var name="$covered" form="buttons"/>
                     </p>
                   </li>
 
@@ -835,7 +834,7 @@
                     </p>
 
                     <p>
-                      <var name="$not" form="buttons" />
+                      <var name="$not" form="buttons"/>
                     </p>
                   </li>
 
@@ -845,7 +844,7 @@
                     </p>
 
                     <p>
-                      <var name="$not" form="buttons" />
+                      <var name="$not" form="buttons"/>
                     </p>
                   </li>
 
@@ -855,7 +854,7 @@
                     </p>
 
                     <p>
-                      <var name="$not" form="buttons" />
+                      <var name="$not" form="buttons"/>
                     </p>
                   </li>
                 </ol>
@@ -872,7 +871,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -888,12 +887,12 @@
             <setup>
             <pg-code>
               $ans=Compute("17x-205");
-              $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
+              $ev=$ans-&gt;cmp(checker=&gt;sub{my($correct,$student,$self )=@_;
                 return 0 if $student == Formula("0");
-                my$context=Context()->copy;
-                $context->flags->set(no_parameters=>0);
-                $context->variables->add('C0'=>'Parameter');
-                $context->variables->add('C1'=>'Parameter');
+                my$context=Context()-&gt;copy;
+                $context-&gt;flags-&gt;set(no_parameters=&gt;0);
+                $context-&gt;variables-&gt;add('C0'=&gt;'Parameter');
+                $context-&gt;variables-&gt;add('C1'=&gt;'Parameter');
                 my$c0=Formula($context,'C0');
                 my$c1=Formula($context,'C1');
                 $student=Formula($context,$student);
@@ -929,7 +928,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -948,10 +947,10 @@
               Context("ArbitraryString");
               $ans[0]=Compute("a velocity function");
               $ans[1]=Compute("an acceleration function");
-              $ev[0]=$ans[0]->cmp(checker => sub {
+              $ev[0]=$ans[0]-&gt;cmp(checker =&gt; sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct->value;
-              $student = $student->value;
+              $correct = $correct-&gt;value;
+              $student = $student-&gt;value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/ /, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -959,10 +958,10 @@
               $words[2] =~ s/^~~W+|~~W+$//g;
               return ($#words &lt;= 2 and ((uc($words[0]) eq 'VELOCITY') or (uc($words[0]) eq 'VELOCITY' and uc($words[1]) eq 'FUNCTION') or (uc($words[0]) eq 'A' and uc($words[1]) eq 'VELOCITY' and uc($words[2]) eq 'FUNCTION')));
               });
-              $ev[1]=$ans[1]->cmp(checker => sub {
+              $ev[1]=$ans[1]-&gt;cmp(checker =&gt; sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct->value;
-              $student = $student->value;
+              $correct = $correct-&gt;value;
+              $student = $student-&gt;value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/ /, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -979,7 +978,7 @@
               </p>
 
               <p>
-                <var name="$ans[0]" width="20" evaluator="$ev[0]" />
+                <var name="$ans[0]" width="20" evaluator="$ev[0]"/>
               </p>
 
               <p>
@@ -987,7 +986,7 @@
               </p>
 
               <p>
-                <var name="$ans[1]" width="20" evaluator="$ev[1]" />
+                <var name="$ans[1]" width="20" evaluator="$ev[1]"/>
               </p>
             </statement>
             <solution>
@@ -1006,19 +1005,19 @@
             <pg-code>
               Context("ArbitraryString");
               $ans=Compute("lb/ft^2");
-              $ev=$ans->cmp(checker => sub {
+              $ev=$ans-&gt;cmp(checker =&gt; sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct->value; # get perl string from String object
-              $student = $student->value; # ditto
+              $correct = $correct-&gt;value; # get perl string from String object
+              $student = $student-&gt;value; # ditto
               my $context = Context(); Context("Numeric");
-              my $check = NumberWithUnits("1 $correct")->cmp->evaluate("1 $student");
+              my $check = NumberWithUnits("1 $correct")-&gt;cmp-&gt;evaluate("1 $student");
               Context($context);
-              $ans->{correct_ans_latex_string} = substr($check->{correct_ans_latex_string},3);
-              if ($check->{score}) {
-                $ans->{preview_latex_string} = substr($check->{preview_latex_string},3);
-                $ans->{preview_text_string} = substr($check->{preview_text_string},3);
+              $ans-&gt;{correct_ans_latex_string} = substr($check-&gt;{correct_ans_latex_string},3);
+              if ($check-&gt;{score}) {
+                $ans-&gt;{preview_latex_string} = substr($check-&gt;{preview_latex_string},3);
+                $ans-&gt;{preview_text_string} = substr($check-&gt;{preview_text_string},3);
               }
-              return $check->{score};
+              return $check-&gt;{score};
               });
             </pg-code>
             </setup>
@@ -1031,7 +1030,7 @@
               </p>
 
               <p>
-                <var name="$ans" width="10" evaluator="$ev" />
+                <var name="$ans" width="10" evaluator="$ev"/>
               </p>
             </statement>
         </webwork>
@@ -1056,11 +1055,11 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="15" />
+                <m>f'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1076,11 +1075,11 @@
             </setup>
             <statement>
               <p>
-                <m>g(x) = <var name="$f" /></m>
+                <m>g(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>g'(x)=</m><var name="$fp" width="15" />
+                <m>g'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1090,19 +1089,19 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $f=Formula("9t^5-1/8t^3+3t-8");
               $fp=Formula("45t^4-3/8t^2+3");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>m(t) = <var name="$f" /></m>
+                <m>m(t) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>m'(t)=</m><var name="$fp" width="15" />
+                <m>m'(t)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1112,14 +1111,14 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
+              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
               $f=Formula("9sin(theta) +10cos(theta)");
               $fp=Formula("9cos(theta)-10sin(theta)");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>f(\theta) = <var name="$f" /></m>
+                <m>f(\theta) = <var name="$f"/></m>
               </p>
 
               <p>
@@ -1127,7 +1126,7 @@
               </p>
 
               <p>
-                <m>f'(\theta)=</m><var name="$fp" width="25" />
+                <m>f'(\theta)=</m><var name="$fp" width="25"/>
               </p>
             </statement>
         </webwork>
@@ -1137,18 +1136,18 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(r=>'Real');
+              Context()-&gt;variables-&gt;are(r=&gt;'Real');
               $f=Formula("6e^r");
               $fp=Formula("6e^r");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>f(r) = <var name="$f" /></m>
+                <m>f(r) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(r)=</m><var name="$fp" width="15" />
+                <m>f'(r)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1158,18 +1157,18 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $f=Formula("10t^4-cos(t) +7sin(t)");
               $fp=Formula("40t^3 + sin(t) + 7cos(t)");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>g(t) = <var name="$f" /></m>
+                <m>g(t) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>g'(t)=</m><var name="$fp" width="15" />
+                <m>g'(t)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1185,11 +1184,11 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="15" />
+                <m>f'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1199,19 +1198,19 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(s=>'Real');
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;variables-&gt;are(s=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $f=Formula("1/4s^4+1/3s^3+1/2s^2+s+1");
               $fp=Formula("s^3+s^2+s+1");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>p(s) = <var name="$f" /></m>
+                <m>p(s) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>p'(s)=</m><var name="$fp" width="15" />
+                <m>p'(s)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1221,18 +1220,18 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $f=Formula("e^t-sin(t)-cos(t)");
               $fp=Formula("e^t-cos(t)+sin(t)");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>h(t) = <var name="$f" /></m>
+                <m>h(t) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>h'(t)=</m><var name="$fp" width="15" />
+                <m>h'(t)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1248,11 +1247,11 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="15" />
+                <m>f'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1262,20 +1261,20 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstantFunctions=>0);
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $f=Formula("ln(17)+e^2+sin(pi)/2");
               $fp=Formula("0");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>f(t) = <var name="$f" /></m>
+                <m>f(t) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(t)=</m><var name="$fp" width="15" />
+                <m>f'(t)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1285,18 +1284,18 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $f=Formula("(1+3t)^2");
               $fp=Formula("18t+6");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>g(t) = <var name="$f" /></m>
+                <m>g(t) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>g'(t)=</m><var name="$fp" width="15" />
+                <m>g'(t)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1312,11 +1311,11 @@
             </setup>
             <statement>
               <p>
-                <m>g(x) = <var name="$f" /></m>
+                <m>g(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>g'(x)=</m><var name="$fp" width="15" />
+                <m>g'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1332,11 +1331,11 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="15" />
+                <m>f'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1352,11 +1351,11 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="15" />
+                <m>f'(x)=</m><var name="$fp" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1371,7 +1370,7 @@
           <statement>
             <p>
               A property of logarithms is that <m>\log_a(x) = \frac{\log_b(x)}{\log_b(a)}</m>,
-              for all bases <m>a,b>0,\neq 1</m>.
+              for all bases <m>a,b&gt;0,\neq 1</m>.
 
               <ol>
                 <li>
@@ -1396,7 +1395,7 @@
             </p>
 
             <p>
-              <var form="essay" />
+              <var form="essay"/>
             </p>
           </statement>
       </webwork>
@@ -1421,23 +1420,23 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$d[0]" width="15" />
+                <m>f'(x)=</m><var name="$d[0]" width="15"/>
               </p>
 
               <p>
-                <m>f''(x)=</m><var name="$d[1]" width="15" />
+                <m>f''(x)=</m><var name="$d[1]" width="15"/>
               </p>
 
               <p>
-                <m>f^{(3)}(x)=</m><var name="$d[2]" width="15" />
+                <m>f^{(3)}(x)=</m><var name="$d[2]" width="15"/>
               </p>
 
               <p>
-                <m>f^{(4)}(x)=</m><var name="$d[3]" width="15" />
+                <m>f^{(4)}(x)=</m><var name="$d[3]" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1453,23 +1452,23 @@
             </setup>
             <statement>
               <p>
-                <m>g(x) = <var name="$f" /></m>
+                <m>g(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>g'(x)=</m><var name="$d[0]" width="15" />
+                <m>g'(x)=</m><var name="$d[0]" width="15"/>
               </p>
 
               <p>
-                <m>g''(x)=</m><var name="$d[1]" width="15" />
+                <m>g''(x)=</m><var name="$d[1]" width="15"/>
               </p>
 
               <p>
-                <m>g^{(3)}(x)=</m><var name="$d[2]" width="15" />
+                <m>g^{(3)}(x)=</m><var name="$d[2]" width="15"/>
               </p>
 
               <p>
-                <m>g^{(4)}(x)=</m><var name="$d[3]" width="15" />
+                <m>g^{(4)}(x)=</m><var name="$d[3]" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1479,30 +1478,30 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $f=Formula("t^2 - e^t");
               @d=(Formula("2t - e^t"), Formula("2 - e^t"), Formula("-e^t"), Formula("-e^t"));
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>h(t) = <var name="$f" /></m>
+                <m>h(t) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>h'(t)=</m><var name="$d[0]" width="15" />
+                <m>h'(t)=</m><var name="$d[0]" width="15"/>
               </p>
 
               <p>
-                <m>h''(t)=</m><var name="$d[1]" width="15" />
+                <m>h''(t)=</m><var name="$d[1]" width="15"/>
               </p>
 
               <p>
-                <m>h^{(3)}(t)=</m><var name="$d[2]" width="15" />
+                <m>h^{(3)}(t)=</m><var name="$d[2]" width="15"/>
               </p>
 
               <p>
-                <m>h^{(4)}(t)=</m><var name="$d[3]" width="15" />
+                <m>h^{(4)}(t)=</m><var name="$d[3]" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1512,14 +1511,14 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
+              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
               $f=Formula("theta^4-theta^3");
               @d=(Formula("4theta^3-3theta^2"), Formula("12theta^2-6theta"), Formula("24theta-6"), Formula("24"));
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>p(\theta) = <var name="$f" /></m>
+                <m>p(\theta) = <var name="$f"/></m>
               </p>
 
               <p>
@@ -1527,19 +1526,19 @@
               </p>
 
               <p>
-                <m>p'(\theta)=</m><var name="$d[0]" width="15" />
+                <m>p'(\theta)=</m><var name="$d[0]" width="15"/>
               </p>
 
               <p>
-                <m>p''(\theta)=</m><var name="$d[1]" width="15" />
+                <m>p''(\theta)=</m><var name="$d[1]" width="15"/>
               </p>
 
               <p>
-                <m>p^{(3)}(\theta)=</m><var name="$d[2]" width="15" />
+                <m>p^{(3)}(\theta)=</m><var name="$d[2]" width="15"/>
               </p>
 
               <p>
-                <m>p^{(4)}(\theta)=</m><var name="$d[3]" width="15" />
+                <m>p^{(4)}(\theta)=</m><var name="$d[3]" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1549,14 +1548,14 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
+              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
               $f=Formula("sin(theta)-cos(theta)");
               @d=(Formula("cos(theta)+sin(theta)"), Formula("-sin(theta)+cos(theta)"), Formula("-cos(theta)-sin(theta)"), Formula("sin(theta)-cos(theta)"));
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m>f(\theta) = <var name="$f" /></m>
+                <m>f(\theta) = <var name="$f"/></m>
               </p>
 
               <p>
@@ -1564,19 +1563,19 @@
               </p>
 
               <p>
-                <m>f'(\theta)=</m><var name="$d[0]" width="15" />
+                <m>f'(\theta)=</m><var name="$d[0]" width="15"/>
               </p>
 
               <p>
-                <m>f''(\theta)=</m><var name="$d[1]" width="15" />
+                <m>f''(\theta)=</m><var name="$d[1]" width="15"/>
               </p>
 
               <p>
-                <m>f^{(3)}(\theta)=</m><var name="$d[2]" width="15" />
+                <m>f^{(3)}(\theta)=</m><var name="$d[2]" width="15"/>
               </p>
 
               <p>
-                <m>f^{(4)}(\theta)=</m><var name="$d[3]" width="15" />
+                <m>f^{(4)}(\theta)=</m><var name="$d[3]" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1592,23 +1591,23 @@
             </setup>
             <statement>
               <p>
-                <m>f(x) = <var name="$f" /></m>
+                <m>f(x) = <var name="$f"/></m>
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$d[0]" width="15" />
+                <m>f'(x)=</m><var name="$d[0]" width="15"/>
               </p>
 
               <p>
-                <m>f''(x)=</m><var name="$d[1]" width="15" />
+                <m>f''(x)=</m><var name="$d[1]" width="15"/>
               </p>
 
               <p>
-                <m>f^{(3)}(x)=</m><var name="$d[2]" width="15" />
+                <m>f^{(3)}(x)=</m><var name="$d[2]" width="15"/>
               </p>
 
               <p>
-                <m>f^{(4)}(x)=</m><var name="$d[3]" width="15" />
+                <m>f^{(4)}(x)=</m><var name="$d[3]" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1628,9 +1627,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=2(x-1)");
               $n=Formula("y=-(1/2)(x-1)");
             </pg-code>
@@ -1641,11 +1640,11 @@
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1655,9 +1654,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->are(y=>'Real',t=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;are(y=&gt;'Real',t=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=t+4");
               $n=Formula("y=-t+4");
             </pg-code>
@@ -1668,11 +1667,11 @@
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1682,9 +1681,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->are(y=>'Real',x=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=x-1");
               $n=Formula("y=-(x-1)");
             </pg-code>
@@ -1695,11 +1694,11 @@
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1709,9 +1708,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->are(y=>'Real',x=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=4");
               $n=Formula("x=pi/2");
             </pg-code>
@@ -1722,11 +1721,11 @@
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1736,10 +1735,10 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
-              Context()->flags->set(reduceConstantFunctions=>0);
-              Context()->variables->are(y=>'Real',x=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=sqrt(2)(x-pi/4)-sqrt(2)");
               $n=Formula("y=-(1/sqrt(2))(x-pi/4)-sqrt(2)");
             </pg-code>
@@ -1750,11 +1749,11 @@
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1764,10 +1763,10 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
-              Context()->flags->set(reduceConstantFunctions=>0);
-              Context()->variables->are(y=>'Real',x=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;are(y=&gt;'Real',x=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=2(x-5)+13");
               $n=Formula("y=-(1/2)(x-5)+13");
             </pg-code>
@@ -1778,11 +1777,11 @@
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1811,7 +1810,7 @@
               </p>
 
               <p>
-                <var name = "$ans" width="5" />
+                <var name="$ans" width="5"/>
               </p>
             </statement>
             <solution>
@@ -1836,7 +1835,7 @@
               </p>
 
               <p>
-                <var name = "$ans" width="5" />
+                <var name="$ans" width="5"/>
               </p>
             </statement>
             <solution>
@@ -1851,4 +1850,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -373,8 +373,8 @@ but our focus is more on the derivative result than on the domain/range conditio
                   <mrow>\amp = \frac{4x(3x-1)}{2x(2x^2-x)}</mrow>
                   <mrow>\amp = \frac{2(3x-1)}{2x^2-x}</mrow>
                 </md>.
-                Note that <m>\ln\mathopen{}\left(4x^3-2x^2\right)\mathclose{}=\ln\mathopen{}\left(4x^2(x-1/2)\right)\mathclose{}</m> was only defined for <m>x\gt1/2</m>,
-                so the result of <m>y'=\frac{2(3x-1)}{2x^2-x}</m> is only valid for <m>x\gt1/2</m> as well.
+                Note that <m>\ln\mathopen{}\left(4x^3-2x^2\right)\mathclose{}=\ln\mathopen{}\left(4x^2(x-1/2)\right)\mathclose{}</m> was only defined for <m>x \gt 1/2</m>,
+                so the result of <m>y'=\frac{2(3x-1)}{2x^2-x}</m> is only valid for <m>x \gt 1/2</m> as well.
               </p>
             </li>
 
@@ -736,7 +736,7 @@ but our focus is more on the derivative result than on the domain/range conditio
 
         <p>
           We can extend this process to use any base <m>a</m>,
-          where <m>a&gt;0</m> and <m>a\neq 1</m>.
+          where <m>a \gt 0</m> and <m>a\neq 1</m>.
           All we need to do is replace each <q>2</q>
           in our work with <q><m>a</m>.</q> The Chain Rule,
           coupled with the derivative rule of <m>e^x</m>,
@@ -753,7 +753,7 @@ but our focus is more on the derivative result than on the domain/range conditio
       <title>Derivatives of Exponential Functions</title>
       <statement>
         <p>
-          Let <m>f(x)=a^x</m>, for <m>a&gt;0, a\neq 1</m>.
+          Let <m>f(x)=a^x</m>, for <m>a \gt 0, a\neq 1</m>.
 
               <idx><h>derivative</h><h>exponential functions</h></idx>
 

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -40,7 +40,7 @@
       <image xml:id="img_chain" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+
         \begin{tikzpicture}
         \begin{axis}[ymin=-1.5,ymax=1.5,
         xmin=-.2,xmax=3.5,
@@ -51,7 +51,7 @@
         \addplot[soliddot] coordinates {(1.571,-0.781)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+
         </latex-image>
       </image>
 
@@ -430,7 +430,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           <image xml:id="img_chain7">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.1,xmax=3.1,
             ymin=-1.1,ymax=1.1,]
@@ -439,7 +439,7 @@ but our focus is more on the derivative result than on the domain/range conditio
             \addplot [soliddot] coordinates{(1,0.54)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
           <!-- figures/fig_chain7.tex END -->
@@ -853,7 +853,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <image xml:id="img_chainrulegears">
           <description></description>
           <latex-image>
-          <![CDATA[
+
           \begin{tikzpicture}[&gt;=latex]
 
           \begin{scope}[shift={(0,-200pt)}]
@@ -891,7 +891,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           \end{scope}
           \end{scope}
           \end{tikzpicture}
-          ]]>
+
           </latex-image>
         </image>
         <!-- figures/fig_chainrule_gears.tex END -->
@@ -1075,7 +1075,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("15(3t-2)^4");
             </pg-code>
             </setup>
@@ -1100,7 +1100,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
+              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $fp=Formula("3(sin(theta)+cos(theta))^2(cos(theta)-sin(theta))");
             </pg-code>
             </setup>
@@ -1129,7 +1129,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("(6t+1)e^(3t^2+t-1)");
             </pg-code>
             </setup>
@@ -1286,7 +1286,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("8 sin^3(2t) cos(2t)");
             </pg-code>
             </setup>
@@ -1311,7 +1311,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("-3 cos^2(t^2+3t+1) sin(t^2+3t+1) (2t+3)");
             </pg-code>
             </setup>
@@ -1408,8 +1408,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(r=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are(r=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("ln(4) 4^r");
             </pg-code>
             </setup>
@@ -1434,8 +1434,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("-ln(5)*5^(cos(t))*sin(t)");
             </pg-code>
             </setup>
@@ -1460,7 +1460,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("0");
             </pg-code>
             </setup>
@@ -1485,8 +1485,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(w=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are(w=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("ln(3/2) (3/2)^w");
             </pg-code>
             </setup>
@@ -1511,8 +1511,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("((3^t+2)ln(2)2^t-(2^t+3)(ln(3)3^t))/(3^t+2)^2");
             </pg-code>
             </setup>
@@ -1537,8 +1537,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(w=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are(w=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("(2^w(ln(3)3^w-ln(2)(3^w+1)))/(2^(2w))");
             </pg-code>
             </setup>
@@ -1563,7 +1563,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("(2^(x^2)(ln(3)3^(x^2)2x+1) - (3^(x^2)+x)ln(2)2^(x^2)2x)/2^(2x^2)");
             </pg-code>
             </setup>
@@ -1627,7 +1627,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("5cos(t^2+3t)cos(5t-7)- (2t+3)sin(t^2+3t)sin(5t-7)");
             </pg-code>
             </setup>
@@ -1665,7 +1665,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $fp=Formula("10t cos(1/t)e^(5t^2)+1/t^2sin(1/t)e^(5t^2)");
             </pg-code>
             </setup>
@@ -1728,8 +1728,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context("Numeric")->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=0");
               $n=Formula("x=0");
             </pg-code>
@@ -1756,9 +1756,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context("Numeric")->variables->add(y=>'Real');
+              parser::Assignment->Allow;
+              Context()->flags->set(reduceConstants=>0);
               $t=Formula("y=15(x-1)+1");
               $n=Formula("y=-1/15(x-1)+1");
             </pg-code>
@@ -1785,9 +1785,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context("Numeric")->variables->add(y=>'Real');
+              parser::Assignment->Allow;
+              Context()->flags->set(reduceConstants=>0);
               $t=Formula("y=-3(x - pi/2)+1");
               $n=Formula("y=1/3(x - pi/2)+1");
             </pg-code>
@@ -1814,9 +1814,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context("Numeric")->variables->add(y=>'Real');
+              parser::Assignment->Allow;
+              Context()->flags->set(reduceConstants=>0);
               $t=Formula("y=-5e(x+1)+e");
               $n=Formula("y=1/(5e)(x+1)+e");
             </pg-code>
@@ -1991,7 +1991,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->flags->set(reduceConstants=>0);
               $fp=Formula("2xe^xcot(x) + x^2e^xcot(x) - x^2e^xcsc^2(x)");
               $gp=Formula("ln(24)24^x");
             </pg-code>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -683,7 +683,7 @@
         </p>
 
         <p>
-          The reader is highly encouraged to look at each term and recognize why it is there. (I.e., the <xref ref="thm_QuotientRule" text="title"/> is used;
+          The reader is highly encouraged to look at each term and recognize why it is there. (<ie/>, the <xref ref="thm_QuotientRule" text="title"/> is used;
           in the numerator, identify the <q>LOdHI</q> term,
           etc.) This example demonstrates that derivatives can be computed systematically,
           no matter how arbitrarily complicated the function is.

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -137,21 +137,24 @@
       </solution>
     </example>
 
-    <p>
-      When composing functions,
-      we need to make sure that the new function is actually defined.
-      For instance,
-      consider <m>f(x) = \sqrt{x}</m> and <m>g(x) = -x^2-1</m>.
-      The domain of <m>f</m> excludes all negative numbers,
-      but the range of <m>g</m> is only negative numbers.
-      Therefore the composition <m>f(g(x)) = \sqrt{-x^2-1}</m> is not defined for any <m>x</m>,
-      and hence is not differentiable.
-    </p>
+    <aside>
+      <p>
+        When composing functions,
+        we need to make sure that the new function is actually defined.
+        For instance,
+        consider <m>f(x) = \sqrt{x}</m> and <m>g(x) = -x^2-1</m>.
+        The domain of <m>f</m> excludes all negative numbers,
+        but the range of <m>g</m> is only negative numbers.
+        Therefore the composition <m>f(g(x)) = \sqrt{-x^2-1}</m> is not defined for any <m>x</m>,
+        and hence is not differentiable.
+      </p>
 
-    <p>
-      The statement of <xref ref="thm_chain_rule">Theorem</xref> takes care to ensure this problem does not arise,
-but our focus is more on the derivative result than on the domain/range conditions.
-    </p>
+      <p>
+        The statement of <xref ref="thm_chain_rule">Theorem</xref> takes care to ensure
+        this problem does not arise, but our focus is more on the derivative result than
+        on the domain/range conditions.
+      </p>
+    </aside>
 
     <theorem xml:id="thm_chain_rule">
       <title>The Chain Rule</title>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_chainrule">
   <title>The Chain Rule</title>
   <introduction>
@@ -9,10 +8,10 @@
       functions.
       The operations of addition, subtraction, multiplication
       (including by a constant)
-      and division led to the <xref ref="sum-difference-derivative-rule" text="title" />,
-      the <xref ref="constant-multiple-derivative-rule" text="title" />,
+      and division led to the <xref ref="sum-difference-derivative-rule" text="title"/>,
+      the <xref ref="constant-multiple-derivative-rule" text="title"/>,
       the <xref ref="thm_PowerRule" text="title">Power Rule</xref>,
-      the <xref ref="thm_ProductRule" text="title" /> and the <xref ref="thm_QuotientRule" text="title" />.
+      the <xref ref="thm_ProductRule" text="title"/> and the <xref ref="thm_QuotientRule" text="title"/>.
       To complete the list of differentiation rules,
       we look at the last way two
       (or more)
@@ -215,15 +214,15 @@ but our focus is more on the derivative result than on the domain/range conditio
                 </me>,
                 where <m>f(x) = x^2</m> and <m>g(x) = 1-x</m>.
                 To find <m>y'</m>,
-                we apply the <xref ref="thm_chain_rule" text="title" />.
+                we apply the <xref ref="thm_chain_rule" text="title"/>.
                 We need to note that <m>\fp(x)=2x</m> and <m>g'(x)=-1</m>.
               </p>
 
               <p>
-                Part of the <xref ref="thm_chain_rule" text="title" /> uses <m>\fp(g(x))</m>.
+                Part of the <xref ref="thm_chain_rule" text="title"/> uses <m>\fp(g(x))</m>.
                 This means substitute <m>g(x)</m> for <m>x</m> in the equation for <m>\fp(x)</m>.
                 That is, <m>\fp(x) = 2(1-x)</m>.
-                Finishing out the <xref ref="thm_chain_rule" text="title" /> we have
+                Finishing out the <xref ref="thm_chain_rule" text="title"/> we have
                 <md>
                   <mrow>y' \amp = \fp(g(x))\cdot g'(x)</mrow>
                   <mrow>\amp = 2(1-x)\cdot (-1)</mrow>
@@ -240,7 +239,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                 where <m>f(x) = x^3</m> and <m>g(x) = (1-x)</m>.
                 We have <m>\fp(x) = 3x^2</m>,
                 so <m>\fp(g(x)) = 3(1-x)^2</m>.
-                The <xref ref="thm_chain_rule" text="title" /> then states
+                The <xref ref="thm_chain_rule" text="title"/> then states
                 <md>
                   <mrow>y' \amp = \fp(g(x))\cdot g'(x)</mrow>
                   <mrow>\amp = 3(1-x)^2\cdot (-1)</mrow>
@@ -310,7 +309,7 @@ but our focus is more on the derivative result than on the domain/range conditio
     </p>
 
     <p>
-      We now consider more examples that employ the <xref ref="thm_chain_rule" text="title" />.
+      We now consider more examples that employ the <xref ref="thm_chain_rule" text="title"/>.
     </p>
 
     <example xml:id="ex_chain3">
@@ -409,7 +408,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           The tangent line goes through the point
           <m>(1,f(1)) \approx (1,0.54)</m> with slope <m>\fp(1)</m>.
           To find <m>\fp</m>,
-          we need the <xref ref="thm_chain_rule" text="title" />.
+          we need the <xref ref="thm_chain_rule" text="title"/>.
         </p>
 
         <p>
@@ -449,7 +448,7 @@ but our focus is more on the derivative result than on the domain/range conditio
     </example>
 
     <p>
-      The <xref ref="thm_chain_rule" text="title" /> is used often in taking derivatives.
+      The <xref ref="thm_chain_rule" text="title"/> is used often in taking derivatives.
       Because of this,
       one can become familiar with the basic process and learn patterns that facilitate finding derivatives quickly.
       For instance,
@@ -482,7 +481,7 @@ but our focus is more on the derivative result than on the domain/range conditio
     </p>
 
     <p>
-      The following is a short list of how the <xref ref="thm_chain_rule" text="title" /> can be quickly applied to familiar functions.
+      The following is a short list of how the <xref ref="thm_chain_rule" text="title"/> can be quickly applied to familiar functions.
 
       <ol cols="2">
         <li>
@@ -518,7 +517,7 @@ but our focus is more on the derivative result than on the domain/range conditio
     </p>
 
     <p>
-      Of course, the <xref ref="thm_chain_rule" text="title" /> can be applied in conjunction with any of the other rules we have already learned.
+      Of course, the <xref ref="thm_chain_rule" text="title"/> can be applied in conjunction with any of the other rules we have already learned.
       We practice this next.
     </p>
 
@@ -548,7 +547,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           <ol>
             <li>
               <p>
-                We must use the <xref ref="thm_ProductRule" text="title" /> and <xref ref="thm_chain_rule" text="title" />.
+                We must use the <xref ref="thm_ProductRule" text="title"/> and <xref ref="thm_chain_rule" text="title"/>.
                 Do not think that you must be able to <q>see</q>
                 the whole answer immediately;
                 rather, just proceed step-by-step.
@@ -563,7 +562,7 @@ but our focus is more on the derivative result than on the domain/range conditio
 
             <li>
               <p>
-                We must employ the <xref ref="thm_QuotientRule" text="title" /> along with the <xref ref="thm_chain_rule" text="title" />.
+                We must employ the <xref ref="thm_QuotientRule" text="title"/> along with the <xref ref="thm_chain_rule" text="title"/>.
                 Again, proceed step-by-step.
                 <md>
                   <mrow>\fp(x) \amp= \frac{e^{-x^2}\cdot \lzoo{x}{5x^3} - 5x^3\cdot \lzoo{x}{e^{-x^2}}}{\left(e^{-x^2}\right)^2}</mrow>
@@ -583,8 +582,8 @@ but our focus is more on the derivative result than on the domain/range conditio
       A key to correctly working these problems is to break the problem down into smaller,
       more manageable pieces.
       For instance,
-      when using the <xref ref="thm_ProductRule" text="title" /> and <xref ref="thm_chain_rule" text="title" /> together,
-      just consider the first part of the <xref ref="thm_ProductRule" text="title" /> at first:
+      when using the <xref ref="thm_ProductRule" text="title"/> and <xref ref="thm_chain_rule" text="title"/> together,
+      just consider the first part of the <xref ref="thm_ProductRule" text="title"/> at first:
       <m>f(x)g'(x)</m>.
       Just rewrite <m>f(x)</m>, then find <m>g'(x)</m>.
       Then move on to the <m>\fp(x)g(x)</m> part.
@@ -592,13 +591,13 @@ but our focus is more on the derivative result than on the domain/range conditio
     </p>
 
     <p>
-      Likewise, using the <xref ref="thm_QuotientRule" text="title" />,
+      Likewise, using the <xref ref="thm_QuotientRule" text="title"/>,
       approach the numerator in two steps and handle the denominator after completing that.
       Only simplify afterward.
     </p>
 
     <p>
-      We can also employ the <xref ref="thm_chain_rule" text="title" /> itself several times,
+      We can also employ the <xref ref="thm_chain_rule" text="title"/> itself several times,
       as shown in the next example.
     </p>
 
@@ -615,7 +614,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           <m>g(x)=\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}</m> function <q>inside</q>
           the <m>f(x)=x^5</m> function;
           that is, we have <m>y = \left(\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}\right)^5</m>.
-          We begin using the <xref ref="thm_gen_power_rule" text="title" />;
+          We begin using the <xref ref="thm_gen_power_rule" text="title"/>;
           in this first step, we do not fully compute the derivative.
           Rather, we are approaching this step-by-step.
           <me>
@@ -625,7 +624,7 @@ but our focus is more on the derivative result than on the domain/range conditio
 
         <p>
           We now find <m>g'(x)</m>.
-          We again need the <xref ref="thm_chain_rule" text="title" />;
+          We again need the <xref ref="thm_chain_rule" text="title"/>;
           <md>
             <mrow>g'(x) \amp = \sec^2\mathopen{}\left(6x^3-7x\right)\mathclose{}\cdot \lzoo{x}{6x^3-7x}.</mrow>
             <mrow>\amp = \sec^2\mathopen{}\left(6x^3-7x\right)\mathclose{}\cdot\left(18x^2-7\right)</mrow>
@@ -668,9 +667,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <p>
           This function likely has no practical use outside of demonstrating derivative skills.
           The answer is given below without simplification.
-          It employs the <xref ref="thm_QuotientRule" text="title" />,
-          the <xref ref="thm_ProductRule" text="title" />,
-          and the <xref ref="thm_chain_rule" text="title" /> three times.
+          It employs the <xref ref="thm_QuotientRule" text="title"/>,
+          the <xref ref="thm_ProductRule" text="title"/>,
+          and the <xref ref="thm_chain_rule" text="title"/> three times.
           <md>
             <mrow>\amp\fp(x)</mrow>
             <mrow>\amp=\Bigg(\ln\mathopen{}\left(x^2+5x^4\right)\mathclose{}\cdot\bigg[\Big(x\cdot\left(-\sin\mathopen{}\left(x^{-2}\right)\mathclose{}\right)\cdot\left(-2x^{-3}\right)</mrow>
@@ -681,7 +680,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         </p>
 
         <p>
-          The reader is highly encouraged to look at each term and recognize why it is there. (I.e., the <xref ref="thm_QuotientRule" text="title" /> is used;
+          The reader is highly encouraged to look at each term and recognize why it is there. (I.e., the <xref ref="thm_QuotientRule" text="title"/> is used;
           in the numerator, identify the <q>LOdHI</q> term,
           etc.) This example demonstrates that derivatives can be computed systematically,
           no matter how arbitrarily complicated the function is.
@@ -690,7 +689,7 @@ but our focus is more on the derivative result than on the domain/range conditio
     </example>
 
     <p>
-      The <xref ref="thm_chain_rule" text="title" /> also has theoretic value.
+      The <xref ref="thm_chain_rule" text="title"/> also has theoretic value.
       That is, it can be used to find the derivatives of functions that we have not yet learned as we do in the following example.
     </p>
 
@@ -712,13 +711,14 @@ but our focus is more on the derivative result than on the domain/range conditio
           <me>
             y=2^x = \left(e^{\ln 2}\right)^x = e^{x(\ln(2))}
           </me>,
+          using the <q>power to a power</q> property of exponents.
         </p>
-        using the <q>power to a power</q> property of exponents.
+
         <p>
           The function is now the composition <m>y=f(g(x))</m>,
           with <m>f(x) = e^x</m> and <m>g(x) = x(\ln(2))</m>.
           Since <m>\fp(x) = e^x</m> and
-          <m>g'(x) = \ln(2)</m>, the <xref ref="thm_chain_rule" text="title" /> gives
+          <m>g'(x) = \ln(2)</m>, the <xref ref="thm_chain_rule" text="title"/> gives
           <me>
             y' = e^{x (\ln(2))} \cdot \ln 2
           </me>.
@@ -736,7 +736,7 @@ but our focus is more on the derivative result than on the domain/range conditio
 
         <p>
           We can extend this process to use any base <m>a</m>,
-          where <m>a>0</m> and <m>a\neq 1</m>.
+          where <m>a&gt;0</m> and <m>a\neq 1</m>.
           All we need to do is replace each <q>2</q>
           in our work with <q><m>a</m>.</q> The Chain Rule,
           coupled with the derivative rule of <m>e^x</m>,
@@ -753,7 +753,7 @@ but our focus is more on the derivative result than on the domain/range conditio
       <title>Derivatives of Exponential Functions</title>
       <statement>
         <p>
-          Let <m>f(x)=a^x</m>, for <m>a>0, a\neq 1</m>.
+          Let <m>f(x)=a^x</m>, for <m>a&gt;0, a\neq 1</m>.
 
               <idx><h>derivative</h><h>exponential functions</h></idx>
 
@@ -769,7 +769,7 @@ but our focus is more on the derivative result than on the domain/range conditio
   <subsection>
     <title>Alternate Chain Rule Notation</title>
     <p>
-      It is instructive to understand what the <xref ref="thm_chain_rule" text="title" />
+      It is instructive to understand what the <xref ref="thm_chain_rule" text="title"/>
       <q>looks like</q> using
       <q><m>\lz{y}{x}</m></q>
       notation instead of <m>y'</m> notation.
@@ -803,7 +803,7 @@ but our focus is more on the derivative result than on the domain/range conditio
       <em>are not</em> canceling these terms;
       the derivative notation of <m>\lz{y}{u}</m> is one symbol.
       It is equally important to realize that this notation was chosen precisely because of this behavior.
-      It makes applying the <xref ref="thm_chain_rule" text="title" /> easy with multiple variables.
+      It makes applying the <xref ref="thm_chain_rule" text="title"/> easy with multiple variables.
       For instance,
       <me>
         \lz{y}{t} = \lz{y}{\bigcirc} \cdot \lz{\bigcirc}{\triangle} \cdot \lz{\triangle}{t}
@@ -813,7 +813,7 @@ but our focus is more on the derivative result than on the domain/range conditio
 
     <p>
       One of the most common ways of <q>visualizing</q>
-      the <xref ref="thm_chain_rule" text="title" /> is to consider a set of gears,
+      the <xref ref="thm_chain_rule" text="title"/> is to consider a set of gears,
       as shown in <xref ref="fig_chainrulegears">Figure</xref>.
       The gears have <m>36</m>, <m>18</m>,
       and <m>6</m> teeth, respectively.
@@ -824,7 +824,7 @@ but our focus is more on the derivative result than on the domain/range conditio
 
     <sidebyside widths="47% 47%">
 
-      <paragraphs>
+      <stack><!-- Old paragraphs title: -->
         <p>
           Using the terminology of calculus,
           the rate of <m>u</m>-change, with respect to <m>x</m>,
@@ -843,9 +843,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         </p>
 
         <p>
-          We can then extend the <xref ref="thm_chain_rule" text="title" /> with more variables by adding more gears to the picture.
+          We can then extend the <xref ref="thm_chain_rule" text="title"/> with more variables by adding more gears to the picture.
         </p>
-      </paragraphs>
+      </stack>
 
       <figure xml:id="fig_chainrulegears">
         <caption>A series of gears to demonstrate the Chain Rule. Note how <m>\lz{y}{x} = \lz{y}{u}\cdot\lz{u}{x}</m></caption>
@@ -854,7 +854,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           <description></description>
           <latex-image>
           <![CDATA[
-          \begin{tikzpicture}[>=latex]
+          \begin{tikzpicture}[&gt;=latex]
 
           \begin{scope}[shift={(0,-200pt)}]
           \begin{scope}
@@ -863,7 +863,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           \draw [rotate around={{\x*10}:(0,0)}] (60pt,0)--(65pt,0) arc (0:{4.}:65pt);
           \draw [rotate around={{\x*10+4.}:(0,0)}] (65pt,0) -- (60pt,0) arc (0:6:60pt);
           }
-          \draw [->] (40pt,0) arc (0:170:40pt);
+          \draw [-&gt;] (40pt,0) arc (0:170:40pt);
           \draw (0,0) node {$x$};
           \end{scope}
 
@@ -873,7 +873,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           \draw [rotate around={{\x*20}:(0,0)}] (30pt,0)--(35pt,0) arc (0:{9}:35pt);
           \draw [rotate around={{\x*20+9}:(0,0)}] (35pt,0) -- (30pt,0) arc (0:11:30pt);
           }
-          \draw [->] (0,25pt) arc (90:-80:25pt);
+          \draw [-&gt;] (0,25pt) arc (90:-80:25pt);
           \draw (0,0) node {$u$};
           \draw (45pt,-30pt) node {\small$\ds \frac{dy}{du} = 3$};
           \draw (-50pt,30pt) node {\small $\ds \frac{du}{dx} = 2$};
@@ -886,7 +886,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           \draw [rotate around={{\x*60}:(0,0)}] (10pt,0)--(15pt,0) arc (0:{29}:15pt);
           \draw [rotate around={{\x*60+29}:(0,0)}] (15pt,0) -- (10pt,0) arc (0:31:10pt);
           }
-          \draw [->] (0,-20pt) arc (-90:70:20pt);
+          \draw [-&gt;] (0,-20pt) arc (-90:70:20pt);
           \draw (0,0) node {$y$};
           \end{scope}
           \end{scope}
@@ -899,19 +899,19 @@ but our focus is more on the derivative result than on the domain/range conditio
     </sidebyside>
 
     <p>
-      It is difficult to overstate the importance of the <xref ref="thm_chain_rule" text="title" />.
+      It is difficult to overstate the importance of the <xref ref="thm_chain_rule" text="title"/>.
       So often the functions that we deal with are compositions of two or more functions,
       requiring us to use this rule to compute derivatives.
       It is also often used in real life when actual functions are unknown.
       Through measurement, we can calculate (or,
       approximate) <m>\lz{y}{u}</m> and <m>\lz{u}{x}</m>.
-      With our knowledge of the <xref ref="thm_chain_rule" text="title" />,
+      With our knowledge of the <xref ref="thm_chain_rule" text="title"/>,
       we can find <m>\lz{y}{x}</m>.
     </p>
 
     <p>
       In <xref ref="sec_imp_deriv">Section</xref>,
-      we use the <xref ref="thm_chain_rule" text="title" /> to justify another differentiation technique.
+      we use the <xref ref="thm_chain_rule" text="title"/> to justify another differentiation technique.
       There are many curves that we can draw in the plane that fail the
       <q>vertical line test.</q> For instance,
       consider <m>x^2+y^2=1</m>, which describes the unit circle.
@@ -1075,7 +1075,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("15(3t-2)^4");
             </pg-code>
             </setup>
@@ -1100,7 +1100,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(theta=>['Real',TeX=>'\theta']);
+              Context()-&gt;variables-&gt;are(theta=&gt;['Real',TeX=&gt;'\theta']);
               $fp=Formula("3(sin(theta)+cos(theta))^2(cos(theta)-sin(theta))");
             </pg-code>
             </setup>
@@ -1129,7 +1129,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("(6t+1)e^(3t^2+t-1)");
             </pg-code>
             </setup>
@@ -1286,7 +1286,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("8 sin^3(2t) cos(2t)");
             </pg-code>
             </setup>
@@ -1311,7 +1311,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("-3 cos^2(t^2+3t+1) sin(t^2+3t+1) (2t+3)");
             </pg-code>
             </setup>
@@ -1408,8 +1408,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(r=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are(r=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("ln(4) 4^r");
             </pg-code>
             </setup>
@@ -1434,8 +1434,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("-ln(5)*5^(cos(t))*sin(t)");
             </pg-code>
             </setup>
@@ -1460,7 +1460,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("0");
             </pg-code>
             </setup>
@@ -1485,8 +1485,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(w=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are(w=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("ln(3/2) (3/2)^w");
             </pg-code>
             </setup>
@@ -1511,8 +1511,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("((3^t+2)ln(2)2^t-(2^t+3)(ln(3)3^t))/(3^t+2)^2");
             </pg-code>
             </setup>
@@ -1537,8 +1537,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(w=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are(w=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("(2^w(ln(3)3^w-ln(2)(3^w+1)))/(2^(2w))");
             </pg-code>
             </setup>
@@ -1563,7 +1563,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("(2^(x^2)(ln(3)3^(x^2)2x+1) - (3^(x^2)+x)ln(2)2^(x^2)2x)/2^(2x^2)");
             </pg-code>
             </setup>
@@ -1627,7 +1627,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("5cos(t^2+3t)cos(5t-7)- (2t+3)sin(t^2+3t)sin(5t-7)");
             </pg-code>
             </setup>
@@ -1665,7 +1665,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $fp=Formula("10t cos(1/t)e^(5t^2)+1/t^2sin(1/t)e^(5t^2)");
             </pg-code>
             </setup>
@@ -1720,7 +1720,7 @@ but our focus is more on the derivative result than on the domain/range conditio
           In the following exercises,
           find the equations of tangent and normal lines to the graph of the function at the given point.
           Note: the functions here are the same as in <xref ref="exer_02_05_06">Exercises</xref>
-          through <xref ref="exer_02_05_09"></xref>.
+          through <xref ref="exer_02_05_09"/>.
         </p>
       </introduction>
 
@@ -1728,8 +1728,8 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=0");
               $n=Formula("x=0");
             </pg-code>
@@ -1741,12 +1741,12 @@ but our focus is more on the derivative result than on the domain/range conditio
 
               <p>
                 At <m>x=0</m>,
-                the tangent line has equation <var name="$t" width="20" />.
+                the tangent line has equation <var name="$t" width="20"/>.
               </p>
 
               <p>
                 At <m>x=0</m>,
-                the normal line has equation <var name="$n" width="20" />.
+                the normal line has equation <var name="$n" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1756,9 +1756,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")->variables->add(y=>'Real');
-              parser::Assignment->Allow;
-              Context()->flags->set(reduceConstants=>0);
+              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $t=Formula("y=15(x-1)+1");
               $n=Formula("y=-1/15(x-1)+1");
             </pg-code>
@@ -1770,12 +1770,12 @@ but our focus is more on the derivative result than on the domain/range conditio
 
               <p>
                 At <m>x=1</m>,
-                the tangent line has equation <var name="$t" width="20" />.
+                the tangent line has equation <var name="$t" width="20"/>.
               </p>
 
               <p>
                 At <m>x=1</m>,
-                the normal line has equation <var name="$n" width="20" />.
+                the normal line has equation <var name="$n" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1785,9 +1785,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")->variables->add(y=>'Real');
-              parser::Assignment->Allow;
-              Context()->flags->set(reduceConstants=>0);
+              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $t=Formula("y=-3(x - pi/2)+1");
               $n=Formula("y=1/3(x - pi/2)+1");
             </pg-code>
@@ -1799,12 +1799,12 @@ but our focus is more on the derivative result than on the domain/range conditio
 
               <p>
                 At <m>x=\pi/2</m>,
-                the tangent line has equation <var name="$t" width="20" />.
+                the tangent line has equation <var name="$t" width="20"/>.
               </p>
 
               <p>
                 At <m>x=\pi/2</m>,
-                the normal line has equation <var name="$n" width="20" />.
+                the normal line has equation <var name="$n" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1814,9 +1814,9 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context("Numeric")->variables->add(y=>'Real');
-              parser::Assignment->Allow;
-              Context()->flags->set(reduceConstants=>0);
+              Context("Numeric")-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $t=Formula("y=-5e(x+1)+e");
               $n=Formula("y=1/(5e)(x+1)+e");
             </pg-code>
@@ -1828,12 +1828,12 @@ but our focus is more on the derivative result than on the domain/range conditio
 
               <p>
                 At <m>x=-1</m>,
-                the tangent line has equation <var name="$t" width="20" />.
+                the tangent line has equation <var name="$t" width="20"/>.
               </p>
 
               <p>
                 At <m>x=-1</m>,
-                the normal line has equation <var name="$n" width="20" />.
+                the normal line has equation <var name="$n" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1854,7 +1854,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
 
@@ -1865,7 +1865,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
               </ol>
@@ -1892,7 +1892,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
 
@@ -1904,7 +1904,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
               </ol>
@@ -1949,7 +1949,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                     </p>
 
                     <p>
-                      <var form="essay" />
+                      <var form="essay"/>
                     </p>
                   </li>
 
@@ -1959,7 +1959,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                     </p>
 
                     <p>
-                      <var name="$sign" form="popup" />
+                      <var name="$sign" form="popup"/>
                     </p>
                   </li>
                 </ol>
@@ -1991,7 +1991,7 @@ but our focus is more on the derivative result than on the domain/range conditio
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $fp=Formula("2xe^xcot(x) + x^2e^xcot(x) - x^2e^xcsc^2(x)");
               $gp=Formula("ln(24)24^x");
             </pg-code>
@@ -2009,7 +2009,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                     </p>
 
                     <p>
-                      <m>f'(x) = </m><var name="$fp" width="40" />
+                      <m>f'(x) = </m><var name="$fp" width="40"/>
                     </p>
                   </li>
 
@@ -2019,7 +2019,7 @@ but our focus is more on the derivative result than on the domain/range conditio
                     </p>
 
                     <p>
-                      <m>g'(x) = </m><var name="$gp" width="40" />
+                      <m>g'(x) = </m><var name="$gp" width="40"/>
                     </p>
                   </li>
                 </ol>
@@ -2048,4 +2048,3 @@ but our focus is more on the derivative result than on the domain/range conditio
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -587,7 +587,7 @@
 
     <p>
       The trouble with this is that the <xref ref="thm_PowerRule" text="title"/> was initially defined only for positive integer powers,
-      <m>n&gt;0</m>.
+      <m>n \gt 0</m>.
       While we did not justify this at the time,
       generally the <xref ref="thm_PowerRule" text="title"/> is proved using something called the Binomial Theorem,
       which deals only with positive integers.
@@ -762,7 +762,7 @@
 
         <p>
           While this is not a particularly simple expression, it is usable.
-          We can see that <m>y''&gt;0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y&gt;0</m>.
+          We can see that <m>y'' \gt 0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y \gt 0</m>.
           In <xref ref="sec_concavity">Section</xref>,
           we will see how this relates to the shape of the graph.
         </p>
@@ -786,7 +786,7 @@
     <p>
       Consider the function <m>y=x^x</m>;
       it is graphed in <xref ref="fig_logdiffa">Figure</xref>.
-      It is well-defined for <m>x&gt;0</m> and we might be interested in finding equations of lines tangent and normal to its graph.<fn>
+      It is well-defined for <m>x \gt 0</m> and we might be interested in finding equations of lines tangent and normal to its graph.<fn>
       In calculus the expression <m>0^0</m> is also considered well-defined and equal to <m>1</m>.
       This is easily confused with a limit of the <em>form</em>
       <m>0^0</m>, which is indeterminate.

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -46,7 +46,7 @@
       <caption>A graph of the implicit relationship <m>\sin(y)+y^3=6-x^3</m>.</caption>
       <!-- START figures/fig_implicit1.tex -->
       <image xml:id="img_implicit1" width="47%">
-        <description/>
+        <description></description>
         <latex-image>
         
         \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
@@ -220,7 +220,7 @@
           <caption>The function <m>\sin(y) +y^3 = 6-x^3</m> and its tangent line at the point <m>(\sqrt[3]{6},0)</m>.</caption>
           <!-- START figures/fig_implicit2.tex -->
           <image xml:id="img_implicit2" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
@@ -337,7 +337,7 @@
           <caption>A graph of the implicitly defined function <m>y^3+x^2y^4=1+2x</m> along with its tangent line at the point <m>(0,1)</m>.</caption>
           <!-- START figures/fig_implicit4.tex -->
           <image xml:id="img_implicit4" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}
@@ -431,7 +431,7 @@
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m>.</caption>
           <!-- START figures/fig_implicit5.tex -->
           <image xml:id="img_implicit5" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}
@@ -467,7 +467,7 @@
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m> and certain tangent lines.</caption>
           <!-- START figures/fig_implicit6.tex -->
           <image xml:id="img_implicit6" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}
@@ -538,7 +538,7 @@
           <caption>The unit circle with its tangent line at <m>(1/2,\sqrt{3}/2)</m>.</caption>
           <!-- START figures/fig_implicit7.tex -->
           <image xml:id="img_implicit7" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}
@@ -667,7 +667,7 @@
           <caption>An astroid, traced out by a point on the smaller circle as it rolls inside the larger circle.</caption>
           <!-- START figures/fig_implicit9.tex -->
           <image xml:id="img_implicit9" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}
@@ -708,7 +708,7 @@
           <caption>An astroid with a tangent line.</caption>
           <!-- START figures/fig_implicit8.tex -->
           <image xml:id="img_implicit8" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}
@@ -807,7 +807,7 @@
       <caption>A plot of <m>y=x^x</m>.</caption>
       <!-- START figures/fig_logdiffa.tex -->
       <image xml:id="img_logdiffa" width="47%">
-        <description/>
+        <description></description>
         <latex-image>
         
         \begin{tikzpicture}
@@ -882,7 +882,7 @@
           <caption>A graph of <m>y=x^x</m> and its tangent line at <m>x=1.5</m>.</caption>
           <!-- START figures/fig_implicit10.tex -->
           <image xml:id="img_implicit10" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
             
             \begin{tikzpicture}

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -924,7 +924,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 In your own words,
@@ -944,7 +944,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -969,7 +969,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -987,7 +987,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1014,7 +1014,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1040,7 +1040,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1067,7 +1067,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1094,7 +1094,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1121,7 +1121,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1147,7 +1147,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1174,7 +1174,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1200,7 +1200,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1237,7 +1237,7 @@
       </introduction>
 
       <exercise xml:id="exer_02_06_ex_09">
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1267,7 +1267,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1297,7 +1297,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1327,7 +1327,7 @@
       </exercise>
 
       <exercise xml:id="exer_02_06_ex_12">
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1357,7 +1357,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1387,7 +1387,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1418,7 +1418,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1449,7 +1449,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1479,7 +1479,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1509,7 +1509,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1553,7 +1553,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1594,7 +1594,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1625,7 +1625,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -1660,7 +1660,7 @@
     </exercisegroup>
 
     <exercise>
-      <webwork seed="1">
+      <webwork>
           <statement>
             <p>
               Show that <m>\lz{y}{x}</m> is the same for each of the following implicitly defined functions.
@@ -1730,7 +1730,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -1795,7 +1795,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -1870,7 +1870,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -1934,7 +1934,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -1998,7 +1998,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -2156,7 +2156,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -2186,7 +2186,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -2216,7 +2216,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -2246,7 +2246,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
             <pg-code>
@@ -2287,7 +2287,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -2333,7 +2333,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -2379,7 +2379,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -2425,7 +2425,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -2472,7 +2472,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 
@@ -2517,7 +2517,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <setup>
 
 

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -222,7 +222,7 @@
           <image xml:id="img_implicit2" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
             \begin{axis}[,xmin=-3.2,xmax=3.2,
             ymin=-3.2,ymax=3.2]
@@ -339,7 +339,7 @@
           <image xml:id="img_implicit4" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.5,xmax=10.5,
             ymin=-10.5,ymax=2.49,]
@@ -433,7 +433,7 @@
           <image xml:id="img_implicit5" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.95,xmax=1.99,
             ymin=-1.95,ymax=1.95,]
@@ -469,7 +469,7 @@
           <image xml:id="img_implicit6" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.95,xmax=1.99,
             ymin=-1.95,ymax=1.95,]
@@ -540,7 +540,7 @@
           <image xml:id="img_implicit7" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.2,xmax=1.2,
             ymin=-1.2,ymax=1.2,
@@ -669,7 +669,7 @@
           <image xml:id="img_implicit9" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-24,xmax=24,
             ymin=-24,ymax=24,
@@ -710,7 +710,7 @@
           <image xml:id="img_implicit8" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-24,xmax=24,
             ymin=-24,ymax=24,
@@ -884,7 +884,7 @@
           <image xml:id="img_implicit10" width="47%">
             <description></description>
             <latex-image>
-            
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-0.1,xmax=2.2,
             ymin=-.1,ymax=4.2]
@@ -1018,7 +1018,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
+              Context()->variables->set(x=>{limits=>[0,4]});
               $fp=Formula("1/(2sqrt(x))-1/(2sqrt(x^3))");
             </pg-code>
             </setup>
@@ -1044,8 +1044,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->variables->set(x=>{limits=>[0,4]});
+              Context()->flags->set(reduceConstants=>0);
               $fp=Formula("1/3 x^(-2/3)+2/3 x^(-1/3)");
             </pg-code>
             </setup>
@@ -1071,8 +1071,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[-1,1]});
+              Context()->variables->are(t=>'Real');
+              Context()->variables->set(t=>{limits=>[-1,1]});
               $fp=Formula("-t/sqrt(1-t^2)");
             </pg-code>
             </setup>
@@ -1098,8 +1098,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[0,4]});
+              Context()->variables->are(t=>'Real');
+              Context()->variables->set(t=>{limits=>[0,4]});
               $fp=Formula("sqrt(t)cos(t)+sin(t)/(2sqrt(t))");
             </pg-code>
             </setup>
@@ -1125,7 +1125,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
+              Context()->variables->set(x=>{limits=>[0,4]});
               $fp=Formula("1.5sqrt(x)");
             </pg-code>
             </setup>
@@ -1151,8 +1151,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->variables->set(x=>{limits=>[0,4]});
+              Context()->flags->set(reduceConstants=>0);
               $fp=Formula("pi x^(pi-1)+1.9x^(0.9)");
             </pg-code>
             </setup>
@@ -1178,7 +1178,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
+              Context()->variables->set(x=>{limits=>[0,4]});
               $fp=Formula("1/(2sqrt(x))-7/(2sqrt(x^3))");
             </pg-code>
             </setup>
@@ -1204,8 +1204,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[0,4]});
+              Context()->variables->are(t=>'Real');
+              Context()->variables->set(t=>{limits=>[0,4]});
               $fp=Formula("1/5t^(-4/5)(sec(t)+e^t)+t^(1/5)(sec(t)tan(t)+e^t)");
             </pg-code>
             </setup>
@@ -1241,12 +1241,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("-4x^3/(2y+1)");
               @y=(random(-2,2,0.2),random(-2,2,0.2),random(-2,2,0.2),random(-2,2,0.2),random(-2,2,0.2));
               @x=map{(7-($_)-($_)**2)**(1/4)*(-1)**(random(-1,1,2))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1271,12 +1271,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("-y^(3/5)/x^(3/5)");
               @y=(random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01));
               @x=map{(1-($_)**(2/5))**(5/2)}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1301,12 +1301,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("sin(x)sec(y)");
               @y=(random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01));
               @x=map{acos(1-sin($_))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1331,12 +1331,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("y/x");
               @x=(random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1));
               @y=map{$_/10}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1361,12 +1361,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("y/x");
               @y=(random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1));
               @x=map{$_/10}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1391,13 +1391,13 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
+              Context()->variables->add(y=>'Real');
+              Context()->flags->set(reduceConstantFunctions=>0);
               $dydx=Formula("-(e^x x(x+2) 2^(-y))/(ln(2))");
               @x=(random(-4,1,0.1),random(-4,1,0.1),random(-4,1,0.1),random(-4,1,0.1),random(-4,1,0.1));
               @y=map{ln(5-($_)**2*exp($_))/ln(2)}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1422,13 +1422,13 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("-2sin(y)cos(y)/x");
               # need to avoid x==0
               @x=(random(-3.9,3.9,0.2),random(-3.9,3.9,0.2),random(-3.9,3.9,0.2),random(-3.9,3.9,0.2),random(-3.9,3.9,0.2));
               @y=map{atan(50/($_)**2)}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1453,12 +1453,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("-x/y^2");
               @x=(random(-0.6,0.6,0.01),random(-0.6,0.6,0.01),random(-0.6,0.6,0.01),random(-0.6,0.6,0.01),random(-0.6,0.6,0.01));
               @y=map{((2**0.25-3*($_)**2)/2&lt;0)?-(abs(-(2**0.25-3*($_)**2)/2))**(1/3):((2**0.25-3*($_)**2)/2)**(1/3)}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1483,12 +1483,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("1/(2y+2)");
               @y=(random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2));
               @x=map{sqrt(200)*(-1)**(random(-1,1,2))+2*($_)+($_)**2}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1513,12 +1513,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("(x^2+2xy^2-y)/(2x^2y-x+y^2)");
               @y=(random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2));
               @x=map{(17+(-1)**(random(-1,1,2))*sqrt(289 - 4*($_)*(1 - 17*($_))))/2}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1557,9 +1557,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("(-cos(x)(x+cos(y))+sin(x)+y)/(sin(y)(sin(x)+y)+x+cos(y))");
-              $dydx-&gt;{test_points}=[[-3.1,-3.83041],[-0.41,0.732269],[0.59,0.759097],[2.6,1.82908],[5.3,6.93017]];
+              $dydx->{test_points}=[[-3.1,-3.83041],[-0.41,0.732269],[0.59,0.759097],[2.6,1.82908],[5.3,6.93017]];
             </pg-code>
             </setup>
             <statement>
@@ -1598,13 +1598,13 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("-x/y");
               @t=(random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01));
               @x=map{exp(exp(1)/2)*cos($_)}(@t);
               @y=map{exp(exp(1)/2)*sin($_)}(@t);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1629,7 +1629,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("-(2x+y)/(2y+x)");
               @t=(random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01));
               @u=map{sqrt(2/3*exp(1))*cos($_)}(@t);
@@ -1637,7 +1637,7 @@
               @x=map{($u[$_]-$v[$_])/sqrt(2)}(0..4);
               @y=map{($u[$_]+$v[$_])/sqrt(2)}(0..4);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1735,25 +1735,25 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               @eq=(Formula("y=0"),Formula("y=-1.859(x-0.1)+0.2811"));
-              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-1,-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $x=Formula("cos^5(t)");
               $y=Formula("sin^5(t)");
-              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
-              $f-&gt;domain(0,6.2831852);
-              $f-&gt;steps(100);
-              $f-&gt;weight(2);
-              $f-&gt;color('blue');
-              $gr-&gt;stamps(closed_circle(0.1,0.2811,'black'));
-              $gr-&gt;lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom'));
+              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
+              $f->domain(0,6.2831852);
+              $f->steps(100);
+              $f->weight(2);
+              $f->color('blue');
+              $gr->stamps(closed_circle(0.1,0.2811,'black'));
+              $gr->lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -1801,25 +1801,25 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               @eq=(Formula("x=1"),Formula("y=-3sqrt(3)/8(x-sqrt(0.6))+sqrt(0.8)"),Formula("y=1"));
-              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-1,-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $x=Formula("(abs(cos(t)))^(1/2)*sgn(cos(t))");
               $y=Formula("(abs(sin(t)))^(1/2)*sgn(sin(t))");
-              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
-              $f-&gt;domain(0,6.2831852);
-              $f-&gt;steps(100);
-              $f-&gt;weight(2);
-              $f-&gt;color('blue');
-              $gr-&gt;stamps(closed_circle(0.7746,0.8944,'black'));
-              $gr-&gt;lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top'));
+              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
+              $f->domain(0,6.2831852);
+              $f->steps(100);
+              $f->weight(2);
+              $f->color('blue');
+              $gr->stamps(closed_circle(0.7746,0.8944,'black'));
+              $gr->lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top'));
             </pg-code>
             </setup>
             <statement>
@@ -1875,25 +1875,25 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               @eq=(Formula("y=4"),Formula("y=3/108^(1/4)(x-2)-108^(1/4)"));
-              $gr=init_graph(-4.2,-4.2,4.2,4.2,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-4,-3,-2,-1,1,2,3,4){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-4,-3,-2,-1,1,2,3,4){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-4.2,-4.2,4.2,4.2,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-4,-3,-2,-1,1,2,3,4){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-4,-3,-2,-1,1,2,3,4){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $x=Formula("sqrt((216 sin^2(t) + sqrt((216 sin^2(t))^2 - (36 sin^2(t))^3))^(1/3) + (216 sin^2(t) - sqrt((216 sin^2(t))^2 - (36sin^2(t))^3))^(1/3) + 4) cos(t)");
               $y=Formula("sqrt((216 sin^2(t) + sqrt((216 sin^2(t))^2 - (36 sin^2(t))^3))^(1/3) + (216 sin^2(t) - sqrt((216 sin^2(t))^2 - (36sin^2(t))^3))^(1/3) + 4) sin(t)");
-              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
-              $f-&gt;domain(0,6.2831852);
-              $f-&gt;steps(100);
-              $f-&gt;weight(2);
-              $f-&gt;color('blue');
-              $gr-&gt;stamps(closed_circle(2,-3.224,'black'));
-              $gr-&gt;lb(new Label(2,-3.224,'(2,-108^(1/4))','black','left','bottom'));
+              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
+              $f->domain(0,6.2831852);
+              $f->steps(100);
+              $f->weight(2);
+              $f->color('blue');
+              $gr->stamps(closed_circle(2,-3.224,'black'));
+              $gr->lb(new Label(2,-3.224,'(2,-108^(1/4))','black','left','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -1939,25 +1939,25 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               @eq=(Formula("y=-x+1"),Formula("y=3sqrt(3)/4"));
-              $gr=init_graph(-2.5,-1.5,0.5,1.5,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-2,-1){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-1,1){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-2.5,-1.5,0.5,1.5,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-2,-1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-1,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $x=Formula("(1 - cos(t))*cos(t)");
               $y=Formula("(1 - cos(t))*sin(t)");
-              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
-              $f-&gt;domain(0,6.2831852);
-              $f-&gt;steps(100);
-              $f-&gt;weight(2);
-              $f-&gt;color('blue');
-              $gr-&gt;stamps(closed_circle(-0.75,1.299,'black'));
-              $gr-&gt;lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','center','bottom'));
+              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
+              $f->domain(0,6.2831852);
+              $f->steps(100);
+              $f->weight(2);
+              $f->color('blue');
+              $gr->stamps(closed_circle(-0.75,1.299,'black'));
+              $gr->lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','center','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -2003,27 +2003,27 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               @eq=(Formula("y=-1/sqrt(3)(x-7/2)+(6+3sqrt(3))/2"),Formula("y=sqrt(3)(x-(4+3sqrt(3)))/2+3/2"));
-              $gr=init_graph(-2,-2,6.5,6.5,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(2,4,6){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(2,4,6){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-2,-2,6.5,6.5,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(2,4,6){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(2,4,6){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()->variables->are(t=>'Real');
               $x=Formula("3*cos(t)+2");
               $y=Formula("3*sin(t)+3");
-              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
-              $f-&gt;domain(0,6.2831852);
-              $f-&gt;steps(100);
-              $f-&gt;weight(2);
-              $f-&gt;color('blue');
-              $gr-&gt;stamps(closed_circle(3.5,5.598,'black'));
-              $gr-&gt;lb(new Label(3.5,5.598,'(7/2,(6+3sqrt(3))/2)','black','right','top'));
-              $gr-&gt;stamps(closed_circle(4.598,1.5,'black'));
-              $gr-&gt;lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom'));
+              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
+              $f->domain(0,6.2831852);
+              $f->steps(100);
+              $f->weight(2);
+              $f->color('blue');
+              $gr->stamps(closed_circle(3.5,5.598,'black'));
+              $gr->lb(new Label(3.5,5.598,'(7/2,(6+3sqrt(3))/2)','black','right','top'));
+              $gr->stamps(closed_circle(4.598,1.5,'black'));
+              $gr->lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -2095,26 +2095,26 @@
         <image xml:id="img_02_06_ex_38" width="47%">
           <description></description>
           <latex-image>
-            <![CDATA[
-            \begin{tikzpicture}[baseline=10pt]
-            \begin{axis}[width=\marginparwidth+25pt,tick label style={font=\scriptsize},axis y line=middle,axis x line=middle,name=myplot,%
-              ymin=-2.5,ymax=2.5,%
-              xmin=-2.5,xmax=2.5,%
-            ]
 
-            \addplot [thick,{\colorone},smooth] coordinates {(-0.4611,0.2468)(-0.465,0.2493)(-0.4663,0.25)(-0.5,0.2699)(-0.5094,0.2763)(-0.5267,0.2857)(-0.5357,0.291)(-0.5485,0.2985)(-0.5548,0.3024)(-0.5714,0.3126)(-0.5856,0.3214)(-0.5989,0.3296)(-0.6071,0.3347)(-0.621,0.3433)(-0.6418,0.356)(-0.6429,0.3568)(-0.6431,0.3569)(-0.6435,0.3571)(-0.6786,0.3799)(-0.6861,0.3854)(-0.6985,0.3929)(-0.7143,0.4033)(-0.7289,0.414)(-0.75,0.4269)(-0.7524,0.4286)(-0.7714,0.4429)(-0.7857,0.4518)(-0.8036,0.4643)(-0.8137,0.4721)(-0.8214,0.4771)(-0.8534,0.5)(-0.8555,0.5017)(-0.8571,0.5028)(-0.8682,0.511)(-0.896,0.5326)(-0.9286,0.559)(-0.9356,0.5644)(-0.9443,0.5714)(-0.9744,0.597)(-1.,0.6204)(-1.012,0.6307)(-1.026,0.6429)(-1.049,0.6656)(-1.063,0.6786)(-1.071,0.6878)(-1.084,0.7014)(-1.096,0.7143)(-1.107,0.7284)(-1.117,0.7402)(-1.125,0.75)(-1.143,0.7765)(-1.147,0.7819)(-1.149,0.7857)(-1.154,0.7928)(-1.158,0.8013)(-1.16,0.8036)(-1.16,0.8042)(-1.161,0.8057)(-1.168,0.8214)(-1.171,0.8289)(-1.179,0.8504)(-1.181,0.8571)(-1.184,0.8877)(-1.185,0.8929)(-1.184,0.8985)(-1.179,0.9216)(-1.177,0.9286)(-1.163,0.9483)(-1.146,0.9643)(-1.143,0.9665)(-1.121,0.9781)(-1.107,0.9831)(-1.082,0.9898)(-1.071,0.9932)(-1.066,0.9947)(-1.037,0.9983)(-1.036,0.9985)(-1.034,0.9987)(-1.018,0.9996)(-1.,1.)(-1.,1.)(-1.,1.)(-1.,1.)(-1.,1.)(-0.9821,0.9997)(-0.9655,0.9988)(-0.9643,0.9987)(-0.963,0.9987)(-0.9329,0.9957)(-0.9286,0.9951)(-0.9231,0.9945)(-0.8929,0.9896)(-0.8722,0.985)(-0.8571,0.9827)(-0.8352,0.9781)(-0.8214,0.9745)(-0.8136,0.9721)(-0.7857,0.9653)(-0.7824,0.9643)(-0.7579,0.9564)(-0.75,0.9536)(-0.734,0.9483)(-0.7143,0.9401)(-0.7056,0.9373)(-0.6829,0.9286)(-0.6549,0.9165)(-0.6429,0.9119)(-0.6128,0.8985)(-0.6052,0.8948)(-0.6009,0.8929)(-0.5714,0.8773)(-0.558,0.8706)(-0.5389,0.8603)(-0.5357,0.8585)(-0.5333,0.8571)(-0.5124,0.8447)(-0.5,0.8369)(-0.4747,0.8214)(-0.4684,0.8173)(-0.4643,0.8144)(-0.4469,0.8031)(-0.4441,0.8012)(-0.4286,0.7901)(-0.4259,0.7883)(-0.4221,0.7857)(-0.4107,0.7773)(-0.4054,0.7732)(-0.3929,0.7633)(-0.3852,0.7576)(-0.3754,0.75)(-0.3571,0.7347)(-0.3459,0.7255)(-0.3328,0.7143)(-0.3214,0.7037)(-0.3082,0.6918)(-0.3036,0.6877)(-0.294,0.6786)(-0.2899,0.6744)(-0.2857,0.67)(-0.2721,0.6565)(-0.259,0.6429)(-0.25,0.6328)(-0.2377,0.6194)(-0.227,0.6071)(-0.2143,0.5916)(-0.2051,0.5806)(-0.1978,0.5714)(-0.1786,0.5458)(-0.1742,0.5401)(-0.171,0.5357)(-0.1593,0.5192)(-0.1535,0.5106)(-0.1466,0.5)(-0.1452,0.4977)(-0.1429,0.4938)(-0.1316,0.4755)(-0.1249,0.4643)(-0.1184,0.453)(-0.1071,0.4328)(-0.1047,0.4286)(-0.09471,0.4053)(-0.08726,0.3929)(-0.07143,0.3584)(-0.07102,0.3576)(-0.07083,0.3571)(-0.07033,0.356)(-0.06112,0.3317)(-0.05723,0.3214)(-0.0513,0.3058)(-0.04846,0.2985)(-0.04474,0.2857)(-0.03571,0.2566)(-0.03431,0.2514)(-0.03255,0.2468)(-0.02505,0.2143)(-0.02249,0.1918)(-0.01772,0.1786)(-0.01197,0.1548)(-0.01166,0.1429)(-0.01291,0.1299)(-0.002361,0.07379)(-0.003401,0.07143)(-0.003605,0.06782)(-0.0005473,0.03626)(-0.001276,0.03571)(-0.002268,0.03345)(0,0)(-0.02138,0.01434)(-0.03571,0.01818)(-0.04573,0.0257)(-0.05357,0.02703)(-0.07058,0.03571)(-0.07118,0.03596)(-0.07143,0.03605)(-0.07198,0.03626)(-0.09413,0.04873)(-0.1071,0.05457)(-0.1395,0.07143)(-0.1418,0.07245)(-0.1429,0.07282)(-0.1452,0.07379)(-0.1786,0.09168)(-0.1874,0.09831)(-0.2074,0.1071)(-0.2143,0.1104)(-0.2339,0.1232)(-0.25,0.1296)(-0.2741,0.1429)(-0.2817,0.1468)(-0.2857,0.1488)(-0.2982,0.1553)(-0.305,0.1593)(-0.3214,0.1683)(-0.3279,0.1721)(-0.3394,0.1786)(-0.3571,0.1881)(-0.373,0.1985)(-0.3929,0.208)(-0.4035,0.2143)(-0.4195,0.2234)(-0.4286,0.2284)(-0.4611,0.2468)};
-            \addplot[thick,{\colorone},smooth] coordinates {(2.,-0.8472)(1.984,-0.8412)(1.903,-0.8113)(1.857,-0.7917)(1.799,-0.772)(1.754,-0.7536)(1.714,-0.738)(1.696,-0.7324)(1.647,-0.7143)(1.593,-0.6926)(1.571,-0.6824)(1.52,-0.6632)(1.491,-0.6523)(1.466,-0.6429)(1.429,-0.6273)(1.388,-0.612)(1.288,-0.5714)(1.286,-0.5709)(1.286,-0.5706)(1.284,-0.5699)(1.214,-0.5411)(1.185,-0.5297)(1.164,-0.5208)(1.143,-0.5122)(1.134,-0.509)(1.111,-0.5)(1.083,-0.4882)(1.071,-0.4826)(1.042,-0.4708)(1.033,-0.4671)(1.,-0.4528)(0.9823,-0.4462)(0.9643,-0.4383)(0.9405,-0.4286)(0.9321,-0.425)(0.9286,-0.4233)(0.9192,-0.4192)(0.8819,-0.4039)(0.8571,-0.3924)(0.7942,-0.3656)(0.7857,-0.3623)(0.7818,-0.3611)(0.7723,-0.3571)(0.7143,-0.331)(0.6812,-0.3188)(0.6429,-0.2999)(0.6324,-0.2961)(0.6096,-0.2857)(0.6071,-0.2846)(0.605,-0.2836)(0.5831,-0.274)(0.5714,-0.2685)(0.5404,-0.2547)(0.5357,-0.2527)(0.5337,-0.252)(0.5292,-0.25)(0.5,-0.2366)(0.4841,-0.2302)(0.4483,-0.2143)(0.4351,-0.2078)(0.4286,-0.204)(0.4092,-0.195)(0.386,-0.1854)(0.3716,-0.1786)(0.3571,-0.1714)(0.3369,-0.1631)(0.3214,-0.1547)(0.2948,-0.1429)(0.2887,-0.1398)(0.2857,-0.1381)(0.2767,-0.1338)(0.2644,-0.1284)(0.25,-0.1212)(0.24,-0.1171)(0.2192,-0.1071)(0.2143,-0.1044)(0.1906,-0.09509)(0.1786,-0.0872)(0.1674,-0.08262)(0.1449,-0.07143)(0.1436,-0.07069)(0.1429,-0.07019)(0.1402,-0.06876)(0.1191,-0.05949)(0.1071,-0.05265)(0.09493,-0.04793)(0.07185,-0.03571)(0.07143,-0.0354)(0.07061,-0.0349)(0.0461,-0.02533)(0.03571,-0.01754)(0.02148,-0.01423)(0,0)(0,0)(-0.0008163,-0.0349)(-0.0005102,-0.03571)(-0.000383,-0.0361)(-0.002664,-0.06876)(-0.002268,-0.07143)(-0.002059,-0.07349)(-0.005456,-0.1017)(-0.00492,-0.1071)(-0.00541,-0.1126)(-0.009061,-0.1338)(-0.00907,-0.1429)(-0.009254,-0.1521)(-0.01449,-0.1786)(-0.01837,-0.1959)(-0.01848,-0.1971)(-0.02119,-0.2143)(-0.0244,-0.2256)(-0.02726,-0.2415)(-0.02938,-0.25)(-0.03084,-0.2549)(-0.03571,-0.2743)(-0.03813,-0.2857)(-0.04587,-0.3113)(-0.05211,-0.3378)(-0.05856,-0.3571)(-0.06241,-0.3662)(-0.07077,-0.3929)(-0.07143,-0.3945)(-0.08076,-0.4192)(-0.08339,-0.4286)(-0.09044,-0.4476)(-0.1006,-0.4708)(-0.1071,-0.4868)(-0.1122,-0.5)(-0.1221,-0.5208)(-0.1279,-0.5357)(-0.1429,-0.5668)(-0.1443,-0.57)(-0.1448,-0.5714)(-0.1467,-0.5753)(-0.156,-0.594)(-0.1623,-0.6071)(-0.1681,-0.6177)(-0.1717,-0.625)(-0.1786,-0.6379)(-0.1803,-0.6412)(-0.1811,-0.6429)(-0.184,-0.6482)(-0.1928,-0.6643)(-0.2004,-0.6786)(-0.2143,-0.7022)(-0.2186,-0.71)(-0.2208,-0.7143)(-0.2301,-0.7301)(-0.2453,-0.7547)(-0.2637,-0.7857)(-0.2729,-0.7986)(-0.2857,-0.817)(-0.3011,-0.8418)(-0.3105,-0.8571)(-0.3299,-0.8843)(-0.3571,-0.9227)(-0.3595,-0.9262)(-0.3609,-0.9286)(-0.371,-0.9424)(-0.4139,-1.)(-0.4209,-1.008)(-0.4286,-1.016)(-0.4845,-1.087)(-0.5288,-1.143)(-0.55,-1.164)(-0.5714,-1.185)(-0.6173,-1.24)(-0.6568,-1.286)(-0.6862,-1.314)(-0.7143,-1.34)(-0.7566,-1.386)(-0.7966,-1.429)(-0.8285,-1.457)(-0.8571,-1.482)(-0.9017,-1.527)(-0.9475,-1.571)(-0.9761,-1.595)(-1.,-1.614)(-1.052,-1.663)(-1.109,-1.714)(-1.128,-1.729)(-1.143,-1.74)(-1.206,-1.794)(-1.282,-1.857)(-1.284,-1.859)(-1.286,-1.86)(-1.3,-1.871)(-1.364,-1.922)(-1.372,-1.929)(-1.429,-1.972)(-1.444,-1.984)(-1.464,-2.)};
-            \filldraw [] (axis cs:-1,1) node [above] {\scriptsize $\left(-1,1\right)$} circle (1pt);
-            \filldraw [thin,->,>=latex] (axis cs:1.25,-1.5) node [fill=white] {\scriptsize $\left(-1,\frac{-1-\sqrt{5}}2\right)$} -- (axis cs: -.9,-1.62);
-            \filldraw [] (axis cs: -1,-1.62)  circle (1pt);
-            \filldraw [->,thin,>=latex] (axis cs:1.25,0.5) node [ fill=white] {\scriptsize $\left(-1,\frac{-1+\sqrt{5}}2\right)$} -- (axis cs: -.9,0.62);
-            \filldraw [] (axis cs:-1,0.62)  circle (1pt);
+          \begin{tikzpicture}[baseline=10pt]
+          \begin{axis}[width=\marginparwidth+25pt,tick label style={font=\scriptsize},axis y line=middle,axis x line=middle,name=myplot,%
+            ymin=-2.5,ymax=2.5,%
+            xmin=-2.5,xmax=2.5,%
+          ]
 
-            \end{axis}
-            \node [right] at (myplot.right of origin) {\scriptsize $x$};
-            \node [above] at (myplot.above origin) {\scriptsize $y$};
-            \end{tikzpicture}
-            ]]>
+          \addplot [thick,{\colorone},smooth] coordinates {(-0.4611,0.2468)(-0.465,0.2493)(-0.4663,0.25)(-0.5,0.2699)(-0.5094,0.2763)(-0.5267,0.2857)(-0.5357,0.291)(-0.5485,0.2985)(-0.5548,0.3024)(-0.5714,0.3126)(-0.5856,0.3214)(-0.5989,0.3296)(-0.6071,0.3347)(-0.621,0.3433)(-0.6418,0.356)(-0.6429,0.3568)(-0.6431,0.3569)(-0.6435,0.3571)(-0.6786,0.3799)(-0.6861,0.3854)(-0.6985,0.3929)(-0.7143,0.4033)(-0.7289,0.414)(-0.75,0.4269)(-0.7524,0.4286)(-0.7714,0.4429)(-0.7857,0.4518)(-0.8036,0.4643)(-0.8137,0.4721)(-0.8214,0.4771)(-0.8534,0.5)(-0.8555,0.5017)(-0.8571,0.5028)(-0.8682,0.511)(-0.896,0.5326)(-0.9286,0.559)(-0.9356,0.5644)(-0.9443,0.5714)(-0.9744,0.597)(-1.,0.6204)(-1.012,0.6307)(-1.026,0.6429)(-1.049,0.6656)(-1.063,0.6786)(-1.071,0.6878)(-1.084,0.7014)(-1.096,0.7143)(-1.107,0.7284)(-1.117,0.7402)(-1.125,0.75)(-1.143,0.7765)(-1.147,0.7819)(-1.149,0.7857)(-1.154,0.7928)(-1.158,0.8013)(-1.16,0.8036)(-1.16,0.8042)(-1.161,0.8057)(-1.168,0.8214)(-1.171,0.8289)(-1.179,0.8504)(-1.181,0.8571)(-1.184,0.8877)(-1.185,0.8929)(-1.184,0.8985)(-1.179,0.9216)(-1.177,0.9286)(-1.163,0.9483)(-1.146,0.9643)(-1.143,0.9665)(-1.121,0.9781)(-1.107,0.9831)(-1.082,0.9898)(-1.071,0.9932)(-1.066,0.9947)(-1.037,0.9983)(-1.036,0.9985)(-1.034,0.9987)(-1.018,0.9996)(-1.,1.)(-1.,1.)(-1.,1.)(-1.,1.)(-1.,1.)(-0.9821,0.9997)(-0.9655,0.9988)(-0.9643,0.9987)(-0.963,0.9987)(-0.9329,0.9957)(-0.9286,0.9951)(-0.9231,0.9945)(-0.8929,0.9896)(-0.8722,0.985)(-0.8571,0.9827)(-0.8352,0.9781)(-0.8214,0.9745)(-0.8136,0.9721)(-0.7857,0.9653)(-0.7824,0.9643)(-0.7579,0.9564)(-0.75,0.9536)(-0.734,0.9483)(-0.7143,0.9401)(-0.7056,0.9373)(-0.6829,0.9286)(-0.6549,0.9165)(-0.6429,0.9119)(-0.6128,0.8985)(-0.6052,0.8948)(-0.6009,0.8929)(-0.5714,0.8773)(-0.558,0.8706)(-0.5389,0.8603)(-0.5357,0.8585)(-0.5333,0.8571)(-0.5124,0.8447)(-0.5,0.8369)(-0.4747,0.8214)(-0.4684,0.8173)(-0.4643,0.8144)(-0.4469,0.8031)(-0.4441,0.8012)(-0.4286,0.7901)(-0.4259,0.7883)(-0.4221,0.7857)(-0.4107,0.7773)(-0.4054,0.7732)(-0.3929,0.7633)(-0.3852,0.7576)(-0.3754,0.75)(-0.3571,0.7347)(-0.3459,0.7255)(-0.3328,0.7143)(-0.3214,0.7037)(-0.3082,0.6918)(-0.3036,0.6877)(-0.294,0.6786)(-0.2899,0.6744)(-0.2857,0.67)(-0.2721,0.6565)(-0.259,0.6429)(-0.25,0.6328)(-0.2377,0.6194)(-0.227,0.6071)(-0.2143,0.5916)(-0.2051,0.5806)(-0.1978,0.5714)(-0.1786,0.5458)(-0.1742,0.5401)(-0.171,0.5357)(-0.1593,0.5192)(-0.1535,0.5106)(-0.1466,0.5)(-0.1452,0.4977)(-0.1429,0.4938)(-0.1316,0.4755)(-0.1249,0.4643)(-0.1184,0.453)(-0.1071,0.4328)(-0.1047,0.4286)(-0.09471,0.4053)(-0.08726,0.3929)(-0.07143,0.3584)(-0.07102,0.3576)(-0.07083,0.3571)(-0.07033,0.356)(-0.06112,0.3317)(-0.05723,0.3214)(-0.0513,0.3058)(-0.04846,0.2985)(-0.04474,0.2857)(-0.03571,0.2566)(-0.03431,0.2514)(-0.03255,0.2468)(-0.02505,0.2143)(-0.02249,0.1918)(-0.01772,0.1786)(-0.01197,0.1548)(-0.01166,0.1429)(-0.01291,0.1299)(-0.002361,0.07379)(-0.003401,0.07143)(-0.003605,0.06782)(-0.0005473,0.03626)(-0.001276,0.03571)(-0.002268,0.03345)(0,0)(-0.02138,0.01434)(-0.03571,0.01818)(-0.04573,0.0257)(-0.05357,0.02703)(-0.07058,0.03571)(-0.07118,0.03596)(-0.07143,0.03605)(-0.07198,0.03626)(-0.09413,0.04873)(-0.1071,0.05457)(-0.1395,0.07143)(-0.1418,0.07245)(-0.1429,0.07282)(-0.1452,0.07379)(-0.1786,0.09168)(-0.1874,0.09831)(-0.2074,0.1071)(-0.2143,0.1104)(-0.2339,0.1232)(-0.25,0.1296)(-0.2741,0.1429)(-0.2817,0.1468)(-0.2857,0.1488)(-0.2982,0.1553)(-0.305,0.1593)(-0.3214,0.1683)(-0.3279,0.1721)(-0.3394,0.1786)(-0.3571,0.1881)(-0.373,0.1985)(-0.3929,0.208)(-0.4035,0.2143)(-0.4195,0.2234)(-0.4286,0.2284)(-0.4611,0.2468)};
+          \addplot[thick,{\colorone},smooth] coordinates {(2.,-0.8472)(1.984,-0.8412)(1.903,-0.8113)(1.857,-0.7917)(1.799,-0.772)(1.754,-0.7536)(1.714,-0.738)(1.696,-0.7324)(1.647,-0.7143)(1.593,-0.6926)(1.571,-0.6824)(1.52,-0.6632)(1.491,-0.6523)(1.466,-0.6429)(1.429,-0.6273)(1.388,-0.612)(1.288,-0.5714)(1.286,-0.5709)(1.286,-0.5706)(1.284,-0.5699)(1.214,-0.5411)(1.185,-0.5297)(1.164,-0.5208)(1.143,-0.5122)(1.134,-0.509)(1.111,-0.5)(1.083,-0.4882)(1.071,-0.4826)(1.042,-0.4708)(1.033,-0.4671)(1.,-0.4528)(0.9823,-0.4462)(0.9643,-0.4383)(0.9405,-0.4286)(0.9321,-0.425)(0.9286,-0.4233)(0.9192,-0.4192)(0.8819,-0.4039)(0.8571,-0.3924)(0.7942,-0.3656)(0.7857,-0.3623)(0.7818,-0.3611)(0.7723,-0.3571)(0.7143,-0.331)(0.6812,-0.3188)(0.6429,-0.2999)(0.6324,-0.2961)(0.6096,-0.2857)(0.6071,-0.2846)(0.605,-0.2836)(0.5831,-0.274)(0.5714,-0.2685)(0.5404,-0.2547)(0.5357,-0.2527)(0.5337,-0.252)(0.5292,-0.25)(0.5,-0.2366)(0.4841,-0.2302)(0.4483,-0.2143)(0.4351,-0.2078)(0.4286,-0.204)(0.4092,-0.195)(0.386,-0.1854)(0.3716,-0.1786)(0.3571,-0.1714)(0.3369,-0.1631)(0.3214,-0.1547)(0.2948,-0.1429)(0.2887,-0.1398)(0.2857,-0.1381)(0.2767,-0.1338)(0.2644,-0.1284)(0.25,-0.1212)(0.24,-0.1171)(0.2192,-0.1071)(0.2143,-0.1044)(0.1906,-0.09509)(0.1786,-0.0872)(0.1674,-0.08262)(0.1449,-0.07143)(0.1436,-0.07069)(0.1429,-0.07019)(0.1402,-0.06876)(0.1191,-0.05949)(0.1071,-0.05265)(0.09493,-0.04793)(0.07185,-0.03571)(0.07143,-0.0354)(0.07061,-0.0349)(0.0461,-0.02533)(0.03571,-0.01754)(0.02148,-0.01423)(0,0)(0,0)(-0.0008163,-0.0349)(-0.0005102,-0.03571)(-0.000383,-0.0361)(-0.002664,-0.06876)(-0.002268,-0.07143)(-0.002059,-0.07349)(-0.005456,-0.1017)(-0.00492,-0.1071)(-0.00541,-0.1126)(-0.009061,-0.1338)(-0.00907,-0.1429)(-0.009254,-0.1521)(-0.01449,-0.1786)(-0.01837,-0.1959)(-0.01848,-0.1971)(-0.02119,-0.2143)(-0.0244,-0.2256)(-0.02726,-0.2415)(-0.02938,-0.25)(-0.03084,-0.2549)(-0.03571,-0.2743)(-0.03813,-0.2857)(-0.04587,-0.3113)(-0.05211,-0.3378)(-0.05856,-0.3571)(-0.06241,-0.3662)(-0.07077,-0.3929)(-0.07143,-0.3945)(-0.08076,-0.4192)(-0.08339,-0.4286)(-0.09044,-0.4476)(-0.1006,-0.4708)(-0.1071,-0.4868)(-0.1122,-0.5)(-0.1221,-0.5208)(-0.1279,-0.5357)(-0.1429,-0.5668)(-0.1443,-0.57)(-0.1448,-0.5714)(-0.1467,-0.5753)(-0.156,-0.594)(-0.1623,-0.6071)(-0.1681,-0.6177)(-0.1717,-0.625)(-0.1786,-0.6379)(-0.1803,-0.6412)(-0.1811,-0.6429)(-0.184,-0.6482)(-0.1928,-0.6643)(-0.2004,-0.6786)(-0.2143,-0.7022)(-0.2186,-0.71)(-0.2208,-0.7143)(-0.2301,-0.7301)(-0.2453,-0.7547)(-0.2637,-0.7857)(-0.2729,-0.7986)(-0.2857,-0.817)(-0.3011,-0.8418)(-0.3105,-0.8571)(-0.3299,-0.8843)(-0.3571,-0.9227)(-0.3595,-0.9262)(-0.3609,-0.9286)(-0.371,-0.9424)(-0.4139,-1.)(-0.4209,-1.008)(-0.4286,-1.016)(-0.4845,-1.087)(-0.5288,-1.143)(-0.55,-1.164)(-0.5714,-1.185)(-0.6173,-1.24)(-0.6568,-1.286)(-0.6862,-1.314)(-0.7143,-1.34)(-0.7566,-1.386)(-0.7966,-1.429)(-0.8285,-1.457)(-0.8571,-1.482)(-0.9017,-1.527)(-0.9475,-1.571)(-0.9761,-1.595)(-1.,-1.614)(-1.052,-1.663)(-1.109,-1.714)(-1.128,-1.729)(-1.143,-1.74)(-1.206,-1.794)(-1.282,-1.857)(-1.284,-1.859)(-1.286,-1.86)(-1.3,-1.871)(-1.364,-1.922)(-1.372,-1.929)(-1.429,-1.972)(-1.444,-1.984)(-1.464,-2.)};
+          \filldraw [] (axis cs:-1,1) node [above] {\scriptsize $\left(-1,1\right)$} circle (1pt);
+          \filldraw [thin,-&gt;,&gt;=latex] (axis cs:1.25,-1.5) node [fill=white] {\scriptsize $\left(-1,\frac{-1-\sqrt{5}}2\right)$} -- (axis cs: -.9,-1.62);
+          \filldraw [] (axis cs: -1,-1.62)  circle (1pt);
+          \filldraw [-&gt;,thin,&gt;=latex] (axis cs:1.25,0.5) node [ fill=white] {\scriptsize $\left(-1,\frac{-1+\sqrt{5}}2\right)$} -- (axis cs: -.9,0.62);
+          \filldraw [] (axis cs:-1,0.62)  circle (1pt);
+
+          \end{axis}
+          \node [right] at (myplot.right of origin) {\scriptsize $x$};
+          \node [above] at (myplot.above origin) {\scriptsize $y$};
+          \end{tikzpicture}
+
           </latex-image>
         </image>
 
@@ -2160,12 +2160,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $ddyddx=Formula("-((2y+1)(12x^2)-4x^3(2*-(4x^3)/(2y+1)))/(2y+1)^2");
               @y=(random(-2,2,0.1),random(-2,2,0.1),random(-2,2,0.1),random(-2,2,0.1),random(-2,2,0.1));
               @x=map{(7-($_)-($_)**2)**(1/4)*(-1)**(random(-1,1,2))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx-&gt;{test_points}=~~@xy;
+              $ddyddx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2190,12 +2190,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $ddyddx=Formula("-(x^(3/5)*3/5y^(-2/5)(-y^(3/5)/x^(3/5))-y^(3/5)*3/5x^(-2/5))/x^(6/5)");
               @y=(random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01));
               @x=map{(1-($_)**(2/5))**(5/2)}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx-&gt;{test_points}=~~@xy;
+              $ddyddx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2220,12 +2220,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $ddyddx=Formula("sin^2(x)sec^2(y)tan(y)+cos(x)sec(y)");
               @y=(random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01));
               @x=map{acos(1-sin($_))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx-&gt;{test_points}=~~@xy;
+              $ddyddx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2250,12 +2250,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $ddyddx=Formula("0");
               @x=(random(-4,4,0.1),random(-4,4,0.1),random(-4,4,0.1),random(-4,4,0.1),random(-4,4,0.1));
               @y=map{$_/10}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx-&gt;{test_points}=~~@xy;
+              $ddyddx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2292,14 +2292,14 @@
 
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-0.9,4]});
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->set(x=>{limits=>[-0.9,4]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("(1+x)^(1/x)(1/(x(x+1))-ln(1+x)/x^2)");
 
               Context("Numeric");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=(1-2ln(2))(x-1)+2");
             </pg-code>
             </setup>
@@ -2338,14 +2338,14 @@
 
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0.01,4]});
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->set(x=>{limits=>[0.01,4]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("(2x)^(x^2)(2x ln(2x)+x)");
 
               Context("Numeric");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=(2+4ln(2))(x-1)+2");
             </pg-code>
             </setup>
@@ -2384,14 +2384,14 @@
 
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0.01,4]});
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->set(x=>{limits=>[0.01,4]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("x^x/(x+1)(ln(x)+1-1/(x+1))");
 
               Context("Numeric");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=1/4*(x-1)+1/2");
             </pg-code>
             </setup>
@@ -2430,14 +2430,14 @@
 
 
             <pg-code>
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0.01,4]});
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->set(x=>{limits=>[0.01,4]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("x^(sin(x)+2)(cos(x)*ln(x)+(sin(x)+2)/x)");
 
               Context("Numeric");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=(3pi^2)/4*(x-pi/2)+(pi/2)^3");
             </pg-code>
             </setup>
@@ -2477,13 +2477,13 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("(x+1)/(x+2)(1/(x+1)-1/(x+2))");
 
               Context("Numeric");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=1/9(x-1)+2/3");
             </pg-code>
             </setup>
@@ -2522,13 +2522,13 @@
 
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("((x+1)(x+2))/((x+3)(x+4))(1/(x+1)+1/(x+2)-1/(x+3)-1/(x+4))");
 
               Context("Numeric");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=11/72x+1/6");
             </pg-code>
             </setup>

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -1787,7 +1787,7 @@
                 </ol>
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -1862,7 +1862,7 @@
                 </ol>
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -1926,7 +1926,7 @@
                 </ol>
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -1990,7 +1990,7 @@
                 </ol>
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -2056,7 +2056,7 @@
                 </ol>
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_imp_deriv">
   <title>Implicit Differentiation</title>
   <introduction>
@@ -47,10 +46,10 @@
       <caption>A graph of the implicit relationship <m>\sin(y)+y^3=6-x^3</m>.</caption>
       <!-- START figures/fig_implicit1.tex -->
       <image xml:id="img_implicit1" width="47%">
-        <description></description>
+        <description/>
         <latex-image>
-        <![CDATA[
-        \begin{tikzpicture}[declare function = {cbrt(\x) = (\x < 0) * -(-\x)^(1/3) + (\x >= 0) * (\x)^(1/3);}]
+        
+        \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
         \begin{axis}[,xmin=-3.2,xmax=3.2,
         ymin=-3.2,ymax=3.2]
         \addplot[firstcurvestyle,variable=\t,domain=-2.7:1.5,leftarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
@@ -58,7 +57,7 @@
         \addplot[firstcurvestyle,variable=\t,domain=1.8:3,rightarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_implicit1.tex END -->
@@ -221,10 +220,10 @@
           <caption>The function <m>\sin(y) +y^3 = 6-x^3</m> and its tangent line at the point <m>(\sqrt[3]{6},0)</m>.</caption>
           <!-- START figures/fig_implicit2.tex -->
           <image xml:id="img_implicit2" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
-            \begin{tikzpicture}[declare function = {cbrt(\x) = (\x < 0) * -(-\x)^(1/3) + (\x >= 0) * (\x)^(1/3);}]
+            
+            \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
             \begin{axis}[,xmin=-3.2,xmax=3.2,
             ymin=-3.2,ymax=3.2]
             \addplot[firstcurvestyle,variable=\t,domain=-2.7:1.5,leftarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
@@ -233,7 +232,7 @@
             \addplot [tangentline,domain=1.617:2.017] {-9.9057*x+18};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit2.tex END -->
@@ -296,7 +295,7 @@
 
         <p>
           The second term, <m>x^2y^4</m>, is a little tricky.
-          It requires the <xref ref="thm_ProductRule" text="title" /> as it is the product of two functions of <m>x</m>:
+          It requires the <xref ref="thm_ProductRule" text="title"/> as it is the product of two functions of <m>x</m>:
           <m>x^2</m> and <m>y^4</m>.
           Its derivative is <m>x^2(4y^3y') + 2xy^4</m>.
           The first part of this expression requires a <m>y'</m> because we are taking the derivative of a <m>y</m> term.
@@ -338,9 +337,9 @@
           <caption>A graph of the implicitly defined function <m>y^3+x^2y^4=1+2x</m> along with its tangent line at the point <m>(0,1)</m>.</caption>
           <!-- START figures/fig_implicit4.tex -->
           <image xml:id="img_implicit4" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.5,xmax=10.5,
             ymin=-10.5,ymax=2.49,]
@@ -353,7 +352,7 @@
             \end{axis}
 
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit4.tex END -->
@@ -384,7 +383,7 @@
         <p>
           Differentiating term by term,
           we find the most difficulty in the first term.
-          It requires both the <xref ref="thm_chain_rule" text="title" /> and <xref ref="thm_ProductRule" text="title" />.
+          It requires both the <xref ref="thm_chain_rule" text="title"/> and <xref ref="thm_ProductRule" text="title"/>.
           <md>
             <mrow>\lzoo{x}{\sin\mathopen{}\left(x^2y^2\right)\mathclose{}} \amp = \cos\mathopen{}\left(x^2y^2\right)\mathclose{}\cdot\lzoo{x}{x^2y^2}</mrow>
             <mrow>\amp = \cos\mathopen{}\left(x^2y^2\right)\mathclose{}\cdot\left(x^2(2yy')+2xy^2\right)</mrow>
@@ -432,9 +431,9 @@
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m>.</caption>
           <!-- START figures/fig_implicit5.tex -->
           <image xml:id="img_implicit5" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.95,xmax=1.99,
             ymin=-1.95,ymax=1.95,]
@@ -442,7 +441,7 @@
             \end{axis}
 
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit5.tex END -->
@@ -468,9 +467,9 @@
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m> and certain tangent lines.</caption>
           <!-- START figures/fig_implicit6.tex -->
           <image xml:id="img_implicit6" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.95,xmax=1.99,
             ymin=-1.95,ymax=1.95,]
@@ -481,7 +480,7 @@
             \addplot [tangentline,domain=-.5:.5] {0.5*(x-0)-1};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit6.tex END -->
@@ -539,9 +538,9 @@
           <caption>The unit circle with its tangent line at <m>(1/2,\sqrt{3}/2)</m>.</caption>
           <!-- START figures/fig_implicit7.tex -->
           <image xml:id="img_implicit7" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.2,xmax=1.2,
             ymin=-1.2,ymax=1.2,
@@ -552,7 +551,7 @@
             \addplot [normallineseg,domain=0:0.5]{1/0.577*x};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit7.tex END -->
@@ -580,20 +579,20 @@
       We allude to a possible solution,
       as we can write the square root function as a power function with a rational (or,
       fractional) power.
-      We are then tempted to apply the <xref ref="thm_PowerRule" text="title" /> and obtain
+      We are then tempted to apply the <xref ref="thm_PowerRule" text="title"/> and obtain
       <me>
         \lzoo{x^{1/2}} = \frac{1}{2}x^{-1/2} = \frac{1}{2\sqrt{x}}
       </me>.
     </p>
 
     <p>
-      The trouble with this is that the <xref ref="thm_PowerRule" text="title" /> was initially defined only for positive integer powers,
-      <m>n>0</m>.
+      The trouble with this is that the <xref ref="thm_PowerRule" text="title"/> was initially defined only for positive integer powers,
+      <m>n&gt;0</m>.
       While we did not justify this at the time,
-      generally the <xref ref="thm_PowerRule" text="title" /> is proved using something called the Binomial Theorem,
+      generally the <xref ref="thm_PowerRule" text="title"/> is proved using something called the Binomial Theorem,
       which deals only with positive integers.
-      The <xref ref="thm_QuotientRule" text="title" /> allowed us to extend the <xref ref="thm_PowerRule" text="title" /> to negative integer powers.
-      Implicit Differentiation allows us to extend the <xref ref="thm_PowerRule" text="title" /> to rational powers,
+      The <xref ref="thm_QuotientRule" text="title"/> allowed us to extend the <xref ref="thm_PowerRule" text="title"/> to negative integer powers.
+      Implicit Differentiation allows us to extend the <xref ref="thm_PowerRule" text="title"/> to rational powers,
       as shown below.
     </p>
 
@@ -617,7 +616,7 @@
     </p>
 
     <p>
-      The above derivation is the key to the proof extending the <xref ref="thm_PowerRule" text="title" /> to rational powers.
+      The above derivation is the key to the proof extending the <xref ref="thm_PowerRule" text="title"/> to rational powers.
       Using limits,
       we can extend this once more to include <em>all</em>
       powers, including irrational
@@ -644,7 +643,7 @@
     </p>
 
     <p>
-      We now apply this final version of the <xref ref="thm_finalpower" text="title" /> in the next example,
+      We now apply this final version of the <xref ref="thm_finalpower" text="title"/> in the next example,
       the second investigation of a <q>famous</q> curve.
     </p>
 
@@ -668,9 +667,9 @@
           <caption>An astroid, traced out by a point on the smaller circle as it rolls inside the larger circle.</caption>
           <!-- START figures/fig_implicit9.tex -->
           <image xml:id="img_implicit9" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-24,xmax=24,
             ymin=-24,ymax=24,
@@ -681,7 +680,7 @@
             \addplot [soliddot] coordinates {(-8,-8)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit9.tex END -->
@@ -709,9 +708,9 @@
           <caption>An astroid with a tangent line.</caption>
           <!-- START figures/fig_implicit8.tex -->
           <image xml:id="img_implicit8" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-24,xmax=24,
             ymin=-24,ymax=24,
@@ -721,7 +720,7 @@
             \addplot [soliddot] coordinates {(8,8)} node[above right] {$(8,8)$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit8.tex END -->
@@ -763,7 +762,7 @@
 
         <p>
           While this is not a particularly simple expression, it is usable.
-          We can see that <m>y''>0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y>0</m>.
+          We can see that <m>y''&gt;0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y&gt;0</m>.
           In <xref ref="sec_concavity">Section</xref>,
           we will see how this relates to the shape of the graph.
         </p>
@@ -787,7 +786,7 @@
     <p>
       Consider the function <m>y=x^x</m>;
       it is graphed in <xref ref="fig_logdiffa">Figure</xref>.
-      It is well-defined for <m>x>0</m> and we might be interested in finding equations of lines tangent and normal to its graph.<fn>
+      It is well-defined for <m>x&gt;0</m> and we might be interested in finding equations of lines tangent and normal to its graph.<fn>
       In calculus the expression <m>0^0</m> is also considered well-defined and equal to <m>1</m>.
       This is easily confused with a limit of the <em>form</em>
       <m>0^0</m>, which is indeterminate.
@@ -808,9 +807,9 @@
       <caption>A plot of <m>y=x^x</m>.</caption>
       <!-- START figures/fig_logdiffa.tex -->
       <image xml:id="img_logdiffa" width="47%">
-        <description></description>
+        <description/>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-0.1,xmax=2.2,
         ymin=-.1,ymax=4.2]
@@ -818,7 +817,7 @@
         \addplot[hollowdot] coordinates{(0,1)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_logdiffa.tex END -->
@@ -883,9 +882,9 @@
           <caption>A graph of <m>y=x^x</m> and its tangent line at <m>x=1.5</m>.</caption>
           <!-- START figures/fig_implicit10.tex -->
           <image xml:id="img_implicit10" width="47%">
-            <description></description>
+            <description/>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-0.1,xmax=2.2,
             ymin=-.1,ymax=4.2]
@@ -895,7 +894,7 @@
             \addplot[soliddot] coordinates{(1.5,1.837)} node[below right] {$\left(1.5,1.5^{1.5}\right)$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_implicit10.tex END -->
@@ -933,7 +932,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -958,7 +957,7 @@
               </p>
 
               <p>
-                <var name="$derivativerules" form="buttons" />
+                <var name="$derivativerules" form="buttons"/>
               </p>
             </statement>
             <solution>
@@ -1019,7 +1018,7 @@
             <setup>
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0,4]});
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
               $fp=Formula("1/(2sqrt(x))-1/(2sqrt(x^3))");
             </pg-code>
             </setup>
@@ -1029,7 +1028,7 @@
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="40" />
+                <m>f'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1045,8 +1044,8 @@
             <setup>
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0,4]});
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $fp=Formula("1/3 x^(-2/3)+2/3 x^(-1/3)");
             </pg-code>
             </setup>
@@ -1056,7 +1055,7 @@
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="40" />
+                <m>f'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1072,8 +1071,8 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->variables->set(t=>{limits=>[-1,1]});
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[-1,1]});
               $fp=Formula("-t/sqrt(1-t^2)");
             </pg-code>
             </setup>
@@ -1083,7 +1082,7 @@
               </p>
 
               <p>
-                <m>f'(t)=</m><var name="$fp" width="40" />
+                <m>f'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1099,8 +1098,8 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->variables->set(t=>{limits=>[0,4]});
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[0,4]});
               $fp=Formula("sqrt(t)cos(t)+sin(t)/(2sqrt(t))");
             </pg-code>
             </setup>
@@ -1110,7 +1109,7 @@
               </p>
 
               <p>
-                <m>g'(t)=</m><var name="$fp" width="40" />
+                <m>g'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1126,7 +1125,7 @@
             <setup>
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0,4]});
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
               $fp=Formula("1.5sqrt(x)");
             </pg-code>
             </setup>
@@ -1136,7 +1135,7 @@
               </p>
 
               <p>
-                <m>h'(x)=</m><var name="$fp" width="40" />
+                <m>h'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1152,8 +1151,8 @@
             <setup>
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0,4]});
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $fp=Formula("pi x^(pi-1)+1.9x^(0.9)");
             </pg-code>
             </setup>
@@ -1163,7 +1162,7 @@
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="40" />
+                <m>f'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1179,7 +1178,7 @@
             <setup>
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0,4]});
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0,4]});
               $fp=Formula("1/(2sqrt(x))-7/(2sqrt(x^3))");
             </pg-code>
             </setup>
@@ -1189,7 +1188,7 @@
               </p>
 
               <p>
-                <m>g'(x)=</m><var name="$fp" width="40" />
+                <m>g'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1205,8 +1204,8 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->variables->set(t=>{limits=>[0,4]});
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[0,4]});
               $fp=Formula("1/5t^(-4/5)(sec(t)+e^t)+t^(1/5)(sec(t)tan(t)+e^t)");
             </pg-code>
             </setup>
@@ -1216,7 +1215,7 @@
               </p>
 
               <p>
-                <m>f'(t)=</m><var name="$fp" width="40" />
+                <m>f'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1242,12 +1241,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("-4x^3/(2y+1)");
               @y=(random(-2,2,0.2),random(-2,2,0.2),random(-2,2,0.2),random(-2,2,0.2),random(-2,2,0.2));
               @x=map{(7-($_)-($_)**2)**(1/4)*(-1)**(random(-1,1,2))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1256,7 +1255,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1272,12 +1271,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("-y^(3/5)/x^(3/5)");
               @y=(random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01));
               @x=map{(1-($_)**(2/5))**(5/2)}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1286,7 +1285,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1302,12 +1301,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("sin(x)sec(y)");
               @y=(random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01));
               @x=map{acos(1-sin($_))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1316,7 +1315,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1332,12 +1331,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("y/x");
               @x=(random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1));
               @y=map{$_/10}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1346,7 +1345,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1362,12 +1361,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("y/x");
               @y=(random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1),random(-4.05,4.05,0.1));
               @x=map{$_/10}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1376,7 +1375,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1392,13 +1391,13 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
-              Context()->flags->set(reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstantFunctions=&gt;0);
               $dydx=Formula("-(e^x x(x+2) 2^(-y))/(ln(2))");
               @x=(random(-4,1,0.1),random(-4,1,0.1),random(-4,1,0.1),random(-4,1,0.1),random(-4,1,0.1));
               @y=map{ln(5-($_)**2*exp($_))/ln(2)}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1407,7 +1406,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1423,13 +1422,13 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("-2sin(y)cos(y)/x");
               # need to avoid x==0
               @x=(random(-3.9,3.9,0.2),random(-3.9,3.9,0.2),random(-3.9,3.9,0.2),random(-3.9,3.9,0.2),random(-3.9,3.9,0.2));
               @y=map{atan(50/($_)**2)}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1438,7 +1437,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1454,12 +1453,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("-x/y^2");
               @x=(random(-0.6,0.6,0.01),random(-0.6,0.6,0.01),random(-0.6,0.6,0.01),random(-0.6,0.6,0.01),random(-0.6,0.6,0.01));
               @y=map{((2**0.25-3*($_)**2)/2&lt;0)?-(abs(-(2**0.25-3*($_)**2)/2))**(1/3):((2**0.25-3*($_)**2)/2)**(1/3)}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1468,7 +1467,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1484,12 +1483,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("1/(2y+2)");
               @y=(random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2));
               @x=map{sqrt(200)*(-1)**(random(-1,1,2))+2*($_)+($_)**2}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1498,7 +1497,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1514,12 +1513,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("(x^2+2xy^2-y)/(2x^2y-x+y^2)");
               @y=(random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2),random(-3.9,1.9,0.2));
               @x=map{(17+(-1)**(random(-1,1,2))*sqrt(289 - 4*($_)*(1 - 17*($_))))/2}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1528,7 +1527,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1558,9 +1557,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("(-cos(x)(x+cos(y))+sin(x)+y)/(sin(y)(sin(x)+y)+x+cos(y))");
-              $dydx->{test_points}=[[-3.1,-3.83041],[-0.41,0.732269],[0.59,0.759097],[2.6,1.82908],[5.3,6.93017]];
+              $dydx-&gt;{test_points}=[[-3.1,-3.83041],[-0.41,0.732269],[0.59,0.759097],[2.6,1.82908],[5.3,6.93017]];
             </pg-code>
             </setup>
             <statement>
@@ -1569,7 +1568,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1599,13 +1598,13 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("-x/y");
               @t=(random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01));
               @x=map{exp(exp(1)/2)*cos($_)}(@t);
               @y=map{exp(exp(1)/2)*sin($_)}(@t);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1614,7 +1613,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1630,7 +1629,7 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("-(2x+y)/(2y+x)");
               @t=(random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01),random(0,6.28,0.01));
               @u=map{sqrt(2/3*exp(1))*cos($_)}(@t);
@@ -1638,7 +1637,7 @@
               @x=map{($u[$_]-$v[$_])/sqrt(2)}(0..4);
               @y=map{($u[$_]+$v[$_])/sqrt(2)}(0..4);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1647,7 +1646,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1675,7 +1674,7 @@
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
 
@@ -1685,7 +1684,7 @@
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
 
@@ -1695,7 +1694,7 @@
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
 
@@ -1705,7 +1704,7 @@
                   </p>
 
                   <p>
-                    <var form="essay" />
+                    <var form="essay"/>
                   </p>
                 </li>
               </ol>
@@ -1736,25 +1735,25 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               @eq=(Formula("y=0"),Formula("y=-1.859(x-0.1)+0.2811"));
-              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $x=Formula("cos^5(t)");
               $y=Formula("sin^5(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(0.1,0.2811,'black'));
-              $gr->lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom'));
+              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
+              $f-&gt;domain(0,6.2831852);
+              $f-&gt;steps(100);
+              $f-&gt;weight(2);
+              $f-&gt;color('blue');
+              $gr-&gt;stamps(closed_circle(0.1,0.2811,'black'));
+              $gr-&gt;lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -1771,7 +1770,7 @@
                     </p>
 
                     <p>
-                      <var name="$eq[0]" width="30" />
+                      <var name="$eq[0]" width="30"/>
                     </p>
                   </li>
 
@@ -1782,15 +1781,15 @@
                     </p>
 
                     <p>
-                      <var name="$eq[1]" width="30" />
+                      <var name="$eq[1]" width="30"/>
                     </p>
                   </li>
                 </ol>
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1802,25 +1801,25 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               @eq=(Formula("x=1"),Formula("y=-3sqrt(3)/8(x-sqrt(0.6))+sqrt(0.8)"),Formula("y=1"));
-              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-1,-0.5,0.5,1){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $x=Formula("(abs(cos(t)))^(1/2)*sgn(cos(t))");
               $y=Formula("(abs(sin(t)))^(1/2)*sgn(sin(t))");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(0.7746,0.8944,'black'));
-              $gr->lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top'));
+              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
+              $f-&gt;domain(0,6.2831852);
+              $f-&gt;steps(100);
+              $f-&gt;weight(2);
+              $f-&gt;color('blue');
+              $gr-&gt;stamps(closed_circle(0.7746,0.8944,'black'));
+              $gr-&gt;lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top'));
             </pg-code>
             </setup>
             <statement>
@@ -1837,7 +1836,7 @@
                     </p>
 
                     <p>
-                      <var name="$eq[0]" width="30" />
+                      <var name="$eq[0]" width="30"/>
                     </p>
                   </li>
 
@@ -1847,7 +1846,7 @@
                     </p>
 
                     <p>
-                      <var name="$eq[1]" width="30" />
+                      <var name="$eq[1]" width="30"/>
                     </p>
                   </li>
 
@@ -1857,15 +1856,15 @@
                     </p>
 
                     <p>
-                      <var name="$eq[2]" width="30" />
+                      <var name="$eq[2]" width="30"/>
                     </p>
                   </li>
                 </ol>
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1876,25 +1875,25 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               @eq=(Formula("y=4"),Formula("y=3/108^(1/4)(x-2)-108^(1/4)"));
-              $gr=init_graph(-4.2,-4.2,4.2,4.2,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-4,-3,-2,-1,1,2,3,4){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-4,-3,-2,-1,1,2,3,4){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-4.2,-4.2,4.2,4.2,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-4,-3,-2,-1,1,2,3,4){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-4,-3,-2,-1,1,2,3,4){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $x=Formula("sqrt((216 sin^2(t) + sqrt((216 sin^2(t))^2 - (36 sin^2(t))^3))^(1/3) + (216 sin^2(t) - sqrt((216 sin^2(t))^2 - (36sin^2(t))^3))^(1/3) + 4) cos(t)");
               $y=Formula("sqrt((216 sin^2(t) + sqrt((216 sin^2(t))^2 - (36 sin^2(t))^3))^(1/3) + (216 sin^2(t) - sqrt((216 sin^2(t))^2 - (36sin^2(t))^3))^(1/3) + 4) sin(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(2,-3.224,'black'));
-              $gr->lb(new Label(2,-3.224,'(2,-108^(1/4))','black','left','bottom'));
+              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
+              $f-&gt;domain(0,6.2831852);
+              $f-&gt;steps(100);
+              $f-&gt;weight(2);
+              $f-&gt;color('blue');
+              $gr-&gt;stamps(closed_circle(2,-3.224,'black'));
+              $gr-&gt;lb(new Label(2,-3.224,'(2,-108^(1/4))','black','left','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -1911,7 +1910,7 @@
                     </p>
 
                     <p>
-                      <var name="$eq[0]" width="30" />
+                      <var name="$eq[0]" width="30"/>
                     </p>
                   </li>
 
@@ -1921,15 +1920,15 @@
                     </p>
 
                     <p>
-                      <var name="$eq[1]" width="30" />
+                      <var name="$eq[1]" width="30"/>
                     </p>
                   </li>
                 </ol>
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1940,25 +1939,25 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               @eq=(Formula("y=-x+1"),Formula("y=3sqrt(3)/4"));
-              $gr=init_graph(-2.5,-1.5,0.5,1.5,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-2,-1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(-1,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-2.5,-1.5,0.5,1.5,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-2,-1){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(-1,1){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $x=Formula("(1 - cos(t))*cos(t)");
               $y=Formula("(1 - cos(t))*sin(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(-0.75,1.299,'black'));
-              $gr->lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','center','bottom'));
+              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
+              $f-&gt;domain(0,6.2831852);
+              $f-&gt;steps(100);
+              $f-&gt;weight(2);
+              $f-&gt;color('blue');
+              $gr-&gt;stamps(closed_circle(-0.75,1.299,'black'));
+              $gr-&gt;lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','center','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -1975,7 +1974,7 @@
                     </p>
 
                     <p>
-                      <var name="$eq[0]" width="30" />
+                      <var name="$eq[0]" width="30"/>
                     </p>
                   </li>
 
@@ -1985,15 +1984,15 @@
                     </p>
 
                     <p>
-                      <var name="$eq[1]" width="30" />
+                      <var name="$eq[1]" width="30"/>
                     </p>
                   </li>
                 </ol>
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -2004,27 +2003,27 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               @eq=(Formula("y=-1/sqrt(3)(x-7/2)+(6+3sqrt(3))/2"),Formula("y=sqrt(3)(x-(4+3sqrt(3)))/2+3/2"));
-              $gr=init_graph(-2,-2,6.5,6.5,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(2,4,6){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top'));};
-              for my$i(2,4,6){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle'));};
+              $gr=init_graph(-2,-2,6.5,6.5,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(2,4,6){$gr-&gt;moveTo($i,-0.04);$gr-&gt;lineTo($i,0.04,'black',2);$gr-&gt;lb(new Label($i,-0.05,$i,'black','center','top'));};
+              for my$i(2,4,6){$gr-&gt;moveTo(-0.04,$i);$gr-&gt;lineTo(0.04,$i,'black',2);$gr-&gt;lb(new Label(-0.05,$i,$i,'black','right','middle'));};
               Context("Numeric");
-              Context()->variables->are(t=>'Real');
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
               $x=Formula("3*cos(t)+2");
               $y=Formula("3*sin(t)+3");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(3.5,5.598,'black'));
-              $gr->lb(new Label(3.5,5.598,'(7/2,(6+3sqrt(3))/2)','black','right','top'));
-              $gr->stamps(closed_circle(4.598,1.5,'black'));
-              $gr->lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom'));
+              $f=new Fun($x-&gt;perlFunction,$y-&gt;perlFunction,$gr);
+              $f-&gt;domain(0,6.2831852);
+              $f-&gt;steps(100);
+              $f-&gt;weight(2);
+              $f-&gt;color('blue');
+              $gr-&gt;stamps(closed_circle(3.5,5.598,'black'));
+              $gr-&gt;lb(new Label(3.5,5.598,'(7/2,(6+3sqrt(3))/2)','black','right','top'));
+              $gr-&gt;stamps(closed_circle(4.598,1.5,'black'));
+              $gr-&gt;lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom'));
             </pg-code>
             </setup>
             <statement>
@@ -2041,7 +2040,7 @@
                     </p>
 
                     <p>
-                      <var name="$eq[0]" width="30" />
+                      <var name="$eq[0]" width="30"/>
                     </p>
                   </li>
 
@@ -2051,15 +2050,15 @@
                     </p>
 
                     <p>
-                      <var name="$eq[1]" width="30" />
+                      <var name="$eq[1]" width="30"/>
                     </p>
                   </li>
                 </ol>
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -2091,30 +2090,57 @@
           </ol>
         </p>
 
-        <p>
-          <img src="figures/fig02_06_ex_38"/>
-        </p>
+        <!-- TODO: Update this image to bring it up to standard. Was just an 'img' before -->
+
+        <image xml:id="img_02_06_ex_38" width="47%">
+          <description></description>
+          <latex-image>
+            <![CDATA[
+            \begin{tikzpicture}[baseline=10pt]
+            \begin{axis}[width=\marginparwidth+25pt,tick label style={font=\scriptsize},axis y line=middle,axis x line=middle,name=myplot,%
+              ymin=-2.5,ymax=2.5,%
+              xmin=-2.5,xmax=2.5,%
+            ]
+
+            \addplot [thick,{\colorone},smooth] coordinates {(-0.4611,0.2468)(-0.465,0.2493)(-0.4663,0.25)(-0.5,0.2699)(-0.5094,0.2763)(-0.5267,0.2857)(-0.5357,0.291)(-0.5485,0.2985)(-0.5548,0.3024)(-0.5714,0.3126)(-0.5856,0.3214)(-0.5989,0.3296)(-0.6071,0.3347)(-0.621,0.3433)(-0.6418,0.356)(-0.6429,0.3568)(-0.6431,0.3569)(-0.6435,0.3571)(-0.6786,0.3799)(-0.6861,0.3854)(-0.6985,0.3929)(-0.7143,0.4033)(-0.7289,0.414)(-0.75,0.4269)(-0.7524,0.4286)(-0.7714,0.4429)(-0.7857,0.4518)(-0.8036,0.4643)(-0.8137,0.4721)(-0.8214,0.4771)(-0.8534,0.5)(-0.8555,0.5017)(-0.8571,0.5028)(-0.8682,0.511)(-0.896,0.5326)(-0.9286,0.559)(-0.9356,0.5644)(-0.9443,0.5714)(-0.9744,0.597)(-1.,0.6204)(-1.012,0.6307)(-1.026,0.6429)(-1.049,0.6656)(-1.063,0.6786)(-1.071,0.6878)(-1.084,0.7014)(-1.096,0.7143)(-1.107,0.7284)(-1.117,0.7402)(-1.125,0.75)(-1.143,0.7765)(-1.147,0.7819)(-1.149,0.7857)(-1.154,0.7928)(-1.158,0.8013)(-1.16,0.8036)(-1.16,0.8042)(-1.161,0.8057)(-1.168,0.8214)(-1.171,0.8289)(-1.179,0.8504)(-1.181,0.8571)(-1.184,0.8877)(-1.185,0.8929)(-1.184,0.8985)(-1.179,0.9216)(-1.177,0.9286)(-1.163,0.9483)(-1.146,0.9643)(-1.143,0.9665)(-1.121,0.9781)(-1.107,0.9831)(-1.082,0.9898)(-1.071,0.9932)(-1.066,0.9947)(-1.037,0.9983)(-1.036,0.9985)(-1.034,0.9987)(-1.018,0.9996)(-1.,1.)(-1.,1.)(-1.,1.)(-1.,1.)(-1.,1.)(-0.9821,0.9997)(-0.9655,0.9988)(-0.9643,0.9987)(-0.963,0.9987)(-0.9329,0.9957)(-0.9286,0.9951)(-0.9231,0.9945)(-0.8929,0.9896)(-0.8722,0.985)(-0.8571,0.9827)(-0.8352,0.9781)(-0.8214,0.9745)(-0.8136,0.9721)(-0.7857,0.9653)(-0.7824,0.9643)(-0.7579,0.9564)(-0.75,0.9536)(-0.734,0.9483)(-0.7143,0.9401)(-0.7056,0.9373)(-0.6829,0.9286)(-0.6549,0.9165)(-0.6429,0.9119)(-0.6128,0.8985)(-0.6052,0.8948)(-0.6009,0.8929)(-0.5714,0.8773)(-0.558,0.8706)(-0.5389,0.8603)(-0.5357,0.8585)(-0.5333,0.8571)(-0.5124,0.8447)(-0.5,0.8369)(-0.4747,0.8214)(-0.4684,0.8173)(-0.4643,0.8144)(-0.4469,0.8031)(-0.4441,0.8012)(-0.4286,0.7901)(-0.4259,0.7883)(-0.4221,0.7857)(-0.4107,0.7773)(-0.4054,0.7732)(-0.3929,0.7633)(-0.3852,0.7576)(-0.3754,0.75)(-0.3571,0.7347)(-0.3459,0.7255)(-0.3328,0.7143)(-0.3214,0.7037)(-0.3082,0.6918)(-0.3036,0.6877)(-0.294,0.6786)(-0.2899,0.6744)(-0.2857,0.67)(-0.2721,0.6565)(-0.259,0.6429)(-0.25,0.6328)(-0.2377,0.6194)(-0.227,0.6071)(-0.2143,0.5916)(-0.2051,0.5806)(-0.1978,0.5714)(-0.1786,0.5458)(-0.1742,0.5401)(-0.171,0.5357)(-0.1593,0.5192)(-0.1535,0.5106)(-0.1466,0.5)(-0.1452,0.4977)(-0.1429,0.4938)(-0.1316,0.4755)(-0.1249,0.4643)(-0.1184,0.453)(-0.1071,0.4328)(-0.1047,0.4286)(-0.09471,0.4053)(-0.08726,0.3929)(-0.07143,0.3584)(-0.07102,0.3576)(-0.07083,0.3571)(-0.07033,0.356)(-0.06112,0.3317)(-0.05723,0.3214)(-0.0513,0.3058)(-0.04846,0.2985)(-0.04474,0.2857)(-0.03571,0.2566)(-0.03431,0.2514)(-0.03255,0.2468)(-0.02505,0.2143)(-0.02249,0.1918)(-0.01772,0.1786)(-0.01197,0.1548)(-0.01166,0.1429)(-0.01291,0.1299)(-0.002361,0.07379)(-0.003401,0.07143)(-0.003605,0.06782)(-0.0005473,0.03626)(-0.001276,0.03571)(-0.002268,0.03345)(0,0)(-0.02138,0.01434)(-0.03571,0.01818)(-0.04573,0.0257)(-0.05357,0.02703)(-0.07058,0.03571)(-0.07118,0.03596)(-0.07143,0.03605)(-0.07198,0.03626)(-0.09413,0.04873)(-0.1071,0.05457)(-0.1395,0.07143)(-0.1418,0.07245)(-0.1429,0.07282)(-0.1452,0.07379)(-0.1786,0.09168)(-0.1874,0.09831)(-0.2074,0.1071)(-0.2143,0.1104)(-0.2339,0.1232)(-0.25,0.1296)(-0.2741,0.1429)(-0.2817,0.1468)(-0.2857,0.1488)(-0.2982,0.1553)(-0.305,0.1593)(-0.3214,0.1683)(-0.3279,0.1721)(-0.3394,0.1786)(-0.3571,0.1881)(-0.373,0.1985)(-0.3929,0.208)(-0.4035,0.2143)(-0.4195,0.2234)(-0.4286,0.2284)(-0.4611,0.2468)};
+            \addplot[thick,{\colorone},smooth] coordinates {(2.,-0.8472)(1.984,-0.8412)(1.903,-0.8113)(1.857,-0.7917)(1.799,-0.772)(1.754,-0.7536)(1.714,-0.738)(1.696,-0.7324)(1.647,-0.7143)(1.593,-0.6926)(1.571,-0.6824)(1.52,-0.6632)(1.491,-0.6523)(1.466,-0.6429)(1.429,-0.6273)(1.388,-0.612)(1.288,-0.5714)(1.286,-0.5709)(1.286,-0.5706)(1.284,-0.5699)(1.214,-0.5411)(1.185,-0.5297)(1.164,-0.5208)(1.143,-0.5122)(1.134,-0.509)(1.111,-0.5)(1.083,-0.4882)(1.071,-0.4826)(1.042,-0.4708)(1.033,-0.4671)(1.,-0.4528)(0.9823,-0.4462)(0.9643,-0.4383)(0.9405,-0.4286)(0.9321,-0.425)(0.9286,-0.4233)(0.9192,-0.4192)(0.8819,-0.4039)(0.8571,-0.3924)(0.7942,-0.3656)(0.7857,-0.3623)(0.7818,-0.3611)(0.7723,-0.3571)(0.7143,-0.331)(0.6812,-0.3188)(0.6429,-0.2999)(0.6324,-0.2961)(0.6096,-0.2857)(0.6071,-0.2846)(0.605,-0.2836)(0.5831,-0.274)(0.5714,-0.2685)(0.5404,-0.2547)(0.5357,-0.2527)(0.5337,-0.252)(0.5292,-0.25)(0.5,-0.2366)(0.4841,-0.2302)(0.4483,-0.2143)(0.4351,-0.2078)(0.4286,-0.204)(0.4092,-0.195)(0.386,-0.1854)(0.3716,-0.1786)(0.3571,-0.1714)(0.3369,-0.1631)(0.3214,-0.1547)(0.2948,-0.1429)(0.2887,-0.1398)(0.2857,-0.1381)(0.2767,-0.1338)(0.2644,-0.1284)(0.25,-0.1212)(0.24,-0.1171)(0.2192,-0.1071)(0.2143,-0.1044)(0.1906,-0.09509)(0.1786,-0.0872)(0.1674,-0.08262)(0.1449,-0.07143)(0.1436,-0.07069)(0.1429,-0.07019)(0.1402,-0.06876)(0.1191,-0.05949)(0.1071,-0.05265)(0.09493,-0.04793)(0.07185,-0.03571)(0.07143,-0.0354)(0.07061,-0.0349)(0.0461,-0.02533)(0.03571,-0.01754)(0.02148,-0.01423)(0,0)(0,0)(-0.0008163,-0.0349)(-0.0005102,-0.03571)(-0.000383,-0.0361)(-0.002664,-0.06876)(-0.002268,-0.07143)(-0.002059,-0.07349)(-0.005456,-0.1017)(-0.00492,-0.1071)(-0.00541,-0.1126)(-0.009061,-0.1338)(-0.00907,-0.1429)(-0.009254,-0.1521)(-0.01449,-0.1786)(-0.01837,-0.1959)(-0.01848,-0.1971)(-0.02119,-0.2143)(-0.0244,-0.2256)(-0.02726,-0.2415)(-0.02938,-0.25)(-0.03084,-0.2549)(-0.03571,-0.2743)(-0.03813,-0.2857)(-0.04587,-0.3113)(-0.05211,-0.3378)(-0.05856,-0.3571)(-0.06241,-0.3662)(-0.07077,-0.3929)(-0.07143,-0.3945)(-0.08076,-0.4192)(-0.08339,-0.4286)(-0.09044,-0.4476)(-0.1006,-0.4708)(-0.1071,-0.4868)(-0.1122,-0.5)(-0.1221,-0.5208)(-0.1279,-0.5357)(-0.1429,-0.5668)(-0.1443,-0.57)(-0.1448,-0.5714)(-0.1467,-0.5753)(-0.156,-0.594)(-0.1623,-0.6071)(-0.1681,-0.6177)(-0.1717,-0.625)(-0.1786,-0.6379)(-0.1803,-0.6412)(-0.1811,-0.6429)(-0.184,-0.6482)(-0.1928,-0.6643)(-0.2004,-0.6786)(-0.2143,-0.7022)(-0.2186,-0.71)(-0.2208,-0.7143)(-0.2301,-0.7301)(-0.2453,-0.7547)(-0.2637,-0.7857)(-0.2729,-0.7986)(-0.2857,-0.817)(-0.3011,-0.8418)(-0.3105,-0.8571)(-0.3299,-0.8843)(-0.3571,-0.9227)(-0.3595,-0.9262)(-0.3609,-0.9286)(-0.371,-0.9424)(-0.4139,-1.)(-0.4209,-1.008)(-0.4286,-1.016)(-0.4845,-1.087)(-0.5288,-1.143)(-0.55,-1.164)(-0.5714,-1.185)(-0.6173,-1.24)(-0.6568,-1.286)(-0.6862,-1.314)(-0.7143,-1.34)(-0.7566,-1.386)(-0.7966,-1.429)(-0.8285,-1.457)(-0.8571,-1.482)(-0.9017,-1.527)(-0.9475,-1.571)(-0.9761,-1.595)(-1.,-1.614)(-1.052,-1.663)(-1.109,-1.714)(-1.128,-1.729)(-1.143,-1.74)(-1.206,-1.794)(-1.282,-1.857)(-1.284,-1.859)(-1.286,-1.86)(-1.3,-1.871)(-1.364,-1.922)(-1.372,-1.929)(-1.429,-1.972)(-1.444,-1.984)(-1.464,-2.)};
+            \filldraw [] (axis cs:-1,1) node [above] {\scriptsize $\left(-1,1\right)$} circle (1pt);
+            \filldraw [thin,->,>=latex] (axis cs:1.25,-1.5) node [fill=white] {\scriptsize $\left(-1,\frac{-1-\sqrt{5}}2\right)$} -- (axis cs: -.9,-1.62);
+            \filldraw [] (axis cs: -1,-1.62)  circle (1pt);
+            \filldraw [->,thin,>=latex] (axis cs:1.25,0.5) node [ fill=white] {\scriptsize $\left(-1,\frac{-1+\sqrt{5}}2\right)$} -- (axis cs: -.9,0.62);
+            \filldraw [] (axis cs:-1,0.62)  circle (1pt);
+
+            \end{axis}
+            \node [right] at (myplot.right of origin) {\scriptsize $x$};
+            \node [above] at (myplot.above origin) {\scriptsize $y$};
+            \end{tikzpicture}
+            ]]>
+          </latex-image>
+        </image>
+
       </statement>
       <answer>
-        <ol>
-          <li>
-            <p>
-              <m>y=1</m>
-            </p>
-          </li>
+        <p>
+          <ol>
+            <li>
+              <p>
+                <m>y=1</m>
+              </p>
+            </li>
 
-          <li>
-            <p>
-              <m>y =-\frac{2}{\sqrt{5}}(x+1)+\frac12(-1+\sqrt{5})</m>
-            </p>
-          </li>
+            <li>
+              <p>
+                <m>y =-\frac{2}{\sqrt{5}}(x+1)+\frac12(-1+\sqrt{5})</m>
+              </p>
+            </li>
 
-          <li>
-            <p>
-              <m>y =-\frac{2}{\sqrt{5}}(x+1)+\frac12(-1+\sqrt{5}),y =\frac{2}{\sqrt{5}}(x+1)+\frac12(-1-\sqrt{5})</m>
-            </p>
-          </li>
-        </ol>
+            <li>
+              <p>
+                <m>y =-\frac{2}{\sqrt{5}}(x+1)+\frac12(-1+\sqrt{5}),y =\frac{2}{\sqrt{5}}(x+1)+\frac12(-1-\sqrt{5})</m>
+              </p>
+            </li>
+          </ol>
+        </p>
       </answer>
     </exercise>
 
@@ -2125,7 +2151,7 @@
         <p>
           In the following exercises, an implicitly defined function is given.
           Find <m>\lzn{2}{y}{x}</m>.
-          Note: these are the same problems used in Exercises <xref ref="exer_02_06_ex_09" autoname="no" /> through <xref ref="exer_02_06_ex_12" autoname="no" />.
+          Note: these are the same problems used in Exercises <xref ref="exer_02_06_ex_09" text="global"/> through <xref ref="exer_02_06_ex_12" text="global"/>.
         </p>
       </introduction>
 
@@ -2134,12 +2160,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $ddyddx=Formula("-((2y+1)(12x^2)-4x^3(2*-(4x^3)/(2y+1)))/(2y+1)^2");
               @y=(random(-2,2,0.1),random(-2,2,0.1),random(-2,2,0.1),random(-2,2,0.1),random(-2,2,0.1));
               @x=map{(7-($_)-($_)**2)**(1/4)*(-1)**(random(-1,1,2))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx->{test_points}=~~@xy;
+              $ddyddx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2148,7 +2174,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2164,12 +2190,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $ddyddx=Formula("-(x^(3/5)*3/5y^(-2/5)(-y^(3/5)/x^(3/5))-y^(3/5)*3/5x^(-2/5))/x^(6/5)");
               @y=(random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01),random(0.01,0.99,0.01));
               @x=map{(1-($_)**(2/5))**(5/2)}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx->{test_points}=~~@xy;
+              $ddyddx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2178,7 +2204,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2194,12 +2220,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $ddyddx=Formula("sin^2(x)sec^2(y)tan(y)+cos(x)sec(y)");
               @y=(random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01),random(0,3.14,0.01));
               @x=map{acos(1-sin($_))}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx->{test_points}=~~@xy;
+              $ddyddx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2208,7 +2234,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2224,12 +2250,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $ddyddx=Formula("0");
               @x=(random(-4,4,0.1),random(-4,4,0.1),random(-4,4,0.1),random(-4,4,0.1),random(-4,4,0.1));
               @y=map{$_/10}(@x);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $ddyddx->{test_points}=~~@xy;
+              $ddyddx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -2238,7 +2264,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$ddyddx" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2266,14 +2292,14 @@
 
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[-0.9,4]});
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-0.9,4]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $dydx=Formula("(1+x)^(1/x)(1/(x(x+1))-ln(1+x)/x^2)");
 
               Context("Numeric");
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=(1-2ln(2))(x-1)+2");
             </pg-code>
             </setup>
@@ -2283,7 +2309,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="50"/>
               </p>
 
               <p>
@@ -2291,7 +2317,7 @@
               </p>
 
               <p>
-                <var name="$t" width="50" />
+                <var name="$t" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2312,14 +2338,14 @@
 
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0.01,4]});
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0.01,4]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $dydx=Formula("(2x)^(x^2)(2x ln(2x)+x)");
 
               Context("Numeric");
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=(2+4ln(2))(x-1)+2");
             </pg-code>
             </setup>
@@ -2329,7 +2355,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="50"/>
               </p>
 
               <p>
@@ -2337,7 +2363,7 @@
               </p>
 
               <p>
-                <var name="$t" width="50" />
+                <var name="$t" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2358,14 +2384,14 @@
 
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0.01,4]});
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0.01,4]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $dydx=Formula("x^x/(x+1)(ln(x)+1-1/(x+1))");
 
               Context("Numeric");
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=1/4*(x-1)+1/2");
             </pg-code>
             </setup>
@@ -2375,7 +2401,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="50"/>
               </p>
 
               <p>
@@ -2383,7 +2409,7 @@
               </p>
 
               <p>
-                <var name="$t" width="50" />
+                <var name="$t" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2404,14 +2430,14 @@
 
 
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0.01,4]});
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[0.01,4]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $dydx=Formula("x^(sin(x)+2)(cos(x)*ln(x)+(sin(x)+2)/x)");
 
               Context("Numeric");
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=(3pi^2)/4*(x-pi/2)+(pi/2)^3");
             </pg-code>
             </setup>
@@ -2421,7 +2447,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="50"/>
               </p>
 
               <p>
@@ -2429,7 +2455,7 @@
               </p>
 
               <p>
-                <var name="$t" width="50" />
+                <var name="$t" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2451,13 +2477,13 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $dydx=Formula("(x+1)/(x+2)(1/(x+1)-1/(x+2))");
 
               Context("Numeric");
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=1/9(x-1)+2/3");
             </pg-code>
             </setup>
@@ -2467,7 +2493,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="50"/>
               </p>
 
               <p>
@@ -2475,7 +2501,7 @@
               </p>
 
               <p>
-                <var name="$t" width="50" />
+                <var name="$t" width="50"/>
               </p>
             </statement>
             <solution>
@@ -2496,13 +2522,13 @@
 
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $dydx=Formula("((x+1)(x+2))/((x+3)(x+4))(1/(x+1)+1/(x+2)-1/(x+3)-1/(x+4))");
 
               Context("Numeric");
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=11/72x+1/6");
             </pg-code>
             </setup>
@@ -2512,7 +2538,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="50" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="50"/>
               </p>
 
               <p>
@@ -2520,7 +2546,7 @@
               </p>
 
               <p>
-                <var name="$t" width="50" />
+                <var name="$t" width="50"/>
               </p>
             </statement>
             <solution>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -343,7 +343,7 @@
           <image xml:id="img_xsquared" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1,xmax=4.1,
             ymin=-.4,ymax=17,
@@ -355,7 +355,7 @@
             \addplot+[domain=-.8:4] {x^2};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
           <!-- figures/fig_xsquared.tex END -->
@@ -377,7 +377,7 @@
           <image xml:id="img_xsquaredwithgrid" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1,xmax=4.1,
             ymin=-.4,ymax=17,
@@ -393,7 +393,7 @@
             \addplot[soliddot] coordinates{(1,1) (3,9)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
           <!-- figures/fig_xsquaredwithgrid.tex END -->
@@ -429,7 +429,7 @@
           <image xml:id="img_fwithderiv" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[minor y tick num=4,
             minor x tick num=0,
@@ -442,7 +442,7 @@
             \addplot+[domain=0.5:3.3] {-12+14*x-3*x^2} node[pos=0.5, above left] {$f'(x)$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
             <!-- figures/fig_fwithderiv.tex END -->
@@ -490,7 +490,7 @@
           <image xml:id="img_fwithderivdots" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[minor y tick num=4,
             minor x tick num=0,
@@ -508,7 +508,7 @@
             \addplot[soliddot] coordinates{(1,-1) (2,4) (3,3)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
           <!-- figures/fig_fwithderivdots.tex END -->
@@ -543,7 +543,7 @@
           <image xml:id="img_fwithderivzoom3" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[minor y tick num=4,
             ymin=1.9,ymax=4.9,
@@ -556,7 +556,7 @@
             \addplot[soliddot] coordinates{(3,4)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+
             </latex-image>
           </image>
           <!-- figures/fig_fwithderivzoom3.tex END -->
@@ -676,10 +676,10 @@
             <pg-code>
                 Context("ArbitraryString");
                 $ans=Compute("Velocity");
-                $ev=$ans-&gt;cmp(checker =&gt; sub {
+                $ev=$ans->cmp(checker => sub {
                 my ($correct,$student,$ans) = @_;
-                $correct = $correct-&gt;value;
-                $student = $student-&gt;value;
+                $correct = $correct->value;
+                $student = $student->value;
                 $student =~ s/^~~W+|~~W+$//g;
                 return uc($correct) eq uc($student);
                 });
@@ -725,10 +725,10 @@
             <pg-code>
                 Context("ArbitraryString");
                 $ans=Compute("Linear functions");
-                $ev=$ans-&gt;cmp(checker =&gt; sub {
+                $ev=$ans->cmp(checker => sub {
                 my ($correct,$student,$ans) = @_;
-                $correct = $correct-&gt;value;
-                $student = $student-&gt;value;
+                $correct = $correct->value;
+                $student = $student->value;
                 $student =~ s/^~~W+|~~W+$//g;
                 return (uc($correct) eq uc($student) or uc('Linear') eq uc($student) or uc('Linears') eq uc($student) or uc('Linear function') eq uc($student));
                 });
@@ -883,10 +883,10 @@
           <pg-code>
               Context("ArbitraryString");
               $ans=Compute("decibels per customer");
-              $ev=$ans-&gt;cmp(checker =&gt; sub {
+              $ev=$ans->cmp(checker => sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct-&gt;value;
-              $student = $student-&gt;value;
+              $correct = $correct->value;
+              $student = $student->value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/per[^s]|~~//, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -917,19 +917,19 @@
           <pg-code>
             Context("ArbitraryString");
             $ans=Compute("ft/s^2");
-            $ev=$ans-&gt;cmp(checker =&gt; sub {
+            $ev=$ans->cmp(checker => sub {
             my ($correct,$student,$ans) = @_;
-            $correct = $correct-&gt;value; # get perl string from String object
-            $student = $student-&gt;value; # ditto
+            $correct = $correct->value; # get perl string from String object
+            $student = $student->value; # ditto
             my $context = Context(); Context("Numeric");
-            my $check = NumberWithUnits("1 $correct")-&gt;cmp-&gt;evaluate("1 $student");
+            my $check = NumberWithUnits("1 $correct")->cmp->evaluate("1 $student");
             Context($context);
-            $ans-&gt;{correct_ans_latex_string} = substr($check-&gt;{correct_ans_latex_string},3);
-            if ($check-&gt;{score}) {
-              $ans-&gt;{preview_latex_string} = substr($check-&gt;{preview_latex_string},3);
-              $ans-&gt;{preview_text_string} = substr($check-&gt;{preview_text_string},3);
+            $ans->{correct_ans_latex_string} = substr($check->{correct_ans_latex_string},3);
+            if ($check->{score}) {
+              $ans->{preview_latex_string} = substr($check->{preview_latex_string},3);
+              $ans->{preview_text_string} = substr($check->{preview_text_string},3);
             }
-            return $check-&gt;{score};
+            return $check->{score};
             });
           </pg-code>
           </setup>
@@ -955,19 +955,19 @@
           <pg-code>
             Context("ArbitraryString");
             $ans=Compute("ft/hr");
-            $ev=$ans-&gt;cmp(checker =&gt; sub {
+            $ev=$ans->cmp(checker => sub {
             my ($correct,$student,$ans) = @_;
-            $correct = $correct-&gt;value; # get perl string from String object
-            $student = $student-&gt;value; # ditto
+            $correct = $correct->value; # get perl string from String object
+            $student = $student->value; # ditto
             my $context = Context(); Context("Numeric");
-            my $check = NumberWithUnits("1 $correct")-&gt;cmp-&gt;evaluate("1 $student");
+            my $check = NumberWithUnits("1 $correct")->cmp->evaluate("1 $student");
             Context($context);
-            $ans-&gt;{correct_ans_latex_string} = substr($check-&gt;{correct_ans_latex_string},3);
-            if ($check-&gt;{score}) {
-              $ans-&gt;{preview_latex_string} = substr($check-&gt;{preview_latex_string},3);
-              $ans-&gt;{preview_text_string} = substr($check-&gt;{preview_text_string},3);
+            $ans->{correct_ans_latex_string} = substr($check->{correct_ans_latex_string},3);
+            if ($check->{score}) {
+              $ans->{preview_latex_string} = substr($check->{preview_latex_string},3);
+              $ans->{preview_text_string} = substr($check->{preview_text_string},3);
             }
-            return $check-&gt;{score};
+            return $check->{score};
             });
           </pg-code>
           </setup>
@@ -1113,14 +1113,14 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-4,-5,4,5,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-3,-2,-1,1,2,3){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-4..-1,1..4){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "0.5*(x-1) for x in &lt;-4,4&gt; using color:blue and weight:2");
-              $gr-&gt;lb(new Label(3,1.2,'f','blue','center','bottom'));
-              add_functions($gr, "0.25*(x-1)^2+2 for x in &lt;-2.46,4&gt; using color:red and weight:2");
-              $gr-&gt;lb(new Label(3,3.2,'g','red','center','bottom'));
+              $gr=init_graph(-4,-5,4,5,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-3,-2,-1,1,2,3){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "0.5*(x-1) for x in &lt;-4,4> using color:blue and weight:2");
+              $gr->lb(new Label(3,1.2,'f','blue','center','bottom'));
+              add_functions($gr, "0.25*(x-1)^2+2 for x in &lt;-2.46,4> using color:red and weight:2");
+              $gr->lb(new Label(3,3.2,'g','red','center','bottom'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],1);
             </pg-code>
             </setup>
@@ -1141,14 +1141,14 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-1,-5,4,5,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-1,1,2,3){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-4..-1,1..4){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "x*(x-1)*(x-2) for x in &lt;-1,4&gt; using color:blue and weight:2");
-              $gr-&gt;lb(new Label(2.5,2,'f','blue','right','bottom'));
-              add_functions($gr, "3*x^2-6*x+2 for x in &lt;-1,4&gt; using color:red and weight:2");
-              $gr-&gt;lb(new Label(2,2.2,'g','red','right','bottom'));
+              $gr=init_graph(-1,-5,4,5,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-1,1,2,3){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "x*(x-1)*(x-2) for x in &lt;-1,4> using color:blue and weight:2");
+              $gr->lb(new Label(2.5,2,'f','blue','right','bottom'));
+              add_functions($gr, "3*x^2-6*x+2 for x in &lt;-1,4> using color:red and weight:2");
+              $gr->lb(new Label(2,2.2,'g','red','right','bottom'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],2);
             </pg-code>
             </setup>
@@ -1169,16 +1169,16 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-5,-5,5,5,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-4..-1,1..4){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-4..-1,1..4){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "1/x for x in &lt;-5,-0.2&gt; using color:blue and weight:2");
-              add_functions($gr, "1/x for x in &lt;0.2,5&gt; using color:blue and weight:2");
-              $gr-&gt;lb(new Label(1,1.2,'f','blue','left','bottom'));
-              add_functions($gr, "-1/x^2 for x in &lt;-5,-0.45&gt; using color:red and weight:2");
-              add_functions($gr, "-1/x^2 for x in &lt;0.45,5&gt; using color:red and weight:2");
-              $gr-&gt;lb(new Label(1,-1.2,'g','red','left','top'));
+              $gr=init_graph(-5,-5,5,5,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-4..-1,1..4){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "1/x for x in &lt;-5,-0.2> using color:blue and weight:2");
+              add_functions($gr, "1/x for x in &lt;0.2,5> using color:blue and weight:2");
+              $gr->lb(new Label(1,1.2,'f','blue','left','bottom'));
+              add_functions($gr, "-1/x^2 for x in &lt;-5,-0.45> using color:red and weight:2");
+              add_functions($gr, "-1/x^2 for x in &lt;0.45,5> using color:red and weight:2");
+              $gr->lb(new Label(1,-1.2,'g','red','left','top'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],2);
             </pg-code>
             </setup>
@@ -1199,14 +1199,14 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-4,-2,4,2,axes=&gt;[0,0],size=&gt;[400,400]);
-              $gr-&gt;lb('reset');
-              for my$i(-3..-1,1..3){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-1,1){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "sin(3.14*x/2) for x in &lt;-4,4&gt; using color:blue and weight:2");
-              $gr-&gt;lb(new Label(1,1.1,'f','blue','left','bottom'));
-              add_functions($gr, "3.14/2*cos(3.14*x/2) for x in &lt;-4,4&gt; using color:red and weight:2");
-              $gr-&gt;lb(new Label(2,-1.67,'g','red','left','top'));
+              $gr=init_graph(-4,-2,4,2,axes=>[0,0],size=>[400,400]);
+              $gr->lb('reset');
+              for my$i(-3..-1,1..3){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-1,1){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "sin(3.14*x/2) for x in &lt;-4,4> using color:blue and weight:2");
+              $gr->lb(new Label(1,1.1,'f','blue','left','bottom'));
+              add_functions($gr, "3.14/2*cos(3.14*x/2) for x in &lt;-4,4> using color:red and weight:2");
+              $gr->lb(new Label(2,-1.67,'g','red','left','top'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],2);
             </pg-code>
             </setup>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_interp_deriv">
   <title>Interpretations of the Derivative</title>
   <introduction>
@@ -50,14 +49,14 @@
     <p>
       Now imagine driving a car and looking at the speedometer,
       which reads <q><quantity>
-        <mag>60</mag><unit base="mileperhour" />
+        <mag>60</mag><unit base="mileperhour"/>
       </quantity>.</q> Five minutes later,
       you wonder how far you have traveled.
       Certainly, lots of things could have happened in those <m>5</m> minutes;
       you could have intentionally sped up significantly,
       you might have come to a complete stop, you might have slowed to
       <quantity>
-        <mag>20</mag><unit base="mileperhour" />
+        <mag>20</mag><unit base="mileperhour"/>
       </quantity>
       as you passed through construction.
       But suppose that you know, as the driver,
@@ -72,7 +71,7 @@
       would be based on <q><m>\text{distance} = \text{rate}\times\text{time.}</m></q> In this case,
       we assume a constant rate of
       <quantity>
-        <mag>60</mag><unit base="mileperhour" />
+        <mag>60</mag><unit base="mileperhour"/>
       </quantity>
       with a time of <m>5</m> minutes or <m>5/60</m> of an hour.
       Hence we would approximate the distance traveled as <m>5</m> miles.
@@ -118,7 +117,7 @@
         <p>
           Let <m>P(t)</m> represent the world population <m>t</m> minutes after 12:00 a.m., January 1, 2012.
           It is fairly accurate to say that <m>P(0) = 7{,}028{,}734{,}178</m>
-          (<url href="www.prb.org" />).
+          (<url href="www.prb.org"/>).
           It is also fairly accurate to state that <m>P'(0) = 156</m>;
           that is, at midnight on January 1, 2012,
           the population of the world was growing by about 156
@@ -173,12 +172,12 @@
     <p>
       The previous examples made use of an important approximation tool that we first used in our previous <q>driving a car at
       <quantity>
-        <mag>60</mag><unit base="mileperhour" />
+        <mag>60</mag><unit base="mileperhour"/>
       </quantity></q> example at the beginning of this section.
       Five minutes after looking at the speedometer,
       our best approximation for distance traveled assumed the rate of change was constant.
       In <xref ref="ex_der_meaning1">Examples</xref>
-      and <xref ref="ex_der_meaning2"></xref>
+      and <xref ref="ex_der_meaning2"/>
       we made similar approximations.
       We were given rate of change information which we used to approximate total change.
       Notationally, we would say that
@@ -218,7 +217,7 @@
       in feet, of an object after <m>t</m> seconds of travel.
       Then <m>s'(t)</m> has units <q>feet per second,</q>
       and <m>s'(t)</m> measures the <em>instantaneous rate of distance change with repsect to time</em>
-      <mdash /> it measures <em>velocity</em>.
+      <mdash/> it measures <em>velocity</em>.
           <idx><h>velocity</h></idx>
     </p>
 
@@ -227,7 +226,7 @@
       That is, at time <m>t</m>, <m>v(t)</m> gives the velocity of an object.
       The derivative of <m>v</m>, <m>v'(t)</m>,
       gives the <em>instantaneous rate of velocity change with respect to time</em>
-      <mdash /> <em>acceleration</em>.
+      <mdash/> <em>acceleration</em>.
       (We often think of acceleration in terms of cars:
       a car may <q>go from <m>0</m> to <m>60</m> in <m>4.8</m> seconds.</q>
       This is an <em>average</em> acceleration,
@@ -539,7 +538,7 @@
         </p>
 
         <figure xml:id="fig_fwithderivzoom3">
-          <caption>Zooming in on <m>f</m> and its tangent line at <m>x=3</m> for the function given in <xref ref="ex_der_meaning4">Examples</xref> and <xref ref="ex_der_meaning5"></xref>.</caption>
+          <caption>Zooming in on <m>f</m> and its tangent line at <m>x=3</m> for the function given in <xref ref="ex_der_meaning4">Examples</xref> and <xref ref="ex_der_meaning5"/>.</caption>
           <!-- START figures/fig_fwithderivzoom3.tex -->
           <image xml:id="img_fwithderivzoom3" width="47%">
             <description></description>
@@ -677,10 +676,10 @@
             <pg-code>
                 Context("ArbitraryString");
                 $ans=Compute("Velocity");
-                $ev=$ans->cmp(checker => sub {
+                $ev=$ans-&gt;cmp(checker =&gt; sub {
                 my ($correct,$student,$ans) = @_;
-                $correct = $correct->value;
-                $student = $student->value;
+                $correct = $correct-&gt;value;
+                $student = $student-&gt;value;
                 $student =~ s/^~~W+|~~W+$//g;
                 return uc($correct) eq uc($student);
                 });
@@ -692,7 +691,7 @@
               </p>
 
               <p>
-                <var name="$ans" width="20" evaluator="$ev" />
+                <var name="$ans" width="20" evaluator="$ev"/>
               </p>
             </statement>
         </webwork>
@@ -707,7 +706,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -726,10 +725,10 @@
             <pg-code>
                 Context("ArbitraryString");
                 $ans=Compute("Linear functions");
-                $ev=$ans->cmp(checker => sub {
+                $ev=$ans-&gt;cmp(checker =&gt; sub {
                 my ($correct,$student,$ans) = @_;
-                $correct = $correct->value;
-                $student = $student->value;
+                $correct = $correct-&gt;value;
+                $student = $student-&gt;value;
                 $student =~ s/^~~W+|~~W+$//g;
                 return (uc($correct) eq uc($student) or uc('Linear') eq uc($student) or uc('Linears') eq uc($student) or uc('Linear function') eq uc($student));
                 });
@@ -741,7 +740,7 @@
               </p>
 
               <p>
-                <var name="$ans" width="20" evaluator="$ev" />
+                <var name="$ans" width="20" evaluator="$ev"/>
               </p>
             </statement>
         </webwork>
@@ -763,7 +762,7 @@
             </p>
 
             <p>
-              <m>f(6)\approx</m><var name="$ans" width="10" />
+              <m>f(6)\approx</m><var name="$ans" width="10"/>
             </p>
           </statement>
       </webwork>
@@ -784,7 +783,7 @@
             </p>
 
             <p>
-              <m>P(110)\approx</m><var name="$ans" width="10" />
+              <m>P(110)\approx</m><var name="$ans" width="10"/>
             </p>
           </statement>
       </webwork>
@@ -805,7 +804,7 @@
             </p>
 
             <p>
-              <m>z(20)\approx</m><var name="$ans" width="10" />
+              <m>z(20)\approx</m><var name="$ans" width="10"/>
             </p>
           </statement>
       </webwork>
@@ -823,7 +822,7 @@
             </p>
 
             <p>
-              <var form="essay" />
+              <var form="essay"/>
             </p>
           </statement>
           <solution>
@@ -850,7 +849,7 @@
             </p>
 
             <p>
-              <m>\fp(7)\approx</m><var name="$ans" width="10" />
+              <m>\fp(7)\approx</m><var name="$ans" width="10"/>
             </p>
           </statement>
       </webwork>
@@ -870,7 +869,7 @@
             </p>
 
             <p>
-              <m>H'(2)\approx</m><var name="$ans" width="10" />
+              <m>H'(2)\approx</m><var name="$ans" width="10"/>
             </p>
           </statement>
       </webwork>
@@ -884,10 +883,10 @@
           <pg-code>
               Context("ArbitraryString");
               $ans=Compute("decibels per customer");
-              $ev=$ans->cmp(checker => sub {
+              $ev=$ans-&gt;cmp(checker =&gt; sub {
               my ($correct,$student,$ans) = @_;
-              $correct = $correct->value;
-              $student = $student->value;
+              $correct = $correct-&gt;value;
+              $student = $student-&gt;value;
               $student =~ s/^~~W+|~~W+$//g;
               my @words = split (/per[^s]|~~//, $student);
               $words[0] =~ s/^~~W+|~~W+$//g;
@@ -904,7 +903,7 @@
             </p>
 
             <p>
-              <var name="$ans" width="20" evaluator="$ev" />
+              <var name="$ans" width="20" evaluator="$ev"/>
             </p>
           </statement>
       </webwork>
@@ -918,19 +917,19 @@
           <pg-code>
             Context("ArbitraryString");
             $ans=Compute("ft/s^2");
-            $ev=$ans->cmp(checker => sub {
+            $ev=$ans-&gt;cmp(checker =&gt; sub {
             my ($correct,$student,$ans) = @_;
-            $correct = $correct->value; # get perl string from String object
-            $student = $student->value; # ditto
+            $correct = $correct-&gt;value; # get perl string from String object
+            $student = $student-&gt;value; # ditto
             my $context = Context(); Context("Numeric");
-            my $check = NumberWithUnits("1 $correct")->cmp->evaluate("1 $student");
+            my $check = NumberWithUnits("1 $correct")-&gt;cmp-&gt;evaluate("1 $student");
             Context($context);
-            $ans->{correct_ans_latex_string} = substr($check->{correct_ans_latex_string},3);
-            if ($check->{score}) {
-              $ans->{preview_latex_string} = substr($check->{preview_latex_string},3);
-              $ans->{preview_text_string} = substr($check->{preview_text_string},3);
+            $ans-&gt;{correct_ans_latex_string} = substr($check-&gt;{correct_ans_latex_string},3);
+            if ($check-&gt;{score}) {
+              $ans-&gt;{preview_latex_string} = substr($check-&gt;{preview_latex_string},3);
+              $ans-&gt;{preview_text_string} = substr($check-&gt;{preview_text_string},3);
             }
-            return $check->{score};
+            return $check-&gt;{score};
             });
           </pg-code>
           </setup>
@@ -956,19 +955,19 @@
           <pg-code>
             Context("ArbitraryString");
             $ans=Compute("ft/hr");
-            $ev=$ans->cmp(checker => sub {
+            $ev=$ans-&gt;cmp(checker =&gt; sub {
             my ($correct,$student,$ans) = @_;
-            $correct = $correct->value; # get perl string from String object
-            $student = $student->value; # ditto
+            $correct = $correct-&gt;value; # get perl string from String object
+            $student = $student-&gt;value; # ditto
             my $context = Context(); Context("Numeric");
-            my $check = NumberWithUnits("1 $correct")->cmp->evaluate("1 $student");
+            my $check = NumberWithUnits("1 $correct")-&gt;cmp-&gt;evaluate("1 $student");
             Context($context);
-            $ans->{correct_ans_latex_string} = substr($check->{correct_ans_latex_string},3);
-            if ($check->{score}) {
-              $ans->{preview_latex_string} = substr($check->{preview_latex_string},3);
-              $ans->{preview_text_string} = substr($check->{preview_text_string},3);
+            $ans-&gt;{correct_ans_latex_string} = substr($check-&gt;{correct_ans_latex_string},3);
+            if ($check-&gt;{score}) {
+              $ans-&gt;{preview_latex_string} = substr($check-&gt;{preview_latex_string},3);
+              $ans-&gt;{preview_text_string} = substr($check-&gt;{preview_text_string},3);
             }
-            return $check->{score};
+            return $check-&gt;{score};
             });
           </pg-code>
           </setup>
@@ -1011,7 +1010,7 @@
             </p>
 
             <p>
-              <var form="essay" />
+              <var form="essay"/>
             </p>
           </statement>
           <solution>
@@ -1068,7 +1067,7 @@
             </p>
 
             <p>
-              <var form="essay" />
+              <var form="essay"/>
             </p>
           </statement>
           <solution>
@@ -1082,14 +1081,14 @@
 
                 <li>
                   <p>
-                    It is likely that <m>T'(8)>0</m> since at 8 in the morning,
+                    It is likely that <m>T'(8)&gt;0</m> since at 8 in the morning,
                     the temperature is likely rising.
                   </p>
                 </li>
 
                 <li>
                   <p>
-                    It is very likely that <m>T(8)>0</m>,
+                    It is very likely that <m>T(8)&gt;0</m>,
                     as at 8 in the morning on July 4, we would expect the temperature to be well above 0.
                   </p>
                 </li>
@@ -1114,25 +1113,25 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-4,-5,4,5,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-3,-2,-1,1,2,3){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "0.5*(x-1) for x in &lt;-4,4> using color:blue and weight:2");
-              $gr->lb(new Label(3,1.2,'f','blue','center','bottom'));
-              add_functions($gr, "0.25*(x-1)^2+2 for x in &lt;-2.46,4> using color:red and weight:2");
-              $gr->lb(new Label(3,3.2,'g','red','center','bottom'));
+              $gr=init_graph(-4,-5,4,5,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-3,-2,-1,1,2,3){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-4..-1,1..4){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "0.5*(x-1) for x in &lt;-4,4&gt; using color:blue and weight:2");
+              $gr-&gt;lb(new Label(3,1.2,'f','blue','center','bottom'));
+              add_functions($gr, "0.25*(x-1)^2+2 for x in &lt;-2.46,4&gt; using color:red and weight:2");
+              $gr-&gt;lb(new Label(3,3.2,'g','red','center','bottom'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],1);
             </pg-code>
             </setup>
             <statement>
               <p>
-                In the figure below, <var name="$popup" form="popup" />.
+                In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1142,25 +1141,25 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-1,-5,4,5,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-1,1,2,3){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "x*(x-1)*(x-2) for x in &lt;-1,4> using color:blue and weight:2");
-              $gr->lb(new Label(2.5,2,'f','blue','right','bottom'));
-              add_functions($gr, "3*x^2-6*x+2 for x in &lt;-1,4> using color:red and weight:2");
-              $gr->lb(new Label(2,2.2,'g','red','right','bottom'));
+              $gr=init_graph(-1,-5,4,5,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-1,1,2,3){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-4..-1,1..4){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "x*(x-1)*(x-2) for x in &lt;-1,4&gt; using color:blue and weight:2");
+              $gr-&gt;lb(new Label(2.5,2,'f','blue','right','bottom'));
+              add_functions($gr, "3*x^2-6*x+2 for x in &lt;-1,4&gt; using color:red and weight:2");
+              $gr-&gt;lb(new Label(2,2.2,'g','red','right','bottom'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],2);
             </pg-code>
             </setup>
             <statement>
               <p>
-                In the figure below, <var name="$popup" form="popup" />.
+                In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1170,27 +1169,27 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-5,-5,5,5,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-4..-1,1..4){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "1/x for x in &lt;-5,-0.2> using color:blue and weight:2");
-              add_functions($gr, "1/x for x in &lt;0.2,5> using color:blue and weight:2");
-              $gr->lb(new Label(1,1.2,'f','blue','left','bottom'));
-              add_functions($gr, "-1/x^2 for x in &lt;-5,-0.45> using color:red and weight:2");
-              add_functions($gr, "-1/x^2 for x in &lt;0.45,5> using color:red and weight:2");
-              $gr->lb(new Label(1,-1.2,'g','red','left','top'));
+              $gr=init_graph(-5,-5,5,5,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-4..-1,1..4){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-4..-1,1..4){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "1/x for x in &lt;-5,-0.2&gt; using color:blue and weight:2");
+              add_functions($gr, "1/x for x in &lt;0.2,5&gt; using color:blue and weight:2");
+              $gr-&gt;lb(new Label(1,1.2,'f','blue','left','bottom'));
+              add_functions($gr, "-1/x^2 for x in &lt;-5,-0.45&gt; using color:red and weight:2");
+              add_functions($gr, "-1/x^2 for x in &lt;0.45,5&gt; using color:red and weight:2");
+              $gr-&gt;lb(new Label(1,-1.2,'g','red','left','top'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],2);
             </pg-code>
             </setup>
             <statement>
               <p>
-                In the figure below, <var name="$popup" form="popup" />.
+                In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1200,25 +1199,25 @@
             <setup>
 
             <pg-code>
-              $gr=init_graph(-4,-2,4,2,axes=>[0,0],size=>[400,400]);
-              $gr->lb('reset');
-              for my$i(-3..-1,1..3){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top'));};
-              for my$i(-1,1){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle'));};
-              add_functions($gr, "sin(3.14*x/2) for x in &lt;-4,4> using color:blue and weight:2");
-              $gr->lb(new Label(1,1.1,'f','blue','left','bottom'));
-              add_functions($gr, "3.14/2*cos(3.14*x/2) for x in &lt;-4,4> using color:red and weight:2");
-              $gr->lb(new Label(2,-1.67,'g','red','left','top'));
+              $gr=init_graph(-4,-2,4,2,axes=&gt;[0,0],size=&gt;[400,400]);
+              $gr-&gt;lb('reset');
+              for my$i(-3..-1,1..3){$gr-&gt;moveTo($i,-0.05);$gr-&gt;lineTo($i,0.05,black,1);$gr-&gt;lb(new Label($i,-0.1,$i,'black','center','top'));};
+              for my$i(-1,1){$gr-&gt;moveTo(-0.05,$i);$gr-&gt;lineTo(0.05,$i,black,1);$gr-&gt;lb(new Label(-0.1,$i,$i,'black','right','middle'));};
+              add_functions($gr, "sin(3.14*x/2) for x in &lt;-4,4&gt; using color:blue and weight:2");
+              $gr-&gt;lb(new Label(1,1.1,'f','blue','left','bottom'));
+              add_functions($gr, "3.14/2*cos(3.14*x/2) for x in &lt;-4,4&gt; using color:red and weight:2");
+              $gr-&gt;lb(new Label(2,-1.67,'g','red','left','top'));
               $popup=PopUp(['?','f is the derivative of g','g is the derivative of f'],2);
             </pg-code>
             </setup>
             <statement>
               <p>
-                In the figure below, <var name="$popup" form="popup" />.
+                In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
             </statement>
         </webwork>
       </exercise>
@@ -1241,7 +1240,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1256,7 +1255,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1276,7 +1275,7 @@
               </p>
 
               <p>
-                <var name="$ans" width="10" />
+                <var name="$ans" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1296,7 +1295,7 @@
               </p>
 
               <p>
-                <var name="$ans" width="10" />
+                <var name="$ans" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1305,4 +1304,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1081,14 +1081,14 @@
 
                 <li>
                   <p>
-                    It is likely that <m>T'(8)&gt;0</m> since at 8 in the morning,
+                    It is likely that <m>T'(8) \gt 0</m> since at 8 in the morning,
                     the temperature is likely rising.
                   </p>
                 </li>
 
                 <li>
                   <p>
-                    It is very likely that <m>T(8)&gt;0</m>,
+                    It is very likely that <m>T(8) \gt 0</m>,
                     as at 8 in the morning on July 4, we would expect the temperature to be well above 0.
                   </p>
                 </li>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1129,7 +1129,7 @@
                 In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -1157,7 +1157,7 @@
                 In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -1187,7 +1187,7 @@
                 In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>
@@ -1215,7 +1215,7 @@
                 In the figure below, <var name="$popup" form="popup"/>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
             </statement>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -181,17 +181,17 @@
         <!-- START figures/fig_derivfalling.tex -->
           <description></description>
           <latex-image>
-          <![CDATA[
+
           \begin{tikzpicture}
           \begin{axis}[xmin=-.5,xmax=3.49,
           ymin=-50,ymax=160,
-          xlabel={$t$}]                                          ]
+          xlabel={$t$}]]
           \addplot+[domain=0:3.06] {-16*x^2+150};
           \addplot+[secantline,domain=1.5:3.2] {-80*(x-2)+86};
           \addplot[soliddot] coordinates {(2,86) (3,6)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+        
           </latex-image>
         </image>
       <!-- figures/fig_derivfalling.tex END -->
@@ -203,7 +203,7 @@
         <!-- START figures/fig_derivfalling2.tex -->
           <description></description>
           <latex-image>
-          <![CDATA[
+      
           \begin{tikzpicture}
           \begin{axis}[xmin=1.8,xmax=3.4,
           ymin=0,ymax=129,
@@ -214,7 +214,7 @@
           \addplot[soliddot] coordinates{(2,86) (3,6)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+      
           </latex-image>
         </image>
         <!-- figures/fig_derivfalling2.tex END -->
@@ -228,7 +228,7 @@
         <!-- START figures/fig_derivfalling3.tex -->
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=1.4,xmax=2.6,
           ymin=0,ymax=129,
@@ -239,7 +239,7 @@
           \addplot[soliddot] coordinates{(2,86)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+          
           </latex-image>
         </image>
         <!-- figures/fig_derivfalling3.tex END -->
@@ -251,7 +251,7 @@
         <image xml:id="img_derivfalling4">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=1.4,xmax=2.6,
           ymin=0,ymax=129,
@@ -262,10 +262,9 @@
           \addplot[soliddot] coordinates{(2,86)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+
           </latex-image>
         </image>
-
       </figure>
     </sidebyside>
   </sbsgroup>
@@ -432,7 +431,7 @@
           <image xml:id="img_tangent1">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-1,xmax=4.1,
             ymin=-11,ymax=66]
@@ -442,7 +441,7 @@
             \addplot[&lt;-&gt;,soliddot] coordinates{(1,1) (3,35)};
             \end{axis}
             \end{tikzpicture}
-            ]]>      
+            
             </latex-image>
           </image>
           <!-- figures/fig_tangent1.tex END -->
@@ -514,7 +513,7 @@
           <image xml:id="img_normal1">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[ymin=-.1,ymax=3.5,
             xmin=-0.1,xmax=4.3,
@@ -524,7 +523,7 @@
             \addplot[soliddot] coordinates{(1,1) (3,35)};
             \end{axis}
             \end{tikzpicture}
-          ]]>      
+      
             </latex-image>
           </image>
           <!-- figures/fig_normal1.tex END -->
@@ -659,7 +658,7 @@
           <image xml:id="img_tangentsinx">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[ymin=-1.1,ymax=1.1,
             xmin=-3.5,xmax=3.5,
@@ -670,7 +669,7 @@
             \addplot [soliddot] coordinates{(0,0)};
             \end{axis}
             \end{tikzpicture}
-            ]]>      
+      
             </latex-image>
           </image>
           <!-- figures/fig_tangentsinx.tex END -->
@@ -908,14 +907,14 @@
         <image xml:id="img_absolutevalue">
           <description></description>
           <latex-image>
-          <![CDATA[
+
           \begin{tikzpicture}
           \begin{axis}[ymin=-.2,ymax=1.1,
           xmin=-1.1,xmax=1.1,]
           \addplot+[domain=-1:1]{abs(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+    
           </latex-image>
         </image>
         <!-- figures/fig_absolutevalue.tex END -->
@@ -1002,7 +1001,7 @@
         <image xml:id="img_absolutevalueprime">
           <description></description>
           <latex-image>
-          <![CDATA[
+
           \begin{tikzpicture}
           \begin{axis}[ymin=-1.4,ymax=1.4,
           xmin=-1.1,xmax=1.1]
@@ -1011,7 +1010,7 @@
           \addplot[hollowdot] coordinates{(0,-1) (0,1)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+    
           </latex-image>
         </image>
         <!-- figures/fig_absolutevalueprime.tex END -->
@@ -1038,7 +1037,7 @@
         <image xml:id="img_piecewisesinx1">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (sin(x*180/pi)) + (\x &gt;= 1.5708) * (1);}]
           \begin{axis}[ymin=-.4,ymax=1.4,
           xmin=-.1,xmax=2.1,
@@ -1047,7 +1046,7 @@
           \addplot+[domain=-.1:2,samples=100]{func(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+          
           </latex-image>
         </image>
         <!-- figures/fig_piecewisesinx1.tex END -->
@@ -1067,7 +1066,7 @@
       <p>
         So far we have
         <me>
-          \fp(x) = \begin{cases}\cos(x) \amp  x\lt \pi/2\\ 0 \amp  x&gt;\pi/2\end{cases}
+          \fp(x) = \begin{cases}\cos(x) \amp  x\lt \pi/2\\ 0 \amp  x\gt\pi/2\end{cases}
         </me>.
       </p>
 
@@ -1130,7 +1129,7 @@
         <image xml:id="img_piecewisecosx1">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (cos(x*180/pi)) + (\x &gt;= 1.5708) * (0);}]
           \begin{axis}[ymin=-.4,ymax=1.4,
           xmin=-.1,xmax=2.1,
@@ -1139,7 +1138,7 @@
           \addplot+[domain=-.1:2,samples=100]{func(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>    
+    
           </latex-image>
         </image>
         <!-- figures/fig_piecewisecosx1.tex END -->
@@ -1285,7 +1284,7 @@
           <image xml:id="img_diff_closed1">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[ymin=-.2,ymax=1.2,
             xmin=-.1,xmax=1.1,
@@ -1296,7 +1295,8 @@
             \draw (axis cs:.7,.35) node {\scriptsize$y=x^{3/2}$};
             \end{axis}
             \end{tikzpicture}
-            ]]>      </latex-image>
+            
+            </latex-image>
           </image>
         </figure>
 
@@ -1640,7 +1640,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Formula("y=6");
               $normalline=Formula("x=-2");
             </pg-code>
@@ -1670,7 +1670,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=2x");
               $normalline=Compute("y=-(1/2)(x-3)+6");
             </pg-code>
@@ -1700,7 +1700,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=-3x+4");
               $normalline=Compute("y=(1/3)(x-7)-17");
             </pg-code>
@@ -1730,7 +1730,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=4(x-2)+4");
               $normalline=Compute("y=-(1/4)(x-2)+4");
             </pg-code>
@@ -1786,7 +1786,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=-7(x+1)+8");
               $normalline=Compute("y=(1/7)(x+1)+8");
             </pg-code>
@@ -1816,7 +1816,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=-(1/4)(x+2)-1/2");
               $normalline=Compute("y=4(x+2)-1/2");
             </pg-code>
@@ -1846,7 +1846,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=-(x-3)+1");
               $normalline=Compute("y=(x-3)+1");
             </pg-code>
@@ -1887,7 +1887,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=8.1(x-3)+16");
             </pg-code>
             </setup>
@@ -1911,7 +1911,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=-0.09901(x-9)+1");
             </pg-code>
             </setup>
@@ -1935,7 +1935,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=7.771(x-2)+e^2");
             </pg-code>
             </setup>
@@ -1959,7 +1959,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
+              Context()->variables->are(x=>'Real',y=>'Real');
               $tangentline=Compute("y=-0.04996x+1");
             </pg-code>
             </setup>
@@ -1990,9 +1990,9 @@
 
 
           <pg-code>
-            $gr = init_graph(-3,-2,3,4,axes=&gt;[0,0],grid=&gt;[6,6],size=&gt;[400,400]);
-            add_functions($gr, "x^2-1 for x in &lt;-3,3&gt; using color:blue and weight:2");
-            @approx=(Compute("-2")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.4),Compute("0")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.1),Compute("4")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;2));
+            $gr = init_graph(-3,-2,3,4,axes=>[0,0],grid=>[6,6],size=>[400,400]);
+            add_functions($gr, "x^2-1 for x in &lt;-3,3> using color:blue and weight:2");
+            @approx=(Compute("-2")->with(tolType=>'absolute',tolerance=>0.4),Compute("0")->with(tolType=>'absolute',tolerance=>0.1),Compute("4")->with(tolType=>'absolute',tolerance=>2));
             $derivative=Formula("2x");
             @slopes=(-2,0,4);
           </pg-code>
@@ -2069,9 +2069,9 @@
 
 
           <pg-code>
-            $gr = init_graph(-1,-1,3,6,axes=&gt;[0,0],grid=&gt;[4,7],size=&gt;[400,400]);
-            add_functions($gr, "1/(x+1) for x in &lt;-0.85,3&gt; using color:blue and weight:2");
-            @approx=(Compute("-1")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.2),Compute("-1/4")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.1));
+            $gr = init_graph(-1,-1,3,6,axes=>[0,0],grid=>[4,7],size=>[400,400]);
+            add_functions($gr, "1/(x+1) for x in &lt;-0.85,3> using color:blue and weight:2");
+            @approx=(Compute("-1")->with(tolType=>'absolute',tolerance=>0.2),Compute("-1/4")->with(tolType=>'absolute',tolerance=>0.1));
             $derivative=Formula("-1/(x+1)^2");
             @slopes=(-1,'-1/4');
           </pg-code>
@@ -2144,17 +2144,16 @@
           <image xml:id="img_02_01_ex_26" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.1,xmax=5.1,
             ymin=-1.5,ymax=3.5]
             \addplot+[domain=-2.1:5.1,&lt;-&gt;] {-.5*x+2};
             \end{axis}
             \end{tikzpicture}
-            ]]>      
+      
             </latex-image>
           </image>
-
         </statement>
       </exercise>
 
@@ -2164,17 +2163,16 @@
           <image xml:id="img_02_01_ex_27" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-7.1,xmax=3.1,
             ymin=-3.5,ymax=3.5]
             \addplot+[domain=-5.6:1.6,samples=40] {.5*(x+2)^2-3};
             \end{axis}
             \end{tikzpicture}
-            ]]>      
+      
             </latex-image>
           </image>
-
         </statement>
       </exercise>
 
@@ -2184,17 +2182,16 @@
           <image xml:id="img_02_01_ex_28" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.1,xmax=3.1,
             ymin=-5.5,ymax=5.5]
             \addplot+[domain=-2.45:2.45,samples=40] {(x-2)*x*(x+2)};
             \end{axis}
             \end{tikzpicture}
-            ]]>      
+      
             </latex-image>
           </image>
-
         </statement>
       </exercise>
 
@@ -2204,7 +2201,7 @@
           <image xml:id="img_02_01_ex_29" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[
+
             \begin{tikzpicture}
             \begin{axis}[xmin=-6.9,xmax=6.9,
             ymin=-1.1,ymax=1.1,
@@ -2213,10 +2210,9 @@
             \addplot+[domain=-6.8:6.8,samples=101] {cos(deg(x))};
             \end{axis}
             \end{tikzpicture}
-            ]]>      
+      
             </latex-image>
           </image>
-
         </statement>
       </exercise>
 
@@ -2232,11 +2228,11 @@
 
 
           <pg-code>
-            $gr = init_graph(-3,-10,3,5,axes=&gt;[0,0],grid=&gt;[6,15],size=&gt;[400,400]);
-            add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2&gt; using color:blue and weight:2");
-            $gr -&gt; lb('reset');
-            for my$i(-2,-1,1,2){$gr-&gt;lb(new Label($i,-0.5,$i,'black','center','top'));};
-            for my$i(-9..-1,1..4){$gr-&gt;lb(new Label(0.1,$i,$i,'black','left','middle'));};
+            $gr = init_graph(-3,-10,3,5,axes=>[0,0],grid=>[6,15],size=>[400,400]);
+            add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2> using color:blue and weight:2");
+            $gr -> lb('reset');
+            for my$i(-2,-1,1,2){$gr->lb(new Label($i,-0.5,$i,'black','center','top'));};
+            for my$i(-9..-1,1..4){$gr->lb(new Label(0.1,$i,$i,'black','left','middle'));};
             Context("Interval");
             $pos=Compute("(-1.5,1.5)");
             $neg=Compute("(-inf,-1.5)U(1.5,inf)");
@@ -2398,7 +2394,7 @@
             <setup>
 
             <pg-code>
-              $root=Compute(0.54)-&gt;with(tolType=&gt;absolute,tolerance=&gt;0.01);
+              $root=Compute(0.54)->with(tolType=>absolute,tolerance=>0.01);
             </pg-code>
             </setup>
             <statement>
@@ -2471,13 +2467,13 @@
 
 
             <pg-code>
-              $gr = init_graph(-5,-1,1,4,axes=&gt;[0,0],grid=&gt;[6,5],size=&gt;[400,400]);
+              $gr = init_graph(-5,-1,1,4,axes=>[0,0],grid=>[6,5],size=>[400,400]);
               add_functions($gr, "(x+3)^2 +1 for x in &lt;-5,-3) using color:blue and weight:2");
-              add_functions($gr, "-(x+3)^2 +3 for x in (-3,-1&gt; using color:blue and weight:2");
-              $gr-&gt;stamps(closed_circle(-3,2,'blue'));
-              $gr -&gt; lb('reset');
-              for my$i(-4..-1){$gr-&gt;lb(new Label($i,-0.5,$i,'black','center','top'));};
-              for my$i(2..4){$gr-&gt;lb(new Label(0.1,$i,$i,'black','left','middle'));};
+              add_functions($gr, "-(x+3)^2 +3 for x in (-3,-1> using color:blue and weight:2");
+              $gr->stamps(closed_circle(-3,2,'blue'));
+              $gr -> lb('reset');
+              for my$i(-4..-1){$gr->lb(new Label($i,-0.5,$i,'black','center','top'));};
+              for my$i(2..4){$gr->lb(new Label(0.1,$i,$i,'black','left','middle'));};
               @L=(1,3,Compute("DNE"));
               Context("Interval");
               $cont=Compute("(-inf,-3)U(-3,inf)");

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -1327,7 +1327,7 @@
             \begin{tikzpicture}
             \begin{axis}[ymin=-.2,ymax=1.2,
             xmin=-.1,xmax=1.1,
-            axisequal]
+            axis equal]
             \addplot+[domain=0:1]({\x^2},{\x^3});
             \addplot+[domain=0:1]({\x^2},{\x});
             \draw (axis cs:.25,.7) node {\scriptsize$y=x^{1/2}$};

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -925,7 +925,7 @@
       <p>
         We need to evaluate <m>\lim\limits_{h\to0}\frac{f(x+h)-f(x)}{h}</m>.
         As <m>f</m> is piecewise-defined,
-        we need to consider separately the limits when <m>x\lt 0</m> and when <m>x&gt;0</m>.
+        we need to consider separately the limits when <m>x\lt 0</m> and when <m>x \gt 0</m>.
       </p>
 
       <p>
@@ -939,7 +939,7 @@
       </p>
 
       <p>
-        When <m>x&gt;0</m>,
+        When <m>x \gt 0</m>,
         a similar computation shows that <m>\frac{d}{dx}(x) = 1</m>.
       </p>
 
@@ -985,7 +985,7 @@
         and <m>f</m> is not differentiable at <m>0</m>.
         So we have
         <me>
-          \fp(x) = \begin{cases} -1 \amp  x\lt 0 \\ 1 \amp  x \gt 0\end{cases}
+          \fp(x) = \begin{cases} -1 \amp  x\lt 0 \\ 1 \amp  x  \gt  0\end{cases}
         </me>.
       </p>
 
@@ -1029,7 +1029,7 @@
     <statement>
       <p>
         Find the derivative of <m>f(x)</m>,
-        where <m>f(x) = \begin{cases}\sin(x) \amp x\leq \pi/2 \\ 1 \amp x\gt\pi/2\end{cases}</m>. See <xref ref="fig_piecewisesinx1">Figure</xref>.
+        where <m>f(x) = \begin{cases}\sin(x) \amp x\leq \pi/2 \\ 1 \amp x \gt \pi/2\end{cases}</m>. See <xref ref="fig_piecewisesinx1">Figure</xref>.
       </p>
 
       <figure xml:id="fig_piecewisesinx1">
@@ -1057,7 +1057,7 @@
       <p>
         Using <xref ref="ex_deriv_sinx">Example</xref>,
         we know that when <m>x\lt \pi/2</m>, <m>\fp(x) = \cos(x)</m>.
-        It is easy to verify that when <m>x&gt;\pi/2</m>,
+        It is easy to verify that when <m>x \gt \pi/2</m>,
         <m>\fp(x) = 0</m>; consider:
         <me>
           \lim_{h\to0}\frac{f(x+h) - f(x)}{h} = \lim_{h\to0}\frac{1-1}{h} = \lim_{h\to0}0 =0
@@ -1115,7 +1115,7 @@
         (and is <m>0</m>).
         Therefore we can fully write <m>\fp</m> as
         <me>
-          \fp(x) = \begin{cases}\cos(x) \amp  x\leq\pi/2\\ 0 \amp  x \gt \pi/2\end{cases}
+          \fp(x) = \begin{cases}\cos(x) \amp  x\leq\pi/2\\ 0 \amp  x  \gt  \pi/2\end{cases}
         </me>.
       </p>
 
@@ -2260,7 +2260,7 @@
               <ol cols="2">
                 <li>
                   <p>
-                    Where is <m>g(x) &gt; 0</m>?
+                    Where is <m>g(x)  \gt  0</m>?
                     <var name="$pos" width="10"/>
                   </p>
                 </li>
@@ -2288,7 +2288,7 @@
 
                 <li>
                   <p>
-                    Where is <m>g'(x) &gt; 0</m>?
+                    Where is <m>g'(x)  \gt  0</m>?
                     <var name="$inc" width="10"/>
                   </p>
                 </li>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2,1163 +2,1202 @@
 <!-- TODO: introduce units tags as appropriate -->
 <section xml:id="sec_derivative">
   <title>Instantaneous Rates of Change: The Derivative</title>
-  <p>
-    A common amusement park ride lifts riders to a height then allows them to freefall a certain distance before safely stopping them.
-    Suppose such a ride drops riders from a height of <m>150</m> feet.
-    Students of physics may recall that the height
-    (in feet)
-    of the riders, <m>t</m> seconds after freefall
-    (and ignoring air resistance, etc.)
-    can be accurately modeled by <m>f(t) = -16t^2+150</m>.
-  </p>
-
-  <p>
-    Using this formula, it is easy to verify that, without intervention,
-    the riders will hit the ground when <m>f(t)=0</m> so at <m>t=2.5\sqrt{1.5} \approx 3.06</m> seconds.
-    Suppose the designers of the ride decide to begin slowing the riders' fall after <m>2</m> seconds (corresponding to a height of <m>f(2)=86</m> ft).
-    How fast will the riders be traveling at that time?
-  </p>
-
-  <p>
-    We have been given a <em>position</em> function,
-    but what we want to compute is a velocity at a specific point in time,
-    i.e., we want an <term>instantaneous velocity</term>.
-    We do not currently know how to calculate this.
-  </p>
-
-  <p>
-    However, we do know from common experience how to calculate an
-    <term>average velocity</term>.
-    (If we travel <m>60</m> miles in <m>2</m> hours,
-    we know we had an average velocity of <m>30</m> mph.)
-    We looked at this concept in <xref ref="sec_limit_intro">Section</xref>
-    when we introduced the difference quotient.
-    We have
-    <me>
-      \frac{\text{change in distance}}{\text{change in time}} = \frac{\text{“rise”}}{\text{“run”}} = \text{average velocity.}
-    </me>
-  </p>
-
-  <p>
-    We can approximate the instantaneous velocity at <m>t=2</m> by considering the average velocity over some time period containing <m>t=2</m>.
-    If we make the time interval small,
-    we will get a good approximation.
-    (This fact is commonly used.
-    For instance,
-    high speed cameras are used to track fast moving objects.
-    Distances are measured over a fixed number of frames to generate an accurate approximation of the velocity.)
-  </p>
-
-  <p>
-    Consider the interval from <m>t=2</m> to <m>t=3</m>
-    (just before the riders hit the ground).
-    On that interval, the average velocity is
-    <me>
-      \frac{f(3)-f(2)}{3-2} = \frac{6-86}{1} =-80\,\text{ft/s}
-    </me>,
-    where the minus sign indicates that the riders are moving <em>down</em>.
-    By narrowing the interval we consider,
-    we will likely get a better approximation of the instantaneous velocity.
-    On <m>[2,2.5]</m> we have
-    <me>
-      \frac{f(2.5)-f(2)}{2.5-2} = \frac{50-86}{0.5} =-72\,\text{ft/s}
-    </me>.
-  </p>
-  <aside>
-    <title>Units in Calculations</title>
+  <introduction>
     <p>
-      In the above calculations,
-      we left off the units until the end of the problem.
-      You should always be sure that you label your answer with the correct units.
-      For example, if <m>g(x)</m> gave you the cost
-      (in $)
-      of producing <m>x</m> widgets,
-      the units on the difference quotient would be $/widget.
-    </p>
-  </aside>
-  <p>
-    We can do this for smaller and smaller intervals of time.
-    For instance, over a time span of one tenth of a second,
-    i.e., on <m>[2,2.1]</m>, we have
-    <me>
-      \frac{f(2.1)-f(2)}{2.1-2} = \frac{79.44-86}{0.1} =-65.6\,\text{ft/s}
-    </me>.
-  </p>
-
-  <p>
-    Over a time span of one hundredth of a second,
-    on <m>[2,2.01]</m>, the average velocity is
-    <me>
-      \frac{f(2.01)-f(2)}{2.01-2} = \frac{85.3584-86}{0.01} =-64.16\,\text{ft/s}
-    </me>.
-  </p>
-
-  <p>
-    What we are really computing is the average velocity on the interval <m>[2,2+h]</m> for small values of <m>h</m>.
-    That is, we are computing
-    <me>
-      \frac{f(2+h) - f(2)}{h}
-    </me>
-    where <m>h</m> is small.
-  </p>
-
-  <p>
-    We really want to use <m>h=0</m>, but this, of course,
-    returns the familiar <q><m>0/0</m></q> indeterminate form.
-    So we employ a limit,
-    as we did in <xref ref="sec_limit_intro">Section</xref>.
-  </p>
-
-  <sidebyside>
-    <p>
-      We can approximate the value of this limit numerically with small values of <m>h</m> as seen in <xref ref="table_falling">Table</xref>.
-      It looks as though the velocity is approaching <m>-64</m> ft/s.
+      A common amusement park ride lifts riders to a height then allows them to freefall a certain distance before safely stopping them.
+      Suppose such a ride drops riders from a height of <m>150</m> feet.
+      Students of physics may recall that the height
+      (in feet)
+      of the riders, <m>t</m> seconds after freefall
+      (and ignoring air resistance, etc.)
+      can be accurately modeled by <m>f(t) = -16t^2+150</m>.
     </p>
 
-    <table xml:id="table_falling">
-      <title>Approximating the instantaneous velocity with average velocities over a small time period <m>h</m>.</title>
-      <tabular>
-        <row bottom="medium">
-          <cell><m>h</m></cell>
-          <cell>Average Velocity (ft/s)</cell>
-        </row>
-        <row>
-          <cell><m>1</m></cell>
-          <cell><m>\phantom{Average}{-80}</m></cell>
-        </row>
-        <row>
-          <cell><m>0.5</m></cell>
-          <cell><m>\phantom{Average}{-72}</m></cell>
-        </row>
-        <row>
-          <cell><m>0.1</m></cell>
-          <cell><m>\phantom{Average}{-65.6}</m></cell>
-        </row>
-        <row>
-          <cell><m>0.01</m></cell>
-          <cell><m>\phantom{Average}{-64.16}</m></cell>
-        </row>
-        <row>
-          <cell><m>0.001</m></cell>
-          <cell><m>\phantom{Average}{-64.016}</m></cell>
-        </row>
-      </tabular>
+    <p>
+      Using this formula, it is easy to verify that, without intervention,
+      the riders will hit the ground when <m>f(t)=0</m> so at <m>t=2.5\sqrt{1.5} \approx 3.06</m> seconds.
+      Suppose the designers of the ride decide to begin slowing the riders' fall after <m>2</m>   seconds (corresponding to a height of <m>f(2)=86</m> ft).
+      How fast will the riders be traveling at that time?
+    </p>
 
-    </table>
+    <p>
+      We have been given a <em>position</em> function,
+      but what we want to compute is a velocity at a specific point in time,
+      i.e., we want an <term>instantaneous velocity</term>.
+      We do not currently know how to calculate this.
+    </p>
 
-  </sidebyside>
+    <p>
+      However, we do know from common experience how to calculate an
+      <term>average velocity</term>.
+      (If we travel <m>60</m> miles in <m>2</m> hours,
+      we know we had an average velocity of <m>30</m> mph.)
+      We looked at this concept in <xref ref="sec_limit_intro">Section</xref>
+      when we introduced the difference quotient.
+      We have
+      <me>
+        \frac{\text{change in distance}}{\text{change in time}} = \frac{\text{“rise”}}{\text{“run”}} = \text{average velocity.}
+      </me>
+    </p>
 
-  <p>
-    Computing the limit directly gives
-    <md>
-      <mrow>\lim_{h\to 0} \frac{f(2+h)-f(2)}{h} \amp = \lim_{h\to 0}\frac{-16(2+h)^2+150 - (-16(2)^2+150)}{h}</mrow>
-      <mrow>\amp = \lim_{h\to 0}\frac{-16(4+4h+h^2)+150 - 86}{h}</mrow>
-      <mrow>\amp = \lim_{h\to 0}\frac{-64-64h-16h^2+64}{h}</mrow>
-      <mrow>\amp = \lim_{h\to 0}\frac{-64h-16h^2}{h}</mrow>
-      <mrow>\amp = \lim_{h\to 0}(-64 -16h)</mrow>
-      <mrow>\amp =-64</mrow>
-    </md>.
-  </p>
+    <p>
+      We can approximate the instantaneous velocity at <m>t=2</m> by considering the average   velocity over some time period containing <m>t=2</m>.
+      If we make the time interval small,
+      we will get a good approximation.
+      (This fact is commonly used.
+      For instance,
+      high speed cameras are used to track fast moving objects.
+      Distances are measured over a fixed number of frames to generate an accurate approximation of the velocity.)
+    </p>
 
-  <p>
-    Graphically,
-    we can view the average velocities we computed numerically as the slopes of secant lines on the graph of <m>f</m> going through the points
-    <m>(2,f(2))</m> and <m>(2+h,f(2+h))</m>.
-    In <xref first="fig_derivfalling" last="fig_derivfalling3">Figures</xref>,
-    the secant line corresponding to <m>h=1</m> is shown in three contexts.
-    <xref ref="fig_derivfalling">Figure</xref> shows a <q>zoomed out</q>
-    version of <m>f</m> with its secant line.
-    In <xref ref="fig_derivfalling2">Figure</xref>,
-    we zoom in around the points of intersection between <m>f</m> and the secant line.
-    Notice how well this secant line approximates <m>f</m> between those two points <mdash/> it is a common practice to approximate functions with straight lines.
-  </p>
+    <p>
+      Consider the interval from <m>t=2</m> to <m>t=3</m>
+      (just before the riders hit the ground).
+      On that interval, the average velocity is
+      <me>
+        \frac{f(3)-f(2)}{3-2} = \frac{6-86}{1} =-80\,\text{ft/s}
+      </me>,
+      where the minus sign indicates that the riders are moving <em>down</em>.
+      By narrowing the interval we consider,
+      we will likely get a better approximation of the instantaneous velocity.
+      On <m>[2,2.5]</m> we have
+      <me>
+        \frac{f(2.5)-f(2)}{2.5-2} = \frac{50-86}{0.5} =-72\,\text{ft/s}
+      </me>.
+    </p>
+    <aside>
+      <title>Units in Calculations</title>
+      <p>
+        In the above calculations,
+        we left off the units until the end of the problem.
+        You should always be sure that you label your answer with the correct units.
+        For example, if <m>g(x)</m> gave you the cost
+        (in $)
+        of producing <m>x</m> widgets,
+        the units on the difference quotient would be $/widget.
+      </p>
+    </aside>
+    <p>
+      We can do this for smaller and smaller intervals of time.
+      For instance, over a time span of one tenth of a second,
+      i.e., on <m>[2,2.1]</m>, we have
+      <me>
+        \frac{f(2.1)-f(2)}{2.1-2} = \frac{79.44-86}{0.1} =-65.6\,\text{ft/s}
+      </me>.
+    </p>
 
-  <sbsgroup>
+    <p>
+      Over a time span of one hundredth of a second,
+      on <m>[2,2.01]</m>, the average velocity is
+      <me>
+        \frac{f(2.01)-f(2)}{2.01-2} = \frac{85.3584-86}{0.01} =-64.16\,\text{ft/s}
+      </me>.
+    </p>
+
+    <p>
+      What we are really computing is the average velocity on the interval <m>[2,2+h]</m> for small values of <m>h</m>.
+      That is, we are computing
+      <me>
+        \frac{f(2+h) - f(2)}{h}
+      </me>
+      where <m>h</m> is small.
+    </p>
+
+    <p>
+      We really want to use <m>h=0</m>, but this, of course,
+      returns the familiar <q><m>0/0</m></q> indeterminate form.
+      So we employ a limit,
+      as we did in <xref ref="sec_limit_intro">Section</xref>.
+    </p>
+
     <sidebyside>
-      <figure xml:id="fig_derivfalling">
-        <caption>The function <m>f(x)</m> and its secant line corresponding to <m>t=2</m> and <m>t=3</m>.</caption>
-        <image xml:id="img_derivfalling">
-        <!-- START figures/fig_derivfalling.tex -->
-          <description></description>
-          <latex-image>
+      <p>
+        We can approximate the value of this limit numerically with small values of <m>h</m> as seen in <xref ref="table_falling">Table</xref>.
+        It looks as though the velocity is approaching <m>-64</m> ft/s.
+      </p>
 
-          \begin{tikzpicture}
-          \begin{axis}[xmin=-.5,xmax=3.49,
-          ymin=-50,ymax=160,
-          xlabel={$t$}]]
-          \addplot+[domain=0:3.06] {-16*x^2+150};
-          \addplot+[secantline,domain=1.5:3.2] {-80*(x-2)+86};
-          \addplot[soliddot] coordinates {(2,86) (3,6)};
-          \end{axis}
-          \end{tikzpicture}
+      <table xml:id="table_falling">
+      <title>Approximating the instantaneous velocity with average velocities over a small time   period <m>h</m>.</title>
+        <tabular>
+          <row bottom="medium">
+            <cell><m>h</m></cell>
+            <cell>Average Velocity (ft/s)</cell>
+          </row>
+          <row>
+            <cell><m>1</m></cell>
+            <cell><m>\phantom{Average}{-80}</m></cell>
+          </row>
+          <row>
+            <cell><m>0.5</m></cell>
+            <cell><m>\phantom{Average}{-72}</m></cell>
+          </row>
+          <row>
+            <cell><m>0.1</m></cell>
+            <cell><m>\phantom{Average}{-65.6}</m></cell>
+          </row>
+          <row>
+            <cell><m>0.01</m></cell>
+            <cell><m>\phantom{Average}{-64.16}</m></cell>
+          </row>
+          <row>
+            <cell><m>0.001</m></cell>
+            <cell><m>\phantom{Average}{-64.016}</m></cell>
+          </row>
+        </tabular>
+
+      </table>
+
+    </sidebyside>
+
+    <p>
+      Computing the limit directly gives
+      <md>
+      <mrow>\lim_{h\to 0} \frac{f(2+h)-f(2)}{h} \amp = \lim_{h\to 0}\frac{-16(2+h)^2+150 -   (-16(2)^2+150)}{h}</mrow>
+        <mrow>\amp = \lim_{h\to 0}\frac{-16(4+4h+h^2)+150 - 86}{h}</mrow>
+        <mrow>\amp = \lim_{h\to 0}\frac{-64-64h-16h^2+64}{h}</mrow>
+        <mrow>\amp = \lim_{h\to 0}\frac{-64h-16h^2}{h}</mrow>
+        <mrow>\amp = \lim_{h\to 0}(-64 -16h)</mrow>
+        <mrow>\amp =-64</mrow>
+      </md>.
+    </p>
+
+    <p>
+      Graphically,
+      we can view the average velocities we computed numerically as the slopes of secant lines on the graph of <m>f</m> going through the points
+      <m>(2,f(2))</m> and <m>(2+h,f(2+h))</m>.
+      In <xref first="fig_derivfalling" last="fig_derivfalling3">Figures</xref>,
+      the secant line corresponding to <m>h=1</m> is shown in three contexts.
+      <xref ref="fig_derivfalling">Figure</xref> shows a <q>zoomed out</q>
+      version of <m>f</m> with its secant line.
+      In <xref ref="fig_derivfalling2">Figure</xref>,
+      we zoom in around the points of intersection between <m>f</m> and the secant line.
+      Notice how well this secant line approximates <m>f</m> between those two points <mdash/> it is a common practice to approximate functions with straight lines.
+    </p>
+
+    <sbsgroup>
+      <sidebyside>
+        <figure xml:id="fig_derivfalling">
+        <caption>The function <m>f(x)</m> and its secant line corresponding to <m>t=2</m> and <m>  t=3</m>.</caption>
+          <image xml:id="img_derivfalling">
+          <!-- START figures/fig_derivfalling.tex -->
+            <description></description>
+            <latex-image>
+
+            \begin{tikzpicture}
+            \begin{axis}[xmin=-.5,xmax=3.49,
+            ymin=-50,ymax=160,
+            xlabel={$t$}]]
+            \addplot+[domain=0:3.06] {-16*x^2+150};
+            \addplot+[secantline,domain=1.5:3.2] {-80*(x-2)+86};
+            \addplot[soliddot] coordinates {(2,86) (3,6)};
+            \end{axis}
+            \end{tikzpicture}
         
-          </latex-image>
-        </image>
-      <!-- figures/fig_derivfalling.tex END -->
-      </figure>
+            </latex-image>
+          </image>
+        <!-- figures/fig_derivfalling.tex END -->
+        </figure>
 
-      <figure xml:id="fig_derivfalling2">
-        <caption>The function <m>f(x)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m>.</caption>
-        <image xml:id="img_derivfalling2">
-        <!-- START figures/fig_derivfalling2.tex -->
-          <description></description>
-          <latex-image>
-      
-          \begin{tikzpicture}
-          \begin{axis}[xmin=1.8,xmax=3.4,
-          ymin=0,ymax=129,
-          xlabel={$t$},
-          xdiscontinuity]
-          \addplot+[domain=0:3.06] {-16*x^2+150};
-          \addplot+[secantline,domain=1.8:3.4] {-80*(x-2)+86};
-          \addplot[soliddot] coordinates{(2,86) (3,6)};
-          \end{axis}
-          \end{tikzpicture}
-      
-          </latex-image>
-        </image>
-        <!-- figures/fig_derivfalling2.tex END -->
-      </figure>
-    </sidebyside>
-
-    <sidebyside>
-      <figure xml:id="fig_derivfalling3">
-        <caption>The function <m>f(x)</m> with the same secant line, zoomed in further.</caption>
-        <image xml:id="img_derivfalling3">
-        <!-- START figures/fig_derivfalling3.tex -->
-          <description></description>
-          <latex-image>
-          
-          \begin{tikzpicture}
-          \begin{axis}[xmin=1.4,xmax=2.6,
-          ymin=0,ymax=129,
-          xlabel={$t$},
-          xdiscontinuity]
-          \addplot+[domain=0:3.06] {-16*x^2+150};
-          \addplot+[secantline,domain=1.5:2.6] {-80*(x-2)+86};
-          \addplot[soliddot] coordinates{(2,86)};
-          \end{axis}
-          \end{tikzpicture}
-          
-          </latex-image>
-        </image>
-        <!-- figures/fig_derivfalling3.tex END -->
-      </figure>
-
-      <figure xml:id="fig_derivfalling4">
-        <caption>The function <m>f(x)</m> with its tangent line at <m>t=2</m>.</caption>
-        <!-- START figures/fig_derivfalling4.tex -->
-        <image xml:id="img_derivfalling4">
-          <description></description>
-          <latex-image>
-          
-          \begin{tikzpicture}
-          \begin{axis}[xmin=1.4,xmax=2.6,
-          ymin=0,ymax=129,
-          xlabel={$t$},
-          xdiscontinuity]
-          \addplot+[domain=0:3.06] {-16*x^2+150};
-          \addplot+[tangentline,domain=1.4:2.6] {-64*(x-2)+86};
-          \addplot[soliddot] coordinates{(2,86)};
-          \end{axis}
-          \end{tikzpicture}
-
-          </latex-image>
-        </image>
-      </figure>
-    </sidebyside>
-  </sbsgroup>
-
-  <p>
-    As <m>h\to 0</m>, these secant lines approach the
-    <term>tangent line</term>,
-    a line that goes through the point
-    <m>(2,f(2))</m> with the special slope of <m>-64</m>.
-    In <xref ref="fig_derivfalling3">Figure</xref>
-    and <xref ref="fig_derivfalling4">Figure</xref>,
-    we zoom in around the point <m>(2,86)</m>.
-    We see the secant line, which approximates <m>f</m> well,
-    but not as well the tangent line shown in <xref ref="fig_derivfalling4">Figure</xref>.
-  </p>
-
-  <p>
-    We have just introduced a number of important concepts that we will flesh out more within this section.
-    First, we formally define two of them.
-  </p>
-
-  <definition xml:id="def_derivative_at_a_point">
-    <title>Derivative at a Point</title>
-    <statement>
-      <p>
-        Let <m>f</m> be a continuous function on an open interval <m>I</m> and let <m>c</m> be in <m>I</m>.
-
-              <idx><h>derivative</h><h>at a point</h></idx>
-
-        The <term>derivative of <m>f</m> at <m>c</m></term>, denoted <m>\fp(c)</m>, is
-        <me>
-          \lim_{h\to 0}\frac{f(c+h)-f(c)}{h}
-        </me>,
-        provided the limit exists.
-        If the limit exists, we say that
-        <term><m>f</m> is differentiable at <m>c</m></term>;
-        if the limit does not exist,
-        then <term><m>f</m> is not differentiable at <m>c</m></term>.
-        If <m>f</m> is differentiable at every point in <m>I</m>,
-        then <term><m>f</m> is differentiable on <m>I</m></term>.
-
-              <idx><h>differentiable</h></idx>
-
-      </p>
-    </statement>
-  </definition>
-
-  <definition xml:id="def_tangent_line">
-    <title>Tangent Line</title>
-    <statement>
-      <p>
-        Let <m>f</m> be continuous on an open interval <m>I</m> and differentiable at <m>c</m>,
-        for some <m>c</m> in <m>I</m>.
-        The line with equation <m>\ell(x) = \fp(c)(x-c)+f(c)</m> is the <term>tangent line</term>
-        to the graph of <m>f</m> at <m>c</m>;
-        that is, it is the line through
-        <m>(c,f(c))</m> whose slope is the derivative of <m>f</m> at <m>c</m>.
-
-              <idx><h>tangent line</h></idx>
-              <idx><h>derivative</h><h>tangent line</h></idx>
-
-      </p>
-    </statement>
-  </definition>
-
-  <p>
-    Some examples will help us understand these definitions.
-  </p>
-
-  <example xml:id="ex_derv_point1">
-    <title>Finding derivatives and tangent lines</title>
-    <statement>
-      <p>
-        Let <m>f(x) = 3x^2+5x-7</m>.
-        Find:
-
-        <ol cols="2">
-          <li>
-            <p>
-              <m>\fp(1)</m>
-            </p>
-          </li>
-
-          <li>
-            <p>
-              The equation of the tangent line to the graph of <m>f</m> at <m>x=1</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              <m>\fp(3)</m>
-            </p>
-          </li>
-
-          <li>
-            <p>
-              The equation of the tangent line to the graph <m>f</m> at <m>x=3</m>.
-            </p>
-          </li>
-        </ol>
-      </p>
-    </statement>
-    <solution>
-      <p>
-        <ol>
-          <li>
-            <p>
-              We compute this directly using <xref ref="def_derivative_at_a_point">Definition</xref>.
-              <md>
-                <mrow>\fp(1)\amp = \lim_{h\to 0} \frac{f(1+h)-f(1)}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3(1+h)^2+5(1+h)-7 - (3(1)^2+5(1)-7)}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3(1+2h+h^2)+5+5h-7 - 1}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3+6h+3h^2+5+5h-8}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3h^2+11h}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} (3h+11)</mrow>
-                <mrow>\amp = 11</mrow>
-              </md>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              The tangent line at <m>x=1</m> has slope <m>\fp(1)</m> and goes through the point <m>(1,f(1)) = (1,1)</m>.
-              Thus the tangent line has equation,
-              in point-slope form, <m>y = 11(x-1) + 1</m>.
-              In slope-intercept form we have <m>y = 11x-10</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              Again, using the definition,
-              <md>
-                <mrow>\fp(3)\amp = \lim_{h\to 0} \frac{f(3+h)-f(3)}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3(3+h)^2+5(3+h)-7 - (3(3)^2+5(3)-7)}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3(9+6h+h^2)+15+3h-7 - 35}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{27+18h+3h^2+15+3h-42}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} \frac{3h^2+23h}{h}</mrow>
-                <mrow>\amp = \lim_{h\to 0} 3h+23</mrow>
-                <mrow>\amp = 23</mrow>
-              </md>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              The tangent line at <m>x=3</m> has slope <m>23</m> and goes through the point <m>(3,f(3)) = (3,35)</m>.
-              Thus the tangent line has equation <m>y=23(x-3)+35 = 23x-34</m>.
-            </p>
-          </li>
-        </ol>
-      </p>
-
-      <sidebyside>
-        <p>
-          A graph of <m>f</m> is given in <xref ref="fig_tangent1">Figure</xref>
-          along with the tangent lines at <m>x=1</m> and <m>x=3</m>.
-        </p>
-
-        <figure xml:id="fig_tangent1">
-          <caption>A graph of <m>f(x) = 3x^2+5x-7</m> and its tangent lines at <m>x=1</m> and <m>x=3</m>.</caption>
-          <!-- START figures/fig_tangent1.tex -->
-          <image xml:id="img_tangent1">
+        <figure xml:id="fig_derivfalling2">
+          <caption>The function <m>f(x)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m>.</caption>
+          <image xml:id="img_derivfalling2">
+          <!-- START figures/fig_derivfalling2.tex -->
             <description></description>
             <latex-image>
-
+      
             \begin{tikzpicture}
-            \begin{axis}[xmin=-1,xmax=4.1,
-            ymin=-11,ymax=66]
-            \addplot+[domain=-1:4]{3*x^2+5*x-7};
-            \addplot+[tangentline,domain=0:4] {11*(x-1)+1};
-            \addplot+[tangentline,domain=1.8:3.8] {23*(x-3)+35};
-            \addplot[&lt;-&gt;,soliddot] coordinates{(1,1) (3,35)};
+            \begin{axis}[xmin=1.8,xmax=3.4,
+            ymin=0,ymax=129,
+            xlabel={$t$},
+            xdiscontinuity]
+            \addplot+[domain=0:3.06] {-16*x^2+150};
+            \addplot+[secantline,domain=1.8:3.4] {-80*(x-2)+86};
+            \addplot[soliddot] coordinates{(2,86) (3,6)};
             \end{axis}
             \end{tikzpicture}
+      
+            </latex-image>
+          </image>
+          <!-- figures/fig_derivfalling2.tex END -->
+        </figure>
+      </sidebyside>
+
+      <sidebyside>
+        <figure xml:id="fig_derivfalling3">
+          <caption>The function <m>f(x)</m> with the same secant line, zoomed in further.</caption>
+          <image xml:id="img_derivfalling3">
+          <!-- START figures/fig_derivfalling3.tex -->
+            <description></description>
+            <latex-image>
+          
+            \begin{tikzpicture}
+            \begin{axis}[xmin=1.4,xmax=2.6,
+            ymin=0,ymax=129,
+            xlabel={$t$},
+            xdiscontinuity]
+            \addplot+[domain=0:3.06] {-16*x^2+150};
+            \addplot+[secantline,domain=1.5:2.6] {-80*(x-2)+86};
+            \addplot[soliddot] coordinates{(2,86)};
+            \end{axis}
+            \end{tikzpicture}
+          
+            </latex-image>
+          </image>
+          <!-- figures/fig_derivfalling3.tex END -->
+        </figure>
+
+        <figure xml:id="fig_derivfalling4">
+          <caption>The function <m>f(x)</m> with its tangent line at <m>t=2</m>.</caption>
+          <!-- START figures/fig_derivfalling4.tex -->
+          <image xml:id="img_derivfalling4">
+            <description></description>
+            <latex-image>
+          
+            \begin{tikzpicture}
+            \begin{axis}[xmin=1.4,xmax=2.6,
+            ymin=0,ymax=129,
+            xlabel={$t$},
+            xdiscontinuity]
+            \addplot+[domain=0:3.06] {-16*x^2+150};
+            \addplot+[tangentline,domain=1.4:2.6] {-64*(x-2)+86};
+            \addplot[soliddot] coordinates{(2,86)};
+            \end{axis}
+            \end{tikzpicture}
+
+            </latex-image>
+          </image>
+        </figure>
+      </sidebyside>
+    </sbsgroup>
+
+    <p>
+      As <m>h\to 0</m>, these secant lines approach the
+      <term>tangent line</term>,
+      a line that goes through the point
+      <m>(2,f(2))</m> with the special slope of <m>-64</m>.
+      In <xref ref="fig_derivfalling3">Figure</xref>
+      and <xref ref="fig_derivfalling4">Figure</xref>,
+      we zoom in around the point <m>(2,86)</m>.
+      We see the secant line, which approximates <m>f</m> well,
+      but not as well the tangent line shown in <xref ref="fig_derivfalling4">Figure</xref>.
+    </p>
+
+    <p>
+    We have just introduced a number of important concepts that we will flesh out more within this   section.
+      First, we formally define two of them.
+    </p>
+
+    <definition xml:id="def_derivative_at_a_point">
+      <title>Derivative at a Point</title>
+      <statement>
+        <p>
+        Let <m>f</m> be a continuous function on an open interval <m>I</m> and let <m>c</m> be
+        in <m>I</m>.
+
+                <idx><h>derivative</h><h>at a point</h></idx>
+
+          The <term>derivative of <m>f</m> at <m>c</m></term>, denoted <m>\fp(c)</m>, is
+          <me>
+            \lim_{h\to 0}\frac{f(c+h)-f(c)}{h}
+          </me>,
+          provided the limit exists.
+          If the limit exists, we say that
+          <term><m>f</m> is differentiable at <m>c</m></term>;
+          if the limit does not exist,
+          then <term><m>f</m> is not differentiable at <m>c</m></term>.
+          If <m>f</m> is differentiable at every point in <m>I</m>,
+          then <term><m>f</m> is differentiable on <m>I</m></term>.
+
+                <idx><h>differentiable</h></idx>
+
+        </p>
+      </statement>
+    </definition>
+
+    <definition xml:id="def_tangent_line">
+      <title>Tangent Line</title>
+      <statement>
+        <p>
+          Let <m>f</m> be continuous on an open interval <m>I</m> and differentiable at <m>c</m>,
+          for some <m>c</m> in <m>I</m>.
+          The line with equation <m>\ell(x) = \fp(c)(x-c)+f(c)</m> is the <term>tangent line</term>
+          to the graph of <m>f</m> at <m>c</m>;
+          that is, it is the line through
+          <m>(c,f(c))</m> whose slope is the derivative of <m>f</m> at <m>c</m>.
+
+                <idx><h>tangent line</h></idx>
+                <idx><h>derivative</h><h>tangent line</h></idx>
+
+        </p>
+      </statement>
+    </definition>
+
+    <p>
+      Some examples will help us understand these definitions.
+    </p>
+
+    <example xml:id="ex_derv_point1">
+      <title>Finding derivatives and tangent lines</title>
+      <statement>
+        <p>
+          Let <m>f(x) = 3x^2+5x-7</m>.
+          Find:
+
+          <ol cols="2">
+            <li>
+              <p>
+                <m>\fp(1)</m>
+              </p>
+            </li>
+
+            <li>
+              <p>
+                The equation of the tangent line to the graph of <m>f</m> at <m>x=1</m>.
+              </p>
+            </li>
+
+            <li>
+              <p>
+                <m>\fp(3)</m>
+              </p>
+            </li>
+
+            <li>
+              <p>
+                The equation of the tangent line to the graph <m>f</m> at <m>x=3</m>.
+              </p>
+            </li>
+          </ol>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          <ol>
+            <li>
+              <p>
+                We compute this directly using <xref ref="def_derivative_at_a_point">Definition</xref>.
+                <md>
+                  <mrow>\fp(1)\amp = \lim_{h\to 0} \frac{f(1+h)-f(1)}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3(1+h)^2+5(1+h)-7 - (3(1)^2+5(1)-7)}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3(1+2h+h^2)+5+5h-7 - 1}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3+6h+3h^2+5+5h-8}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3h^2+11h}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} (3h+11)</mrow>
+                  <mrow>\amp = 11</mrow>
+                </md>.
+              </p>
+            </li>
+
+            <li>
+              <p>
+                The tangent line at <m>x=1</m> has slope <m>\fp(1)</m> and goes through the point
+                <m>(1,f(1)) = (1,1)</m>.
+                Thus the tangent line has equation,
+                in point-slope form, <m>y = 11(x-1) + 1</m>.
+                In slope-intercept form we have <m>y = 11x-10</m>.
+              </p>
+            </li>
+
+            <li>
+              <p>
+                Again, using the definition,
+                <md>
+                  <mrow>\fp(3)\amp = \lim_{h\to 0} \frac{f(3+h)-f(3)}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3(3+h)^2+5(3+h)-7 - (3(3)^2+5(3)-7)}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3(9+6h+h^2)+15+3h-7 - 35}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{27+18h+3h^2+15+3h-42}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} \frac{3h^2+23h}{h}</mrow>
+                  <mrow>\amp = \lim_{h\to 0} 3h+23</mrow>
+                  <mrow>\amp = 23</mrow>
+                </md>.
+              </p>
+            </li>
+
+            <li>
+              <p>
+                The tangent line at <m>x=3</m> has slope <m>23</m> and goes through the point
+                <m>(3,f(3)) = (3,35)</m>.
+                Thus the tangent line has equation <m>y=23(x-3)+35 = 23x-34</m>.
+              </p>
+            </li>
+          </ol>
+        </p>
+
+        <sidebyside>
+          <p>
+            A graph of <m>f</m> is given in <xref ref="fig_tangent1">Figure</xref>
+            along with the tangent lines at <m>x=1</m> and <m>x=3</m>.
+          </p>
+
+          <figure xml:id="fig_tangent1">
+            <caption>A graph of <m>f(x) = 3x^2+5x-7</m> and its tangent lines at <m>x=1</m> and
+            <m>x=3</m>.</caption>
+            <!-- START figures/fig_tangent1.tex -->
+            <image xml:id="img_tangent1">
+              <description></description>
+              <latex-image>
+
+              \begin{tikzpicture}
+              \begin{axis}[xmin=-1,xmax=4.1,
+              ymin=-11,ymax=66]
+              \addplot+[domain=-1:4]{3*x^2+5*x-7};
+              \addplot+[tangentline,domain=0:4] {11*(x-1)+1};
+              \addplot+[tangentline,domain=1.8:3.8] {23*(x-3)+35};
+              \addplot[&lt;-&gt;,soliddot] coordinates{(1,1) (3,35)};
+              \end{axis}
+              \end{tikzpicture}
             
-            </latex-image>
-          </image>
-          <!-- figures/fig_tangent1.tex END -->
-        </figure>
-      </sidebyside>
-    </solution>
-  </example>
+              </latex-image>
+            </image>
+            <!-- figures/fig_tangent1.tex END -->
+          </figure>
+        </sidebyside>
+      </solution>
+    </example>
 
-  <p>
-    Another important line that can be created using information from the derivative is the <em>normal line.</em>
-    It is perpendicular to the tangent line,
-    hence its slope is the negative-reciprocal of the tangent line's slope.
-  </p>
+    <p>
+    Another important line that can be created using information from the derivative is the
+    <em>normal line.</em>
+      It is perpendicular to the tangent line,
+      hence its slope is the negative-reciprocal of the tangent line's slope.
+    </p>
 
-  <definition xml:id="def_normal_line">
-    <title>Normal Line</title>
-    <statement>
-      <p>
-        Let <m>f</m> be continuous on an open interval <m>I</m> and differentiable at <m>c</m>,
-        for some <m>c</m> in <m>I</m>.
-        The <term>normal line</term> to the graph of <m>f</m> at <m>c</m> is the line with equation
-        <me>
-          n(x) =\frac{-1}{\fp(c)}(x-c)+f(c)
-        </me>,
-        when <m>\fp(c)\neq 0</m>. (When <m>\fp(c)=0</m>,
-        the normal line is the vertical line through <m>\left(c,f(c)\right)</m>;
-        that is, <m>x=c</m>.)
-
-              <idx><h>derivative</h><h>normal line</h></idx>
-              <idx><h>normal line</h></idx>
-
-      </p>
-    </statement>
-  </definition>
-
-  <example xml:id="ex_normal1">
-    <title>Finding equations of normal lines</title>
-    <statement>
-      <p>
-        Let <m>f(x) = 3x^2+5x-7</m>, as in <xref ref="ex_derv_point1">Example</xref>.
-        Find the equations of the normal lines to the graph of <m>f</m> at <m>x=1</m> and <m>x=3</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        In <xref ref="ex_derv_point1">Example</xref>,
-        we found that <m>\fp(1)=11</m>.
-        Hence at <m>x=1</m>, the normal line will have slope <m>-1/11</m>.
-        An equation for the normal line is
-        <me>
-          n(x) = \frac{-1}{11}(x-1)+1
-        </me>.
-      </p>
-
-      <sidebyside>
+    <definition xml:id="def_normal_line">
+      <title>Normal Line</title>
+      <statement>
         <p>
-          The normal line is plotted with <m>y=f(x)</m> in <xref ref="fig_normal1">Figure</xref>.
-          Note how the line looks perpendicular to <m>f</m>. (A key word here is
-          <q>looks.</q> Mathematically,
-          we say that the normal line <em>is</em>
-          perpendicular to <m>f</m> at <m>x=1</m> as the slope of the normal line is the negative-reciprocal of the slope of the tangent line.
-          However, normal lines may not always
-          <em>look</em> perpendicular.
+          Let <m>f</m> be continuous on an open interval <m>I</m> and differentiable at <m>c</m>,
+          for some <m>c</m> in <m>I</m>.
+          The <term>normal line</term> to the graph of <m>f</m> at <m>c</m> is the line with equation
+          <me>
+            n(x) =\frac{-1}{\fp(c)}(x-c)+f(c)
+          </me>,
+          when <m>\fp(c)\neq 0</m>. (When <m>\fp(c)=0</m>,
+          the normal line is the vertical line through <m>\left(c,f(c)\right)</m>;
+          that is, <m>x=c</m>.)
+
+                <idx><h>derivative</h><h>normal line</h></idx>
+                <idx><h>normal line</h></idx>
+
+        </p>
+      </statement>
+    </definition>
+
+    <example xml:id="ex_normal1">
+      <title>Finding equations of normal lines</title>
+      <statement>
+        <p>
+          Let <m>f(x) = 3x^2+5x-7</m>, as in <xref ref="ex_derv_point1">Example</xref>.
+          Find the equations of the normal lines to the graph of <m>f</m> at <m>x=1</m> and
+          <m>x=3</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          In <xref ref="ex_derv_point1">Example</xref>,
+          we found that <m>\fp(1)=11</m>.
+          Hence at <m>x=1</m>, the normal line will have slope <m>-1/11</m>.
+          An equation for the normal line is
+          <me>
+            n(x) = \frac{-1}{11}(x-1)+1
+          </me>.
         </p>
 
-        <figure xml:id="fig_normal1">
-          <caption>A graph of <m>f(x)=3x^2+5x-7</m>, along with its normal line at <m>x=1</m>.</caption>
-          <!-- START figures/fig_normal1.tex -->
-          <image xml:id="img_normal1">
-            <description></description>
-            <latex-image>
+        <sidebyside>
+          <p>
+            The normal line is plotted with <m>y=f(x)</m> in <xref ref="fig_normal1">Figure</xref>.
+            Note how the line looks perpendicular to <m>f</m>. (A key word here is
+            <q>looks.</q> Mathematically,
+            we say that the normal line <em>is</em>
+            perpendicular to <m>f</m> at <m>x=1</m> as the slope of the normal line is the   negative-reciprocal of the slope of the tangent line.
+            However, normal lines may not always
+            <em>look</em> perpendicular.
+          </p>
 
-            \begin{tikzpicture}
-            \begin{axis}[ymin=-.1,ymax=3.5,
-            xmin=-0.1,xmax=4.3,
-            axis equal]
-            \addplot+[domain=0.9:1.2]{3*x^2+5*x-7};
-            \addplot+[normalline,domain=2.2:3.5] {(-1/23)*(x-3)+35};
-            \addplot[soliddot] coordinates{(1,1) (3,35)};
-            \end{axis}
-            \end{tikzpicture}
+          <figure xml:id="fig_normal1">
+            <caption>A graph of <m>f(x)=3x^2+5x-7</m>, along with its normal line at <m>x=1</m>.
+            </caption>
+            <!-- START figures/fig_normal1.tex -->
+            <image xml:id="img_normal1">
+              <description></description>
+              <latex-image>
+
+              \begin{tikzpicture}
+              \begin{axis}[ymin=-.1,ymax=3.5,
+              xmin=-0.1,xmax=4.3,
+              axis equal]
+              \addplot+[domain=0.9:1.2]{3*x^2+5*x-7};
+              \addplot+[normalline,domain=2.2:3.5] {(-1/23)*(x-3)+35};
+              \addplot[soliddot] coordinates{(1,1) (3,35)};
+              \end{axis}
+              \end{tikzpicture}
       
-            </latex-image>
-          </image>
-          <!-- figures/fig_normal1.tex END -->
-        </figure>
-      </sidebyside>
+              </latex-image>
+            </image>
+            <!-- figures/fig_normal1.tex END -->
+          </figure>
+        </sidebyside>
 
-      <p>
-        The aspect ratio of the picture of the graph plays a big role in this.
-        When using graphing software,
-        there is usually an option called <c>Zoom Square</c> that keeps the aspect ratio <m>1:1</m>
-      </p>
-
-      <p>
-        We also found that <m>\fp(3) = 23</m>,
-        so the normal line to the graph of <m>f</m> at <m>x=3</m> will have slope <m>-1/23</m>.
-        An equation for the normal line is
-        <me>
-          n(x) = \frac{-1}{23}(x-3)+35
-        </me>.
-      </p>
-    </solution>
-  </example>
-
-  <p>
-    Linear functions are easy to work with;
-    many functions that arise in the course of solving real problems are not easy to work with.
-    A common practice in mathematical problem solving is to approximate difficult functions with not-so-difficult functions.
-    Lines are a common choice.
-    It turns out that at any given point on the graph of a differentiable function <m>f</m>,
-    the best linear approximation to <m>f</m> is its tangent line.
-    That is one reason we'll spend considerable time finding tangent lines to functions.
-  </p>
-
-  <p>
-    One type of function that does not benefit from a tangent line approximation is a line;
-    it is rather simple to recognize that the tangent line to a line is the line itself.
-    We look at this in the following example.
-  </p>
-
-  <example xml:id="ex_der_line">
-    <title>Finding the derivative of a linear function</title>
-    <statement>
-      <p>
-        Consider <m>f(x) = 3x+5</m>.
-        Find the equation of the tangent line to <m>f</m> at <m>x=1</m> and <m>x=7</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        We find the slope of the tangent line by using <xref ref="def_derivative_at_a_point">Definition</xref>.
-        <md>
-          <mrow>\fp(1) \amp =    \lim_{h\to 0}\frac{f(1+h)-f(1)}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0} \frac{3(1+h)+5 - (3+5)}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0} \frac{3h}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0} 3</mrow>
-          <mrow>\amp = 3</mrow>
-        </md>.
-      </p>
-
-      <p>
-        We just found that <m>\fp(1) = 3</m>.
-        That is, we found the <term>instantaneous rate of change</term>
-        of <m>f(x) = 3x+5</m> is <m>3</m>.
-        This is not surprising; lines are characterized by being the
-        <em>only</em> functions with a
-        <em>constant rate of change.</em>
-        That rate of change is called the
-        <term>slope</term> of the line.
-        Since their rates of change are constant,
-        their <em>instantaneous</em> rates of change are always the same;
-        they are all the slope.
-      </p>
-
-      <p>
-        So given a line <m>f(x) = ax+b</m>,
-        the derivative at any point <m>x</m> will be <m>a</m>;
-        that is, <m>\fp(x) = a</m>.
-      </p>
-
-      <p>
-        It is now easy to see that the tangent line to the graph of <m>f</m> at <m>x=1</m> is just <m>f</m>,
-        with the same being true at <m>x=7</m>.
-      </p>
-    </solution>
-  </example>
-
-  <p>
-    We often desire to find the tangent line to the graph of a function without knowing the actual derivative of the function.
-    While we will eventually be able to find derivatives of many common functions,
-    the algebra and limit calculations on some functions are complex.
-    Until we develop futher techniques,
-    the best we may be able to do is approximate the tangent line.
-    We demonstrate this in the next example.
-  </p>
-
-  <example xml:id="ex_der_num_approx">
-    <title>Numerical approximation of the tangent line</title>
-    <statement>
-      <p>
-        Approximate the equation of the tangent line to the graph of <m>f(x)=\sin(x)</m> at <m>x=0</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        In order to find the equation of the tangent line,
-        we need a slope and a point.
-        The point is given to us: <m>(0,\sin(0)) = (0,0)</m>.
-        To compute the slope, we need the derivative.
-        This is where we will make an approximation.
-        Recall that
-        <me>
-          \fp(0) \approx \frac{\sin(0+h)- \sin(0) }{h}
-        </me>
-        for a small value of <m>h</m>.
-        We choose (somewhat arbitrarily) to let <m>h=0.1</m>.
-        Thus
-        <me>
-          \fp(0) \approx \frac{\sin(0.1)-\sin(0) }{0.1} \approx 0.9983
-        </me>.
-      </p>
-
-      <sidebyside>
         <p>
-          Thus our approximation of the equation of the tangent line is <m>y = 0.9983(x-0) +0 = 0.9983x</m>;
-          it is graphed in <xref ref="fig_tangentsinx">Figure</xref>.
-          The graph seems to imply the approximation is rather good.
+          The aspect ratio of the picture of the graph plays a big role in this.
+          When using graphing software,
+          there is usually an option called <c>Zoom Square</c> that keeps the aspect ratio
+          <m>1:1</m>
         </p>
 
-        <figure xml:id="fig_tangentsinx">
-          <caption><m>f(x) = \sin(x)</m> graphed with an approximation to its tangent line at <m>x=0</m>.</caption>
-          <!-- START figures/fig_tangentsinx.tex -->
-          <image xml:id="img_tangentsinx">
-            <description></description>
-            <latex-image>
-
-            \begin{tikzpicture}
-            \begin{axis}[ymin=-1.1,ymax=1.1,
-            xmin=-3.5,xmax=3.5,
-            xtick={-3.14,-1.57,1.57,3.14},
-            xticklabels={$-\pi$,$-\frac{\pi}2$,$\frac{\pi}2$,$\pi$}]
-            \addplot+[domain=-3.5:3.5,samples=100]{sin(deg(x))};
-            \addplot+[tangentline,domain=-1:1] {sin(deg(1)))*x};
-            \addplot [soliddot] coordinates{(0,0)};
-            \end{axis}
-            \end{tikzpicture}
-      
-            </latex-image>
-          </image>
-          <!-- figures/fig_tangentsinx.tex END -->
-        </figure>
-      </sidebyside>
-    </solution>
-  </example>
-
-  <p>
-    Recall from <xref ref="sec_limit_analytically">Section</xref>
-    that <m>\lim\limits_{x\to 0}\frac{\sin(x)}x =1</m>,
-    meaning for values of <m>x</m> near <m>0</m>, <m>\sin(x) \approx x</m>.
-    Since the slope of the line <m>y=x</m> is <m>1</m> at <m>x=0</m>,
-    it should seem reasonable that <q>the slope of <m>f(x)=\sin(x)</m></q>
-    is near <m>1</m> at <m>x=0</m>.
-    In fact, since we <em>approximated</em>
-    the value of the slope to be <m>0.9983</m>,
-    we might guess the <em>actual value</em> is 1.
-    We'll come back to this later.
-  </p>
-
-  <p>
-    Consider again <xref ref="ex_derv_point1">Example</xref>.
-    To find the derivative of <m>f</m> at <m>x=1</m>,
-    we needed to evaluate a limit.
-    To find the derivative of <m>f</m> at <m>x=3</m>,
-    we needed to again evaluate a limit.
-    We have this process:
-<!-- TODO: original ptx conversion has a tikz image here. Is this a better replacement? -->
-
-    <me>
-      \begin{array}{c}\text{input specific}\\\text{number }c\end{array}\longrightarrow\begin{array}{|c|}\hline\text{do something}\\\text{to }f\text{ and }c\\\hline\end{array}\longrightarrow\begin{array}{c}\text{return}\\\text{number }f'(c)\end{array}
-    </me>
-  </p>
-
-  <p>
-    This process describes a <term>function</term>;
-    given one input
-    (the value of <m>c</m>),
-    we return exactly one output (the value of <m>\fp(c)</m>).
-    The <q>do something</q> box is where the tedious work
-    (taking limits)
-    of this function occurs.
-  </p>
-
-  <p>
-    Instead of applying this function repeatedly for different values of <m>c</m>,
-    let us apply it just once to the variable <m>x</m>.
-    We then take a limit just once.
-    The process now looks like:
-
-<!-- TODO: original ptx conversion has a tikz image here. Is this a better replacement? -->
-    <me>
-      \begin{array}{c}\text{input}\\\text{variable }x\end{array}\longrightarrow\begin{array}{|c|}\hline\text{do something}\\\text{to }f\text{ and }x\\\hline\end{array}\longrightarrow\begin{array}{c}\text{return}\\\text{function }f'(x)\end{array}
-    </me>
-  </p>
-
-  <p>
-    The output is the <term>derivative function,</term> <m>\fp(x)</m>.
-    The <m>\fp(x)</m> function will take a number <m>c</m> as input and return the derivative of <m>f</m> at <m>c</m>.
-    This calls for a definition.
-  </p>
-
-  <definition xml:id="def_the_derivative">
-    <title>Derivative Function</title>
-    <statement>
-      <p>
-        Let <m>f</m> be a differentiable function on an open interval <m>I</m>.
-        The function
-        <me>
-          \fp(x) = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}
-        </me>
-        is <term>the derivative of <m>f</m></term>.
-
-              <idx><h>derivative</h><h>as a function</h></idx>
-              <idx><h>derivative</h><h>notation</h></idx>
-
-      </p>
-
-      <p>
-        Let <m>y = f(x)</m>.
-        The following notations all represent the derivative of <m>f</m>:
-        <me>
-          \fp(x)\ =\ y'\ =\ \frac{dy}{dx}\ =\ \frac{df}{dx}\ =\ \frac{d}{dx}(f)\ =\ \frac{d}{dx}(y)
-        </me>.
-      </p>
-    </statement>
-  </definition>
-
-  <p>
-    <alert>Important:</alert> The notation <m>\frac{dy}{dx}</m> is one symbol;
-    it is <em>not</em> the fraction <q><m>dy/dx</m></q>.
-    The notation,
-    while somewhat confusing at first, was chosen with care.
-    A fraction-looking symbol was chosen because the derivative has many fraction-like properties.
-    Among other places,
-    we see these properties at work when we talk about the units of the derivative,
-    when we discuss the Chain Rule,
-    and when we learn about integration
-    (topics that appear in later sections and chapters).
-  </p>
-
-  <p>
-    Examples will help us understand this definition.
-  </p>
-
-  <example xml:id="ex_deriv1">
-    <title>Finding the derivative of a function</title>
-    <statement>
-      <p>
-        Let <m>f(x) = 3x^2+5x-7</m> as in <xref ref="ex_derv_point1">Example</xref>.
-        Find <m>\fp(x)</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        We apply <xref ref="def_the_derivative">Definition</xref>.
-        <md>
-          <mrow>\fp(x) \amp = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0} \frac{3(x+h)^2+5(x+h)-7-(3x^2+5x-7)}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0} \frac{3h^2 +6xh+5h}{h}</mrow>
-          <mrow>\amp = \lim_{h\to 0} (3h+6x+5)</mrow>
-          <mrow>\amp = 6x+5</mrow>
-        </md>
-      </p>
-
-      <p>
-        So <m>\fp(x) = 6x+5</m>.
-        Recall earlier we found that
-        <m>\fp(1) = 11</m> and <m>\fp(3) = 23</m>.
-        Note our new computation of <m>\fp(x)</m> affirm these facts.
-      </p>
-    </solution>
-  </example>
-
-  <example xml:id="ex_deriv2">
-    <title>Finding the derivative of a function</title>
-    <statement>
-      <p>
-        Let <m>f(x) = \frac{1}{x+1}</m>.
-        Find <m>\fp(x)</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        We apply <xref ref="def_the_derivative">Definition</xref>.
-        <md>
-          <mrow>\fp(x)     \amp = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0} \frac{\frac{1}{x+h+1}-\frac{1}{x+1}}{h}</mrow>
-          <intertext>Now find common denominator then subtract; pull <m>1/h</m> out front to facilitate reading.</intertext>
-          <mrow>\amp = \lim_{h\to 0} \frac{1}{h}\cdot\left(\frac{x+1}{(x+1)(x+h+1)} - \frac{x+h+1}{(x+1)(x+h+1)}\right)</mrow>
-          <intertext>Now simplify algebraically.</intertext>
-          <mrow>\amp =    \lim_{h\to 0} \frac 1h\cdot\left(\frac{x+1-(x+h+1)}{(x+1)(x+h+1)}\right)</mrow>
-          <mrow>\amp =    \lim_{h\to 0} \frac1h\cdot\left(\frac{-h}{(x+1)(x+h+1)}\right)</mrow>
-          <intertext>Finally, apply the limit.</intertext>
-          <mrow>\amp =    \lim_{h\to 0} \frac{-1}{(x+1)(x+h+1)}</mrow>
-          <mrow>\amp = \frac{-1}{(x+1)(x+1)}</mrow>
-          <mrow>\amp = \frac{-1}{(x+1)^2}</mrow>
-        </md>.
-      </p>
-
-      <p>
-        So <m>\fp(x) = \frac{-1}{(x+1)^2}</m>.
-        To practice using our notation, we could also state
-        <me>
-          \frac{d}{dx}\left(\frac{1}{x+1}\right) = \frac{-1}{(x+1)^2}
-        </me>.
-      </p>
-    </solution>
-  </example>
-
-  <example xml:id="ex_deriv_sinx">
-    <title>Finding the derivative of a function</title>
-    <statement>
-      <p>
-        Find the derivative of <m>f(x) = \sin(x)</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        Before applying <xref ref="def_the_derivative">Definition</xref>,
-        note that once this is found,
-        we can find the actual tangent line to <m>f(x) = \sin(x)</m> at <m>x=0</m>,
-        whereas we settled for an approximation in <xref ref="ex_der_num_approx">Example</xref>.
-        <md>
-          <mrow>\fp(x) \amp = \lim_{h\to 0} \frac{\sin(x+h)-\sin(x)}{h} \amp  \amp \text{Derivative definition}</mrow>
-          <mrow>\amp = \lim_{h\to 0} \frac{\sin(x)\cos(h)+\cos(x)\sin(h)-\sin(x)}{h} \amp \amp \text{Angle addition identity}</mrow>
-          <mrow>\amp = \lim_{h\to 0} \frac{\sin(x)(\cos(h)-1) + \cos(x)\sin(h)}{h} \amp  \amp \text{Regrouped and factored}</mrow>
-          <mrow>\amp = \lim_{h\to 0} \left(\frac{\sin(x)(\cos(h)-1)}{h} + \frac{\cos(x)\sin(h)}{h}\right) \amp  \amp  \text{Split into two fractions}</mrow>
-          <mrow>\amp = \lim_{h\to 0} \sin(x) \cdot \lim_{h\to 0}\frac{\cos(h)-1}{h}</mrow>
-          <mrow>\amp\quad{}+\lim_{h\to 0}\cos(x)\cdot  \lim_{h\to 0}\frac{\sin(h)}{h} \amp  \amp  \text{Product/sum limit rules}</mrow>
-          <mrow>\amp = \sin(x)\cdot 0 + \cos(x) \cdot 1 \amp \amp  \text{Applied } <xref ref="thm_special_limits">Theorem </xref></mrow>
-          <mrow>\amp = \cos(x)\ \text{!}</mrow>
-        </md>
-      </p>
-
-      <p>
-        We have found that when <m>f(x) = \sin(x)</m>, <m>\fp(x) = \cos(x)</m>.
-        This should be somewhat surprising;
-        the result of a tedious limit process on the sine function is a nice function.
-        Then again, perhaps this is not entirely surprising.
-        The sine function is periodic <mdash/> it repeats itself on regular intervals.
-        Therefore its rate of change also repeats itself on the same regular intervals.
-        We should have known the derivative would be periodic;
-        we now know exactly which periodic function it is.
-      </p>
-
-      <p>
-        Thinking back to <xref ref="ex_der_num_approx">Example</xref>,
-        we can find the slope of the tangent line to
-        <m>f(x)=\sin(x)</m> at <m>x=0</m> using our derivative.
-        We approximated the slope as <m>0.9983</m>;
-        we now know the slope is <em>exactly</em> <m>\cos(0) =1</m>.
-      </p>
-    </solution>
-  </example>
-
-  <example xml:id="ex_not_diff">
-    <title>Finding the derivative of a piecewise defined function</title>
-    <statement>
-      <p>
-        Find the derivative of the absolute value function,
-        <me>
-          f(x) = \abs{x} = \begin{cases} -x \amp  x\lt 0 \\ x \amp  x\geq 0\end{cases}
-        </me>.
-      </p>
-
-      <p>
-        See <xref ref="fig_absolutevalue">Figure</xref>.
-      </p>
-
-      <figure xml:id="fig_absolutevalue">
-        <caption>The absolute value function, <m>f(x) = \abs{x}</m>. Notice how the slope of the lines (and hence the tangent lines) abruptly changes at <m>x=0</m>.</caption>
-        <!-- START figures/fig_absolutevalue.tex -->
-        <image xml:id="img_absolutevalue">
-          <description></description>
-          <latex-image>
-
-          \begin{tikzpicture}
-          \begin{axis}[ymin=-.2,ymax=1.1,
-          xmin=-1.1,xmax=1.1,]
-          \addplot+[domain=-1:1]{abs(x)};
-          \end{axis}
-          \end{tikzpicture}
-    
-          </latex-image>
-        </image>
-        <!-- figures/fig_absolutevalue.tex END -->
-      </figure>
-    </statement>
-    <solution>
-      <p>
-        We need to evaluate <m>\lim\limits_{h\to0}\frac{f(x+h)-f(x)}{h}</m>.
-        As <m>f</m> is piecewise-defined,
-        we need to consider separately the limits when <m>x\lt 0</m> and when <m>x \gt 0</m>.
-      </p>
-
-      <p>
-        When <m>x\lt 0</m>:
-        <md>
-          <mrow>\frac{d}{dx}(-x)     \amp = \lim_{h\to 0}\frac{-(x+h) - (-x)}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0}\frac{-h}{h}</mrow>
-          <mrow>\amp =    \lim_{h\to 0}-1</mrow>
-          <mrow>\amp =    -1</mrow>
-        </md>.
-      </p>
-
-      <p>
-        When <m>x \gt 0</m>,
-        a similar computation shows that <m>\frac{d}{dx}(x) = 1</m>.
-      </p>
-
-      <p>
-        We need to also find the derivative at <m>x=0</m>.
-        By the definition of the derivative at a point, we have
-        <me>
-          \fp(0) = \lim_{h\to0}\frac{f(0+h)-f(0)}{h}
-        </me>.
-      </p>
-
-      <p>
-        Since <m>x=0</m> is the point where our function's definition switches from one piece to the other,
-        we need to consider left and right-hand limits.
-        Consider the following,
-        where we compute the left and right hand limits side by side.
-      </p>
-
-      <sidebyside>
         <p>
+          We also found that <m>\fp(3) = 23</m>,
+          so the normal line to the graph of <m>f</m> at <m>x=3</m> will have slope <m>-1/23</m>.
+          An equation for the normal line is
+          <me>
+            n(x) = \frac{-1}{23}(x-3)+35
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      Linear functions are easy to work with;
+      many functions that arise in the course of solving real problems are not easy to work with.
+      A common practice in mathematical problem solving is to approximate difficult functions
+      with not-so-difficult functions.
+      Lines are a common choice.
+      It turns out that at any given point on the graph of a differentiable function <m>f</m>,
+      the best linear approximation to <m>f</m> is its tangent line.
+      That is one reason we'll spend considerable time finding tangent lines to functions.
+    </p>
+
+    <p>
+      One type of function that does not benefit from a tangent line approximation is a line;
+      it is rather simple to recognize that the tangent line to a line is the line itself.
+      We look at this in the following example.
+    </p>
+
+    <example xml:id="ex_der_line">
+      <title>Finding the derivative of a linear function</title>
+      <statement>
+        <p>
+          Consider <m>f(x) = 3x+5</m>.
+          Find the equation of the tangent line to <m>f</m> at <m>x=1</m> and <m>x=7</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We find the slope of the tangent line by using <xref ref="def_derivative_at_a_point">
+          Definition</xref>.
           <md>
-            <mrow>\amp\lim_{h\to0^-}\frac{f(0+h)-f(0)}{h}</mrow>
-            <mrow>\amp= \lim_{h\to0^-}\frac{-h-0}{h}</mrow>
-            <mrow>\amp=\lim_{h\to0^-}-1</mrow>
-            <mrow>\amp  =-1</mrow>
+            <mrow>\fp(1) \amp =    \lim_{h\to 0}\frac{f(1+h)-f(1)}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0} \frac{3(1+h)+5 - (3+5)}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0} \frac{3h}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0} 3</mrow>
+            <mrow>\amp = 3</mrow>
+          </md>.
+        </p>
+
+        <p>
+          We just found that <m>\fp(1) = 3</m>.
+          That is, we found the <term>instantaneous rate of change</term>
+          of <m>f(x) = 3x+5</m> is <m>3</m>.
+          This is not surprising; lines are characterized by being the
+          <em>only</em> functions with a
+          <em>constant rate of change.</em>
+          That rate of change is called the
+          <term>slope</term> of the line.
+          Since their rates of change are constant,
+          their <em>instantaneous</em> rates of change are always the same;
+          they are all the slope.
+        </p>
+
+        <p>
+          So given a line <m>f(x) = ax+b</m>,
+          the derivative at any point <m>x</m> will be <m>a</m>;
+          that is, <m>\fp(x) = a</m>.
+        </p>
+
+        <p>
+          It is now easy to see that the tangent line to the graph of <m>f</m> at <m>x=1</m>
+          is just <m>f</m>,
+          with the same being true at <m>x=7</m>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      We often desire to find the tangent line to the graph of a function without knowing
+      the actual derivative of the function.
+      While we will eventually be able to find derivatives of many common functions,
+      the algebra and limit calculations on some functions are complex.
+      Until we develop futher techniques,
+      the best we may be able to do is approximate the tangent line.
+      We demonstrate this in the next example.
+    </p>
+
+    <example xml:id="ex_der_num_approx">
+      <title>Numerical approximation of the tangent line</title>
+      <statement>
+        <p>
+        Approximate the equation of the tangent line to the graph of <m>f(x)=\sin(x)</m> at
+        <m>x=0</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          In order to find the equation of the tangent line,
+          we need a slope and a point.
+          The point is given to us: <m>(0,\sin(0)) = (0,0)</m>.
+          To compute the slope, we need the derivative.
+          This is where we will make an approximation.
+          Recall that
+          <me>
+            \fp(0) \approx \frac{\sin(0+h)- \sin(0) }{h}
+          </me>
+          for a small value of <m>h</m>.
+          We choose (somewhat arbitrarily) to let <m>h=0.1</m>.
+          Thus
+          <me>
+            \fp(0) \approx \frac{\sin(0.1)-\sin(0) }{0.1} \approx 0.9983
+          </me>.
+        </p>
+
+        <sidebyside>
+          <p>
+            Thus our approximation of the equation of the tangent line is
+            <m>y = 0.9983(x-0) +0 = 0.9983x</m>;
+            it is graphed in <xref ref="fig_tangentsinx">Figure</xref>.
+            The graph seems to imply the approximation is rather good.
+          </p>
+
+          <figure xml:id="fig_tangentsinx">
+            <caption><m>f(x) = \sin(x)</m> graphed with an approximation to its tangent
+            line at <m>x=0</m>.</caption>
+            <!-- START figures/fig_tangentsinx.tex -->
+            <image xml:id="img_tangentsinx">
+              <description></description>
+              <latex-image>
+
+              \begin{tikzpicture}
+              \begin{axis}[ymin=-1.1,ymax=1.1,
+              xmin=-3.5,xmax=3.5,
+              xtick={-3.14,-1.57,1.57,3.14},
+              xticklabels={$-\pi$,$-\frac{\pi}2$,$\frac{\pi}2$,$\pi$}]
+              \addplot+[domain=-3.5:3.5,samples=100]{sin(deg(x))};
+              \addplot+[tangentline,domain=-1:1] {sin(deg(1)))*x};
+              \addplot [soliddot] coordinates{(0,0)};
+              \end{axis}
+              \end{tikzpicture}
+      
+              </latex-image>
+            </image>
+            <!-- figures/fig_tangentsinx.tex END -->
+          </figure>
+        </sidebyside>
+      </solution>
+    </example>
+
+    <p>
+      Recall from <xref ref="sec_limit_analytically">Section</xref>
+      that <m>\lim\limits_{x\to 0}\frac{\sin(x)}x =1</m>,
+      meaning for values of <m>x</m> near <m>0</m>, <m>\sin(x) \approx x</m>.
+      Since the slope of the line <m>y=x</m> is <m>1</m> at <m>x=0</m>,
+      it should seem reasonable that <q>the slope of <m>f(x)=\sin(x)</m></q>
+      is near <m>1</m> at <m>x=0</m>.
+      In fact, since we <em>approximated</em>
+      the value of the slope to be <m>0.9983</m>,
+      we might guess the <em>actual value</em> is 1.
+      We'll come back to this later.
+    </p>
+
+    <p>
+      Consider again <xref ref="ex_derv_point1">Example</xref>.
+      To find the derivative of <m>f</m> at <m>x=1</m>,
+      we needed to evaluate a limit.
+      To find the derivative of <m>f</m> at <m>x=3</m>,
+      we needed to again evaluate a limit.
+      We have this process:
+  <!-- TODO: original ptx conversion has a tikz image here. Is this a better replacement? -->
+
+      <me>
+        \begin{array}{c}\text{input specific}\\\text{number }c\end{array}\longrightarrow
+        \begin{array}{|c|}\hline\text{do something}\\\text{to }f\text{ and }c\\\hline\end{array}
+        \longrightarrow\begin{array}{c}\text{return}\\\text{number }f'(c)\end{array}
+      </me>
+    </p>
+
+    <p>
+      This process describes a <term>function</term>;
+      given one input
+      (the value of <m>c</m>),
+      we return exactly one output (the value of <m>\fp(c)</m>).
+      The <q>do something</q> box is where the tedious work
+      (taking limits)
+      of this function occurs.
+    </p>
+
+    <p>
+      Instead of applying this function repeatedly for different values of <m>c</m>,
+      let us apply it just once to the variable <m>x</m>.
+      We then take a limit just once.
+      The process now looks like:
+
+  <!-- TODO: original ptx conversion has a tikz image here. Is this a better replacement? -->
+      <me>
+        \begin{array}{c}\text{input}\\\text{variable }x\end{array}\longrightarrow
+        \begin{array}{|c|}\hline\text{do something}\\\text{to }f\text{ and }x\\\hline\end{array}
+        \longrightarrow\begin{array}{c}\text{return}\\\text{function }f'(x)\end{array}
+      </me>
+    </p>
+
+    <p>
+      The output is the <term>derivative function,</term> <m>\fp(x)</m>.
+      The <m>\fp(x)</m> function will take a number <m>c</m> as input and return the
+      derivative of <m>f</m> at <m>c</m>.
+      This calls for a definition.
+    </p>
+
+    <definition xml:id="def_the_derivative">
+      <title>Derivative Function</title>
+      <statement>
+        <p>
+          Let <m>f</m> be a differentiable function on an open interval <m>I</m>.
+          The function
+          <me>
+            \fp(x) = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}
+          </me>
+          is <term>the derivative of <m>f</m></term>.
+
+                <idx><h>derivative</h><h>as a function</h></idx>
+                <idx><h>derivative</h><h>notation</h></idx>
+
+        </p>
+
+        <p>
+          Let <m>y = f(x)</m>.
+          The following notations all represent the derivative of <m>f</m>:
+          <me>
+            \fp(x)\ =\ y'\ =\ \frac{dy}{dx}\ =\ \frac{df}{dx}\ =\ \frac{d}{dx}(f)\ =\ 
+            \frac{d}{dx}(y)
+          </me>.
+        </p>
+      </statement>
+    </definition>
+
+    <p>
+      <alert>Important:</alert> The notation <m>\frac{dy}{dx}</m> is one symbol;
+      it is <em>not</em> the fraction <q><m>dy/dx</m></q>.
+      The notation,
+      while somewhat confusing at first, was chosen with care.
+      A fraction-looking symbol was chosen because the derivative has many fraction-like properties.
+      Among other places,
+      we see these properties at work when we talk about the units of the derivative,
+      when we discuss the Chain Rule,
+      and when we learn about integration
+      (topics that appear in later sections and chapters).
+    </p>
+
+    <p>
+      Examples will help us understand this definition.
+    </p>
+
+    <example xml:id="ex_deriv1">
+      <title>Finding the derivative of a function</title>
+      <statement>
+        <p>
+          Let <m>f(x) = 3x^2+5x-7</m> as in <xref ref="ex_derv_point1">Example</xref>.
+          Find <m>\fp(x)</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We apply <xref ref="def_the_derivative">Definition</xref>.
+          <md>
+            <mrow>\fp(x) \amp = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0} \frac{3(x+h)^2+5(x+h)-7-(3x^2+5x-7)}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0} \frac{3h^2 +6xh+5h}{h}</mrow>
+            <mrow>\amp = \lim_{h\to 0} (3h+6x+5)</mrow>
+            <mrow>\amp = 6x+5</mrow>
           </md>
         </p>
 
         <p>
+          So <m>\fp(x) = 6x+5</m>.
+          Recall earlier we found that
+          <m>\fp(1) = 11</m> and <m>\fp(3) = 23</m>.
+          Note our new computation of <m>\fp(x)</m> affirm these facts.
+        </p>
+      </solution>
+    </example>
+
+    <example xml:id="ex_deriv2">
+      <title>Finding the derivative of a function</title>
+      <statement>
+        <p>
+          Let <m>f(x) = \frac{1}{x+1}</m>.
+          Find <m>\fp(x)</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We apply <xref ref="def_the_derivative">Definition</xref>.
           <md>
-            <mrow>\amp \lim_{h\to0^+}\frac{f(0+h)-f(0)}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^+}\frac{h-0}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^+}1</mrow>
-            <mrow>\amp  =1</mrow>
+            <mrow>\fp(x)     \amp = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0} \frac{\frac{1}{x+h+1}-\frac{1}{x+1}}{h}</mrow>
+            <intertext>Now find common denominator then subtract; pull <m>1/h</m> out front to   facilitate reading.</intertext>
+            <mrow>\amp = \lim_{h\to 0} \frac{1}{h}\cdot\left(\frac{x+1}{(x+1)(x+h+1)} - 
+            \frac{x+h+1}{(x+1)(x+h+1)}\right)</mrow>
+            <intertext>Now simplify algebraically.</intertext>
+            <mrow>\amp = \lim_{h\to 0} \frac 1h\cdot\left(\frac{x+1-(x+h+1)}{(x+1)(x+h+1)}\right)  </mrow>
+            <mrow>\amp = \lim_{h\to 0} \frac1h\cdot\left(\frac{-h}{(x+1)(x+h+1)}\right)</mrow>
+            <intertext>Finally, apply the limit.</intertext>
+            <mrow>\amp = \lim_{h\to 0} \frac{-1}{(x+1)(x+h+1)}</mrow>
+            <mrow>\amp = \frac{-1}{(x+1)(x+1)}</mrow>
+            <mrow>\amp = \frac{-1}{(x+1)^2}</mrow>
+          </md>.
+        </p>
+
+        <p>
+          So <m>\fp(x) = \frac{-1}{(x+1)^2}</m>.
+          To practice using our notation, we could also state
+          <me>
+            \frac{d}{dx}\left(\frac{1}{x+1}\right) = \frac{-1}{(x+1)^2}
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <example xml:id="ex_deriv_sinx">
+      <title>Finding the derivative of a function</title>
+      <statement>
+        <p>
+          Find the derivative of <m>f(x) = \sin(x)</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Before applying <xref ref="def_the_derivative">Definition</xref>,
+          note that once this is found,
+          we can find the actual tangent line to <m>f(x) = \sin(x)</m> at <m>x=0</m>,
+          whereas we settled for an approximation in <xref ref="ex_der_num_approx">Example</xref>.
+          <md>
+          <mrow>\fp(x) \amp = \lim_{h\to 0} \frac{\sin(x+h)-\sin(x)}{h} \amp  \amp 
+          \text{Derivative definition}</mrow>
+          <mrow>\amp = \lim_{h\to 0} \frac{\sin(x)\cos(h)+\cos(x)\sin(h)-\sin(x)}{h} \amp \amp
+          \text{Angle addition identity}</mrow>
+          <mrow>\amp = \lim_{h\to 0} \frac{\sin(x)(\cos(h)-1) + \cos(x)\sin(h)}{h} \amp  \amp 
+          \text{Regrouped and factored}</mrow>
+          <mrow>\amp = \lim_{h\to 0} \left(\frac{\sin(x)(\cos(h)-1)}{h} + \frac{\cos(x)\sin(h)}{h}
+          \right) \amp  \amp  \text{Split into two fractions}</mrow>
+            <mrow>\amp = \lim_{h\to 0} \sin(x) \cdot \lim_{h\to 0}\frac{\cos(h)-1}{h}</mrow>
+          <mrow>\amp\quad{}+\lim_{h\to 0}\cos(x)\cdot  \lim_{h\to 0}\frac{\sin(h)}{h} \amp  \amp
+          \text{Product/sum limit rules}</mrow>
+          <mrow>\amp = \sin(x)\cdot 0 + \cos(x) \cdot 1 \amp \amp  \text{Applied } 
+          <xref ref="thm_special_limits">Theorem </xref></mrow>
+            <mrow>\amp = \cos(x)\ \text{!}</mrow>
           </md>
         </p>
-      </sidebyside>
 
-      <p>
-        The last lines of each column tell the story:
-        the left and right hand limits are not equal.
-        Therefore the limit does not exist at <m>0</m>,
-        and <m>f</m> is not differentiable at <m>0</m>.
-        So we have
-        <me>
-          \fp(x) = \begin{cases} -1 \amp  x\lt 0 \\ 1 \amp  x  \gt  0\end{cases}
-        </me>.
-      </p>
-
-      <p>
-        At <m>x=0</m>, <m>\fp(x)</m> does not exist;
-        there is a jump discontinuity at <m>0</m>;
-        see <xref ref="fig_absolutevalueprime">Figure</xref>.
-        So <m>f(x) = \abs{x}</m> is differentiable everywhere except at <m>0</m>.
-      </p>
-
-      <figure xml:id="fig_absolutevalueprime">
-        <caption>A graph of the derivative of <m>f(x) = \abs{x}</m>.</caption>
-        <!-- START figures/fig_absolutevalueprime.tex -->
-        <image xml:id="img_absolutevalueprime">
-          <description></description>
-          <latex-image>
-
-          \begin{tikzpicture}
-          \begin{axis}[ymin=-1.4,ymax=1.4,
-          xmin=-1.1,xmax=1.1]
-          \addplot [firstcurvestyle,leftarrow,domain=-1:0]{1};
-          \addplot [firstcurvestyle,rightarrow,domain=0:1]{-1};
-          \addplot[hollowdot] coordinates{(0,-1) (0,1)};
-          \end{axis}
-          \end{tikzpicture}
-    
-          </latex-image>
-        </image>
-        <!-- figures/fig_absolutevalueprime.tex END -->
-      </figure>
-    </solution>
-  </example>
-
-  <p>
-    The point of non-differentiability came where the piecewise defined function switched from one piece to the other.
-    Our next example shows that this does not always cause trouble.
-  </p>
-
-  <example xml:id="ex_diff_piecewise">
-    <title>Finding the derivative of a piecewise defined function</title>
-    <statement>
-      <p>
-        Find the derivative of <m>f(x)</m>,
-        where <m>f(x) = \begin{cases}\sin(x) \amp x\leq \pi/2 \\ 1 \amp x \gt \pi/2\end{cases}</m>. See <xref ref="fig_piecewisesinx1">Figure</xref>.
-      </p>
-
-      <figure xml:id="fig_piecewisesinx1">
-        <caption>A graph of <m>f(x)</m> as defined in <xref ref="ex_diff_piecewise">Example</xref>.</caption>
-        <!-- START figures/fig_piecewisesinx1.tex -->
-        <image xml:id="img_piecewisesinx1">
-          <description></description>
-          <latex-image>
-          
-          \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (sin(x*180/pi)) + (\x &gt;= 1.5708) * (1);}]
-          \begin{axis}[ymin=-.4,ymax=1.4,
-          xmin=-.1,xmax=2.1,
-          xtick={1.57},
-          xticklabels={$\frac{\pi}2$}]
-          \addplot+[domain=-.1:2,samples=100]{func(x)};
-          \end{axis}
-          \end{tikzpicture}
-          
-          </latex-image>
-        </image>
-        <!-- figures/fig_piecewisesinx1.tex END -->
-      </figure>
-    </statement>
-    <solution>
-      <p>
-        Using <xref ref="ex_deriv_sinx">Example</xref>,
-        we know that when <m>x\lt \pi/2</m>, <m>\fp(x) = \cos(x)</m>.
-        It is easy to verify that when <m>x \gt \pi/2</m>,
-        <m>\fp(x) = 0</m>; consider:
-        <me>
-          \lim_{h\to0}\frac{f(x+h) - f(x)}{h} = \lim_{h\to0}\frac{1-1}{h} = \lim_{h\to0}0 =0
-        </me>.
-      </p>
-
-      <p>
-        So far we have
-        <me>
-          \fp(x) = \begin{cases}\cos(x) \amp  x\lt \pi/2\\ 0 \amp  x\gt\pi/2\end{cases}
-        </me>.
-      </p>
-
-      <p>
-        We still need to find <m>\fp(\pi/2)</m>.
-        Notice at <m>x=\pi/2</m> that both pieces of <m>\fp</m> are <m>0</m>,
-        meaning we can state that <m>\fp(\pi/2)=0</m>.
-      </p>
-
-      <p>
-        Being more rigorous,
-        we can again evaluate the difference quotient limit at <m>x=\pi/2</m>,
-        utilizing again left- and right-hand limits.
-        We will begin with the left-hand limit:
-      </p>
-
-      <sidebyside>
         <p>
-          <md>
-            <mrow>\amp \lim_{h\to0^-}\frac{f(\pi/2+h)-f(\pi/2)}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^-}\frac{\sin(\pi/2+h)-\sin(\pi/2)}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^-}{ \frac{\sin(\frac{\pi}{2})\cos(h)+\sin(h)\cos(\frac{\pi}{2})-\sin(\frac{\pi}{2})}{h}}</mrow>
-            <mrow>\amp =\lim_{h\to0^-}\frac{1\cdot\cos(h)+\sin(h)\cdot 0-1}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^-}\frac{\cos(h)-1}{h} \cdot \lim_{h\to0^-}\frac{\sin(h)}{h}</mrow>
-            <mrow>\amp=1\cdot 0</mrow>
-            <mrow>\amp =0</mrow>
-          </md>.
-          Notice we used <xref ref="thm_lim_continuous" text="title"/> to finally evaluate the limit.
+          We have found that when <m>f(x) = \sin(x)</m>, <m>\fp(x) = \cos(x)</m>.
+          This should be somewhat surprising;
+          the result of a tedious limit process on the sine function is a nice function.
+          Then again, perhaps this is not entirely surprising.
+          The sine function is periodic <mdash/> it repeats itself on regular intervals.
+          Therefore its rate of change also repeats itself on the same regular intervals.
+          We should have known the derivative would be periodic;
+          we now know exactly which periodic function it is.
         </p>
 
         <p>
-          Now we will find the right-hand limit:
+          Thinking back to <xref ref="ex_der_num_approx">Example</xref>,
+          we can find the slope of the tangent line to
+          <m>f(x)=\sin(x)</m> at <m>x=0</m> using our derivative.
+          We approximated the slope as <m>0.9983</m>;
+          we now know the slope is <em>exactly</em> <m>\cos(0) =1</m>.
+        </p>
+      </solution>
+    </example>
+
+    <example xml:id="ex_not_diff">
+      <title>Finding the derivative of a piecewise defined function</title>
+      <statement>
+        <p>
+          Find the derivative of the absolute value function,
+          <me>
+            f(x) = \abs{x} = \begin{cases} -x \amp  x\lt 0 \\ x \amp  x\geq 0\end{cases}
+          </me>.
+        </p>
+
+        <p>
+          See <xref ref="fig_absolutevalue">Figure</xref>.
+        </p>
+
+        <figure xml:id="fig_absolutevalue">
+          <caption>The absolute value function, <m>f(x) = \abs{x}</m>. Notice how the slope of
+          the lines (and hence the tangent lines) abruptly changes at <m>x=0</m>.</caption>
+          <!-- START figures/fig_absolutevalue.tex -->
+          <image xml:id="img_absolutevalue">
+            <description></description>
+            <latex-image>
+
+            \begin{tikzpicture}
+            \begin{axis}[ymin=-.2,ymax=1.1,
+            xmin=-1.1,xmax=1.1,]
+            \addplot+[domain=-1:1]{abs(x)};
+            \end{axis}
+            \end{tikzpicture}
+    
+            </latex-image>
+          </image>
+          <!-- figures/fig_absolutevalue.tex END -->
+        </figure>
+      </statement>
+      <solution>
+        <p>
+          We need to evaluate <m>\lim\limits_{h\to0}\frac{f(x+h)-f(x)}{h}</m>.
+          As <m>f</m> is piecewise-defined,
+          we need to consider separately the limits when <m>x\lt 0</m> and when <m>x \gt 0</m>.
+        </p>
+
+        <p>
+          When <m>x\lt 0</m>:
           <md>
-            <mrow>\amp \lim_{h\to0^+}\frac{f(\pi/2+h)-f(\pi/2)}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^+}\frac{1-1}{h}</mrow>
-            <mrow>\amp =\lim_{h\to0^+}\frac{0}{h}</mrow>
-            <mrow>\amp =0</mrow>
+            <mrow>\frac{d}{dx}(-x)     \amp = \lim_{h\to 0}\frac{-(x+h) - (-x)}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0}\frac{-h}{h}</mrow>
+            <mrow>\amp =    \lim_{h\to 0}-1</mrow>
+            <mrow>\amp =    -1</mrow>
           </md>.
         </p>
-      </sidebyside>
 
-      <p>
-        Since both the left and right hand limits are <m>0</m> at <m>x=\pi/2</m>,
-        the limit exists and <m>\fp(\pi/2)</m> exists
-        (and is <m>0</m>).
-        Therefore we can fully write <m>\fp</m> as
-        <me>
-          \fp(x) = \begin{cases}\cos(x) \amp  x\leq\pi/2\\ 0 \amp  x  \gt  \pi/2\end{cases}
-        </me>.
-      </p>
+        <p>
+          When <m>x \gt 0</m>,
+          a similar computation shows that <m>\frac{d}{dx}(x) = 1</m>.
+        </p>
 
-      <p>
-        See <xref ref="fig_piecewisecosx1">Figure</xref>
-        for a graph of this derivative function.
-      </p>
+        <p>
+          We need to also find the derivative at <m>x=0</m>.
+          By the definition of the derivative at a point, we have
+          <me>
+            \fp(0) = \lim_{h\to0}\frac{f(0+h)-f(0)}{h}
+          </me>.
+        </p>
 
-      <figure xml:id="fig_piecewisecosx1">
-        <caption>A graph of <m>\fp(x)</m> in <xref ref="ex_diff_piecewise">Example</xref>.</caption>
-        <!-- START figures/fig_piecewisecosx1.tex -->
-        <image xml:id="img_piecewisecosx1">
-          <description></description>
-          <latex-image>
-          
-          \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (cos(x*180/pi)) + (\x &gt;= 1.5708) * (0);}]
-          \begin{axis}[ymin=-.4,ymax=1.4,
-          xmin=-.1,xmax=2.1,
-          xtick={1.57},
-          xticklabels={$\frac{\pi}2$},]
-          \addplot+[domain=-.1:2,samples=100]{func(x)};
-          \end{axis}
-          \end{tikzpicture}
+        <p>
+          Since <m>x=0</m> is the point where our function's definition switches from
+          one piece to the other, we need to consider left and right-hand limits.
+          Consider the following,
+          where we compute the left and right hand limits side by side.
+        </p>
+
+        <sidebyside>
+          <p>
+            <md>
+              <mrow>\amp\lim_{h\to0^-}\frac{f(0+h)-f(0)}{h}</mrow>
+              <mrow>\amp= \lim_{h\to0^-}\frac{-h-0}{h}</mrow>
+              <mrow>\amp=\lim_{h\to0^-}-1</mrow>
+              <mrow>\amp  =-1</mrow>
+            </md>
+          </p>
+
+          <p>
+            <md>
+              <mrow>\amp \lim_{h\to0^+}\frac{f(0+h)-f(0)}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^+}\frac{h-0}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^+}1</mrow>
+              <mrow>\amp  =1</mrow>
+            </md>
+          </p>
+        </sidebyside>
+
+        <p>
+          The last lines of each column tell the story:
+          the left and right hand limits are not equal.
+          Therefore the limit does not exist at <m>0</m>,
+          and <m>f</m> is not differentiable at <m>0</m>.
+          So we have
+          <me>
+            \fp(x) = \begin{cases} -1 \amp  x\lt 0 \\ 1 \amp  x  \gt  0\end{cases}
+          </me>.
+        </p>
+
+        <p>
+          At <m>x=0</m>, <m>\fp(x)</m> does not exist;
+          there is a jump discontinuity at <m>0</m>;
+          see <xref ref="fig_absolutevalueprime">Figure</xref>.
+          So <m>f(x) = \abs{x}</m> is differentiable everywhere except at <m>0</m>.
+        </p>
+
+        <figure xml:id="fig_absolutevalueprime">
+          <caption>A graph of the derivative of <m>f(x) = \abs{x}</m>.</caption>
+          <!-- START figures/fig_absolutevalueprime.tex -->
+          <image xml:id="img_absolutevalueprime">
+            <description></description>
+            <latex-image>
+
+            \begin{tikzpicture}
+            \begin{axis}[ymin=-1.4,ymax=1.4,
+            xmin=-1.1,xmax=1.1]
+            \addplot [firstcurvestyle,leftarrow,domain=-1:0]{1};
+            \addplot [firstcurvestyle,rightarrow,domain=0:1]{-1};
+            \addplot[hollowdot] coordinates{(0,-1) (0,1)};
+            \end{axis}
+            \end{tikzpicture}
     
-          </latex-image>
-        </image>
-        <!-- figures/fig_piecewisecosx1.tex END -->
-      </figure>
-    </solution>
-  </example>
+            </latex-image>
+          </image>
+          <!-- figures/fig_absolutevalueprime.tex END -->
+        </figure>
+      </solution>
+    </example>
 
-  <p>
-    Recall we pseudo-defined a continuous function as one in which we could sketch its graph without lifting our pencil.
-    We can give a pseudo-definition for differentiability as well:
-    it is a continuous function that does not have any <q>sharp corners</q>
-    or a vertical tangent line.
-    One such sharp corner is shown in <xref ref="fig_absolutevalue">Figure</xref>.
-    Even though the function <m>f</m> in <xref ref="ex_diff_piecewise">Example</xref> is piecewise-defined,
-    the transition is <q>smooth</q>
-    hence it is differentiable.
-    Note how in the graph of <m>f</m> in <xref ref="fig_piecewisesinx1">Figure</xref>
-    it is difficult to tell when <m>f</m> switches from one piece to the other;
-    there is no <q>corner.</q>
-  </p>
+    <p>
+      The point of non-differentiability came where the piecewise defined function
+      switched from one piece to the other.
+      Our next example shows that this does not always cause trouble.
+    </p>
+
+    <example xml:id="ex_diff_piecewise">
+      <title>Finding the derivative of a piecewise defined function</title>
+      <statement>
+        <p>
+          Find the derivative of <m>f(x)</m>,
+          where
+          <me>
+            f(x) = \begin{cases}\sin(x) \amp x\leq \pi/2 \\ 1 \amp x \gt \pi/2\end{cases}
+          </me>.
+          See <xref ref="fig_piecewisesinx1">Figure</xref>.
+        </p>
+
+        <figure xml:id="fig_piecewisesinx1">
+          <caption>A graph of <m>f(x)</m> as defined in
+          <xref ref="ex_diff_piecewise">Example</xref>.</caption>
+          <!-- START figures/fig_piecewisesinx1.tex -->
+          <image xml:id="img_piecewisesinx1">
+            <description></description>
+            <latex-image>
+          
+            \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (sin(x*180/pi)) + (\x &gt;= 1.5708) * (1);}]
+            \begin{axis}[ymin=-.4,ymax=1.4,
+            xmin=-.1,xmax=2.1,
+            xtick={1.57},
+            xticklabels={$\frac{\pi}2$}]
+            \addplot+[domain=-.1:2,samples=100]{func(x)};
+            \end{axis}
+            \end{tikzpicture}
+          
+            </latex-image>
+          </image>
+          <!-- figures/fig_piecewisesinx1.tex END -->
+        </figure>
+      </statement>
+      <solution>
+        <p>
+          Using <xref ref="ex_deriv_sinx">Example</xref>,
+          we know that when <m>x\lt \pi/2</m>, <m>\fp(x) = \cos(x)</m>.
+          It is easy to verify that when <m>x \gt \pi/2</m>,
+          <m>\fp(x) = 0</m>; consider:
+          <me>
+            \lim_{h\to0}\frac{f(x+h) - f(x)}{h} = \lim_{h\to0}\frac{1-1}{h} = \lim_{h\to0}0 =0
+          </me>.
+        </p>
+
+        <p>
+          So far we have
+          <me>
+            \fp(x) = \begin{cases}\cos(x) \amp  x\lt \pi/2\\ 0 \amp  x\gt\pi/2\end{cases}
+          </me>.
+        </p>
+
+        <p>
+          We still need to find <m>\fp(\pi/2)</m>.
+          Notice at <m>x=\pi/2</m> that both pieces of <m>\fp</m> are <m>0</m>,
+          meaning we can state that <m>\fp(\pi/2)=0</m>.
+        </p>
+
+        <p>
+          Being more rigorous,
+          we can again evaluate the difference quotient limit at <m>x=\pi/2</m>,
+          utilizing again left- and right-hand limits.
+          We will begin with the left-hand limit:
+        </p>
+
+        <sidebyside>
+          <p>
+            <md>
+              <mrow>\amp \lim_{h\to0^-}\frac{f(\pi/2+h)-f(\pi/2)}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^-}\frac{\sin(\pi/2+h)-\sin(\pi/2)}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^-}{ \frac{\sin(\frac{\pi}{2})\cos(h)+\sin(h)\cos(\frac{\pi}{2})-\sin(\frac{\pi}{2})}{h}}</mrow>
+              <mrow>\amp =\lim_{h\to0^-}\frac{1\cdot\cos(h)+\sin(h)\cdot 0-1}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^-}\frac{\cos(h)-1}{h} \cdot \lim_{h\to0^-}\frac{\sin(h)}{h}
+              </mrow>
+              <mrow>\amp=1\cdot 0</mrow>
+              <mrow>\amp =0</mrow>
+            </md>.
+          Notice we used <xref ref="thm_lim_continuous" text="title"/> to finally evaluate the   limit.
+          </p>
+
+          <p>
+            Now we will find the right-hand limit:
+            <md>
+              <mrow>\amp \lim_{h\to0^+}\frac{f(\pi/2+h)-f(\pi/2)}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^+}\frac{1-1}{h}</mrow>
+              <mrow>\amp =\lim_{h\to0^+}\frac{0}{h}</mrow>
+              <mrow>\amp =0</mrow>
+            </md>.
+          </p>
+        </sidebyside>
+
+        <p>
+          Since both the left and right hand limits are <m>0</m> at <m>x=\pi/2</m>,
+          the limit exists and <m>\fp(\pi/2)</m> exists
+          (and is <m>0</m>).
+          Therefore we can fully write <m>\fp</m> as
+          <me>
+            \fp(x) = \begin{cases}\cos(x) \amp  x\leq\pi/2\\ 0 \amp  x  \gt  \pi/2\end{cases}
+          </me>.
+        </p>
+
+        <p>
+          See <xref ref="fig_piecewisecosx1">Figure</xref>
+          for a graph of this derivative function.
+        </p>
+
+        <figure xml:id="fig_piecewisecosx1">
+          <caption>A graph of <m>\fp(x)</m> in <xref ref="ex_diff_piecewise">Example</xref>.
+          </caption>
+          <!-- START figures/fig_piecewisecosx1.tex -->
+          <image xml:id="img_piecewisecosx1">
+            <description></description>
+            <latex-image>
+          
+            \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (cos(x*180/pi)) + (\x &gt;= 1.5708) * (0);}]
+            \begin{axis}[ymin=-.4,ymax=1.4,
+            xmin=-.1,xmax=2.1,
+            xtick={1.57},
+            xticklabels={$\frac{\pi}2$},]
+            \addplot+[domain=-.1:2,samples=100]{func(x)};
+            \end{axis}
+            \end{tikzpicture}
+    
+            </latex-image>
+          </image>
+          <!-- figures/fig_piecewisecosx1.tex END -->
+        </figure>
+      </solution>
+    </example>
+
+    <p>
+      Recall we pseudo-defined a continuous function as one in which we could sketch its graph   without lifting our pencil.
+      We can give a pseudo-definition for differentiability as well:
+      it is a continuous function that does not have any <q>sharp corners</q>
+      or a vertical tangent line.
+      One such sharp corner is shown in <xref ref="fig_absolutevalue">Figure</xref>.
+      Even though the function <m>f</m> in <xref ref="ex_diff_piecewise">Example</xref> is   piecewise-defined,
+      the transition is <q>smooth</q>
+      hence it is differentiable.
+      Note how in the graph of <m>f</m> in <xref ref="fig_piecewisesinx1">Figure</xref>
+      it is difficult to tell when <m>f</m> switches from one piece to the other;
+      there is no <q>corner.</q>
+    </p>
+  </introduction>
 
   <subsection>
     <title>Differentiablity on Closed Intervals</title>
@@ -1295,7 +1334,7 @@
             \draw (axis cs:.7,.35) node {\scriptsize$y=x^{3/2}$};
             \end{axis}
             \end{tikzpicture}
-            
+          
             </latex-image>
           </image>
         </figure>
@@ -1349,8 +1388,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -1370,8 +1407,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -1636,8 +1671,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1666,8 +1699,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1696,8 +1727,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1726,8 +1755,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1782,8 +1809,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1812,8 +1837,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1842,8 +1865,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1884,7 +1905,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1908,7 +1928,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1932,7 +1951,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1956,7 +1974,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1982,13 +1999,6 @@
     <exercise>
       <webwork seed="1">
           <setup>
-
-
-
-
-
-
-
           <pg-code>
             $gr = init_graph(-3,-2,3,4,axes=>[0,0],grid=>[6,6],size=>[400,400]);
             add_functions($gr, "x^2-1 for x in &lt;-3,3> using color:blue and weight:2");
@@ -2063,11 +2073,6 @@
     <exercise>
       <webwork seed="1">
           <setup>
-
-
-
-
-
           <pg-code>
             $gr = init_graph(-1,-1,3,6,axes=>[0,0],grid=>[4,7],size=>[400,400]);
             add_functions($gr, "1/(x+1) for x in &lt;-0.85,3> using color:blue and weight:2");
@@ -2151,7 +2156,7 @@
             \addplot+[domain=-2.1:5.1,&lt;-&gt;] {-.5*x+2};
             \end{axis}
             \end{tikzpicture}
-      
+    
             </latex-image>
           </image>
         </statement>
@@ -2170,7 +2175,7 @@
             \addplot+[domain=-5.6:1.6,samples=40] {.5*(x+2)^2-3};
             \end{axis}
             \end{tikzpicture}
-      
+    
             </latex-image>
           </image>
         </statement>
@@ -2189,7 +2194,7 @@
             \addplot+[domain=-2.45:2.45,samples=40] {(x-2)*x*(x+2)};
             \end{axis}
             \end{tikzpicture}
-      
+    
             </latex-image>
           </image>
         </statement>
@@ -2210,7 +2215,7 @@
             \addplot+[domain=-6.8:6.8,samples=101] {cos(deg(x))};
             \end{axis}
             \end{tikzpicture}
-      
+    
             </latex-image>
           </image>
         </statement>
@@ -2221,12 +2226,6 @@
     <exercise>
       <webwork seed="1">
           <setup>
-
-
-
-
-
-
           <pg-code>
             $gr = init_graph(-3,-10,3,5,axes=>[0,0],grid=>[6,15],size=>[400,400]);
             add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2> using color:blue and weight:2");
@@ -2372,7 +2371,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
             <pg-code>
               $L=-24;
             </pg-code>
@@ -2392,7 +2390,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
             <pg-code>
               $root=Compute(0.54)->with(tolType=>absolute,tolerance=>0.01);
             </pg-code>
@@ -2414,10 +2411,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
-
-
             <pg-code>
               Context("Interval");
               @cont=(Compute("(-inf,inf)"),Compute("(-inf,-1)U(-1,1)U(1,inf)"),Compute("(-inf,5]"),Compute("[-sqrt(5),sqrt(5)]"));
@@ -2462,10 +2455,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
-
-
             <pg-code>
               $gr = init_graph(-5,-1,1,4,axes=>[0,0],grid=>[6,5],size=>[400,400]);
               add_functions($gr, "(x+3)^2 +1 for x in &lt;-5,-3) using color:blue and weight:2");

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -16,7 +16,8 @@
     <p>
       Using this formula, it is easy to verify that, without intervention,
       the riders will hit the ground when <m>f(t)=0</m> so at <m>t=2.5\sqrt{1.5} \approx 3.06</m> seconds.
-      Suppose the designers of the ride decide to begin slowing the riders' fall after <m>2</m>   seconds (corresponding to a height of <m>f(2)=86</m> ft).
+      Suppose the designers of the ride decide to begin slowing the riders' fall after <m>2</m>   seconds (corresponding to a height of <m>f(2)=</m>
+      <quantity><mag>86</mag><unit base="feet"/></quantity>).
       How fast will the riders be traveling at that time?
     </p>
 
@@ -31,7 +32,8 @@
       However, we do know from common experience how to calculate an
       <term>average velocity</term>.
       (If we travel <m>60</m> miles in <m>2</m> hours,
-      we know we had an average velocity of <m>30</m> mph.)
+      we know we had an average velocity of
+      <quantity><mag>30</mag><unit base="mileperhour"/></quantity>.)
       We looked at this concept in <xref ref="sec_limit_intro">Section</xref>
       when we introduced the difference quotient.
       We have
@@ -113,7 +115,8 @@
     <sidebyside>
       <p>
         We can approximate the value of this limit numerically with small values of <m>h</m> as seen in <xref ref="table_falling">Table</xref>.
-        It looks as though the velocity is approaching <m>-64</m> ft/s.
+        It looks as though the velocity is approaching
+        <quantity><mag>-64</mag><unit base="feet"/><per base="second"/></quantity>.
       </p>
 
       <table xml:id="table_falling">
@@ -121,7 +124,7 @@
         <tabular>
           <row bottom="medium">
             <cell><m>h</m></cell>
-            <cell>Average Velocity (ft/s)</cell>
+            <cell>Average Velocity (<quantity><mag/><unit base="feet"/><per base="second"/></quantity>)</cell>
           </row>
           <row>
             <cell><m>1</m></cell>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- TODO: introduce units tags as appropriate -->
-
 <section xml:id="sec_derivative">
   <title>Instantaneous Rates of Change: The Derivative</title>
   <p>
@@ -72,9 +71,9 @@
       we left off the units until the end of the problem.
       You should always be sure that you label your answer with the correct units.
       For example, if <m>g(x)</m> gave you the cost
-      (in <dollar />)
+      (in $)
       of producing <m>x</m> widgets,
-      the units on the difference quotient would be <dollar />/widget.
+      the units on the difference quotient would be $/widget.
     </p>
   </aside>
   <p>
@@ -117,7 +116,7 @@
     </p>
 
     <table xml:id="table_falling">
-      <caption>Approximating the instantaneous velocity with average velocities over a small time period <m>h</m>.</caption>
+      <title>Approximating the instantaneous velocity with average velocities over a small time period <m>h</m>.</title>
       <tabular>
         <row bottom="medium">
           <cell><m>h</m></cell>
@@ -171,7 +170,7 @@
     version of <m>f</m> with its secant line.
     In <xref ref="fig_derivfalling2">Figure</xref>,
     we zoom in around the points of intersection between <m>f</m> and the secant line.
-    Notice how well this secant line approximates <m>f</m> between those two points <mdash /> it is a common practice to approximate functions with straight lines.
+    Notice how well this secant line approximates <m>f</m> between those two points <mdash/> it is a common practice to approximate functions with straight lines.
   </p>
 
   <sbsgroup>
@@ -182,7 +181,8 @@
         <!-- START figures/fig_derivfalling.tex -->
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}
+          <![CDATA[
+          \begin{tikzpicture}
           \begin{axis}[xmin=-.5,xmax=3.49,
           ymin=-50,ymax=160,
           xlabel={$t$}]                                          ]
@@ -191,7 +191,7 @@
           \addplot[soliddot] coordinates {(2,86) (3,6)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
       <!-- figures/fig_derivfalling.tex END -->
@@ -203,7 +203,8 @@
         <!-- START figures/fig_derivfalling2.tex -->
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}
+          <![CDATA[
+          \begin{tikzpicture}
           \begin{axis}[xmin=1.8,xmax=3.4,
           ymin=0,ymax=129,
           xlabel={$t$},
@@ -213,7 +214,7 @@
           \addplot[soliddot] coordinates{(2,86) (3,6)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
         <!-- figures/fig_derivfalling2.tex END -->
@@ -227,7 +228,8 @@
         <!-- START figures/fig_derivfalling3.tex -->
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}
+          <![CDATA[
+          \begin{tikzpicture}
           \begin{axis}[xmin=1.4,xmax=2.6,
           ymin=0,ymax=129,
           xlabel={$t$},
@@ -237,7 +239,7 @@
           \addplot[soliddot] coordinates{(2,86)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
         <!-- figures/fig_derivfalling3.tex END -->
@@ -249,7 +251,8 @@
         <image xml:id="img_derivfalling4">
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}
+          <![CDATA[
+          \begin{tikzpicture}
           \begin{axis}[xmin=1.4,xmax=2.6,
           ymin=0,ymax=129,
           xlabel={$t$},
@@ -429,16 +432,17 @@
           <image xml:id="img_tangent1">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[xmin=-1,xmax=4.1,
             ymin=-11,ymax=66]
             \addplot+[domain=-1:4]{3*x^2+5*x-7};
             \addplot+[tangentline,domain=0:4] {11*(x-1)+1};
             \addplot+[tangentline,domain=1.8:3.8] {23*(x-3)+35};
-            \addplot[<->,soliddot] coordinates{(1,1) (3,35)};
+            \addplot[&lt;-&gt;,soliddot] coordinates{(1,1) (3,35)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>      
             </latex-image>
           </image>
           <!-- figures/fig_tangent1.tex END -->
@@ -510,8 +514,8 @@
           <image xml:id="img_normal1">
             <description></description>
             <latex-image>
-
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[ymin=-.1,ymax=3.5,
             xmin=-0.1,xmax=4.3,
             axis equal]
@@ -520,7 +524,7 @@
             \addplot[soliddot] coordinates{(1,1) (3,35)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+          ]]>      
             </latex-image>
           </image>
           <!-- figures/fig_normal1.tex END -->
@@ -655,7 +659,8 @@
           <image xml:id="img_tangentsinx">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[ymin=-1.1,ymax=1.1,
             xmin=-3.5,xmax=3.5,
             xtick={-3.14,-1.57,1.57,3.14},
@@ -665,7 +670,7 @@
             \addplot [soliddot] coordinates{(0,0)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>      
             </latex-image>
           </image>
           <!-- figures/fig_tangentsinx.tex END -->
@@ -867,7 +872,7 @@
         This should be somewhat surprising;
         the result of a tedious limit process on the sine function is a nice function.
         Then again, perhaps this is not entirely surprising.
-        The sine function is periodic <mdash /> it repeats itself on regular intervals.
+        The sine function is periodic <mdash/> it repeats itself on regular intervals.
         Therefore its rate of change also repeats itself on the same regular intervals.
         We should have known the derivative would be periodic;
         we now know exactly which periodic function it is.
@@ -903,13 +908,14 @@
         <image xml:id="img_absolutevalue">
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}
+          <![CDATA[
+          \begin{tikzpicture}
           \begin{axis}[ymin=-.2,ymax=1.1,
           xmin=-1.1,xmax=1.1,]
           \addplot+[domain=-1:1]{abs(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
         <!-- figures/fig_absolutevalue.tex END -->
@@ -919,7 +925,7 @@
       <p>
         We need to evaluate <m>\lim\limits_{h\to0}\frac{f(x+h)-f(x)}{h}</m>.
         As <m>f</m> is piecewise-defined,
-        we need to consider separately the limits when <m>x\lt 0</m> and when <m>x>0</m>.
+        we need to consider separately the limits when <m>x\lt 0</m> and when <m>x&gt;0</m>.
       </p>
 
       <p>
@@ -933,7 +939,7 @@
       </p>
 
       <p>
-        When <m>x>0</m>,
+        When <m>x&gt;0</m>,
         a similar computation shows that <m>\frac{d}{dx}(x) = 1</m>.
       </p>
 
@@ -996,7 +1002,8 @@
         <image xml:id="img_absolutevalueprime">
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}
+          <![CDATA[
+          \begin{tikzpicture}
           \begin{axis}[ymin=-1.4,ymax=1.4,
           xmin=-1.1,xmax=1.1]
           \addplot [firstcurvestyle,leftarrow,domain=-1:0]{1};
@@ -1004,7 +1011,7 @@
           \addplot[hollowdot] coordinates{(0,-1) (0,1)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
         <!-- figures/fig_absolutevalueprime.tex END -->
@@ -1031,7 +1038,8 @@
         <image xml:id="img_piecewisesinx1">
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}[declare function = {func(\x) = (\x < 1.5708) * (sin(x*180/pi)) + (\x >= 1.5708) * (1);}]
+          <![CDATA[
+          \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (sin(x*180/pi)) + (\x &gt;= 1.5708) * (1);}]
           \begin{axis}[ymin=-.4,ymax=1.4,
           xmin=-.1,xmax=2.1,
           xtick={1.57},
@@ -1039,7 +1047,7 @@
           \addplot+[domain=-.1:2,samples=100]{func(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
         <!-- figures/fig_piecewisesinx1.tex END -->
@@ -1049,7 +1057,7 @@
       <p>
         Using <xref ref="ex_deriv_sinx">Example</xref>,
         we know that when <m>x\lt \pi/2</m>, <m>\fp(x) = \cos(x)</m>.
-        It is easy to verify that when <m>x>\pi/2</m>,
+        It is easy to verify that when <m>x&gt;\pi/2</m>,
         <m>\fp(x) = 0</m>; consider:
         <me>
           \lim_{h\to0}\frac{f(x+h) - f(x)}{h} = \lim_{h\to0}\frac{1-1}{h} = \lim_{h\to0}0 =0
@@ -1059,7 +1067,7 @@
       <p>
         So far we have
         <me>
-          \fp(x) = \begin{cases}\cos(x) \amp  x\lt \pi/2\\ 0 \amp  x>\pi/2\end{cases}
+          \fp(x) = \begin{cases}\cos(x) \amp  x\lt \pi/2\\ 0 \amp  x&gt;\pi/2\end{cases}
         </me>.
       </p>
 
@@ -1122,7 +1130,8 @@
         <image xml:id="img_piecewisecosx1">
           <description></description>
           <latex-image>
-          <![CDATA[\begin{tikzpicture}[declare function = {func(\x) = (\x < 1.5708) * (cos(x*180/pi)) + (\x >= 1.5708) * (0);}]
+          <![CDATA[
+          \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1.5708) * (cos(x*180/pi)) + (\x &gt;= 1.5708) * (0);}]
           \begin{axis}[ymin=-.4,ymax=1.4,
           xmin=-.1,xmax=2.1,
           xtick={1.57},
@@ -1130,7 +1139,7 @@
           \addplot+[domain=-.1:2,samples=100]{func(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          ]]>    
           </latex-image>
         </image>
         <!-- figures/fig_piecewisecosx1.tex END -->
@@ -1160,7 +1169,10 @@
       Open intervals are required so that we can take a limit at any point <m>c</m> in <m>I</m>,
       meaning we want to approach <m>c</m> from both the left and right.
     </p>
-    <idx><h>differentiable</h><h>on a closed interval</h></idx>
+
+    <p>
+      <idx><h>differentiable</h><h>on a closed interval</h></idx>
+    </p>
 
     <p>
       Recall we also required open intervals in <xref ref="def_continuous">Definition</xref>
@@ -1184,7 +1196,7 @@
     <p>
       Secondly, consider <m>f(x) = \sqrt{x}</m>.
       The domain of <m>f</m> is <m>[0,\infty)</m>.
-      Is <m>f</m> differentiable on its domain <mdash /> specifically,
+      Is <m>f</m> differentiable on its domain <mdash/> specifically,
       is <m>f</m> differentiable at <m>0</m>? (We'll consider this in the next example.)
     </p>
 
@@ -1273,7 +1285,8 @@
           <image xml:id="img_diff_closed1">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[ymin=-.2,ymax=1.2,
             xmin=-.1,xmax=1.1,
             axisequal]
@@ -1282,8 +1295,8 @@
             \draw (axis cs:.25,.7) node {\scriptsize$y=x^{1/2}$};
             \draw (axis cs:.7,.35) node {\scriptsize$y=x^{3/2}$};
             \end{axis}
-            \end{tikzpicture}]]>
-            </latex-image>
+            \end{tikzpicture}
+            ]]>      </latex-image>
           </image>
         </figure>
 
@@ -1383,7 +1396,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1400,11 +1413,11 @@
               <p>
                 In your own words,
                 explain the difference between <xref ref="def_derivative_at_a_point">Definitions</xref>
-                and <xref ref="def_the_derivative"></xref>.
+                and <xref ref="def_the_derivative"/>.
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1424,7 +1437,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1444,7 +1457,7 @@
           </p>
 
           <p>
-            <var form="essay" />
+            <var form="essay"/>
           </p>
         </statement>
         <solution>
@@ -1476,7 +1489,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1493,7 +1506,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1510,7 +1523,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1527,7 +1540,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1544,7 +1557,7 @@
             </p>
 
             <p>
-              <var form="essay" />
+              <var form="essay"/>
             </p>
           </statement>
           <solution>
@@ -1566,7 +1579,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1583,7 +1596,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1600,7 +1613,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1614,7 +1627,7 @@
           In the following exercises,
           a function and an <m>x</m>-value <m>c</m> are given.
           (Note: these functions are the same as those given in <xref ref="exer_derivative_definition_constant">Exercises</xref>
-          through <xref ref="exer_derivative_definition_fractional_linear"></xref>.)
+          through <xref ref="exer_derivative_definition_fractional_linear"/>.)
           Give the equation of the tangent line at <m>c</m>,
           and give the equation of the normal line at <m>c</m>.
         </p>
@@ -1627,7 +1640,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Formula("y=6");
               $normalline=Formula("x=-2");
             </pg-code>
@@ -1639,12 +1652,12 @@
 
               <p>
                 At <m>x=-2</m>,
-                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=-2</m>,
-                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1657,7 +1670,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=2x");
               $normalline=Compute("y=-(1/2)(x-3)+6");
             </pg-code>
@@ -1669,12 +1682,12 @@
 
               <p>
                 At <m>x=3</m>,
-                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=3</m>,
-                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1687,7 +1700,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=-3x+4");
               $normalline=Compute("y=(1/3)(x-7)-17");
             </pg-code>
@@ -1699,12 +1712,12 @@
 
               <p>
                 At <m>x=7</m>,
-                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=7</m>,
-                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1717,7 +1730,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=4(x-2)+4");
               $normalline=Compute("y=-(1/4)(x-2)+4");
             </pg-code>
@@ -1729,12 +1742,12 @@
 
               <p>
                 At <m>x=2</m>,
-                the equation of the tangent line to the graph of <m>g</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>g</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=2</m>,
-                the equation of the normal line to the graph of <m>g</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>g</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1748,19 +1761,21 @@
           </p>
         </statement>
         <answer>
-          <ol>
-            <li>
-              <p>
-                <m>y = 48(x-4)+64</m>
-              </p>
-            </li>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  <m>y = 48(x-4)+64</m>
+                </p>
+              </li>
 
-            <li>
-              <p>
-                <m>y = -\frac{1}{48}(x-4)+64</m>
-              </p>
-            </li>
-          </ol>
+              <li>
+                <p>
+                  <m>y = -\frac{1}{48}(x-4)+64</m>
+                </p>
+              </li>
+            </ol>
+          </p>
         </answer>
       </exercise>
 
@@ -1771,7 +1786,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=-7(x+1)+8");
               $normalline=Compute("y=(1/7)(x+1)+8");
             </pg-code>
@@ -1783,12 +1798,12 @@
 
               <p>
                 At <m>x=-1</m>,
-                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>f</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=-1</m>,
-                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>f</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1801,7 +1816,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=-(1/4)(x+2)-1/2");
               $normalline=Compute("y=4(x+2)-1/2");
             </pg-code>
@@ -1813,12 +1828,12 @@
 
               <p>
                 At <m>x=-2</m>,
-                the equation of the tangent line to the graph of <m>r</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>r</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=-2</m>,
-                the equation of the normal line to the graph of <m>r</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>r</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1831,7 +1846,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=-(x-3)+1");
               $normalline=Compute("y=(x-3)+1");
             </pg-code>
@@ -1843,12 +1858,12 @@
 
               <p>
                 At <m>x=3</m>,
-                the equation of the tangent line to the graph of <m>r</m> is <var name="$tangentline" width="20" />.
+                the equation of the tangent line to the graph of <m>r</m> is <var name="$tangentline" width="20"/>.
               </p>
 
               <p>
                 At <m>x=3</m>,
-                the equation of the normal line to the graph of <m>r</m> is <var name="$normalline" width="20" />.
+                the equation of the normal line to the graph of <m>r</m> is <var name="$normalline" width="20"/>.
               </p>
             </statement>
         </webwork>
@@ -1872,7 +1887,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=8.1(x-3)+16");
             </pg-code>
             </setup>
@@ -1884,7 +1899,7 @@
               </p>
 
               <p>
-                <var name="$tangentline" width="20" />
+                <var name="$tangentline" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1896,7 +1911,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=-0.09901(x-9)+1");
             </pg-code>
             </setup>
@@ -1908,7 +1923,7 @@
               </p>
 
               <p>
-                <var name="$tangentline" width="20" />
+                <var name="$tangentline" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1920,7 +1935,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=7.771(x-2)+e^2");
             </pg-code>
             </setup>
@@ -1932,7 +1947,7 @@
               </p>
 
               <p>
-                <var name="$tangentline" width="20" />
+                <var name="$tangentline" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1944,7 +1959,7 @@
 
             <pg-code>
               Context("ImplicitPlane");
-              Context()->variables->are(x=>'Real',y=>'Real');
+              Context()-&gt;variables-&gt;are(x=&gt;'Real',y=&gt;'Real');
               $tangentline=Compute("y=-0.04996x+1");
             </pg-code>
             </setup>
@@ -1956,7 +1971,7 @@
               </p>
 
               <p>
-                <var name="$tangentline" width="20" />
+                <var name="$tangentline" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1975,9 +1990,9 @@
 
 
           <pg-code>
-            $gr = init_graph(-3,-2,3,4,axes=>[0,0],grid=>[6,6],size=>[400,400]);
-            add_functions($gr, "x^2-1 for x in &lt;-3,3> using color:blue and weight:2");
-            @approx=(Compute("-2")->with(tolType=>'absolute',tolerance=>0.4),Compute("0")->with(tolType=>'absolute',tolerance=>0.1),Compute("4")->with(tolType=>'absolute',tolerance=>2));
+            $gr = init_graph(-3,-2,3,4,axes=&gt;[0,0],grid=&gt;[6,6],size=&gt;[400,400]);
+            add_functions($gr, "x^2-1 for x in &lt;-3,3&gt; using color:blue and weight:2");
+            @approx=(Compute("-2")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.4),Compute("0")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.1),Compute("4")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;2));
             $derivative=Formula("2x");
             @slopes=(-2,0,4);
           </pg-code>
@@ -1987,9 +2002,9 @@
               The graph of <m>f(x)=x^2-1</m> is shown.
             </p>
 
-            <figure>
-              <image pg-name="$gr" />
-            </figure>
+            <sidebyside width="67%">
+              <image pg-name="$gr"/>
+            </sidebyside>
 
             <p>
               <ol>
@@ -2000,24 +2015,24 @@
 
                   <p>
                     At <m>(-1,0)</m>,
-                    the slope is approximately <var name="$approx[0]" width="10" />.
+                    the slope is approximately <var name="$approx[0]" width="10"/>.
                   </p>
 
                   <p>
                     At <m>(0,-1)</m>,
-                    the slope is approximately <var name="$approx[1]" width="10" />.
+                    the slope is approximately <var name="$approx[1]" width="10"/>.
                   </p>
 
                   <p>
                     At <m>(2,3)</m>,
-                    the slope is approximately <var name="$approx[2]" width="10" />.
+                    the slope is approximately <var name="$approx[2]" width="10"/>.
                   </p>
                 </li>
 
                 <li>
                   <p>
                     Using the definition,
-                    <m>\fp(x)=</m><var name="$derivative" width="10" />.
+                    <m>\fp(x)=</m><var name="$derivative" width="10"/>.
                   </p>
                 </li>
 
@@ -2028,15 +2043,15 @@
                   </p>
 
                   <p>
-                    At <m>(-1,0)</m>, the slope is <var name="$slopes[0]" width="10" />.
+                    At <m>(-1,0)</m>, the slope is <var name="$slopes[0]" width="10"/>.
                   </p>
 
                   <p>
-                    At <m>(0,-1)</m>, the slope is <var name="$slopes[1]" width="10" />.
+                    At <m>(0,-1)</m>, the slope is <var name="$slopes[1]" width="10"/>.
                   </p>
 
                   <p>
-                    At <m>(2,3)</m>, the slope is <var name="$slopes[2]" width="10" />.
+                    At <m>(2,3)</m>, the slope is <var name="$slopes[2]" width="10"/>.
                   </p>
                 </li>
               </ol>
@@ -2054,9 +2069,9 @@
 
 
           <pg-code>
-            $gr = init_graph(-1,-1,3,6,axes=>[0,0],grid=>[4,7],size=>[400,400]);
-            add_functions($gr, "1/(x+1) for x in &lt;-0.85,3> using color:blue and weight:2");
-            @approx=(Compute("-1")->with(tolType=>'absolute',tolerance=>0.2),Compute("-1/4")->with(tolType=>'absolute',tolerance=>0.1));
+            $gr = init_graph(-1,-1,3,6,axes=&gt;[0,0],grid=&gt;[4,7],size=&gt;[400,400]);
+            add_functions($gr, "1/(x+1) for x in &lt;-0.85,3&gt; using color:blue and weight:2");
+            @approx=(Compute("-1")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.2),Compute("-1/4")-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.1));
             $derivative=Formula("-1/(x+1)^2");
             @slopes=(-1,'-1/4');
           </pg-code>
@@ -2066,9 +2081,9 @@
               The graph of <m>f(x)=\frac{1}{x+1}</m> is shown.
             </p>
 
-            <figure>
-              <image pg-name="$gr" />
-            </figure>
+            <sidebyside width="67%">
+              <image pg-name="$gr"/>
+            </sidebyside>
 
             <p>
               <ol>
@@ -2079,19 +2094,19 @@
 
                   <p>
                     At <m>(0,1)</m>,
-                    the slope is approximately <var name="$approx[0]" width="10" />.
+                    the slope is approximately <var name="$approx[0]" width="10"/>.
                   </p>
 
                   <p>
                     At <m>(1,0.5)</m>,
-                    the slope is approximately <var name="$approx[1]" width="10" />.
+                    the slope is approximately <var name="$approx[1]" width="10"/>.
                   </p>
                 </li>
 
                 <li>
                   <p>
                     Using the definition,
-                    <m>\fp(x)=</m><var name="$derivative" width="10" />.
+                    <m>\fp(x)=</m><var name="$derivative" width="10"/>.
                   </p>
                 </li>
 
@@ -2101,11 +2116,11 @@
                   </p>
 
                   <p>
-                    At <m>(0,1)</m>, the slope is <var name="$slopes[0]" width="10" />.
+                    At <m>(0,1)</m>, the slope is <var name="$slopes[0]" width="10"/>.
                   </p>
 
                   <p>
-                    At <m>(1,0.5)</m>, the slope is <var name="$slopes[1]" width="10" />.
+                    At <m>(1,0.5)</m>, the slope is <var name="$slopes[1]" width="10"/>.
                   </p>
                 </li>
               </ol>
@@ -2129,13 +2144,14 @@
           <image xml:id="img_02_01_ex_26" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[xmin=-2.1,xmax=5.1,
             ymin=-1.5,ymax=3.5]
-            \addplot+[domain=-2.1:5.1,<->] {-.5*x+2};
+            \addplot+[domain=-2.1:5.1,&lt;-&gt;] {-.5*x+2};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>      
             </latex-image>
           </image>
 
@@ -2148,13 +2164,14 @@
           <image xml:id="img_02_01_ex_27" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[xmin=-7.1,xmax=3.1,
             ymin=-3.5,ymax=3.5]
             \addplot+[domain=-5.6:1.6,samples=40] {.5*(x+2)^2-3};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>      
             </latex-image>
           </image>
 
@@ -2167,13 +2184,14 @@
           <image xml:id="img_02_01_ex_28" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[xmin=-3.1,xmax=3.1,
             ymin=-5.5,ymax=5.5]
             \addplot+[domain=-2.45:2.45,samples=40] {(x-2)*x*(x+2)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>      
             </latex-image>
           </image>
 
@@ -2186,7 +2204,8 @@
           <image xml:id="img_02_01_ex_29" width="50%">
             <description></description>
             <latex-image>
-            <![CDATA[\begin{tikzpicture}
+            <![CDATA[
+            \begin{tikzpicture}
             \begin{axis}[xmin=-6.9,xmax=6.9,
             ymin=-1.1,ymax=1.1,
             xtick={-6.28,-3.14,3.14,6.28},
@@ -2194,7 +2213,7 @@
             \addplot+[domain=-6.8:6.8,samples=101] {cos(deg(x))};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>      
             </latex-image>
           </image>
 
@@ -2213,11 +2232,11 @@
 
 
           <pg-code>
-            $gr = init_graph(-3,-10,3,5,axes=>[0,0],grid=>[6,15],size=>[400,400]);
-            add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2> using color:blue and weight:2");
-            $gr -> lb('reset');
-            for my$i(-2,-1,1,2){$gr->lb(new Label($i,-0.5,$i,'black','center','top'));};
-            for my$i(-9..-1,1..4){$gr->lb(new Label(0.1,$i,$i,'black','left','middle'));};
+            $gr = init_graph(-3,-10,3,5,axes=&gt;[0,0],grid=&gt;[6,15],size=&gt;[400,400]);
+            add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2&gt; using color:blue and weight:2");
+            $gr -&gt; lb('reset');
+            for my$i(-2,-1,1,2){$gr-&gt;lb(new Label($i,-0.5,$i,'black','center','top'));};
+            for my$i(-9..-1,1..4){$gr-&gt;lb(new Label(0.1,$i,$i,'black','left','middle'));};
             Context("Interval");
             $pos=Compute("(-1.5,1.5)");
             $neg=Compute("(-inf,-1.5)U(1.5,inf)");
@@ -2233,51 +2252,51 @@
               answer the following questions.
             </p>
 
-            <figure>
-              <image pg-name="$gr" />
-            </figure>
+             <sidebyside width="67%">
+              <image pg-name="$gr"/>
+            </sidebyside>
 
             <p>
               <ol cols="2">
                 <li>
                   <p>
-                    Where is <m>g(x) > 0</m>?
-                    <var name="$pos" width="10" />
+                    Where is <m>g(x) &gt; 0</m>?
+                    <var name="$pos" width="10"/>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     Where is <m>g(x) \lt 0</m>?
-                    <var name="$neg" width="10" />
+                    <var name="$neg" width="10"/>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     Where is <m>g(x) = 0</m>?
-                    <var name="$zer" width="10" />
+                    <var name="$zer" width="10"/>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     Where is <m>g'(x) \lt 0</m>?
-                    <var name="$dec" width="10" />
+                    <var name="$dec" width="10"/>
                   </p>
                 </li>
 
                 <li>
                   <p>
-                    Where is <m>g'(x) > 0</m>?
-                    <var name="$inc" width="10" />
+                    Where is <m>g'(x) &gt; 0</m>?
+                    <var name="$inc" width="10"/>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     Where is <m>g'(x) = 0</m>?
-                    <var name="$fla" width="10" />
+                    <var name="$fla" width="10"/>
                   </p>
                 </li>
               </ol>
@@ -2301,7 +2320,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\ds f(x) = \sqrt{x^5(1-x)}</m>,<nbsp />domain = <m>[0,1]</m>,<nbsp /><m>\ds\fp(x) =
+            <m>\ds f(x) = \sqrt{x^5(1-x)}</m>,<nbsp/>domain = <m>[0,1]</m>,<nbsp/><m>\ds\fp(x) =
             \frac{(5-6x)x^{3/2}}{2\sqrt{1-x}}</m>
           </p>
         </statement>
@@ -2327,8 +2346,8 @@
       <exercise>
         <statement>
           <p>
-            <m>\ds f(x) = \cos\big(\sqrt{x}\big)</m>,<nbsp />domain =
-            <m>[0,\infty)</m>,<nbsp /><m>\ds\fp(x) = -\frac{\sin\big(\sqrt{x}\big)}{2\sqrt{x}}</m>
+            <m>\ds f(x) = \cos\big(\sqrt{x}\big)</m>,<nbsp/>domain =
+            <m>[0,\infty)</m>,<nbsp/><m>\ds\fp(x) = -\frac{\sin\big(\sqrt{x}\big)}{2\sqrt{x}}</m>
           </p>
         </statement>
         <answer>
@@ -2379,7 +2398,7 @@
             <setup>
 
             <pg-code>
-              $root=Compute(0.54)->with(tolType=>absolute,tolerance=>0.01);
+              $root=Compute(0.54)-&gt;with(tolType=&gt;absolute,tolerance=&gt;0.01);
             </pg-code>
             </setup>
             <statement>
@@ -2452,13 +2471,13 @@
 
 
             <pg-code>
-              $gr = init_graph(-5,-1,1,4,axes=>[0,0],grid=>[6,5],size=>[400,400]);
+              $gr = init_graph(-5,-1,1,4,axes=&gt;[0,0],grid=&gt;[6,5],size=&gt;[400,400]);
               add_functions($gr, "(x+3)^2 +1 for x in &lt;-5,-3) using color:blue and weight:2");
-              add_functions($gr, "-(x+3)^2 +3 for x in (-3,-1> using color:blue and weight:2");
-              $gr->stamps(closed_circle(-3,2,'blue'));
-              $gr -> lb('reset');
-              for my$i(-4..-1){$gr->lb(new Label($i,-0.5,$i,'black','center','top'));};
-              for my$i(2..4){$gr->lb(new Label(0.1,$i,$i,'black','left','middle'));};
+              add_functions($gr, "-(x+3)^2 +3 for x in (-3,-1&gt; using color:blue and weight:2");
+              $gr-&gt;stamps(closed_circle(-3,2,'blue'));
+              $gr -&gt; lb('reset');
+              for my$i(-4..-1){$gr-&gt;lb(new Label($i,-0.5,$i,'black','center','top'));};
+              for my$i(2..4){$gr-&gt;lb(new Label(0.1,$i,$i,'black','left','middle'));};
               @L=(1,3,Compute("DNE"));
               Context("Interval");
               $cont=Compute("(-inf,-3)U(-3,inf)");
@@ -2469,34 +2488,34 @@
                 Use the graph of <m>f(x)</m> provided to answer the following.
               </p>
 
-              <figure>
-                <image pg-name="$gr" />
-              </figure>
+              <sidebyside width="67%">
+                <image pg-name="$gr"/>
+              </sidebyside>
 
               <p>
                 <ol cols="2">
                   <li>
                     <p>
-                      <m>\lim\limits_{x\to-3^-} f(x) =</m> <var name="$L[0]" width="5" />
+                      <m>\lim\limits_{x\to-3^-} f(x) =</m> <var name="$L[0]" width="5"/>
                     </p>
                   </li>
 
                   <li>
                     <p>
-                      <m>\lim\limits_{x\to-3^+} f(x) =</m> <var name="$L[1]" width="5" />
+                      <m>\lim\limits_{x\to-3^+} f(x) =</m> <var name="$L[1]" width="5"/>
                     </p>
                   </li>
 
                   <li>
                     <p>
-                      <m>\lim\limits_{x\to-3} f(x) =</m> <var name="$L[2]" width="5" />
+                      <m>\lim\limits_{x\to-3} f(x) =</m> <var name="$L[2]" width="5"/>
                     </p>
                   </li>
 
                   <li>
                     <p>
                       Where is <m>f</m> continuous?
-                      <var name="$cont" width="15" />
+                      <var name="$cont" width="15"/>
                     </p>
                   </li>
                 </ol>
@@ -2508,4 +2527,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2012,7 +2012,7 @@
               The graph of <m>f(x)=x^2-1</m> is shown.
             </p>
 
-            <sidebyside width="67%">
+            <sidebyside width="50%">
               <image pg-name="$gr"/>
             </sidebyside>
 
@@ -2086,7 +2086,7 @@
               The graph of <m>f(x)=\frac{1}{x+1}</m> is shown.
             </p>
 
-            <sidebyside width="67%">
+            <sidebyside width="50%">
               <image pg-name="$gr"/>
             </sidebyside>
 
@@ -2247,7 +2247,7 @@
               answer the following questions.
             </p>
 
-             <sidebyside width="67%">
+             <sidebyside width="50%">
               <image pg-name="$gr"/>
             </sidebyside>
 
@@ -2473,7 +2473,7 @@
                 Use the graph of <m>f(x)</m> provided to answer the following.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -61,7 +61,7 @@
     <image xml:id="img_inverse1" width="47%">
       <description></description>
       <latex-image>
-      <![CDATA[
+
       \begin{tikzpicture}
       \begin{axis}[axis equal image,
       ymin=-1.3,ymax=2,
@@ -76,7 +76,7 @@
       \addplot [soliddot] coordinates{(1.5,1)} node[below right] {$(1.5,1)$};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+  
       </latex-image>
     </image>
       <!-- figures/fig_inverse1.tex END -->
@@ -113,7 +113,7 @@
     <image xml:id="img_inverse2" width="47%">
       <description></description>
       <latex-image>
-      <![CDATA[
+    
       \begin{tikzpicture}
       \begin{axis}[axis equal image,
       ymin=-1.3,ymax=2,
@@ -135,7 +135,7 @@
       \addplot [soliddot] coordinates{(1.5,1)} node[below right] {$(1.5,1)$};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+     
       </latex-image>
     </image>
       <!-- figures/fig_inverse2.tex END -->
@@ -274,7 +274,7 @@
         <image xml:id="img_inverse3" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+       
           \begin{tikzpicture}
           \coordinate (O) at (0,0);
           \coordinate (A) at (5,0);
@@ -290,7 +290,7 @@
           opacity=.4](A,O,B)
           \tkzLabelAngle[pos = 0.75](A,O,B){$y$}
           \end{tikzpicture}
-          ]]>          
+             
           </latex-image>
         </image>
           <!-- figures/fig_inverse3.tex END -->
@@ -332,12 +332,10 @@
   <caption>Graphs of <m>\sin(x)</m> and <m>\sin^{-1}(x)</m> along with corresponding tangent lines.</caption>
   <sidebyside widths="47% 47%">
       <!-- START figures/fig_inverse4.tex -->
-    
-
       <image xml:id="img_inverse4">
         <description></description>
         <latex-image>
-        <![CDATA[
+  
         \begin{tikzpicture}
         \begin{axis}[ymin=-1.7,ymax=1.7,
         xmin=-1.7,xmax=1.7,
@@ -350,18 +348,14 @@
         \addplot [soliddot] coordinates {(1.06,.866)} node [above left] {$\left(\frac{\pi}{3},\frac{\sqrt{3}}{2}\right)$};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+    
         </latex-image>
       </image>
-
-    
-
-    
 
       <image xml:id="img_inverse5">
         <description></description>
         <latex-image>
-        <![CDATA[
+ 
         \begin{tikzpicture}
         \begin{axis}[ymin=-1.7,ymax=1.7,
         xmin=-1.7,xmax=1.7,
@@ -373,11 +367,9 @@
         \addplot [soliddot] coordinates {(0.866,1.06)} node [below right] {$\left(\frac{\sqrt{3}}{2},\frac{\pi}{3}\right)$};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+     
         </latex-image>
       </image>
-
-    
   </sidebyside>
   </figure>
 
@@ -930,7 +922,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/5");
             </pg-code>
             </setup>
@@ -955,7 +947,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/4");
             </pg-code>
             </setup>
@@ -981,7 +973,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1");
             </pg-code>
             </setup>
@@ -1007,7 +999,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/6");
             </pg-code>
             </setup>
@@ -1033,7 +1025,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("-2");
             </pg-code>
             </setup>
@@ -1060,7 +1052,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/18");
             </pg-code>
             </setup>
@@ -1095,9 +1087,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[-0.25,0.25]});
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(t=>{limits=>[-0.25,0.25]});
               $fp=Formula("2/sqrt(1-4t^2)");
             </pg-code>
             </setup>
@@ -1123,8 +1115,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("1/(|t|sqrt(4t^2+1))");
             </pg-code>
             </setup>
@@ -1150,7 +1142,7 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("2/(1+4x^2)");
             </pg-code>
             </setup>
@@ -1176,8 +1168,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("x/sqrt(1-x^2)+sin^(-1)(x)");
             </pg-code>
             </setup>
@@ -1203,9 +1195,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[-1,1]});
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(t=>{limits=>[-1,1]});
               $fp=Formula("cos^(-1)(t)cos(t)-sin(t)/sqrt(1-t^2)");
             </pg-code>
             </setup>
@@ -1231,9 +1223,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;are(t=&gt;'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[1,5]});
+              Context()->variables->are(t=>'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(t=>{limits=>[1,5]});
               $fp=Formula("e^t/t+ln(t)e^t");
             </pg-code>
             </setup>
@@ -1258,8 +1250,8 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("(sin^-1(x)+cos^-1(x))/(sqrt(1-x^2)(cos^-1(x))^2)");
             </pg-code>
             </setup>
@@ -1285,8 +1277,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[1,5]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(x=>{limits=>[1,5]});
               $fp=Formula("1/(2sqrt(x)(1+x))");
             </pg-code>
             </setup>
@@ -1312,8 +1304,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("-1/sqrt(1-x^2)");
             </pg-code>
             </setup>
@@ -1339,8 +1331,8 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
-              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("1");
             </pg-code>
             </setup>
@@ -1520,9 +1512,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $t=Formula("y=sqrt(2)(x-sqrt(2)/2)+pi/4");
             </pg-code>
             </setup>
@@ -1549,9 +1541,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $t=Formula("y=-4(x-sqrt(3)/4)+pi/6");
             </pg-code>
             </setup>
@@ -1587,12 +1579,12 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              Context()->variables->add(y=>'Real');
               $dydx=Formula("(y(y-2x))/(x(x-2y))");
               @y=(random(0.1,5,0.1),random(0.1,5,0.1),random(0.1,5,0.1),random(0.1,5,0.1),random(0.1,5,0.1));
               @x=map{$_/2 +(-1)**(random(-1,1,2))*sqrt(($_)**2/4+1/$_)}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx-&gt;{test_points}=~~@xy;
+              $dydx->{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1617,9 +1609,9 @@
             <setup>
 
             <pg-code>
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $t=Formula("y=-4/5(x-1)+2");
             </pg-code>
             </setup>

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_deriv_inverse_function">
   <title>Derivatives of Inverse Functions</title>
   <!--<introduction>-->
@@ -147,7 +146,7 @@
   </p>
 
   <table xml:id="table_fandfinv">
-    <caption></caption>
+    <title/>
     <tabular>
       <col width="30%" halign="center"/>
       <col width="30%" halign="center"/>
@@ -185,7 +184,7 @@
     Let <m>y = g(x)</m>, where again <m>g = f^{-1}</m>.
     We want to find <m>y'</m>.
     Since <m>y = g(x)</m>, we know that <m>f(y) = x</m>.
-    Using the <xref ref="thm_chain_rule" text="title" /> and Implicit Differentiation,
+    Using the <xref ref="thm_chain_rule" text="title"/> and Implicit Differentiation,
     take the derivative of both sides of this last equality.
     <md>
       <mrow>\lzoo{x}{f(y)} \amp = \lzoo{x}{x}</mrow>
@@ -291,7 +290,7 @@
           opacity=.4](A,O,B)
           \tkzLabelAngle[pos = 0.75](A,O,B){$y$}
           \end{tikzpicture}
-          ]]>
+          ]]>          
           </latex-image>
         </image>
           <!-- figures/fig_inverse3.tex END -->
@@ -333,7 +332,7 @@
   <caption>Graphs of <m>\sin(x)</m> and <m>\sin^{-1}(x)</m> along with corresponding tangent lines.</caption>
   <sidebyside widths="47% 47%">
       <!-- START figures/fig_inverse4.tex -->
-    <figure>
+    
 
       <image xml:id="img_inverse4">
         <description></description>
@@ -351,14 +350,13 @@
         \addplot [soliddot] coordinates {(1.06,.866)} node [above left] {$\left(\frac{\pi}{3},\frac{\sqrt{3}}{2}\right)$};
         \end{axis}
         \end{tikzpicture}
-
         ]]>
         </latex-image>
       </image>
 
-    </figure>
+    
 
-    <figure>
+    
 
       <image xml:id="img_inverse5">
         <description></description>
@@ -379,7 +377,7 @@
         </latex-image>
       </image>
 
-    </figure>
+    
   </sidebyside>
   </figure>
 
@@ -408,7 +406,7 @@
   </p>
 
   <table xml:id="tab_domain_trig">
-    <caption>Domains and ranges of the trigonometric and inverse trigonometric functions.</caption>
+    <title>Domains and ranges of the trigonometric and inverse trigonometric functions.</title>
     <tabular>
       <row bottom="medium">
         <cell>Function</cell>
@@ -584,7 +582,7 @@
         Let <m>f</m> and <m>g</m> be differentiable functions,
         and let <m>a</m>,
         <m>c</m> and <m>n</m> be real numbers,
-        <m>a>0</m>, <m>n\neq 0</m>.
+        <m>a&gt;0</m>, <m>n\neq 0</m>.
       </p>
 
       <p>
@@ -771,7 +769,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -791,7 +789,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -812,7 +810,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -843,7 +841,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -864,7 +862,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -885,7 +883,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -905,7 +903,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -932,7 +930,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fip=Formula("1/5");
             </pg-code>
             </setup>
@@ -942,7 +940,7 @@
               </p>
 
               <p>
-                <m>\left(f^{-1}\right)'(20)=</m><var name="$fip" width="10" />
+                <m>\left(f^{-1}\right)'(20)=</m><var name="$fip" width="10"/>
               </p>
             </statement>
             <solution>
@@ -957,7 +955,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fip=Formula("1/4");
             </pg-code>
             </setup>
@@ -968,7 +966,7 @@
               </p>
 
               <p>
-                <m>\left(f^{-1}\right)'(7)=</m><var name="$fip" width="10" />
+                <m>\left(f^{-1}\right)'(7)=</m><var name="$fip" width="10"/>
               </p>
             </statement>
             <solution>
@@ -983,7 +981,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fip=Formula("1");
             </pg-code>
             </setup>
@@ -994,7 +992,7 @@
               </p>
 
               <p>
-                <m>\left(f^{-1}\right)'\left(\sqrt{3}/2\right)=</m><var name="$fip" width="10" />
+                <m>\left(f^{-1}\right)'\left(\sqrt{3}/2\right)=</m><var name="$fip" width="10"/>
               </p>
             </statement>
             <solution>
@@ -1009,7 +1007,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fip=Formula("1/6");
             </pg-code>
             </setup>
@@ -1019,7 +1017,7 @@
               </p>
 
               <p>
-                <m>\left(f^{-1}\right)'(8)=</m><var name="$fip" width="10" />
+                <m>\left(f^{-1}\right)'(8)=</m><var name="$fip" width="10"/>
               </p>
             </statement>
             <solution>
@@ -1035,7 +1033,7 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fip=Formula("-2");
             </pg-code>
             </setup>
@@ -1046,7 +1044,7 @@
               </p>
 
               <p>
-                <m>\left(f^{-1}\right)'(1/2)=</m><var name="$fip" width="10" />
+                <m>\left(f^{-1}\right)'(1/2)=</m><var name="$fip" width="10"/>
               </p>
             </statement>
             <solution>
@@ -1062,7 +1060,7 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fip=Formula("1/18");
             </pg-code>
             </setup>
@@ -1072,7 +1070,7 @@
               </p>
 
               <p>
-                <m>\left(f^{-1}\right)'(6)=</m><var name="$fip" width="10" />
+                <m>\left(f^{-1}\right)'(6)=</m><var name="$fip" width="10"/>
               </p>
             </statement>
             <solution>
@@ -1097,9 +1095,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(t=>{limits=>[-0.25,0.25]});
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[-0.25,0.25]});
               $fp=Formula("2/sqrt(1-4t^2)");
             </pg-code>
             </setup>
@@ -1109,7 +1107,7 @@
               </p>
 
               <p>
-                <m>h'(t)=</m><var name="$fp" width="40" />
+                <m>h'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1125,8 +1123,8 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("1/(|t|sqrt(4t^2+1))");
             </pg-code>
             </setup>
@@ -1136,7 +1134,7 @@
               </p>
 
               <p>
-                <m>f'(t)=</m><var name="$fp" width="40" />
+                <m>f'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1152,7 +1150,7 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $fp=Formula("2/(1+4x^2)");
             </pg-code>
             </setup>
@@ -1162,7 +1160,7 @@
               </p>
 
               <p>
-                <m>g'(x)=</m><var name="$fp" width="40" />
+                <m>g'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1178,8 +1176,8 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(x=>{limits=>[-1,1]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
               $fp=Formula("x/sqrt(1-x^2)+sin^(-1)(x)");
             </pg-code>
             </setup>
@@ -1189,7 +1187,7 @@
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="40" />
+                <m>f'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1205,9 +1203,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(t=>{limits=>[-1,1]});
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[-1,1]});
               $fp=Formula("cos^(-1)(t)cos(t)-sin(t)/sqrt(1-t^2)");
             </pg-code>
             </setup>
@@ -1217,7 +1215,7 @@
               </p>
 
               <p>
-                <m>g'(t)=</m><var name="$fp" width="40" />
+                <m>g'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1233,9 +1231,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->are(t=>'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(t=>{limits=>[1,5]});
+              Context()-&gt;variables-&gt;are(t=&gt;'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(t=&gt;{limits=&gt;[1,5]});
               $fp=Formula("e^t/t+ln(t)e^t");
             </pg-code>
             </setup>
@@ -1245,7 +1243,7 @@
               </p>
 
               <p>
-                <m>f'(t)=</m><var name="$fp" width="40" />
+                <m>f'(t)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1260,8 +1258,8 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(x=>{limits=>[-1,1]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
               $fp=Formula("(sin^-1(x)+cos^-1(x))/(sqrt(1-x^2)(cos^-1(x))^2)");
             </pg-code>
             </setup>
@@ -1271,7 +1269,7 @@
               </p>
 
               <p>
-                <m>h'(x)=</m><var name="$fp" width="40" />
+                <m>h'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1287,8 +1285,8 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(x=>{limits=>[1,5]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[1,5]});
               $fp=Formula("1/(2sqrt(x)(1+x))");
             </pg-code>
             </setup>
@@ -1298,7 +1296,7 @@
               </p>
 
               <p>
-                <m>g'(x)=</m><var name="$fp" width="40" />
+                <m>g'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1314,8 +1312,8 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(x=>{limits=>[-1,1]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
               $fp=Formula("-1/sqrt(1-x^2)");
             </pg-code>
             </setup>
@@ -1325,7 +1323,7 @@
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="40" />
+                <m>f'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1341,8 +1339,8 @@
             <setup>
 
             <pg-code>
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-              Context()->variables->set(x=>{limits=>[-1,1]});
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()-&gt;variables-&gt;set(x=&gt;{limits=&gt;[-1,1]});
               $fp=Formula("1");
             </pg-code>
             </setup>
@@ -1352,7 +1350,7 @@
               </p>
 
               <p>
-                <m>f'(x)=</m><var name="$fp" width="40" />
+                <m>f'(x)=</m><var name="$fp" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1387,14 +1385,12 @@
         <p>
           <ol>
             <li>
-              <title>(a)</title>
               <p>
                 By simplifying first, then taking the derivative, and
               </p>
             </li>
 
             <li>
-              <title>(b)</title>
               <p>
                 by using the Chain Rule first then simplifying.
               </p>
@@ -1418,7 +1414,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1452,7 +1448,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1486,7 +1482,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1524,9 +1520,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $t=Formula("y=sqrt(2)(x-sqrt(2)/2)+pi/4");
             </pg-code>
             </setup>
@@ -1537,7 +1533,7 @@
               </p>
 
               <p>
-                <var name="$t" width="30" />
+                <var name="$t" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1553,9 +1549,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $t=Formula("y=-4(x-sqrt(3)/4)+pi/6");
             </pg-code>
             </setup>
@@ -1566,7 +1562,7 @@
               </p>
 
               <p>
-                <var name="$t" width="30" />
+                <var name="$t" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1591,12 +1587,12 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
               $dydx=Formula("(y(y-2x))/(x(x-2y))");
               @y=(random(0.1,5,0.1),random(0.1,5,0.1),random(0.1,5,0.1),random(0.1,5,0.1),random(0.1,5,0.1));
               @x=map{$_/2 +(-1)**(random(-1,1,2))*sqrt(($_)**2/4+1/$_)}(@y);
               @xy=map{[$x[$_],$y[$_]]}(0..4);
-              $dydx->{test_points}=~~@xy;
+              $dydx-&gt;{test_points}=~~@xy;
             </pg-code>
             </setup>
             <statement>
@@ -1605,7 +1601,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
             <solution>
@@ -1621,9 +1617,9 @@
             <setup>
 
             <pg-code>
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $t=Formula("y=-4/5(x-1)+2");
             </pg-code>
             </setup>
@@ -1634,7 +1630,7 @@
               </p>
 
               <p>
-                <var name="$t" width="30" />
+                <var name="$t" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1659,7 +1655,7 @@
               </p>
 
               <p>
-                <m>\lim\limits_{s\to 0} \frac{f(x+s)-f(x)}{s}=</m><var name="$l" width="20" />
+                <m>\lim\limits_{s\to 0} \frac{f(x+s)-f(x)}{s}=</m><var name="$l" width="20"/>
               </p>
             </statement>
             <solution>
@@ -1673,4 +1669,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -582,7 +582,7 @@
         Let <m>f</m> and <m>g</m> be differentiable functions,
         and let <m>a</m>,
         <m>c</m> and <m>n</m> be real numbers,
-        <m>a&gt;0</m>, <m>n\neq 0</m>.
+        <m>a \gt 0</m>, <m>n\neq 0</m>.
       </p>
 
       <p>

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_prod_quot_rules">
   <title>The Product and Quotient Rules</title>
   <!--<introduction> Violates DTD to have introduction with no subsections -->
   <p>
     <xref ref="sec_basic_diff_rules">Section</xref> showed that,
     in some ways, derivatives behave nicely.
-    The <xref ref="constant-multiple-derivative-rule" text="title" /> and <xref ref="sum-difference-derivative-rule" text="title" /> established that the derivative of <m>f(x) = 5x^2+\sin(x)</m> was not complicated.
+    The <xref ref="constant-multiple-derivative-rule" text="title"/> and <xref ref="sum-difference-derivative-rule" text="title"/> established that the derivative of <m>f(x) = 5x^2+\sin(x)</m> was not complicated.
     We neglected computing the derivative of things like
     <m>g(x) = 5x^2\sin(x)</m> and <m>h(x) = \frac{5x^2}{\sin(x) }</m> on purpose;
     their derivatives are <em>not</em> as straightforward.
@@ -35,7 +34,7 @@
   <warning>
     <p>
       <m>\lzoo{x}{f(x)g(x)}\neq \fp(x)g'(x)</m>!
-      While this would be simpler than the <xref ref="thm_ProductRule" text="title" />, it is wrong.
+      While this would be simpler than the <xref ref="thm_ProductRule" text="title"/>, it is wrong.
     </p>
   </warning>
 
@@ -54,7 +53,7 @@
     </statement>
     <solution>
       <p>
-        To make our use of the <xref ref="thm_ProductRule" text="title" /> explicit,
+        To make our use of the <xref ref="thm_ProductRule" text="title"/> explicit,
         let's set <m>f(x) = 5x^2</m> and <m>g(x) = \sin(x)</m>.
         We easily compute/recall that
         <m>\fp(x) = 10x</m> and <m>g'(x) = \cos(x)</m>.
@@ -107,7 +106,7 @@
   </example>
 
   <p>
-    We now investigate why the <xref ref="thm_ProductRule" text="title" /> is true.
+    We now investigate why the <xref ref="thm_ProductRule" text="title"/> is true.
   </p>
 
   <proof statement="thm_ProductRule">
@@ -154,7 +153,7 @@
   <p>
     It is often true that we can recognize that a theorem is true through its proof yet somehow doubt its applicability to real problems.
     In the following example,
-    we compute the derivative of a product of functions in two ways to verify that the <xref ref="thm_ProductRule" text="title" /> is indeed <q>right.</q>
+    we compute the derivative of a product of functions in two ways to verify that the <xref ref="thm_ProductRule" text="title"/> is indeed <q>right.</q>
   </p>
 
   <example xml:id="ex_prod2">
@@ -165,7 +164,7 @@
         Find <m>y'</m> two ways: first,
         by expanding the given product and then taking the derivative,
         and second,
-        by applying the <xref ref="thm_ProductRule" text="title" />.
+        by applying the <xref ref="thm_ProductRule" text="title"/>.
         Verify that both methods give the same answer.
       </p>
     </statement>
@@ -180,7 +179,7 @@
       </p>
 
       <p>
-        Instead, let's apply the <xref ref="thm_ProductRule" text="title" /> to the original factored form:
+        Instead, let's apply the <xref ref="thm_ProductRule" text="title"/> to the original factored form:
         <md>
           <mrow>y' \amp = \lzoo{x}{x^2+3x+1}(2x^2-3x+1)+(x^2+3x+1)\lzoo{x}{2x^2-3x+1}</mrow>
           <mrow>\amp = (2x+3)(2x^2-3x+1)+(x^2+3x+1)(4x-3)</mrow>
@@ -208,10 +207,10 @@
     </statement>
     <solution>
       <p>
-        We have a product of three functions while the <xref ref="thm_ProductRule" text="title" /> only specifies how to handle a product of two functions.
+        We have a product of three functions while the <xref ref="thm_ProductRule" text="title"/> only specifies how to handle a product of two functions.
         Our method of handling this problem is to simply group the latter two functions together,
         and consider <m>y = x^3\cdot\left[\ln(x) \cos(x) \right]</m>.
-        Following the <xref ref="thm_ProductRule" text="title" />, we have
+        Following the <xref ref="thm_ProductRule" text="title"/>, we have
         <md>
           <mrow>\yp \amp = \lzoo{x}{x^3}\ln(x) \cos(x) + (x^3)\lzoo{x}{\ln(x) \cos(x)}</mrow>
           <intertext>To evaluate <m>\lzoo{x}{\ln(x) \cos(x)}</m>, we apply the Product Rule again:</intertext>
@@ -222,7 +221,7 @@
 
       <p>
         Recognize the pattern in our answer above:
-        when applying the <xref ref="thm_ProductRule" text="title" /> to a product of three functions,
+        when applying the <xref ref="thm_ProductRule" text="title"/> to a product of three functions,
         there are three terms added together in the final derivative.
         Each term contains only one derivative of one of the original functions,
         and each function's derivative shows up in only one term.
@@ -271,14 +270,14 @@
     <solution>
       <p>
         Recalling that the derivative of <m>\ln(x)</m> is <m>1/x</m>,
-        we use the <xref ref="thm_ProductRule" text="title" /> to find our answers.
+        we use the <xref ref="thm_ProductRule" text="title"/> to find our answers.
       </p>
 
       <p>
         <ol>
           <li>
             <p>
-              Applying the <xref ref="thm_ProductRule" text="title" />:
+              Applying the <xref ref="thm_ProductRule" text="title"/>:
               <md>
                 <mrow>\lzoo{x}{x\ln(x)}\amp= 1\cdot \ln(x) + x\cdot 1/x</mrow>
                 <mrow>\amp = \ln(x) + 1</mrow>
@@ -333,7 +332,7 @@
   </theorem>
 
   <p>
-    The <xref ref="thm_QuotientRule" text="title" /> is not hard to use,
+    The <xref ref="thm_QuotientRule" text="title"/> is not hard to use,
     although it might be a bit tricky to remember.
     A useful mnemonic works as follows.
     Consider a fraction's numerator and denominator as <q>HI</q>
@@ -365,7 +364,7 @@
     </statement>
     <solution>
       <p>
-        Directly applying the <xref ref="thm_QuotientRule" text="title" /> gives:
+        Directly applying the <xref ref="thm_QuotientRule" text="title"/> gives:
         <md>
           <mrow>\lzoo{x}{frac{5x^2}{\sin(x) }} \amp = \frac{\sin(x) \cdot \lzoo{x}{5x^2} - 5x^2\cdot \lzoo{x}{\sin(x)} }{\sin^2(x) }</mrow>
           <mrow>\amp =    \frac{10x\sin(x) - 5x^2\cos(x) }{\sin^2(x) }</mrow>
@@ -375,7 +374,7 @@
   </example>
 
   <p>
-    The <xref ref="thm_QuotientRule" text="title" /> allows us to fill in holes in our understanding of derivatives of the common trigonometric functions.
+    The <xref ref="thm_QuotientRule" text="title"/> allows us to fill in holes in our understanding of derivatives of the common trigonometric functions.
     We start with finding the derivative of the tangent function.
   </p>
 
@@ -390,7 +389,7 @@
       <p>
         At first, one might feel unequipped to answer this question.
         But recall that <m>\tan(x) = \sin(x) /\cos(x)</m>,
-        so we can apply the <xref ref="thm_QuotientRule" text="title" />.
+        so we can apply the <xref ref="thm_QuotientRule" text="title"/>.
         <md>
           <mrow>\lzoo{x}{\tan(x)}\amp = \lzoo{x}{\frac{\sin(x) }{\cos(x) }}</mrow>
           <mrow>\amp = \frac{\cos(x) \lzoo{x}{\sin(x)} - \sin(x)\lzoo{x}{\cos(x)}}{\cos^2(x) }</mrow>
@@ -442,7 +441,7 @@
     and stated the derivative of the cosine function in <xref ref="thm_deriv_common">Theorem</xref>.
     The derivatives of the cotangent,
     cosecant and secant functions can all be computed directly using <xref ref="thm_deriv_common">Theorem</xref>
-    and the <xref ref="thm_QuotientRule" text="title" />.
+    and the <xref ref="thm_QuotientRule" text="title"/>.
   </p>
 
   <theorem xml:id="thm_deriv_trig">
@@ -504,7 +503,7 @@
     <statement>
       <p>
         In <xref ref="ex_quot1">Example</xref>
-        the derivative of <m>f(x) = \frac{5x^2}{\sin(x) }</m> was found using the <xref ref="thm_QuotientRule" text="title" />.
+        the derivative of <m>f(x) = \frac{5x^2}{\sin(x) }</m> was found using the <xref ref="thm_QuotientRule" text="title"/>.
         Rewriting <m>f</m> as <m>f(x) = 5x^2\csc(x)</m>,
         find <m>\fp</m> using <xref ref="thm_deriv_trig">Theorem</xref>
         and verify the two answers are the same.
@@ -514,7 +513,7 @@
       <p>
         We found in <xref ref="ex_quot1">Example</xref>
         that <m>\fp(x) = \frac{10x\sin(x) - 5x^2\cos(x) }{\sin^2(x) }</m>.
-        We now find <m>\fp</m> using the <xref ref="thm_ProductRule" text="title" />, considering <m>f</m> as <m>f(x) = 5x^2\csc(x)</m>.
+        We now find <m>\fp</m> using the <xref ref="thm_ProductRule" text="title"/>, considering <m>f</m> as <m>f(x) = 5x^2\csc(x)</m>.
         <md>
           <mrow>\fp(x) \amp = \lzoo{x}{5x^2\csc(x)}</mrow>
           <mrow>\amp = 5x^2\lzoo{x}{\csc(x)} + \lzoo{x}{5x^2}\csc(x)</mrow>
@@ -537,7 +536,7 @@
   </example>
 
   <p>
-    The <xref ref="thm_QuotientRule" text="title" /> gives other useful results,
+    The <xref ref="thm_QuotientRule" text="title"/> gives other useful results,
     as shown in the next example.
   </p>
 
@@ -556,7 +555,7 @@
 
           <li>
             <p>
-              <m>f(x)= \dfrac{1}{x^n}</m>, where <m>n>0</m> is an integer.
+              <m>f(x)= \dfrac{1}{x^n}</m>, where <m>n&gt;0</m> is an integer.
             </p>
           </li>
         </ol>
@@ -564,7 +563,7 @@
     </statement>
     <solution>
       <p>
-        We employ the <xref ref="thm_QuotientRule" text="title" />.
+        We employ the <xref ref="thm_QuotientRule" text="title"/>.
 
         <ol>
           <li>
@@ -603,10 +602,10 @@
   </p>
 
   <p>
-    This is reminiscent of the <xref ref="power-derivative-rule" text="title" />:
+    This is reminiscent of the <xref ref="power-derivative-rule" text="title"/>:
     multiply by the power, then subtract <m>1</m> from the power.
     We now add to our previous Power Rule,
-    which had the restriction of <m>n>0</m>.
+    which had the restriction of <m>n&gt;0</m>.
   </p>
 
   <theorem xml:id="thm_PowerRule">
@@ -647,13 +646,13 @@
         <ol>
           <li>
             <p>
-              By applying the <xref ref="thm_QuotientRule" text="title" />,
+              By applying the <xref ref="thm_QuotientRule" text="title"/>,
             </p>
           </li>
 
           <li>
             <p>
-              by viewing <m>f</m> as <m>f(x) = \left(x^2-3x+1\right)\cdot x^{-1}</m> and applying the <xref ref="thm_ProductRule" text="title" /> and <xref ref="thm_PowerRule" text="title" />, and
+              by viewing <m>f</m> as <m>f(x) = \left(x^2-3x+1\right)\cdot x^{-1}</m> and applying the <xref ref="thm_ProductRule" text="title"/> and <xref ref="thm_PowerRule" text="title"/>, and
             </p>
           </li>
 
@@ -672,7 +671,7 @@
         <ol>
           <li>
             <p>
-              Applying the <xref ref="thm_QuotientRule" text="title" /> gives:
+              Applying the <xref ref="thm_QuotientRule" text="title"/> gives:
               <md>
                 <mrow>\fp(x) \amp =\frac{x\cdot\lzoo{x}{x^2-3x+1}-\left(x^2-3x+1\right)\lzoo{x}{x}}{x^2}</mrow>
                 <mrow>\amp = \frac{x\cdot(2x-3)-\left(x^2-3x+1\right)\cdot 1}{x^2}</mrow>
@@ -685,7 +684,7 @@
           <li>
             <p>
               By rewriting <m>f</m>,
-              we can apply the <xref ref="thm_ProductRule" text="title" /> and <xref ref="thm_PowerRule" text="title" /> as follows:
+              we can apply the <xref ref="thm_ProductRule" text="title"/> and <xref ref="thm_PowerRule" text="title"/> as follows:
               <md>
                 <mrow>\fp(x) \amp = \left(x^2-3x+1\right)\lzoo{x}{x^{-1}} + \lzoo{x}{x^2-3x+1} x^{-1}</mrow>
                 <mrow>\amp = \left(x^2-3x+1\right)\cdot (-1)x^{-2} + (2x-3)\cdot x^{-1}</mrow>
@@ -701,7 +700,7 @@
             <p>
               As <m>x\neq 0</m>, we can divide through by <m>x</m> first,
               giving <m>f(x) = x-3+x^{-1}</m>.
-              Now apply the <xref ref="thm_PowerRule" text="title" />.
+              Now apply the <xref ref="thm_PowerRule" text="title"/>.
               <me>
                 \fp(x) = 1-\frac{1}{x^2}
               </me>,
@@ -718,7 +717,7 @@
     demonstrates three methods of finding <m>\fp</m>.
     One is hard pressed to argue for a <q>best method</q>
     as all three gave the same result without too much difficulty,
-    although it is clear that using the <xref ref="thm_ProductRule" text="title" /> required more steps.
+    although it is clear that using the <xref ref="thm_ProductRule" text="title"/> required more steps.
     Ultimately, the important principle to take away from this is:
     reduce the answer to a form that seems
     <q>simple</q> and easy to interpret.
@@ -741,10 +740,10 @@
     In the next section we continue to learn rules that allow us to more easily compute derivatives than using the limit definition directly.
     We have to memorize the derivatives of a certain set of functions,
     such as <q>the derivative of <m>\sin(x)</m> is <m>\cos(x)</m>.</q>
-    The <xref ref="sum-difference-derivative-rule" text="title" />,
-    <xref ref="constant-multiple-derivative-rule" text="title" />,
+    The <xref ref="sum-difference-derivative-rule" text="title"/>,
+    <xref ref="constant-multiple-derivative-rule" text="title"/>,
     <xref ref="thm_PowerRule" text="title">Power Rule</xref>,
-    <xref ref="thm_ProductRule" text="title" /> and <xref ref="thm_QuotientRule" text="title" /> show us how to find the derivatives of certain combinations of these functions.
+    <xref ref="thm_ProductRule" text="title"/> and <xref ref="thm_QuotientRule" text="title"/> show us how to find the derivatives of certain combinations of these functions.
     The next section shows how to find the derivatives when we <em>compose</em>
     these functions together.
   </p>
@@ -858,7 +857,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -928,7 +927,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -964,7 +963,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1000,7 +999,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1036,7 +1035,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1102,7 +1101,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1138,7 +1137,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1174,7 +1173,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1210,7 +1209,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1233,18 +1232,18 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("$x sin($x)");
-              $deriv = $formula->D("$x");
+              $deriv = $formula-&gt;D("$x");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1285,18 +1284,18 @@
             <setup>            <pg-code>
               $f = 'f';
               $x = 't';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("1/$x^2*(csc($x)-4)");
-              $deriv = $formula->D("$x");
+              $deriv = $formula-&gt;D("$x");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1308,18 +1307,18 @@
             <pg-code>
               $f = 'g';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("($x+7)/($x-5)");
               $deriv = Formula("-12/(x-5)^2");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1331,18 +1330,18 @@
             <pg-code>
               $f = 'g';
               $x = 't';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("$x^5/(cos($x)-2 $x^2)");
-              $deriv = $formula->D("$x");
+              $deriv = $formula-&gt;D("$x");
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1354,18 +1353,18 @@
             <pg-code>
               $f = 'h';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("cot($x) - e^$x");
-              $deriv = $formula->D("$x")->reduce;
+              $deriv = $formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1392,18 +1391,18 @@
             <pg-code>
               $f = 'h';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("cot($x) - e^$x");
-              $deriv = $formula->D("$x")->reduce;
+              $deriv = $formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1415,18 +1414,18 @@
             <pg-code>
               $f = 'h';
               $x = 't';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("7$x^2+6$x-2");
-              $deriv = Formula("14$x+6");#$formula->D("$x")->reduce;
+              $deriv = Formula("14$x+6");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1438,18 +1437,18 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("($x^4+2$x^3)/($x+2)");
-              $deriv = $formula->D("$x")->reduce;
+              $deriv = $formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1461,18 +1460,18 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("(16$x^4+24$x^2+3)*((7$x-1)/(16$x^4+24$x^2+3))");
-              $deriv = Formula("7");#$formula->D("$x")->reduce;
+              $deriv = Formula("7");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1484,18 +1483,18 @@
             <pg-code>
               $f = 'f';
               $x = 't';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("$x^5(sec($x) + e^$x)");
-              $deriv = Formula("5$x^4*(sec($x)+e^$x)+t^5*(sec($x)*tan($x)+e^$x)");#$formula->D("$x")->reduce;
+              $deriv = Formula("5$x^4*(sec($x)+e^$x)+t^5*(sec($x)*tan($x)+e^$x)");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1507,18 +1506,18 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("sin($x)/(cos($x)+3)");
-              $deriv = Formula("(1+3*cos($x))/(cos($x)+3)^2");#$formula->D("$x")->reduce;
+              $deriv = Formula("(1+3*cos($x))/(cos($x)+3)^2");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1556,19 +1555,19 @@
             <pg-code>
               $f = 'g';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
-              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
               $formula = Formula("e^2*(sin(pi/4) - 1)");
-              $deriv = Formula("0");#$formula->D("$x")->reduce;
+              $deriv = Formula("0");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1580,18 +1579,18 @@
             <pg-code>
               $f = 'g';
               $x = 't';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("4$x^3e^$x - sin($x)*cos($x)");
-              $deriv = Formula("12$x^2e^$x + 4$x^3e^$x - cos^2($x) + sin^2($x)");#$formula->D("$x")->reduce;
+              $deriv = Formula("12$x^2e^$x + 4$x^3e^$x - cos^2($x) + sin^2($x)");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1603,18 +1602,18 @@
             <pg-code>
               $f = 'h';
               $x = 't';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("($x^2*sin($x)+3)/($x^2*cos($x)+2)");
-              $deriv = $formula->D("$x")->reduce;
+              $deriv = $formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1626,18 +1625,18 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("$x^2*e^$x*tan($x)");
-              $deriv = Formula("2$x*e^$x*tan($x) + $x^2*e^$x*tan($x) + $x^2*e^$x*sec^2($x)");#$formula->D("$x")->reduce;
+              $deriv = Formula("2$x*e^$x*tan($x) + $x^2*e^$x*tan($x) + $x^2*e^$x*sec^2($x)");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1649,18 +1648,18 @@
             <pg-code>
               $f = 'g';
               $x = 'x';
-              Context()->variables->are($x => 'Real');
+              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
               $formula = Formula("2$x*sin($x)*sec($x)");
-              $deriv = Formula("2*tan($x)+2*$x*sec^2($x)");#$formula->D("$x")->reduce;
+              $deriv = Formula("2*tan($x)+2*$x*sec^2($x)");#$formula-&gt;D("$x")-&gt;reduce;
             </pg-code>
             </setup>
             <statement>
               <p>
-                <m><var name="$f" />(<var name="$x" />) = <var name="$formula" /></m>
+                <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
               </p>
 
               <p>
-                <m><var name="$f" />'(<var name="$x" />) = </m><var name="$deriv" width="15" />
+                <m><var name="$f"/>'(<var name="$x"/>) = </m><var name="$deriv" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1683,9 +1682,9 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("e^x(x^2+2)");
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=2x+2");
               $n=Formula("y=-(1/2)x+2");
               Context("Point");
@@ -1694,16 +1693,16 @@
             </setup>
             <statement>
               <p>
-                Let <m><var name="$f" />(x) = <var name="$formula" /></m>.
-                Find the equations of the tangent line and normal line at <m><var name="$point" /></m>.
+                Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
+                Find the equations of the tangent line and normal line at <m><var name="$point"/></m>.
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1715,28 +1714,28 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("x sin(x)");
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=-x");
               $n=Compute("y=x-3pi");
               Context("Point");
-              Context()->flags->set(reduceConstants=>0);
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
               $point='\left(\frac{3\pi}{2},-\frac{3\pi}{2}\right)';
             </pg-code>
             </setup>
             <statement>
               <p>
-                Let <m><var name="$f" />(x) = <var name="$formula" /></m>.
-                Find the equations of the tangent line and normal line at <m><var name="$point" /></m>.
+                Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
+                Find the equations of the tangent line and normal line at <m><var name="$point"/></m>.
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1748,9 +1747,9 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("x^2/(x-1)");
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=4");
               $n=Formula("x=2");
               Context("Point");
@@ -1759,16 +1758,16 @@
             </setup>
             <statement>
               <p>
-                Let <m><var name="$f" />(x) = <var name="$formula" /></m>.
-                Find the equations of the tangent line and normal line at <m><var name="$point" /></m>.
+                Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
+                Find the equations of the tangent line and normal line at <m><var name="$point"/></m>.
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1780,9 +1779,9 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("(cos(x)-8x)/(x+1)");
-              Context()->flags->set(reduceConstants=>0);
-              Context()->variables->add(y=>'Real');
-              parser::Assignment->Allow;
+              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()-&gt;variables-&gt;add(y=&gt;'Real');
+              parser::Assignment-&gt;Allow;
               $t=Formula("y=-9x+1");
               $n=Formula("y=1/9x+1");
               Context("Point");
@@ -1791,16 +1790,16 @@
             </setup>
             <statement>
               <p>
-                Let <m><var name="$f" />(x) = <var name="$formula" /></m>.
-                Find the equations of the tangent line and normal line at <m><var name="$point" /></m>.
+                Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
+                Find the equations of the tangent line and normal line at <m><var name="$point"/></m>.
               </p>
 
               <p>
-                Tangent line equation: <var name="$t" width="20" />
+                Tangent line equation: <var name="$t" width="20"/>
               </p>
 
               <p>
-                Normal line equation: <var name="$n" width="20" />
+                Normal line equation: <var name="$n" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1833,7 +1832,7 @@
               </p>
 
               <p>
-                <var name="$points" width="15" />
+                <var name="$points" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1856,7 +1855,7 @@
               </p>
 
               <p>
-                <var name="$points" width="15" />
+                <var name="$points" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1879,7 +1878,7 @@
               </p>
 
               <p>
-                <var name="$points" width="15" />
+                <var name="$points" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1902,7 +1901,7 @@
               </p>
 
               <p>
-                <var name="$points" width="15" />
+                <var name="$points" width="15"/>
               </p>
             </statement>
         </webwork>
@@ -1930,7 +1929,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$answer" width="20" />
+                <m>\fpp(x)=</m><var name="$answer" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1949,7 +1948,7 @@
               </p>
 
               <p>
-                <m>f^{(4)}(x)=</m><var name="$answer" width="20" />
+                <m>f^{(4)}(x)=</m><var name="$answer" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1968,7 +1967,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$answer" width="20" />
+                <m>\fpp(x)=</m><var name="$answer" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1987,7 +1986,7 @@
               </p>
 
               <p>
-                <m>f^{(8)}(x)=</m><var name="$answer" width="20" />
+                <m>f^{(8)}(x)=</m><var name="$answer" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -2009,7 +2008,7 @@
           <image xml:id="img_02_04_ex_42" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2017,7 +2016,7 @@
             \addplot+[domain=-3.5:2.75] {2*x+1};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_42.tex END -->
@@ -2027,7 +2026,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2035,7 +2034,7 @@
             \addplot+[domain=-3.5:3.5] {2};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2045,7 +2044,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2053,7 +2052,7 @@
             \addplot+[domain=-3.5:3.5] {2};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2066,7 +2065,7 @@
           <image xml:id="img_02_04_ex_43" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2074,7 +2073,7 @@
             \addplot+[] coordinates {(-3.5,-4.5) (-1,3) (3.5,-1.5)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_43.tex END -->
@@ -2084,7 +2083,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2094,7 +2093,7 @@
             \addplot[hollowdot] coordinates {(-1,3) (-1,-1)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2104,7 +2103,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2114,7 +2113,7 @@
             \addplot[hollowdot] coordinates {(-1,3) (-1,-1)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2127,7 +2126,7 @@
           <image xml:id="img_02_04_ex_44" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.5,xmax=5.5,
             ymin=-6.5,ymax=6.5,
@@ -2135,7 +2134,7 @@
             \addplot+[domain=-1.9:5.3,samples=60] {x^3/3-2*x^2+x+5};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_44.tex END -->
@@ -2145,7 +2144,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.5,xmax=5.5,
             ymin=-6.5,ymax=6.5,
@@ -2153,7 +2152,7 @@
             \addplot+[domain=-1:5] {x^2-4*x+1};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2163,7 +2162,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.5,xmax=5.5,
             ymin=-6.5,ymax=6.5,
@@ -2171,7 +2170,7 @@
             \addplot+[domain=-1:5] {x^2-4*x+1};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2184,7 +2183,7 @@
           <image xml:id="img_02_04_ex_45" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-5.5,xmax=5.5,
             ymin=-11,ymax=11,
@@ -2196,7 +2195,7 @@
             \addplot[asymptote] coordinates {(-1,-11) (-1,11)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_45.tex END -->
@@ -2206,7 +2205,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-5.5,xmax=5.5,
             ymin=-11,ymax=11,
@@ -2216,7 +2215,7 @@
             \addplot[asymptote] coordinates {(-1,-11) (-1,11)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2226,7 +2225,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            <![CDATA[  
             \begin{tikzpicture}
             \begin{axis}[xmin=-5.5,xmax=5.5,
             ymin=-11,ymax=11,
@@ -2236,7 +2235,7 @@
             \addplot[asymptote] coordinates {(-1,-11) (-1,11)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            ]]>  
             </latex-image>
           </image>
 
@@ -2246,4 +2245,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -86,7 +86,7 @@
         <image xml:id="img_5xsquaredsinx" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-0.1,xmax=3.5,
           ymin=-1.1,ymax=21,
@@ -97,7 +97,7 @@
           \addplot[soliddot] coordinates{(1.57,12.34)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_5xsquaredsinx.tex END -->
@@ -415,7 +415,7 @@
         <image xml:id="img_tanx" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-1.65,xmax=1.7,
           ymin=-11,ymax=11,
@@ -426,7 +426,7 @@
           \addplot [soliddot] coordinates{(0.785,1)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_tanx.tex END -->
@@ -1232,9 +1232,9 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("$x sin($x)");
-              $deriv = $formula-&gt;D("$x");
+              $deriv = $formula->D("$x");
             </pg-code>
             </setup>
             <statement>
@@ -1284,9 +1284,9 @@
             <setup>            <pg-code>
               $f = 'f';
               $x = 't';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("1/$x^2*(csc($x)-4)");
-              $deriv = $formula-&gt;D("$x");
+              $deriv = $formula->D("$x");
             </pg-code>
             </setup>
             <statement>
@@ -1307,7 +1307,7 @@
             <pg-code>
               $f = 'g';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("($x+7)/($x-5)");
               $deriv = Formula("-12/(x-5)^2");
             </pg-code>
@@ -1330,9 +1330,9 @@
             <pg-code>
               $f = 'g';
               $x = 't';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("$x^5/(cos($x)-2 $x^2)");
-              $deriv = $formula-&gt;D("$x");
+              $deriv = $formula->D("$x");
             </pg-code>
             </setup>
             <statement>
@@ -1353,9 +1353,9 @@
             <pg-code>
               $f = 'h';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("cot($x) - e^$x");
-              $deriv = $formula-&gt;D("$x")-&gt;reduce;
+              $deriv = $formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1391,9 +1391,9 @@
             <pg-code>
               $f = 'h';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("cot($x) - e^$x");
-              $deriv = $formula-&gt;D("$x")-&gt;reduce;
+              $deriv = $formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1414,9 +1414,9 @@
             <pg-code>
               $f = 'h';
               $x = 't';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("7$x^2+6$x-2");
-              $deriv = Formula("14$x+6");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("14$x+6");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1437,9 +1437,9 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("($x^4+2$x^3)/($x+2)");
-              $deriv = $formula-&gt;D("$x")-&gt;reduce;
+              $deriv = $formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1460,9 +1460,9 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("(16$x^4+24$x^2+3)*((7$x-1)/(16$x^4+24$x^2+3))");
-              $deriv = Formula("7");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("7");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1483,9 +1483,9 @@
             <pg-code>
               $f = 'f';
               $x = 't';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("$x^5(sec($x) + e^$x)");
-              $deriv = Formula("5$x^4*(sec($x)+e^$x)+t^5*(sec($x)*tan($x)+e^$x)");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("5$x^4*(sec($x)+e^$x)+t^5*(sec($x)*tan($x)+e^$x)");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1506,9 +1506,9 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("sin($x)/(cos($x)+3)");
-              $deriv = Formula("(1+3*cos($x))/(cos($x)+3)^2");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("(1+3*cos($x))/(cos($x)+3)^2");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1555,10 +1555,10 @@
             <pg-code>
               $f = 'g';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0,reduceConstantFunctions=&gt;0);
+              Context()->variables->are($x => 'Real');
+              Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $formula = Formula("e^2*(sin(pi/4) - 1)");
-              $deriv = Formula("0");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("0");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1579,9 +1579,9 @@
             <pg-code>
               $f = 'g';
               $x = 't';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("4$x^3e^$x - sin($x)*cos($x)");
-              $deriv = Formula("12$x^2e^$x + 4$x^3e^$x - cos^2($x) + sin^2($x)");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("12$x^2e^$x + 4$x^3e^$x - cos^2($x) + sin^2($x)");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1602,9 +1602,9 @@
             <pg-code>
               $f = 'h';
               $x = 't';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("($x^2*sin($x)+3)/($x^2*cos($x)+2)");
-              $deriv = $formula-&gt;D("$x")-&gt;reduce;
+              $deriv = $formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1625,9 +1625,9 @@
             <pg-code>
               $f = 'f';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("$x^2*e^$x*tan($x)");
-              $deriv = Formula("2$x*e^$x*tan($x) + $x^2*e^$x*tan($x) + $x^2*e^$x*sec^2($x)");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("2$x*e^$x*tan($x) + $x^2*e^$x*tan($x) + $x^2*e^$x*sec^2($x)");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1648,9 +1648,9 @@
             <pg-code>
               $f = 'g';
               $x = 'x';
-              Context()-&gt;variables-&gt;are($x =&gt; 'Real');
+              Context()->variables->are($x => 'Real');
               $formula = Formula("2$x*sin($x)*sec($x)");
-              $deriv = Formula("2*tan($x)+2*$x*sec^2($x)");#$formula-&gt;D("$x")-&gt;reduce;
+              $deriv = Formula("2*tan($x)+2*$x*sec^2($x)");#$formula->D("$x")->reduce;
             </pg-code>
             </setup>
             <statement>
@@ -1682,9 +1682,9 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("e^x(x^2+2)");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=2x+2");
               $n=Formula("y=-(1/2)x+2");
               Context("Point");
@@ -1714,13 +1714,13 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("x sin(x)");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=-x");
               $n=Compute("y=x-3pi");
               Context("Point");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->flags->set(reduceConstants=>0);
               $point='\left(\frac{3\pi}{2},-\frac{3\pi}{2}\right)';
             </pg-code>
             </setup>
@@ -1747,9 +1747,9 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("x^2/(x-1)");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=4");
               $n=Formula("x=2");
               Context("Point");
@@ -1779,9 +1779,9 @@
             <pg-code>
               $f = 'g';
               $formula = Formula("(cos(x)-8x)/(x+1)");
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
-              Context()-&gt;variables-&gt;add(y=&gt;'Real');
-              parser::Assignment-&gt;Allow;
+              Context()->flags->set(reduceConstants=>0);
+              Context()->variables->add(y=>'Real');
+              parser::Assignment->Allow;
               $t=Formula("y=-9x+1");
               $n=Formula("y=1/9x+1");
               Context("Point");
@@ -2008,7 +2008,7 @@
           <image xml:id="img_02_04_ex_42" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2016,7 +2016,7 @@
             \addplot+[domain=-3.5:2.75] {2*x+1};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+            
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_42.tex END -->
@@ -2026,7 +2026,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2034,7 +2034,7 @@
             \addplot+[domain=-3.5:3.5] {2};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
 
@@ -2044,7 +2044,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2052,7 +2052,7 @@
             \addplot+[domain=-3.5:3.5] {2};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
 
@@ -2065,7 +2065,7 @@
           <image xml:id="img_02_04_ex_43" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2073,7 +2073,7 @@
             \addplot+[] coordinates {(-3.5,-4.5) (-1,3) (3.5,-1.5)};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_43.tex END -->
@@ -2083,7 +2083,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2093,7 +2093,7 @@
             \addplot[hollowdot] coordinates {(-1,3) (-1,-1)};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
 
@@ -2103,7 +2103,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.5,xmax=3.5,
             ymin=-6.5,ymax=6.5,
@@ -2113,7 +2113,7 @@
             \addplot[hollowdot] coordinates {(-1,3) (-1,-1)};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+            
             </latex-image>
           </image>
 
@@ -2126,7 +2126,7 @@
           <image xml:id="img_02_04_ex_44" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.5,xmax=5.5,
             ymin=-6.5,ymax=6.5,
@@ -2134,7 +2134,7 @@
             \addplot+[domain=-1.9:5.3,samples=60] {x^3/3-2*x^2+x+5};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+            
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_44.tex END -->
@@ -2144,7 +2144,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.5,xmax=5.5,
             ymin=-6.5,ymax=6.5,
@@ -2152,7 +2152,7 @@
             \addplot+[domain=-1:5] {x^2-4*x+1};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+            
             </latex-image>
           </image>
 
@@ -2162,7 +2162,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.5,xmax=5.5,
             ymin=-6.5,ymax=6.5,
@@ -2170,7 +2170,7 @@
             \addplot+[domain=-1:5] {x^2-4*x+1};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
 
@@ -2183,7 +2183,7 @@
           <image xml:id="img_02_04_ex_45" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-5.5,xmax=5.5,
             ymin=-11,ymax=11,
@@ -2195,7 +2195,7 @@
             \addplot[asymptote] coordinates {(-1,-11) (-1,11)};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
             <!-- figures/fig_02_04_ex_45.tex END -->
@@ -2205,7 +2205,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-5.5,xmax=5.5,
             ymin=-11,ymax=11,
@@ -2215,7 +2215,7 @@
             \addplot[asymptote] coordinates {(-1,-11) (-1,11)};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
 
@@ -2225,7 +2225,7 @@
           <image width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[  
+  
             \begin{tikzpicture}
             \begin{axis}[xmin=-5.5,xmax=5.5,
             ymin=-11,ymax=11,
@@ -2235,7 +2235,7 @@
             \addplot[asymptote] coordinates {(-1,-11) (-1,11)};
             \end{axis}
             \end{tikzpicture}
-            ]]>  
+  
             </latex-image>
           </image>
 

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -555,7 +555,7 @@
 
           <li>
             <p>
-              <m>f(x)= \dfrac{1}{x^n}</m>, where <m>n&gt;0</m> is an integer.
+              <m>f(x)= \dfrac{1}{x^n}</m>, where <m>n \gt 0</m> is an integer.
             </p>
           </li>
         </ol>
@@ -605,7 +605,7 @@
     This is reminiscent of the <xref ref="power-derivative-rule" text="title"/>:
     multiply by the power, then subtract <m>1</m> from the power.
     We now add to our previous Power Rule,
-    which had the restriction of <m>n&gt;0</m>.
+    which had the restriction of <m>n \gt 0</m>.
   </p>
 
   <theorem xml:id="thm_PowerRule">

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_concavity">
   <title>Concavity and the Second Derivative</title>
   <introduction>
@@ -14,7 +13,7 @@
     <p>
       The key to studying <m>\fp</m> is to consider its derivative,
       namely <m>\fp'</m>, which is the second derivative of <m>f</m>.
-      When <m>\fp'>0</m>, <m>\fp</m> is increasing.
+      When <m>\fp'\gt 0</m>, <m>\fp</m> is increasing.
       When <m>\fp'\lt 0</m>, <m> \fp </m>is decreasing.
       <m>\fp</m> has relative maxima and minima where <m>\fp'=0</m> or is undefined.
     </p>
@@ -75,10 +74,10 @@
     <figure xml:id="fig_concavity1">
       <caption>A function <m>f</m> with a concave up graph. Notice how the slopes of the tangent lines, when looking from left to right, are increasing. (The slope values pictured are <m>-12, -6, 6 </m>  and <m>12</m>).</caption>
       <!-- START figures/fig_concavity1.tex -->
-      <image xml:id="img_concavity1"  width="47%">
+      <image xml:id="img_concavity1" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-3.5,xmax=3.5,
         ymin=-1,ymax=35,]
@@ -89,7 +88,7 @@
         \addplot [tangentlineseg,domain =-.5:2.5] {6*(x-1)+8} ;
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_concavity1.tex END -->
@@ -130,10 +129,10 @@
     <figure xml:id="fig_concavity2">
       <caption>A function <m>f</m> with a concave down graph. Notice how the slopes of the tangent lines, when looking from left to right, are decreasing.</caption>
       <!-- START figures/fig_concavity2.tex -->
-      <image xml:id="img_concavity2"  width="47%">
+      <image xml:id="img_concavity2" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-3.5,xmax=3.5,
 			 ymin=-1,ymax=35,]
@@ -144,7 +143,7 @@
         \addplot [tangentlineseg, domain =.2:2.5] {-6*(x-1)+28} ;
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_concavity2.tex END -->
@@ -169,7 +168,7 @@
     <p>
       Our definition of concave up and concave down is given in terms of when the first derivative is increasing or decreasing.
       We can apply the results of the previous section to find intervals on which a graph is concave up or down.
-      That is, we recognize that <m>\fp</m> is increasing when <m>\fpp>0</m>, etc.
+      That is, we recognize that <m>\fp</m> is increasing when <m>\fpp \gt 0</m>, etc.
     </p>
 
     <theorem xml:id="thm_concavity">
@@ -177,7 +176,7 @@
       <statement>
         <p>
           Let <m>f</m> be twice differentiable on an interval <m>I</m>.
-          The graph of <m>f</m> is concave up if <m>\fpp>0</m> on <m>I</m>,
+          The graph of <m>f</m> is concave up if <m>\fpp \gt 0</m> on <m>I</m>,
           and is concave down if <m>\fpp\lt 0</m> on <m>I</m>.
               <idx><h>concavity</h><h>test for</h></idx>
               <idx><h>concavity</h><h>inflection point</h></idx>
@@ -185,19 +184,20 @@
       </statement>
     </theorem>
     <!-- Known issue: numbering is off here -->
+    <!--ToDo: sbsgroup can't have a caption. Figure?-->
     <sbsgroup xml:id="fig_concavity3" widths="20% 20%" margins="15%">
       <caption>Demonstrating the four ways that concavity interacts with increasing/decreasing, along with the relationships with the first and second derivatives.</caption>
       <sidebyside>
         <figure>
-          <caption><m>\fp>0</m>, <m>f</m> increasing; <m>\fpp\lt0</m>, <m>f</m> is concave down</caption>
+          <caption><m>\fp\gt 0</m>, <m>f</m> increasing; <m>\fpp\lt0</m>, <m>f</m> is concave down</caption>
           <image>
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \draw [thick] (0,0) arc (180:90:2);
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
 
@@ -208,11 +208,11 @@
           <image>
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \draw [thick] (0,0) arc (90:0:2);
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
 
@@ -221,30 +221,30 @@
 
       <sidebyside>
         <figure>
-          <caption><m>\fp\lt0</m>, <m>f</m> decreasing; <m>\fpp>0</m>, <m>f</m> is concave up</caption>
+          <caption><m>\fp\lt0</m>, <m>f</m> decreasing; <m>\fpp\gt 0</m>, <m>f</m> is concave up</caption>
           <image>
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \draw [thick] (0,0) arc (180:270:2);
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
 
         </figure>
 
         <figure>
-          <caption><m>\fp>0</m>, <m>f</m> increasing; <m>\fpp>0</m>, <m>f</m> is concave up</caption>
+          <caption><m>\fp\gt 0</m>, <m>f</m> increasing; <m>\fpp\gt 0</m>, <m>f</m> is concave up</caption>
           <image>
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \draw [thick] (0,0) arc (0:-90:2);
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
 
@@ -289,18 +289,18 @@
       <image xml:id="img_concavity4" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-.5,xmax=4.5,
         ymin=-1,ymax=16,]
         \addplot+[domain=.7:4.2, samples=40] {2*(x-1)*(x-2)*(x-3)*(x-4)+5};
         \addplot[soliddot] coordinates {(1.85,4.39) (3.15, 4.39)};
-        \addplot[guideline] coordinates {(1.85,-1) (1.85,16)} node[left, anchor=north east] {\parbox{4em}{\flushright$\fpp>0$, $f$ is concave up}};
-        \addplot[guideline] coordinates {(3.15,-1) (3.15,16)} node[right, anchor=north west] {\parbox{4em}{\flushleft$\fpp>0$, $f$ is concave up}};
-        \draw (axis cs:2.5,16) node[anchor=north] {\parbox{4em}{\centering$\fpp<0$, $f$ is concave down}};
+        \addplot[guideline] coordinates {(1.85,-1) (1.85,16)} node[left, anchor=north east] {\parbox{4em}{\flushright$\fpp&gt;0$, $f$ is concave up}};
+        \addplot[guideline] coordinates {(3.15,-1) (3.15,16)} node[right, anchor=north west] {\parbox{4em}{\flushleft$\fpp&gt;0$, $f$ is concave up}};
+        \draw (axis cs:2.5,16) node[anchor=north] {\parbox{4em}{\centering$\fpp&lt;0$, $f$ is concave down}};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_concavity4.tex END -->
@@ -359,8 +359,8 @@
           We use a process similar to the one used in the previous section to determine increasing/decreasing.
           Pick any <m>c\lt 0</m>;
           <m>\fpp(c)\lt 0</m> so <m>f</m> is concave down on <m>(-\infty,0)</m>.
-          Pick any <m>c>0</m>;
-          <m>\fpp(c)>0</m> so <m>f</m> is concave up on <m>(0,\infty)</m>.
+          Pick any <m>c\gt 0</m>;
+          <m>\fpp(c)\gt 0</m> so <m>f</m> is concave up on <m>(0,\infty)</m>.
           Since the concavity changes at <m>x=0</m>,
           the point <m>(0,1)</m> is an inflection point.
         </p>
@@ -371,7 +371,7 @@
           <xref ref="fig_conc1">Figure</xref>
           shows a graph of <m>f</m> and <m>\fpp</m>, confirming our results.
           Notice how <m>f</m> is concave down precisely when
-          <m>\fpp(x)\lt 0</m> and concave up when <m>\fpp(x)>0</m>.
+          <m>\fpp(x)\lt 0</m> and concave up when <m>\fpp(x)\gt 0</m>.
         </p>
 
         <figure xml:id="fig_concline1">
@@ -380,7 +380,7 @@
           <image xml:id="img_concline1"  width="67%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[numberline,
             xmin=-0.9,xmax=0.9,
@@ -389,11 +389,11 @@
             node [anchor=north,yshift=-0.075cm] {\footnotesize 0};
             },]
             \addplot[guideline] coordinates {(0,0) (0,2)};
-            \addplot[mark=none] coordinates {(-0.5,1)} node {\parbox{8em}{\centering \small $\fpp<0$\\$f$ is concave down}};
-            \addplot[mark=none] coordinates {(0.5,1)} node {\parbox{8em}{\centering \small $\fpp>0$\\$f$ is concave up}};
+            \addplot[mark=none] coordinates {(-0.5,1)} node {\parbox{8em}{\centering \small $\fpp&lt;0$\\$f$ is concave down}};
+            \addplot[mark=none] coordinates {(0.5,1)} node {\parbox{8em}{\centering \small $\fpp&gt;0$\\$f$ is concave up}};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_concline1.tex END -->
@@ -402,10 +402,10 @@
         <figure xml:id="fig_conc1">
           <caption>A graph of <m>f(x)</m> used in <xref ref="ex_conc1">Example</xref>.</caption>
           <!-- START figures/fig_conc1.tex -->
-          <image xml:id="img_conc1"  width="47%">
+          <image xml:id="img_conc1" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.2,xmax=2.2,
 			ymin=-3.5,ymax=3.5,]
@@ -413,7 +413,7 @@
             \addplot+[domain=-.5:.5] {6*x} node[below right]{$\fpp(x)$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_conc1.tex END -->
@@ -484,7 +484,7 @@
                 the factor <m>2c</m> in the numerator will be negative,
                 the factor <m>\left(c^2+3\right)</m> in the numerator will be positive,
                 and the factor <m>\left(c^2-1\right)^3</m> in the denominator will be negative.
-                Thus <m>\fpp(c)>0</m> and <m>f</m> is concave up on this interval.
+                Thus <m>\fpp(c)\gt 0</m> and <m>f</m> is concave up on this interval.
               </p>
             </li>
 
@@ -501,7 +501,7 @@
               <title>Interval 4: <m>(1,\infty)</m></title>
               <p>
                 Choose a large value for <m>c</m>.
-                It is evident that <m>\fpp(c)>0</m>,
+                It is evident that <m>\fpp(c)\gt 0</m>,
                 so we conclude that <m>f</m> is concave up on <m>(1,\infty)</m>.
               </p>
             </li>
@@ -511,10 +511,10 @@
         <figure xml:id="fig_concline2">
           <caption>Number line for <m>f</m> in <xref ref="ex_conc2">Example</xref>.</caption>
           <!-- START figures/fig_concline2.tex -->
-          <image xml:id="img_concline2"  width="80%">
+          <image xml:id="img_concline2" width="80%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[numberline,
             xmin=-2,xmax=2,
@@ -524,12 +524,12 @@
             \addplot[guideline] coordinates {(0,0) (0,2)};
             \addplot[guideline] coordinates {(1,0) (1,2)};
             \addplot[mark=none] coordinates {(-1.5,1.5)} node {\parbox{3em}{\centering \small  $\fpp\lt0$\\$f$ conc down}};
-            \addplot[mark=none] coordinates {(-0.5,1.5)} node {\parbox{3em}{\centering \small  $\fpp>0$\\$f$ conc up}};
+            \addplot[mark=none] coordinates {(-0.5,1.5)} node {\parbox{3em}{\centering \small  $\fpp&gt;0$\\$f$ conc up}};
             \addplot[mark=none] coordinates {(0.5,1.5)} node {\parbox{3em}{\centering \small  $\fpp\lt0$\\$f$ conc down}};
-            \addplot[mark=none] coordinates {(1.5,1.5)} node {\parbox{3em}{\centering \small  $\fpp>0$\\$f$ conc up}};
+            \addplot[mark=none] coordinates {(1.5,1.5)} node {\parbox{3em}{\centering \small  $\fpp&gt;0$\\$f$ conc up}};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_concline2.tex END -->
@@ -549,10 +549,10 @@
         <figure xml:id="fig_conc2">
           <caption>A graph of <m>f(x)</m> and <m>\fpp(x)</m> in <xref ref="ex_conc2">Example</xref>.</caption>
           <!-- START figures/fig_conc2.tex -->
-          <image xml:id="img_conc2"  width="47%">
+          <image xml:id="img_conc2" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-3.2,xmax=3.2,
 			ymin=-11,ymax=11,]
@@ -565,7 +565,7 @@
             \addplot[secondcurvestyle, domain=1.5:3.1] {(2*x*(x^2+3))/((x^2-1)^3)} node[right, pos=0.1] {$\fpp(x)$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_conc2.tex END -->
@@ -585,7 +585,7 @@
     <p>
       What does a <q>relative maximum of <m>\fp</m></q> <em>mean</em>?
       The derivative measures the rate of change of <m>f</m>;
-      maximizing <m>\fp</m> means finding where <m>f</m> is increasing the most <mdash /> where <m>f</m> has the steepest tangent line.
+      maximizing <m>\fp</m> means finding where <m>f</m> is increasing the most <mdash/> where <m>f</m> has the steepest tangent line.
       A similar statement can be made for minimizing <m>\fp</m>; it corresponds to where <m>f</m> has the steepest negatively-sloped tangent line.
     </p>
 
@@ -607,10 +607,10 @@
         <figure xml:id="fig_conc3">
           <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3">Example</xref>, modeling the sale of a product over time.</caption>
           <!-- START figures/fig_conc3.tex -->
-          <image xml:id="img_conc3"  width="47%">
+          <image xml:id="img_conc3" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-.2,xmax=3.2,
 		ymin=-1,ymax=21,
@@ -619,7 +619,7 @@
             \addplot+[rightarrow, domain=0:2.8, samples=40] {x^4-8*x^2+20} node[above right, pos=0.3]{$S(t)$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_conc3.tex END -->
@@ -659,10 +659,10 @@
         <figure xml:id="fig_conc3b">
           <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3">Example</xref>, modeling the sale of a product over time.</caption>
           <!-- START figures/fig_conc3b.tex -->
-          <image xml:id="img_conc3b"  width="47%">
+          <image xml:id="img_conc3b" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-.2,xmax=3.2,
             ymin=-16,ymax=21,
@@ -673,7 +673,7 @@
             \addplot[soliddot] coordinates {(1.16,11.04) (1.16,-12.32)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_conc3.tex END -->
@@ -698,17 +698,17 @@
     <figure xml:id="fig_concavity5">
       <caption>A graph of <m>f(x) = x^4</m>. Clearly <m>f</m> is always concave up, despite the fact that <m>\fpp(x) = 0</m> when <m>x=0</m>. It this example, the <em>possible</em> point of inflection <m>(0,0)</m> is not a point of inflection.</caption>
       <!-- START figures/fig_concavity5.tex -->
-      <image xml:id="img_concavity5"  width="47%">
+      <image xml:id="img_concavity5" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-1.1,xmax=1.1,
         ymin=-.1,ymax=1.1,]
         \addplot+[domain=-1:1] {x^4};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_concavity5.tex END -->
@@ -730,10 +730,10 @@
     <figure xml:id="fig_concavity6">
       <caption>Demonstrating the fact that relative maxima occur when the graph is concave down and relative minima occur when the graph is concave up.</caption>
       <!-- START figures/fig_concavity6.tex -->
-      <image xml:id="img_concavity6"  width="47%">
+      <image xml:id="img_concavity6" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-2.1,xmax=2.1,
         ymin=-11,ymax=11,
@@ -744,7 +744,7 @@
         \addplot[mark=none] coordinates {(1,-7.5)} node {\parbox{6em}{\centering concave up\\$\implies$ rel min}};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_concavity6.tex END -->
@@ -766,7 +766,7 @@
           <ol>
             <li>
               <p>
-                If <m>\fpp(c)>0</m>,
+                If <m>\fpp(c)\gt 0</m>,
                 then <m>f</m> has a local minimum at <m>(c,f(c))</m>.
               </p>
             </li>
@@ -791,12 +791,12 @@
         If you've already determined the sign diagram for <m>\fp</m>,
         the <xref ref="thm_first_der" text="title"/> is usually
         easier to apply, and it applies in cases when
-        xref ref="thm_first_der" text="title"/> does not.
+        <xref ref="thm_first_der" text="title"/> does not.
       </p>
     </aside>
     <p>
       The Second Derivative Test relates to the <xref ref="thm_first_der" text="title"/> in the following way.
-      If <m>\fpp(c)>0</m>,
+      If <m>\fpp(c)\gt 0</m>,
       then the graph is concave up at a critical point <m>c</m> and <m>\fp</m> itself is growing.
       Since <m>\fp(c)=0</m> and <m>\fp</m> is growing at <m>c</m>,
       then it must go from negative to positive at <m>c</m>.
@@ -820,7 +820,7 @@
           but neither is <m>f</m> so this is not a critical value.)
           We find the critical values are <m>x=\pm 10</m>.
           We now evaluate the second derivative at these critical numbers.
-          Evaluating <m> \fpp(10)=0.1>0</m>,
+          Evaluating <m> \fpp(10)=0.1\gt 0</m>,
           so there is a local minimum at <m>x=10</m>.
           Evaluating <m>\fpp(-10)=-0.1\lt 0</m>,
           determining a relative maximum at <m>x=-10</m>.
@@ -830,20 +830,20 @@
         <figure xml:id="fig_conc4">
           <caption>A graph of <m>f(x)</m> in <xref ref="ex_conc4">Example</xref>. The second derivative is evaluated at each critical point. When the graph is concave up, the critical point represents a local minimum; when the graph is concave down, the critical point represents a local maximum.</caption>
           <!-- START figures/fig_conc4.tex -->
-          <image xml:id="img_conc4"  width="47%">
+          <image xml:id="img_conc4" width="47%">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-21,xmax=21,
             ymin=-51,ymax=51,]
             \addplot+[domain=-20:-2.2] {100/x+x};
             \addplot[firstcurvestyle,domain=2.2:20] {100/x+x};
-            \addplot[soliddot] coordinates{(10,20)} node [below] {$\fpp(10)>0$};
+            \addplot[soliddot] coordinates{(10,20)} node [below] {$\fpp(10)&gt;0$};
             \addplot[soliddot] coordinates{(-10,-20)} node [above] {$\fpp(-10)\lt0$};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_conc4.tex END -->
@@ -995,7 +995,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1020,7 +1020,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1045,7 +1045,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1070,7 +1070,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1095,7 +1095,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1120,7 +1120,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1145,7 +1145,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1170,7 +1170,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1195,7 +1195,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1220,7 +1220,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1245,7 +1245,7 @@
               </p>
 
               <p>
-                <m>\fpp(x)=</m><var name="$der" width="30" />
+                <m>\fpp(x)=</m><var name="$der" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1283,7 +1283,8 @@
 
       <exercise xml:id="exer_03_04_ex_16">
         <webwork seed="1">
-            <setup>            <pg-code>
+            <setup>
+            <pg-code>
               Context()->strings->add('does not apply'=>{});
               $i=Compute("does not apply");
               $up=Compute("(-inf,inf)");
@@ -1305,7 +1306,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1317,7 +1318,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1329,7 +1330,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1369,7 +1370,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1381,7 +1382,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1393,7 +1394,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1433,7 +1434,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1445,7 +1446,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1457,7 +1458,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1499,7 +1500,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1511,7 +1512,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1523,7 +1524,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1565,7 +1566,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1577,7 +1578,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1589,7 +1590,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1631,7 +1632,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1643,7 +1644,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1655,7 +1656,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1697,7 +1698,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1709,7 +1710,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1721,7 +1722,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1776,7 +1777,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1788,7 +1789,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1800,7 +1801,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1842,7 +1843,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1854,7 +1855,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1866,7 +1867,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1907,7 +1908,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1919,7 +1920,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1931,7 +1932,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1973,7 +1974,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -1985,7 +1986,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -1997,7 +1998,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2039,7 +2040,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -2051,7 +2052,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -2063,7 +2064,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2104,7 +2105,7 @@
                     </p>
 
                     <p>
-                      <var name="$i" width="30" />
+                      <var name="$i" width="30"/>
                     </p>
                   </li>
 
@@ -2116,7 +2117,7 @@
                     </p>
 
                     <p>
-                      <var name="$up" width="30" />
+                      <var name="$up" width="30"/>
                     </p>
                   </li>
 
@@ -2128,7 +2129,7 @@
                     </p>
 
                     <p>
-                      <var name="$down" width="30" />
+                      <var name="$down" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2155,7 +2156,7 @@
           when possible,
           to determine the relative extrema.
           (Note: these are the same functions as in <xref ref="exer_03_04_ex_16">Exercises</xref>
-          <mdash /> <xref ref="exer_03_04_ex_28"></xref>.)
+          <mdash/> <xref ref="exer_03_04_ex_28"/>.)
         </p>
       </introduction>
 
@@ -2184,7 +2185,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2196,7 +2197,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2208,7 +2209,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2247,7 +2248,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2259,7 +2260,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2271,7 +2272,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2310,7 +2311,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2322,7 +2323,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2334,7 +2335,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2374,7 +2375,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2386,7 +2387,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2398,7 +2399,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2437,7 +2438,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2449,7 +2450,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2461,7 +2462,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2500,7 +2501,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2512,7 +2513,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2524,7 +2525,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2564,7 +2565,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2576,7 +2577,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2588,7 +2589,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2641,7 +2642,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2653,7 +2654,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2665,7 +2666,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2704,7 +2705,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2716,7 +2717,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2728,7 +2729,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2767,7 +2768,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2779,7 +2780,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2791,7 +2792,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2831,7 +2832,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2843,7 +2844,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2855,7 +2856,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2895,7 +2896,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2907,7 +2908,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2919,7 +2920,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -2958,7 +2959,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -2970,7 +2971,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -2982,7 +2983,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3004,7 +3005,7 @@
           In the following exercises, a function <m>f(x)</m> is given.
           Find the <m>x</m> values where <m>\fp(x)</m> has a relative maximum or minimum.
           (Note: these are the same functions as in <xref ref="exer_03_04_ex_16">Exercises</xref>
-          <mdash /> <xref ref="exer_03_04_ex_28"></xref>.)
+          <mdash/> <xref ref="exer_03_04_ex_28"/>.)
         </p>
       </introduction>
 
@@ -3032,7 +3033,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3044,7 +3045,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3082,7 +3083,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3094,7 +3095,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3132,7 +3133,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3144,7 +3145,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3182,7 +3183,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3194,7 +3195,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3232,7 +3233,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3244,7 +3245,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3284,7 +3285,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3296,7 +3297,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3336,7 +3337,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3348,7 +3349,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3400,7 +3401,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3412,7 +3413,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3451,7 +3452,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3463,7 +3464,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3501,7 +3502,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3513,7 +3514,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3552,7 +3553,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3564,7 +3565,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3603,7 +3604,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3615,7 +3616,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3653,7 +3654,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -3665,7 +3666,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -3683,4 +3684,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_extreme_values">
   <title>Extreme Values</title>
   <p>
@@ -68,18 +67,18 @@
  
  <p>
     Consider <xref ref="fig_extreme">Figure</xref>.
-    The function displayed in <xref ref="fig_extreme1" /> has a maximum,
+    The function displayed in <xref ref="fig_extreme1"/> has a maximum,
     but no minimum,
     as the interval over which the function is defined is open.
-    In <xref ref="fig_extreme2" />, the function has a minimum,
+    In <xref ref="fig_extreme2"/>, the function has a minimum,
     but no maximum;
     there is a discontinuity in the <q>natural</q>
     place for the maximum to occur.
-    Finally, the function shown in <xref ref="fig_extreme3" />has both a maximum and a minimum;
+    Finally, the function shown in <xref ref="fig_extreme3"/>has both a maximum and a minimum;
     note that the function is continuous and the interval on which it is defined is closed.
   </p>
 
-  <todo>I'm not sure if the intervals need to be shown on the x axis. I left them there for now. </todo>
+  <!-- ToDo: I'm not sure if the intervals need to be shown on the x axis. I left them there for now.  -->
 
   <figure xml:id="fig_extreme">
   <caption>Graphs of functions with and without extreme values.</caption>
@@ -90,7 +89,7 @@
       <image xml:id="img_extreme1">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[ ymin=-.9,ymax=5.5,xmin=-2.2,xmax=2.2,]
         \addplot+[domain=-2:2,-] {-x^2+5};
@@ -98,7 +97,7 @@
         \addplot[openinterval] coordinates {(-2,0) (2,0)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
         <!-- figures/fig_extreme1.tex END -->
@@ -110,7 +109,7 @@
       <image xml:id="img_extreme2">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[ ymin=-.9,ymax=5.5,xmin=-2.2,xmax=2.2,]
         \addplot+[domain=-2:2,-] {-x^2+5};
@@ -119,7 +118,7 @@
         \addplot[hollowdot] coordinates {(0,5)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
 
@@ -131,7 +130,7 @@
       <image xml:id="img_extreme3">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[ ymin=-.9,ymax=5.5,xmin=-2.2,xmax=2.2,]
         \addplot+[domain=-2:2,-] {-x^2+5};
@@ -139,7 +138,7 @@
         \addplot[closedinterval] coordinates {(-2,0) (2,0)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
         <!-- figures/fig_extreme3.tex END -->
@@ -190,10 +189,10 @@
         <caption>A graph of <m>f(x) = 2x^3-9x^2</m> as in <xref ref="ex_extval1">Example</xref>.</caption>
 
           <!-- START figures/fig_extval1.tex -->
-        <image xml:id="img_extval1"  width="47%">
+        <image xml:id="img_extval1" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-2,xmax=5.7,
           ymin=-33,ymax=31,]
@@ -204,7 +203,7 @@
           \addplot[soliddot] coordinates{(5,25)} node[above] {$(5,25)$};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_extval1.tex END -->
@@ -248,7 +247,7 @@
         <ol>
           <li>
             <p>
-              If there is a <m>\delta>0</m> such that
+              If there is a <m>\delta \gt 0</m> such that
               <m>f(c) \leq f(x)</m> for all <m>x</m> in <m>I</m> where <m>\abs{x-c}\lt \delta</m>,
               then <m>f(c)</m> is a <term>relative minimum</term> of <m>f</m>.
               We also say that <m>f</m> has a relative minimum at <m>(c,f(c))</m>.
@@ -259,7 +258,7 @@
 
           <li>
             <p>
-              If there is a <m>\delta>0</m> such that
+              If there is a <m>\delta \gt 0</m> such that
               <m>f(c) \geq f(x)</m> for all <m>x</m> in <m>I</m> where <m>\abs{x-c}\lt \delta</m>,
               then <m>f(c)</m> is a <term>relative maximum</term> of <m>f</m>.
               We also say that <m>f</m> has a relative maximum at <m>(c,f(c))</m>.
@@ -309,17 +308,17 @@
       <figure xml:id="fig_extval2">
         <caption>A graph of <m>f(x) = (3x^4-4x^3-12x^2+5)/5</m> as in <xref ref="ex_extval2">Example</xref>.</caption>
           <!-- START figures/fig_extval2.tex -->
-        <image xml:id="img_extval2"  width="47%">
+        <image xml:id="img_extval2" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-2.2,xmax=3.2,
           ymin=-6.5,ymax=6.9,]
           \addplot+[domain=-1.8:3, samples=50] {(3*x^4-4*x^3-12*x^2+5)/5};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_extval2.tex END -->
@@ -359,10 +358,10 @@
       <figure xml:id="fig_extval3">
         <caption>A graph of <m>f(x) = (x-1)^{2/3}+2</m> as in <xref ref="ex_extval3">Example</xref>.</caption>
           <!-- START figures/fig_extval3.tex -->
-        <image xml:id="img_extval3"  width="47%">
+        <image xml:id="img_extval3" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-.6,xmax=2.6,
           ymin=-.5,ymax=3.5]
@@ -370,7 +369,7 @@
           \addplot[firstcurvestyle,rightarrow,domain=2:3.2] ({-(x-2)^1.5+1},{x});
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_extval3.tex END -->
@@ -447,17 +446,17 @@
   <figure xml:id="fig_extreme4">
     <caption>A graph of <m>f(x)=x^3</m> which has a critical value of <m>x=0</m>, but no relative extrema.</caption>
       <!-- START figures/fig_extreme4.tex -->
-    <image xml:id="img_extreme4"  width="47%">
+    <image xml:id="img_extreme4" width="47%">
       <description></description>
       <latex-image>
-      <![CDATA[
+      
       \begin{tikzpicture}
       \begin{axis}[xmin=-1.1,xmax=1.1,
 			ymin=-1.1,ymax=1.1]
       \addplot+[domain=-1:1] {x^3};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+      
       </latex-image>
     </image>
       <!-- figures/fig_extreme4.tex END -->
@@ -524,10 +523,10 @@
       <figure xml:id="fig_extval4">
         <caption>A graph of <m>f(x) = 2x^3+3x^2-12x</m> on <m>[0,3]</m> as in <xref ref="ex_extval4">Example</xref>.</caption>
           <!-- START figures/fig_extval4.tex -->
-        <image xml:id="img_extval4"  width="47%">
+        <image xml:id="img_extval4" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-.4,xmax=3.3,
           ymin=-7.5,ymax=45.5]
@@ -535,7 +534,7 @@
           \addplot[soliddot] coordinates {(0,0) (3,45)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_extval4.tex END -->
@@ -569,8 +568,8 @@
       </p>
 
       <table xml:id="table_ext4">
-        <caption>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in
-        <xref ref="ex_extval4">Example</xref>.</caption>
+        <title>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in
+        <xref ref="ex_extval4">Example</xref>.</title>
         <tabular>
           <row bottom="medium">
             <cell><m>x</m></cell>
@@ -613,7 +612,7 @@
       <p>
         Find the maximum and minimum values of <m>f</m> on <m>[-4,2]</m>, where
         <me>
-          f(x) = \begin{cases}(x-1)^2 \amp  x\leq 0 \\ x+1 \amp  x>0\end{cases}
+          f(x) = \begin{cases}(x-1)^2 \amp  x\leq 0 \\ x+1 \amp  x \gt 0\end{cases}
         </me>.
 
       </p>
@@ -634,7 +633,7 @@
         We now find the critical numbers of <m>f</m>.
         We have to define <m>\fp</m> in a piecewise manner; it is
         <me>
-          \fp(x) =\begin{cases}2(x-1) \amp  x \lt  0 \\ 1 \amp  x>0\end{cases}
+          \fp(x) =\begin{cases}2(x-1) \amp  x \lt  0 \\ 1 \amp  x \gt 0\end{cases}
         </me>.
       </p>
 
@@ -649,7 +648,7 @@
 
       <p>
         We now set <m>\fp(x) = 0</m>.
-        When <m>x >0</m>, <m>\fp(x)</m> is never 0.
+        When <m>x \gt 0</m>, <m>\fp(x)</m> is never 0.
         When <m>x\lt 0</m>,
         <m>\fp(x)</m> is also never 0, so we find no critical values from setting <m>\fp(x)=0</m>.
       </p>
@@ -668,7 +667,7 @@
       <sidebyside widths="47% 47%">
 
         <table xml:id="table_ext5">
-          <caption>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref>.</caption>
+          <title>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref>.</title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -700,7 +699,7 @@
           <image xml:id="img_extval5">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-4.5,xmax=2.5,
             ymin=-.9,ymax=25.5]
@@ -709,7 +708,7 @@
             \addplot[soliddot] coordinates {(-4,25) (2,3)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_extval5.tex END -->
@@ -735,7 +734,7 @@
       </p>
 
       <p>
-        Applying the <xref ref="thm_chain_rule" text="title" />,
+        Applying the <xref ref="thm_chain_rule" text="title"/>,
         we find <m>\fp(x) = -2x\sin\mathopen{}\left(x^2\right)\mathclose{}</m>.
         Set <m>\fp(x) = 0</m> and solve for <m>x</m> to find the critical values of <m>f</m>.
       </p>
@@ -762,7 +761,7 @@
       <sidebyside widths="47% 47%">
 
         <table xml:id="table_ext6">
-          <caption>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref>.</caption>
+          <title>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref>.</title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -798,7 +797,7 @@
           <image xml:id="img_extval6">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-2.2,xmax=2.2,
             ymin=-1.1,ymax=1.1]
@@ -806,7 +805,7 @@
             \addplot[soliddot] coordinates{(-2,-0.65)(2,-0.65)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_extval6.tex END -->
@@ -843,7 +842,7 @@
           <image xml:id="img_extval7">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.2,xmax=1.2,
             ymin=-1.2,ymax=1.2,
@@ -852,14 +851,14 @@
             \addplot[soliddot] coordinates{(-1,0) (1,0)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_extval7.tex END -->
         </figure>
 
         <table xml:id="table_ext7">
-          <caption>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref>.</caption>
+          <title>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref>.</title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -884,7 +883,7 @@
       </sidebyside>
 
       <p>
-        Using the <xref ref="thm_chain_rule" text="title" />, we find <m>\fp(x) = -x\big/\sqrt{1-x^2}</m>.
+        Using the <xref ref="thm_chain_rule" text="title"/>, we find <m>\fp(x) = -x\big/\sqrt{1-x^2}</m>.
         The critical points of <m>f</m> are found when
         <m>\fp(x) = 0</m> or when <m>\fp</m> is undefined.
         It is straightforward to find that <m>\fp(x) = 0</m> when <m>x=0</m>,
@@ -945,7 +944,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -977,7 +976,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1024,7 +1023,7 @@
       <exercise>
         <statement>
           <p>
-            Fill in the blanks: The critical points of a function <m>f</m> are found where <m>\fp(x)</m> is equal to <fillin /> or where <m>\fp(x)</m> is <fillin />.
+            Fill in the blanks: The critical points of a function <m>f</m> are found where <m>\fp(x)</m> is equal to <fillin/> or where <m>\fp(x)</m> is <fillin/>.
           </p>
         </statement>
         <answer>
@@ -1095,36 +1094,36 @@
                 a relative maximum or minimum, or none of the above.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>A</m> is <var name="$A" form="popup" />.
+                <m>A</m> is <var name="$A" form="popup"/>.
               </p>
 
               <p>
-                <m>B</m> is <var name="$B" form="popup" />.
+                <m>B</m> is <var name="$B" form="popup"/>.
               </p>
 
               <p>
-                <m>C</m> is <var name="$C" form="popup" />.
+                <m>C</m> is <var name="$C" form="popup"/>.
               </p>
 
               <p>
-                <m>D</m> is <var name="$D" form="popup" />.
+                <m>D</m> is <var name="$D" form="popup"/>.
               </p>
 
               <p>
-                <m>E</m> is <var name="$E" form="popup" />.
+                <m>E</m> is <var name="$E" form="popup"/>.
               </p>
 
               <p>
-                <m>F</m> is <var name="$F" form="popup" />.
+                <m>F</m> is <var name="$F" form="popup"/>.
               </p>
 
               <p>
-                <m>G</m> is <var name="$G" form="popup" />.
+                <m>G</m> is <var name="$G" form="popup"/>.
               </p>
             </statement>
         </webwork>
@@ -1170,28 +1169,28 @@
                 a relative maximum or minimum, or none of the above.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>A</m> is <var name="$A" form="popup" />.
+                <m>A</m> is <var name="$A" form="popup"/>.
               </p>
 
               <p>
-                <m>B</m> is <var name="$B" form="popup" />.
+                <m>B</m> is <var name="$B" form="popup"/>.
               </p>
 
               <p>
-                <m>C</m> is <var name="$C" form="popup" />.
+                <m>C</m> is <var name="$C" form="popup"/>.
               </p>
 
               <p>
-                <m>D</m> is <var name="$D" form="popup" />.
+                <m>D</m> is <var name="$D" form="popup"/>.
               </p>
 
               <p>
-                <m>E</m> is <var name="$E" form="popup" />.
+                <m>E</m> is <var name="$E" form="popup"/>.
               </p>
             </statement>
         </webwork>
@@ -1230,12 +1229,12 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(0)=</m><var name="0" width="10" />
+                <m>f'(0)=</m><var name="0" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1266,16 +1265,16 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(0)=</m><var name="0" width="10" />
+                <m>f'(0)=</m><var name="0" width="10"/>
               </p>
 
               <p>
-                <m>f'(2)=</m><var name="0" width="10" />
+                <m>f'(2)=</m><var name="0" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1305,16 +1304,16 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(\pi/2)=</m><var name="0" width="10" />
+                <m>f'(\pi/2)=</m><var name="0" width="10"/>
               </p>
 
               <p>
-                <m>f'(3\pi/2)=</m><var name="0" width="10" />
+                <m>f'(3\pi/2)=</m><var name="0" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1345,16 +1344,16 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(0)=</m><var name="0" width="10" />
+                <m>f'(0)=</m><var name="0" width="10"/>
               </p>
 
               <p>
-                <m>f'(16/5)=</m><var name="0" width="10" />
+                <m>f'(16/5)=</m><var name="0" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1385,12 +1384,12 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(0)=</m><var name="0" width="10" />
+                <m>f'(0)=</m><var name="0" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1421,12 +1420,12 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(0)=</m><var name="DNE" width="10" />
+                <m>f'(0)=</m><var name="DNE" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1459,16 +1458,16 @@
                 you may enter <q><c>DNE</c></q>.
               </p>
 
-              <figure>
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
-              </figure>
+              </sidebyside>
 
               <p>
-                <m>f'(2)=</m><var name="DNE" width="10" />
+                <m>f'(2)=</m><var name="DNE" width="10"/>
               </p>
 
               <p>
-                <m>f'(6)=</m><var name="0" width="10" />
+                <m>f'(6)=</m><var name="0" width="10"/>
               </p>
             </statement>
         </webwork>
@@ -1502,7 +1501,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1526,7 +1525,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1552,7 +1551,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1577,7 +1576,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1602,7 +1601,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1627,7 +1626,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1652,7 +1651,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1677,7 +1676,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1702,7 +1701,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1727,7 +1726,7 @@
               </p>
 
               <p>
-                The absolute maximum is <var name="$maxy" width="10" /> at <var name="$maxx" width="10" /> and the absolute minimum is <var name="$miny" width="10" /> at <var name="$minx" width="10" />.
+                The absolute maximum is <var name="$maxy" width="10"/> at <var name="$maxx" width="10"/> and the absolute minimum is <var name="$miny" width="10"/> at <var name="$minx" width="10"/>.
               </p>
             </statement>
         </webwork>
@@ -1761,7 +1760,7 @@
               </p>
 
               <p>
-                <m>\lz{y}{x}=</m><var name="$dydx" width="40" />
+                <m>\lz{y}{x}=</m><var name="$dydx" width="40"/>
               </p>
             </statement>
         </webwork>
@@ -1784,7 +1783,7 @@
               </p>
 
               <p>
-                <var name="$line" width="20" />
+                <var name="$line" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1804,7 +1803,7 @@
               </p>
 
               <p>
-                <m>\lim\limits_{s\to 0} \frac{f(x+s)-f(x)}{s}=</m><var name="$L" width="20" />
+                <m>\lim\limits_{s\to 0} \frac{f(x+s)-f(x)}{s}=</m><var name="$L" width="20"/>
               </p>
             </statement>
         </webwork>
@@ -1813,4 +1812,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_incr_decr">
   <title>Increasing and Decreasing Functions</title>
   <p>
@@ -21,17 +20,17 @@
     where would you say the function is <em>increasing</em>?
     <em>Decreasing</em>?
     Even though we have not defined these terms mathematically,
-    one likely answered that <m>f</m> is increasing when <m>x>1</m> and decreasing when <m>x\lt 1</m>.
+    one likely answered that <m>f</m> is increasing when <m>x \gt 1</m> and decreasing when <m>x\lt 1</m>.
     We formally define these terms here.
   </p>
 
   <figure xml:id="fig_incr0">
     <caption>A graph of a function <m>f</m> used to illustrate the concepts of <em>increasing</em> and <em>decreasing</em>.</caption>
       <!-- START figures/fig_incr0.tex -->
-    <image xml:id="img_incr0"  width="47%">
+    <image xml:id="img_incr0" width="47%">
       <description></description>
       <latex-image>
-      <![CDATA[
+      
       \begin{tikzpicture}
       \begin{axis}[xmin=-.9,xmax=3.2,
       ymin=-.5,ymax=5.1,
@@ -39,14 +38,14 @@
       \addplot+[domain=-.5:2.5] {(x-1)^2+2};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+      
       </latex-image>
     </image>
       <!-- figures/fig_incr0.tex END -->
   </figure>
 
 <!--TODO: assemblage or definition? -->
-  <assemblage xml:id="def_incr_decr">
+  <definition xml:id="def_incr_decr">
     <title>Increasing and Decreasing Functions</title>
     <statement>
       <p>
@@ -68,13 +67,13 @@
           <li>
             <p>
               <m>f</m> is <em>decreasing</em>
-              on <m>I</m> if for every <m>a\lt b</m> in <m>I</m>, <m>f(a) > f(b)</m>.
+              on <m>I</m> if for every <m>a\lt b</m> in <m>I</m>, <m>f(a) \gt f(b)</m>.
             </p>
           </li>
         </ol>
       </p>
     </statement>
-  </assemblage>
+  </definition>
 
   <p>
     Informally, a function is increasing if as <m>x</m> gets larger (i.e., looking left to right) <m>f(x)</m> gets larger.
@@ -113,9 +112,9 @@
     <p>
       <md>
         <mrow>\amp\frac{f(b)-f(a)}{b-a} \gt 0</mrow>
-        <mrow>\implies\amp \text{slope of the secant line} >0</mrow>
+        <mrow>\implies\amp \text{slope of the secant line} \gt 0</mrow>
         <mrow>\implies\amp \text{Average rate of change of }f</mrow>
-        <mrow>\amp\text{ on }[a,b]\text{ is }>0</mrow>
+        <mrow>\amp\text{ on }[a,b]\text{ is } \gt 0</mrow>
       </md>.
     </p>
 
@@ -125,7 +124,7 @@
       <image xml:id="img_incr00">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-.2,xmax=2.2,
         ymin=-.5,ymax=2.2,
@@ -137,7 +136,7 @@
         \addplot [soliddot] coordinates {(1.67,1.95)} node [above left]{$(b,f(b))$};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
         <!-- figures/fig_incr00.tex END -->
@@ -153,13 +152,13 @@
     guarantees that there is a number <m>c</m>,
     where <m>a\lt c\lt b</m>, such that
     <me>
-      \fp(c) = \frac{f(b)-f(a)}{b-a}>0
+      \fp(c) = \frac{f(b)-f(a)}{b-a} \gt 0
     </me>.
   </p>
 
   <p>
     By considering all such secant lines in <m>I</m>,
-    we strongly imply that <m>\fp(x) > 0</m> on <m>I</m>.
+    we strongly imply that <m>\fp(x) \gt 0</m> on <m>I</m>.
     A similar statement can be made for decreasing functions.
   </p>
 
@@ -186,7 +185,7 @@
           <li xml:id="thm_incr">
 
             <p>
-              If <m>\fp(c) > 0</m> for all <m>c</m> in <m>(a,b)</m>,
+              If <m>\fp(c) \gt 0</m> for all <m>c</m> in <m>(a,b)</m>,
               then <m>f</m> is increasing on <m>[a,b]</m>.
             </p>
           </li>
@@ -209,7 +208,7 @@
       </p>
 
       <p>
-        The conclusions of <xref ref="thm_incr" /> and <xref ref="thm_decr" /> also hold if if
+        The conclusions of <xref ref="thm_incr"/> and <xref ref="thm_decr"/> also hold if if
         <m>\fp(c) = 0</m> for a finite number of nonadjacent values of <m>c</m> in <m>I</m>.
       </p>
     </statement>
@@ -217,7 +216,7 @@
 
   <p>
     Let <m>f</m> be differentiable on an interval <m>I</m> and let <m>a</m> and <m>b</m> be in <m>I</m> where
-    <m>\fp(a)>0</m> and <m>\fp(b)\lt 0</m>.
+    <m>\fp(a) \gt 0</m> and <m>\fp(b)\lt 0</m>.
     If <m>\fp</m> is continuous on <m>[a,b]</m>,
     it follows from the Intermediate Value Theorem that there must be some value
     <m>c</m> between <m>a</m> and <m>b</m> where <m>\fp(c) = 0</m>.
@@ -268,7 +267,7 @@
             <ol>
               <li>
                 <p>
-                  If <m>\fp(p)>0</m>, then <m>f</m> is increasing on that subinterval.
+                  If <m>\fp(p) \gt 0</m>, then <m>f</m> is increasing on that subinterval.
                 </p>
               </li>
 
@@ -316,10 +315,10 @@
       </p>
       <figure xml:id="fig_incrline1">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr1">Example</xref>.</caption>
-        <image xml:id="img_incrline1"  width="67%">
+        <image xml:id="img_incrline1" width="67%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[numberline,
           xmin=-2,xmax=1,
@@ -329,7 +328,7 @@
           \addplot[guideline] coordinates {(0.3333,0) (0.3333,2)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
 
@@ -349,7 +348,7 @@
             <p>
               We (arbitrarily) pick <m>p=-2</m>.
               We can compute <m>\fp(-2)</m> directly:
-              <m>\fp(-2) = 3(-2)^2+2(-2)-1=7>0</m>.
+              <m>\fp(-2) = 3(-2)^2+2(-2)-1=7\gt 0</m>.
               We conclude that <m>f</m> is increasing on <m>(-\infty,-1)</m>.
             </p>
 
@@ -359,7 +358,7 @@
               The first term in <m>\fp(-100)</m>,
               i.e., <m>3(-100)^2</m> is clearly positive and very large.
               The other terms are small in comparison,
-              so we know <m>\fp(-100)>0</m>.
+              so we know <m>\fp(-100)\gt 0</m>.
               All we need is the sign.
             </p>
           </li>
@@ -376,7 +375,7 @@
           <li>
             <title>Subinterval 3: <m>(1/3,\infty)</m></title>
             <p>
-              Pick an arbitrarily large value for <m>p>1/3</m> and note that <m>\fp(p) =3p^2+2p-1 >0</m>.
+              Pick an arbitrarily large value for <m>p\gt 1/3</m> and note that <m>\fp(p) =3p^2+2p-1 \gt 0</m>.
               We conclude that <m>f</m> is increasing on <m>(1/3,\infty)</m>.
             </p>
           </li>
@@ -388,12 +387,12 @@
       </p>
 
       <figure xml:id="fig_incrline1a">
-        <caption></caption>
+        <caption/>
           <!-- START figures/fig_incrline1.tex -->
-        <image xml:id="img_incrline1a"  width="67%">
+        <image xml:id="img_incrline1a" width="67%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[numberline,
           xmin=-2,xmax=1,
@@ -401,12 +400,12 @@
           extra x tick labels={$-1$,$1/3$},]
           \addplot[guideline] coordinates {(-1,0) (-1,2)};
           \addplot[guideline] coordinates {(0.3333,0) (0.3333,2)};
-          \addplot[mark=none] coordinates {(-1.6666,1)} node {\parbox{3em}{\centering \small $\fp>0$\\$f$ incr }};
+          \addplot[mark=none] coordinates {(-1.6666,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
           \addplot[mark=none] coordinates {(-0.3333,1)} node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-          \addplot[mark=none] coordinates {(1,1)} node {\parbox{3em}{\centering \small $\fp>0$\\$f$ incr }};
+          \addplot[mark=none] coordinates {(1,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_incrline1.tex END -->
@@ -416,17 +415,17 @@
         We can verify our calculations by considering <xref ref="fig_incr1">Figure</xref>,
         where <m>f</m> is graphed.
         The graph also presents <m>\fp</m>;
-        note how <m>\fp>0</m> when <m>f</m> is increasing and
+        note how <m>\fp\gt 0</m> when <m>f</m> is increasing and
         <m>\fp\lt 0</m> when <m>f</m> is decreasing.
       </p>
 
       <figure xml:id="fig_incr1">
         <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr1">Example</xref>, showing where <m>f</m> is increasing and decreasing.</caption>
           <!-- START figures/fig_incr1.tex -->
-        <image xml:id="img_incr1"  width="47%">
+        <image xml:id="img_incr1" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-2.2,xmax=2.2,
           ymin=-3,ymax=11,
@@ -436,7 +435,7 @@
           \addplot+[domain=-1.8:1.5] {3*x^2+2*x-1} node[pos=0.1, above right] {$\fp(x)$};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_incr1.tex END -->
@@ -560,10 +559,10 @@
 
     <figure xml:id="fig_inc_counter">
       <caption>A discontinuous function where <m>\fp</m> changes sign at 1, but <m>f(1)</m> is not a local maximum.</caption>
-      <image xml:id="img_incr_counter"  width="47%">
+      <image xml:id="img_incr_counter" width="47%">
         <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-1,xmax=3,
         ymin=-3,ymax=4,]
@@ -573,7 +572,7 @@
         \addplot[hollowdot] coordinates{(1,2)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
         <!-- figures/fig_incr1.tex END -->
@@ -704,12 +703,12 @@
       </p>
 
       <figure xml:id="fig_incrline2">
-        <caption></caption>
+        <caption/>
           <!-- START figures/fig_incrline2.tex -->
-        <image xml:id="img_incrline2"  width="67%">
+        <image xml:id="img_incrline2" width="67%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[numberline,
           xmin=-3,xmax=5,
@@ -718,16 +717,16 @@
           \addplot[guideline] coordinates {(-1,0) (-1,2)};
           \addplot[guideline] coordinates {(1,0) (1,2)};
           \addplot[guideline] coordinates {(3,0) (3,2)};
-          \addplot[mark=none] coordinates {(-2,1)} node {\parbox{3em}{\centering \small  $\fp>0$\\$f$ incr }};
+          \addplot[mark=none] coordinates {(-2,1)} node {\parbox{3em}{\centering \small  $\fp&gt;0$\\$f$ incr }};
           \addplot[mark=none] coordinates {(0,1)} node {\parbox{3em}{\centering \small  $\fp\lt0$\\$f$ decr }};
           \addplot[mark=none] coordinates {(2,1)} node {\parbox{3em}{\centering \small  $\fp\lt0$\\$f$ decr }};
-          \addplot[mark=none] coordinates {(4,1)} node {\parbox{3em}{\centering \small  $\fp>0$\\$f$ incr }};
+          \addplot[mark=none] coordinates {(4,1)} node {\parbox{3em}{\centering \small  $\fp&gt;0$\\$f$ incr }};
           \addplot[mark=none] coordinates {(-1,2)} node[above] {\parbox{3em}{\centering \small  rel\\max}};
           \addplot[mark=none] coordinates {(1,2)} node[above] {\parbox{3em}{\centering \small  VA}};
           \addplot[mark=none] coordinates {(3,2)} node[above] {\parbox{3em}{\centering \small  rel\\min}};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_incrline2.tex END -->
@@ -738,16 +737,16 @@
         Also, <xref ref="fig_incr2">Figure</xref> shows a graph of <m>f</m>,
         confirming our calculations.
         This figure also shows <m>\fp</m>,
-        again demonstrating that <m>f</m> is increasing when <m>\fp>0</m> and decreasing when <m>\fp\lt 0</m>.
+        again demonstrating that <m>f</m> is increasing when <m>\fp\gt 0</m> and decreasing when <m>\fp\lt 0</m>.
       </p>
 
       <figure xml:id="fig_incr2">
         <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr2">Example</xref>, showing where <m>f</m> is increasing and decreasing.</caption>
           <!-- START figures/fig_incr2.tex -->
-        <image xml:id="img_incr2"  width="47%">
+        <image xml:id="img_incr2" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-4.2,xmax=4.2,
           ymin=-21,ymax=21,]
@@ -757,7 +756,7 @@
           \addplot[secondcurvestyle,domain=1.5:4] {(x^2-2*x-3)/((x-1)^2)} ;
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_incr2.tex END -->
@@ -768,7 +767,7 @@
   <p>
     One is often tempted to think that functions always alternate
     <q>increasing, decreasing, increasing,
-    decreasing,<ellipsis /></q> around critical values.
+    decreasing,<ellipsis/></q> around critical values.
     Our previous example demonstrated that this is not always the case.
     While <m>x=1</m> was not technically a critical value,
     it was an important value we needed to consider.
@@ -829,12 +828,12 @@
               We have <m>\fp(p) = (8/3)p^{-1/3}(p-1)(p+1)</m>;
               find the sign of each of the three terms at the chosen value of <m>p</m>.
               <me>
-                \fp(p) = \frac{8}{3} \cdot \underbrace{p^{-\frac{1}{3}}}_{\lt 0}\cdot \underbrace{(p-1)}_{\lt 0}\underbrace{(p+1)}_{>0}
+                \fp(p) = \frac{8}{3} \cdot \underbrace{p^{-\frac{1}{3}}}_{\lt 0}\cdot \underbrace{(p-1)}_{\lt 0}\underbrace{(p+1)}_{\gt 0}
               </me>.
             </p>
 
             <p>
-              We have a <q>negative <times /> negative <times /> positive</q>
+              We have a <q>negative <times/> negative <times/> positive</q>
               giving a positive number;
               <m>f</m> is increasing on <m>(-1,0)</m>.
             </p>
@@ -846,7 +845,7 @@
               We do a similar sign analysis as before,
               using <m>p</m> in <m>(0,1)</m>.
               <me>
-                \fp(p) = \frac{8}{3} \cdot \underbrace{p^{-\frac{1}{3}}}_{>0}\cdot \underbrace{(p-1)}_{\lt 0}\underbrace{(p+1)}_{>0}
+                \fp(p) = \frac{8}{3} \cdot \underbrace{p^{-\frac{1}{3}}}_{\gt 0}\cdot \underbrace{(p-1)}_{\lt 0}\underbrace{(p+1)}_{\gt 0}
               </me>.
             </p>
 
@@ -860,7 +859,7 @@
             <title>Interval 4: <m>(1,\infty)</m></title>
             <p>
               Similar work to that done for the other three intervals shows that
-              <m>\fp(x)>0</m> on <m>(1,\infty)</m>,
+              <m>\fp(x)\gt 0</m> on <m>(1,\infty)</m>,
               so <m>f</m> is increasing on this interval.
             </p>
           </li>
@@ -870,10 +869,10 @@
       <figure xml:id="fig_incrline3">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr3">Example</xref>.</caption>
           <!-- START figures/fig_incrline3.tex -->
-        <image xml:id="img_incrline3"  width="67%">
+        <image xml:id="img_incrline3" width="67%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[numberline,
           xmin=-2,xmax=2,
@@ -883,15 +882,15 @@
           \addplot[guideline] coordinates {(0,0) (0,2)};
           \addplot[guideline] coordinates {(1,0) (1,2)};
           \addplot[mark=none] coordinates {(-1.5,1)} node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-          \addplot[mark=none] coordinates {(-0.5,1)} node {\parbox{3em}{\centering \small $\fp>0$\\$f$ incr }};
+          \addplot[mark=none] coordinates {(-0.5,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
           \addplot[mark=none] coordinates {(0.5,1)}  node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-          \addplot[mark=none] coordinates {(1.5,1)}  node {\parbox{3em}{\centering \small $\fp>0$\\$f$ incr }};
+          \addplot[mark=none] coordinates {(1.5,1)}  node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
           \addplot[mark=none] coordinates {(-1,2)} node[above] {\parbox{3em}{\centering \small rel\\min}};
           \addplot[mark=none] coordinates {(0,2)} node[above] {\parbox{3em}{\centering \small rel\\max}};
           \addplot[mark=none] coordinates {(1,2)} node[above] {\parbox{3em}{\centering \small rel\\min}};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_incrline3.tex END -->
@@ -900,7 +899,7 @@
       <p>
         We conclude by stating that <m>f</m> is increasing on the intervals <m>(-1,0)</m> and
         <m>(1,\infty)</m> and decreasing on the intervals <m>(-\infty,-1)</m> and <m>(0,1)</m>.
-        The sign of <m>\fp</m><nbsp />changes from negative to positive around <m>x=-1</m> and <m>x=1</m>,
+        The sign of <m>\fp</m><nbsp/>changes from negative to positive around <m>x=-1</m> and <m>x=1</m>,
         meaning by <xref ref="thm_first_der">Theorem</xref>
         that <m>f(-1)</m> and <m>f(1)</m> are relative minima of <m>f</m>.
         As the sign of <m>\fp</m> changes from positive to negative at <m>x=0</m>,
@@ -908,16 +907,16 @@
         <xref ref="fig_incr3">Figure</xref>
         shows a graph of <m>f</m>, confirming our result.
         We also graph <m>\fp</m>,
-        highlighting once more that <m>f</m> is increasing when <m>\fp>0</m> and is decreasing when <m>\fp\lt 0</m>.
+        highlighting once more that <m>f</m> is increasing when <m>\fp\gt 0</m> and is decreasing when <m>\fp\lt 0</m>.
       </p>
 
       <figure xml:id="fig_incr3">
         <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr3">Example</xref>, showing where <m>f</m> is increasing and decreasing.</caption>
           <!-- START figures/fig_incr3.tex -->
-        <image xml:id="img_incr3"  width="47%">
+        <image xml:id="img_incr3" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-3.2,xmax=3.2,
           ymin=-5,ymax=11,]
@@ -927,7 +926,7 @@
           \addplot[secondcurvestyle,domain=-2:-0.2,samples=50] {(8*((-x)^2 - 1))/(3 *(-x)^(1/3))};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_incr3.tex END -->
@@ -959,7 +958,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -973,7 +972,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1010,7 +1009,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
         </webwork>
@@ -1027,7 +1026,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1062,7 +1061,7 @@
       <statement>
         <p>
           A function <m>f</m> has derivative <m>\fp(x) = (\sin x+2)e^{x^2+1}</m>,
-          where <m>\fp(x) >1</m> for all <m>x</m>.
+          where <m>\fp(x) \gt 1</m> for all <m>x</m>.
           Is <m>f</m> increasing, decreasing,
           or can we not tell from the given information?
         </p>
@@ -1115,7 +1114,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1139,7 +1138,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1163,7 +1162,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1187,7 +1186,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1211,7 +1210,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1235,7 +1234,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1259,7 +1258,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1283,7 +1282,7 @@
               </p>
 
               <p>
-                <m>\fp(x)=</m><var name="$c" width="30" />
+                <m>\fp(x)=</m><var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1358,7 +1357,7 @@
                     </p>
 
                     <p>
-                      <var name="$d" width="30" />
+                      <var name="$d" width="30"/>
                     </p>
                   </li>
 
@@ -1370,7 +1369,7 @@
                     </p>
 
                     <p>
-                      <var name="$crit" width="30" />
+                      <var name="$crit" width="30"/>
                     </p>
                   </li>
 
@@ -1382,7 +1381,7 @@
                     </p>
 
                     <p>
-                      <var name="$inc" width="30" />
+                      <var name="$inc" width="30"/>
                     </p>
                   </li>
 
@@ -1394,7 +1393,7 @@
                     </p>
 
                     <p>
-                      <var name="$dec" width="30" />
+                      <var name="$dec" width="30"/>
                     </p>
                   </li>
 
@@ -1406,7 +1405,7 @@
                     </p>
 
                     <p>
-                      <var name="$max" width="30" />
+                      <var name="$max" width="30"/>
                     </p>
                   </li>
 
@@ -1418,7 +1417,7 @@
                     </p>
 
                     <p>
-                      <var name="$min" width="30" />
+                      <var name="$min" width="30"/>
                     </p>
                   </li>
                 </ol>
@@ -1489,14 +1488,15 @@
                 <m>\ds f(x) =x^3+3x^2+3</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -1508,7 +1508,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -1520,7 +1520,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -1532,7 +1532,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -1544,7 +1544,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -1556,10 +1556,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -1624,14 +1625,15 @@
                 <m>f(x) =2 x^3+x^2-x+3</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -1643,7 +1645,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -1655,7 +1657,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -1667,7 +1669,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -1679,7 +1681,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -1691,10 +1693,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -1759,14 +1762,15 @@
                 <m>\ds f(x) =x^3-3x^2+3x-1</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -1778,7 +1782,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -1793,7 +1797,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -1805,7 +1809,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -1817,7 +1821,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -1829,10 +1833,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -1897,14 +1902,15 @@
                 <m>\ds f(x) =\frac{1}{x^2-2x+2}</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -1916,7 +1922,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -1928,7 +1934,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -1940,7 +1946,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -1952,7 +1958,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -1964,10 +1970,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -2032,14 +2039,15 @@
                 <m>\ds f(x) =\frac{x^2-4}{x^2-1}</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -2051,7 +2059,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -2063,7 +2071,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -2075,7 +2083,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -2087,7 +2095,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -2099,10 +2107,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -2167,14 +2176,15 @@
                 <m>\ds f(x) =\frac{x}{x^2-2x-8}</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -2186,7 +2196,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -2198,7 +2208,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -2210,7 +2220,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -2222,7 +2232,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -2234,10 +2244,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -2302,14 +2313,15 @@
                 <m>\ds f(x) =\frac{(x-2)^{2/3}}{x}</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -2321,7 +2333,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -2333,7 +2345,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -2345,7 +2357,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -2357,7 +2369,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -2369,10 +2381,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -2437,14 +2450,15 @@
                 <m>\ds f(x) =\sin(x) \cos(x)</m> on <m>(-\pi,\pi)</m>.
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -2456,7 +2470,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -2468,7 +2482,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -2480,7 +2494,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -2492,7 +2506,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -2504,10 +2518,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -2572,14 +2587,15 @@
                 <m>\ds f(x) =x^5-5x</m>
               </p>
 
-              <ol>
+              <p>
+                <ol>
                 <li>
                   <p>
                     Give the domain of <m>f</m>.
                   </p>
 
                   <p>
-                    <var name="$d" width="30" />
+                    <var name="$d" width="30"/>
                   </p>
                 </li>
 
@@ -2590,7 +2606,7 @@
                   </p>
 
                   <p>
-                    <var name="$crit" width="30" />
+                    <var name="$crit" width="30"/>
                   </p>
                 </li>
 
@@ -2602,7 +2618,7 @@
                   </p>
 
                   <p>
-                    <var name="$inc" width="30" />
+                    <var name="$inc" width="30"/>
                   </p>
                 </li>
 
@@ -2614,7 +2630,7 @@
                   </p>
 
                   <p>
-                    <var name="$dec" width="30" />
+                    <var name="$dec" width="30"/>
                   </p>
                 </li>
 
@@ -2626,7 +2642,7 @@
                   </p>
 
                   <p>
-                    <var name="$max" width="30" />
+                    <var name="$max" width="30"/>
                   </p>
                 </li>
 
@@ -2638,10 +2654,11 @@
                   </p>
 
                   <p>
-                    <var name="$min" width="30" />
+                    <var name="$min" width="30"/>
                   </p>
                 </li>
               </ol>
+            </p>
             </statement>
             <solution>
               <p>
@@ -2712,7 +2729,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -2739,7 +2756,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -2753,4 +2770,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -43,9 +43,7 @@
     <md>
       <mrow>\frac{\Delta f}{\Delta t} \amp = \frac{f(2)-f(0)}{2-0}</mrow>
       <mrow>\amp  = \frac{100-0}{2}</mrow>
-      <mrow>\amp = <quantity>
-      <mag>50</mag><unit base="mileperhour"/>
-    </quantity></mrow>
+      <mrow>\amp = 50 \text{ mph}</mrow>
     </md>.
   </p>
 

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_mvt">
   <title>The Mean Value Theorem</title>
   <p>
@@ -13,17 +12,17 @@
     it is clear that the <em>average</em>
     speed for the entire trip is
     <quantity>
-      <mag>50</mag><unit base="mileperhour" />
+      <mag>50</mag><unit base="mileperhour"/>
     </quantity>
-    (<ie /> <m>100</m> miles in <m>2</m> hours),
+    (<ie/> <m>100</m> miles in <m>2</m> hours),
     but the question is whether or not your
     <em>instantaneous</em> speed is ever exactly
     <quantity>
-      <mag>50</mag><unit base="mileperhour" />
+      <mag>50</mag><unit base="mileperhour"/>
     </quantity>.
     More simply, does your speedometer ever read exactly
     <quantity>
-      <mag>50</mag><unit base="mileperhour" />
+      <mag>50</mag><unit base="mileperhour"/>
     </quantity>?. The answer,
     under some very reasonable assumptions, is <q>yes.</q>
   </p>
@@ -45,7 +44,7 @@
       <mrow>\frac{\Delta f}{\Delta t} \amp = \frac{f(2)-f(0)}{2-0}</mrow>
       <mrow>\amp  = \frac{100-0}{2}</mrow>
       <mrow>\amp = <quantity>
-      <mag>50</mag><unit base="mileperhour" />
+      <mag>50</mag><unit base="mileperhour"/>
     </quantity></mrow>
     </md>.
   </p>
@@ -56,7 +55,7 @@
     this means that at some time during the trip,
     the derivative takes on the value of
     <quantity>
-      <mag>50</mag><unit base="mileperhour" />
+      <mag>50</mag><unit base="mileperhour"/>
     </quantity>.
     Symbolically,
     <me>
@@ -105,7 +104,7 @@
           <image xml:id="img_mvt1">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.95,xmax=1.95,
             ymin=-.6,ymax=3.5,]
@@ -115,7 +114,7 @@
             \addplot[soliddot] coordinates {(-1,1) (1,1)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_mvt1.tex END -->
@@ -127,7 +126,7 @@
           <image xml:id="img_mvt2">
             <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.95,xmax=1.95,
             ymin=-.6,ymax=3.5,]
@@ -136,7 +135,7 @@
             \addplot[soliddot] coordinates {(-1,1) (1,1)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_mvt2.tex END -->
@@ -207,10 +206,10 @@
   <figure xml:id="fig_mvt3">
     <caption>A graph of <m>f(x) = x^3-5x^2+3x+5</m>, where <m>f(a) = f(b)</m>. Note the existence of <m>c</m>, where <m>a\lt c\lt b</m>, where <m>\fp(c)=0</m>.</caption>
       <!-- START figures/fig_mvt3.tex -->
-    <image xml:id="img_mvt3"  width="47%">
+    <image xml:id="img_mvt3" width="47%">
       <description></description>
       <latex-image>
-      <![CDATA[
+      
       \begin{tikzpicture}
       \begin{axis}[xmin=-1.5,xmax=2.5,
       ymin=-5.2,ymax=8,
@@ -222,7 +221,7 @@
       \addplot [tangentlineseg,domain=-.75:1.5] {5.48};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+      
       </latex-image>
     </image>
       <!-- figures/fig_mvt3.tex END -->
@@ -307,7 +306,7 @@
     By the <xref ref="thm_mvt">Mean Value Theorem</xref>,
     we are guaranteed a time during the trip where our instantaneous speed is
     <quantity>
-      <mag>50</mag><unit base="mileperhour" />
+      <mag>50</mag><unit base="mileperhour"/>
     </quantity>.
     This fact is used in practice.
     Some law enforcement agencies monitor traffic speeds while in aircraft.
@@ -370,10 +369,10 @@
       <figure xml:id="fig_mvt4">
         <caption>Demonstrating the Mean Value Theorem in <xref ref="ex_mvt2">Example</xref>.</caption>
           <!-- START figures/fig_mvt4.tex -->
-        <image xml:id="img_mvt4"  width="47%">
+        <image xml:id="img_mvt4" width="47%">
           <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-3.2,xmax=3.2,
           ymin=-45,ymax=51,]
@@ -384,7 +383,7 @@
           \addplot [tangentlineseg,domain=-.1:3] {14*(x-1.732)+18.86};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_mvt4.tex END -->
@@ -417,7 +416,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -436,7 +435,7 @@
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -478,7 +477,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
         </webwork>
@@ -503,7 +502,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
         </webwork>
@@ -529,7 +528,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
         </webwork>
@@ -555,7 +554,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
         </webwork>
@@ -581,7 +580,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
         </webwork>
@@ -608,7 +607,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
         </webwork>
@@ -634,7 +633,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
 <!--           <solution>
@@ -663,7 +662,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
 <!--           <solution>
@@ -717,7 +716,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
  <!--          <solution>
@@ -746,7 +745,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
 <!--           <solution>
@@ -775,7 +774,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
 <!--           <solution>
@@ -804,7 +803,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
 <!--           <solution>
@@ -833,7 +832,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
 <!--           <solution>
@@ -862,7 +861,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -894,7 +893,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -925,7 +924,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -956,7 +955,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -987,7 +986,7 @@
               </p>
 
               <p>
-                <var name="$c" width="30" />
+                <var name="$c" width="30"/>
               </p>
             </statement>
             <solution>
@@ -1018,7 +1017,7 @@
             Find the extreme values of <m>f(x) =x^2-3x+9</m> on <m>[-2,5]</m>
           </p>
 
-          . <!-- State your answer(s) in the form <m>x=...</m>. If any of the extreme values below are not present, state <q><c>does not apply</c></q></p> -->
+          <!-- State your answer(s) in the form <m>x=...</m>. If any of the extreme values below are not present, state <q><c>does not apply</c></q></p> -->
             <!-- <p><var form="essay" /></p> -->
         </statement>
         <solution>
@@ -1075,4 +1074,3 @@
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -398,7 +398,7 @@
     it is mostly used to advance other theory.
     We will use it in the next section to relate the shape of a graph to its derivative.
   </p>
-  
+
   <exercises>
     <exercisegroup>
 

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_sketch">
   <title>Curve Sketching</title>
   <p>
@@ -14,7 +13,7 @@
     Graphing utilities are very accessible,
     whether on a computer, a hand-held calculator, or a smartphone.
     These resources are usually very fast and accurate.
-    We will see that our method is not particularly fast <mdash /> it will require time
+    We will see that our method is not particularly fast <mdash/> it will require time
     (but it is not <em>hard</em>).
     So again: why bother?
   </p>
@@ -201,7 +200,7 @@
 <!--TODO: Sean is not so sure about the table that has
 replaced Greg's sign diagram image here... Also, can we consider having separate sign diagrams for f, f', f'' or is Sean the only one who does it that way?-->
       <table xml:id="tab_sketchline1">
-        <caption />
+        <title/>
 
         <tabular halign="center">
           <row bottom="major">
@@ -227,7 +226,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               <line><m>f</m> c. up</line></cell>
           </row>
           <row>
-            <cell />
+            <cell></cell>
             <cell colspan="2">
               <line><m>\frac{1}{9}\left(10-\sqrt{37}\right)</m></line>
               <line><m>\approx0.435</m></line></cell>
@@ -237,7 +236,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             <cell colspan="2">
               <line><m>\frac{1}{9}\left(10+\sqrt{37}\right)</m></line>
               <line><m>\approx1.787</m></line></cell>
-            <cell />
+            <cell></cell>
           </row>
         </tabular>
 
@@ -276,7 +275,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             <image xml:id="img_sketch1a">
               <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[ymin=-5.5,ymax=10.9,xmin=-1.2,xmax=3.2,]
               \addplot[firstcurvestyle,leftarrow,domain=-1:0.435] {(5-6.4)/(0-0.435)*(x-0.435)+6.4};
@@ -285,7 +284,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \addplot[soliddot] coordinates{(0.435,6.4) (1.11,4.55) (1.79,2.69)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_sketch1a.tex END -->
@@ -297,7 +296,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             <image xml:id="img_sketch1b">
               <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[ymin=-5.5,ymax=10.9,xmin=-1.2,xmax=3.2,]
               \addplot[firstcurvestyle,leftarrow,domain=-0.8:0.435] {(x-0.435)^2/(0-0.435)^2*(5-6.4)  + 6.4};
@@ -306,7 +305,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \addplot[soliddot] coordinates{(0.435,6.4) (1.11,4.55) (1.79,2.69)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
               <!-- figures/fig_sketch1b.tex END -->
@@ -358,7 +357,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             <p>
               To find the critical values of <m>f</m>,
               we first find <m>\fp(x)</m>.
-              Using the <xref ref="thm_QuotientRule" text="title" />, we find
+              Using the <xref ref="thm_QuotientRule" text="title"/>, we find
               <me>
                 \fp(x) = \frac{-8x+4}{(x^2+x-6)^2} = \frac{-8x+4}{(x-3)^2(x+2)^2}
               </me>.
@@ -373,7 +372,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           <li>
             <p>
               To find the possible points of inflection, we find <m>\fpp(x)</m>,
-              again employing the <xref ref="thm_QuotientRule" text="title" />:
+              again employing the <xref ref="thm_QuotientRule" text="title"/>:
               <me>
                 \fpp(x) = \frac{24x^2-24x+56}{(x-3)^3(x+2)^3}
               </me>.
@@ -436,15 +435,15 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </p>
 <!--TODO: Another vote fro Sean for going back to the TikZ number line -->
       <table xml:id="tab_sketchline2">
-        <caption>Number line for <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</caption>
+        <title>Number line for <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</title>
 
 
         <tabular halign="center">
           <row bottom="major">
             <cell colspan="2" right="minor">
-              <line><m>\fp>0</m>,</line>
+              <line><m>\fp\gt 0</m>,</line>
               <line><m>f</m> incr;</line>
-              <line><m>\fpp>0</m>,</line>
+              <line><m>\fpp\gt 0</m>,</line>
               <line><m>f</m> c. up</line></cell>
             <cell colspan="2" right="minor">
               <line><m>\fp\gt0</m>,</line>
@@ -463,11 +462,11 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               <line><m>f</m> c. up</line></cell>
           </row>
           <row>
-            <cell />
+            <cell></cell>
             <cell colspan="2"><m>-2</m></cell>
             <cell colspan="2"><m>\frac{1}{2}</m></cell>
             <cell colspan="2"><m>3</m></cell>
-            <cell />
+            <cell></cell>
           </row>
         </tabular>
 
@@ -499,15 +498,14 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
         </figure> -->
       <figure xml:id="fig_sketch2">
         <caption>Sketching <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</caption>
-        <sidebyside widths="32% 32% 32%">
-          <caption>Sketching <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</caption>
+    <sidebyside widths="32% 32% 32%">
           <figure xml:id="fig_sketch2a">
             <caption/>
               <!-- START figures/fig_sketch2a.tex -->
             <image xml:id="img_sketch2a">
               <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[ymin=-5.2,ymax=5.2,xmin=-5.1,xmax=5.1,]
               \addplot[firstcurvestyle,domain=-4.5:-2.5] {(x+3)+3};
@@ -520,7 +518,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \addplot[soliddot] coordinates{(0.5,0.36)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
               <!-- figures/fig_sketch2a.tex END -->
@@ -532,7 +530,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             <image xml:id="img_sketch2b">
               <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[ymin=-5.2,ymax=5.2,xmin=-5.1,xmax=5.1,]
               \addplot[firstcurvestyle,domain=-5.1:-2.3] {-1/(x+2)+1};
@@ -544,7 +542,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \addplot[soliddot] coordinates{(0.5,0.36) (-1,0) (2,0)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
               <!-- figures/fig_sketch2b.tex END -->
@@ -669,7 +667,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </p>
 <!--TODO: take a look at this table too -->
       <table xml:id="tab_sketchline3">
-        <caption>Number line for <m>f</m> in Example <xref ref="ex_sketch3">Example</xref>.</caption>
+        <title>Number line for <m>f</m> in Example <xref ref="ex_sketch3">Example</xref>.</title>
 
         <tabular halign="center">
           <row bottom="major">
@@ -705,13 +703,13 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               <line><m>f</m> c. down</line></cell>
           </row>
           <row>
-            <cell />
+            <cell/>
             <cell colspan="2"><m>-5.579</m></cell>
             <cell colspan="2"><m>-4</m></cell>
             <cell colspan="2"><m>-1.305</m></cell>
             <cell colspan="2"><m>0</m></cell>
             <cell colspan="2"><m>1.064</m></cell>
-            <cell />
+            <cell/>
           </row>
         </tabular>
 
@@ -746,15 +744,15 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           </image>
         </figure> -->
         <figure xml:id="fig_sketch3">
+        <caption>Sketching <m>f</m> in <xref ref="ex_sketch3">Example</xref>.</caption>
         <sidebyside widths="32% 32% 32%">
-          <caption>Sketching <m>f</m> in <xref ref="ex_sketch3">Example</xref>.</caption>
           <figure xml:id="fig_sketch3a">
             <caption/>
               <!-- START figures/fig_sketch3a.tex -->
             <image xml:id="img_sketch3a">
               <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[ ymin=-3.1,ymax=8.1,xmin=-7.5,xmax=6.5,]
               \addplot[firstcurvestyle,leftarrow,domain=-7:-4] {(7.2-7.5)/(-5.579+4)*(x+4)+7.5};
@@ -767,7 +765,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \addplot[soliddot] coordinates{(0,-2.5) (-1,0) (2,0) (-5.579,7.2) (-1.305,1.630) (1.064,-1.331) (-4,7.5)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
               <!-- figures/fig_sketch3a.tex END -->
@@ -779,7 +777,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             <image xml:id="img_sketch3b">
               <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[ ymin=-3.1,ymax=8.1,xmin=-7.5,xmax=6.5,]
               \addplot[firstcurvestyle,leftarrow,domain=-7.5:-4] {7.5-0.3/(exp(-1/2/(-5.579+4)^2*(-5.579+4)^2) - 1)*(-1+exp(-1/2/(-5.579+4)^2*(x+4)^2))};
@@ -792,7 +790,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \addplot[soliddot] coordinates{(0,-2.5) (-1,0) (2,0) (-5.579,7.2) (-1.305,1.630) (1.064,-1.331) (-4,7.5)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
               <!-- figures/fig_sketch3b.tex END -->
@@ -842,28 +840,28 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
     However, in regions where the graph is very <q>curvy,</q>
     this can generate noticeable sharp edges on the graph unless a large number of points are used.
     High quality computer algebra systems,
-    such as <booktitle>Mathematica</booktitle> and <booktitle>Sage</booktitle>,
+    such as <pubtitle>Mathematica</pubtitle> and <pubtitle>Sage</pubtitle>,
     use special algorithms to plot lots of points only where the graph is <q>curvy.</q>
   </p>
 
   <p>
     In <xref ref="fig_sage_sinx">Figure</xref>,
     two graph of <m>y=\sin(x)</m> is given,
-    generated by <booktitle>Sage</booktitle> and <booktitle>Mathematica</booktitle>.
+    generated by <pubtitle>Sage</pubtitle> and <pubtitle>Mathematica</pubtitle>.
     The small points represent each of the places where each <init>CAS</init> sampled the function.
     Notice how at the <q>bends</q>
     of <m>\sin(x)</m>, lots of points are used;
     where <m>\sin(x)</m> is relatively straight, fewer points are used.
-    (In the <booktitle>Mathematica</booktitle> plot,
+    (In the <pubtitle>Mathematica</pubtitle> plot,
     many points are also used at the endpoints to ensure the
     <q>end behavior</q> is accurate.)
   </p>
 
   <figure xml:id="fig_sage_sinx">
+    <caption>CAS plots of <m>y=\sin(x)</m> illustrating the sample points</caption>
     <sidebyside widths="47% 47%">
-      <caption>CAS plots of <m>y=\sin(x)</m> illustrating the sample points</caption>
       <figure>
-        <caption><booktitle>Sage</booktitle> output</caption>
+        <caption><pubtitle>Sage</pubtitle> output</caption>
         <image xml:id="img_sage_sinx">
           <description></description>
 
@@ -875,18 +873,18 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </figure>
 
       <figure>
-        <caption><booktitle>Mathematica</booktitle> output</caption>
-        <image xml:id="img_mathematica_sinx" source="images/figmathematica_sinx" />
+        <caption><pubtitle>Mathematica</pubtitle> output</caption>
+        <image source="images/figmathematica_sinx" xml:id="img_mathematica_sinx"/>
       </figure>
     </sidebyside>
   </figure>
 
   <p>
-    How does <booktitle>Sage</booktitle> know where the graph is <q>curvy</q>?
+    How does <pubtitle>Sage</pubtitle> know where the graph is <q>curvy</q>?
     Calculus.
     When we study <em>curvature</em> in a later chapter,
     we will see how the first and second derivatives of a function work together to provide a measurement of <q>curviness.</q>
-    <booktitle>Sage</booktitle> employs algorithms to determine regions of <q>high curvature</q>
+    <pubtitle>Sage</pubtitle> employs algorithms to determine regions of <q>high curvature</q>
     and plots extra points there.
   </p>
 
@@ -924,7 +922,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -947,7 +945,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               </p>
 
               <p>
-                <var form="essay" />
+                <var form="essay"/>
               </p>
             </statement>
             <solution>
@@ -1500,4 +1498,3 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
     </exercisegroup>
   </exercises>
 </section>
-

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -143,6 +143,21 @@
     </statement>
   </theorem>
 
+  <aside>
+    <p>
+      Many people like to remember <xref ref="sum-difference-limit-rule">Property</xref>
+      as stating that <q>the limit of the sum is the sum of the limits</q>, and
+      <xref ref="product-limit-rule">Property</xref> as stating that the
+      <q>limit of a product is the product of the limits.</q>
+    </p>
+    <p>
+      In practice, <xref ref="scalar-multiple-limit-rule">Property</xref> is often
+      viewed as telling us that we can <q>take constants out of limits</q>:
+      <me>
+        \lim_{x\to c}(b\cdot f(x)) = b\cdot\lim_{x\to c}f(x).
+      </me>
+    </p>
+  </aside>
   <p>
     We apply the theorem to an example.
   </p>
@@ -184,7 +199,12 @@
           <li>
             <p>
               Using the <xref ref="sum-difference-limit-rule" text="title"/> rule,
-              we know that <m>\lim_{x\to 2}(f(x) + g(x)) = 2+3 =5</m>.
+              we know that
+              <md>
+                <mrow>\lim_{x\to 2}(f(x) + g(x)) \amp = 
+                        \lim_{x\to 2}f(x) + \lim_{x\to 2}g(x)</mrow>
+                <mrow>\amp = 2+3 =5</mrow>
+              </md>.
             </p>
           </li>
 
@@ -193,7 +213,13 @@
               Using the <xref ref="scalar-multiple-limit-rule" text="title"/>,
               <xref ref="sum-difference-limit-rule" text="title"/>,
               and <xref ref="power-limit-rule" text="title"/> rules,
-              we find that <m>\lim\limits_{x\to 2}(5f(x) + g(x)^2) = 5\cdot 2 + 3^2 = 19</m>.
+              we find that
+              <md>
+                <mrow>\lim_{x\to 2}(5f(x) + g(x)^2) \amp = 
+                        \lim_{x\to 2}(5f(x))+\lim_{x\to 2}(g(x)^2)</mrow>
+                <mrow>\amp = 5\lim_{x\to 2}f(x) + \mathopen{}\left(\lim_{x\to 2}g(x)\right)\mathclose{}</mrow>
+                <mrow>\amp = 5\cdot 2 + 3^2 = 19</mrow>
+              </md>.
             </p>
           </li>
 
@@ -205,7 +231,9 @@
               We show quite a few steps, but in general these can be omitted:
               <md>
                 <mrow>\lim_{x\to 2} p(x) \amp = \lim_{x\to 2}\left(3x^2-5x+7\right)</mrow>
-                <mrow>\amp = \lim_{x\to 2}\left(3x^2\right)-\lim_{x\to 2}(5x)+\lim_{x\to 2}7</mrow>
+                <mrow>\amp = \lim_{x\to 2}\mathopen{}\left(3x^2\right)\mathclose{}
+                             -\lim_{x\to 2}(5x)+\lim_{x\to 2}7</mrow>
+                <mrow>\amp = 3\bigl(\lim_{x\to 2}x\bigr)^2-5\lim_{x\to 2}(x) +7</mrow>
                 <mrow>\amp = 3\cdot 2^2 - 5\cdot 2+7</mrow>
                 <mrow>\amp = 9</mrow>
               </md>

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -523,9 +523,9 @@
   <figure xml:id="fig-squeeze-theorem">
     <caption>An illustration of the Squeeze Theorem</caption>
     <image xml:id="img-squeeze-theorem" width="47%">
-      <description/>
+      <description></description>
       <latex-image>
-      <![CDATA[
+      
       \begin{tikzpicture}
       \begin{axis}[xtick={5},ytick={4},xticklabel={$c$}, yticklabel={$L$}]
       \addplot+[-,smooth] coordinates {(1,3) (2,5) (3,5) (4,4.3) (5,4) (6,3.7) (7,4.5) (8,5) (9,6)} node[below left] {$g$};
@@ -533,15 +533,14 @@
       \addplot+[-,smooth] coordinates {(1,6.5) (2,6.9) (3,6.5) (4,5) (5,4) (6,4.2) (7,5) (8,5.3) (9,7)} node[below left] {$h$};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+      
       </latex-image>
     </image>
 
   </figure>
 
   <theorem xml:id="thm_sqz">
-    <title>Squeeze Theorem</title>
-    <statement>
+    <title>Squeeze Theorem</title> <statement>
       <p>
         Let <m>f</m>,
         <m>g</m> and <m>h</m> be functions on an open interval <m>I</m> containing <m>c</m> such that for all <m>x</m> in <m>I</m>,
@@ -603,9 +602,9 @@
         <caption>The unit circle and related triangles.</caption>
           <!-- START figures/fig_squeeze1.tex -->
         <image xml:id="img_squeeze_sinx" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[compat=1.5.1,
           clip=false,
@@ -621,7 +620,7 @@
           \addplot[soliddot] coordinates {(1,0.839) (1,0) (0.766,0.643)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_squeeze1.tex END -->
@@ -648,39 +647,39 @@
       <sidebyside widths="32% 32% 32%">
           <!-- START figures/fig_squeeze1a.tex -->
         <image xml:id="img_squeeze1a">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[x=100pt,y=100pt]
           \fill [draw=black,thick,fill=blue!20] (0,0) node [shift={(22.5:0.2)}] {$\theta$} -- (1,.839) -- node [pos=.5,below,rotate=90] {$\tan(\theta)$} (1,0) -- cycle;
           \draw (.5,0) node [below] {$1$};
           \draw [black,dashed,thick] (1,0) arc (0:40:1);
           \draw [black,dashed,thick] (1,0) -- (.766,.643);
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_squeeze1a.tex END -->
           <!-- START figures/fig_squeeze1b.tex -->
         <image xml:id="img_squeeze1b">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[x=100pt,y=100pt]
           \fill [draw=black,thick,fill=blue!20] (0,0) node [shift={(22.5:0.2)}] {$\theta$} -- (1,0) arc(0:40:1) -- cycle;
           \draw (.5,0) node [below] {$1$};
           \draw [black,dashed,thick] (1,0) arc (0:40:1);
           \draw [black,dashed,thick] (1,0) -- (.766,.643) -- (1,.839) -- node [pos=.5,below,rotate=90,opacity=0] {$\tan(\theta)$} cycle;
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_squeeze1b.tex END -->
           <!-- START figures/fig_squeeze1c.tex -->
         <image xml:id="img_squeeze1c">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[x=100pt,y=100pt]
           \fill [draw=black,thick,fill=blue!20] (0,0) node [shift={(22.5:0.2)}] {$\theta$} -- (1,0) --(.766,.643) -- cycle;
           \draw [dashed,thick] (.766,0)  -- node [pos=.4,above,rotate=90] {$\sin(\theta) $}(.766,.643);
@@ -688,7 +687,7 @@
           \draw (.5,0) node [below] {$1$};
           \draw [black,dashed,thick] (1,0) arc(0:40:1) --  (1,.839) -- node [pos=.5,below,rotate=90,opacity=0] {$\tan(\theta)$} cycle;
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_squeeze1c.tex END -->
@@ -880,9 +879,9 @@
         <caption>Graphing <m>f</m> in <xref ref="ex_limit_onept">Example</xref> to understand a limit.</caption>
           <!-- START figures/figLimitXplus1.tex -->
         <image xml:id="img_limitxplus1" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-.1,xmax=2.2,
           ymin=-.1,ymax=3.2,
@@ -891,7 +890,7 @@
           \addplot[hollowdot] coordinates {(1,2)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/figLimitXplus1.tex END -->
@@ -1202,32 +1201,28 @@
             </solution>
         </webwork>
       </exercise>
-
-      <exercise>
-        <webwork seed="1">
-          <setup>
-            <!-- <var name="$iszero" > -->
-            <!-- <set><member correct="yes">True</member> -->
-            <!-- <member>False</member></set> -->
-            <!-- </var> -->
-          <pg-code>
-            $iszero=PopUp(['?','True','False'],'True');
-          </pg-code>
-          </setup>
-          <statement>
-            <p>
-              True or False? <m>\lim\limits_{x\to 1}\ln x = 0</m>.
-              Use a theorem to defend your answer.
-            </p>
-          </statement>
-          <solution>
-            <p>
-              True; by <xref ref="thm_lim_continuous">Theorem</xref>,
-              <m>\lim_{x\to 1}\ln x = \ln 1 =0</m>.
-            </p>
-          </solution>
-        </webwork>
-      </exercise>
+<!--TODO: fix WeBWorK code in this problem-->
+      <!-- <exercise> -->
+        <!-- <webwork seed="1"> -->
+          <!-- <setup> -->
+          <!-- <pg-code> -->
+            <!-- $iszero=PopUp(['?','True','False'],'True'); -->
+          <!-- </pg-code> -->
+          <!-- </setup> -->
+          <!-- <statement> -->
+            <!-- <p> -->
+              <!-- True or False? <m>\lim\limits_{x\to 1}\ln x = 0</m>. -->
+              <!-- Use a theorem to defend your answer. -->
+            <!-- </p> -->
+          <!-- </statement> -->
+          <!-- <solution> -->
+            <!-- <p> -->
+              <!-- True; by <xref ref="thm_lim_continuous">Theorem</xref>, -->
+              <!--<m>\lim_{x\to 1}\ln x = \ln 1 =0</m>.-->
+            <!-- </p> -->
+          <!-- </solution> -->
+        <!-- </webwork> -->
+      <!-- </exercise> -->
     </exercisegroup>
 
     <!--TODO: Resolve the repeated instructions in the exercises in this exercisegroup. -->

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -94,10 +94,10 @@
         <caption>A graph of <m>f</m> in <xref ref="ex_contint1">Example</xref>.</caption>
           <!-- START figures/fig_continuous1.tex -->
         <image xml:id="img_continuous1" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
-          \begin{tikzpicture}[declare function = {func(\x) = (\x >= 0)*(\x <= 1)*(-(\x-1/4)^2+1/16+1.5) + (\x > 1)*(\x <= 2) + (\x > 2)*(\x <= 3)*((2-\x)*(\x-3)+1);}]
+          
+          \begin{tikzpicture}[declare function = {func(\x) = (\x &gt;= 0)*(\x &lt;= 1)*(-(\x-1/4)^2+1/16+1.5) + (\x &gt; 1)*(\x &lt;= 2) + (\x &gt; 2)*(\x &lt;= 3)*((2-\x)*(\x-3)+1);}]
           \begin{axis}[xmin=-.4,xmax=3.4,
           ymin=-.4,ymax=1.7]
           \addplot+[domain=0:3,-,samples=48] {func(x)};
@@ -105,7 +105,7 @@
           \addplot[hollowdot] coordinates {(1,1)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_continuous1.tex END -->
@@ -177,9 +177,9 @@
         <caption>A graph of the step function in <xref ref="ex_contint2">Example</xref>.</caption>
           <!-- START figures/fig_continuous2.tex -->
         <image xml:id="img_continuous2" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-2.4,xmax=3.4,
           ymin=-2.4,ymax=2.4]
@@ -192,7 +192,7 @@
           \addplot[hollowdot] coordinates {(-1,-2) (0,-1) (1,0) (2,1) (3,2)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_continuous2.tex END -->
@@ -533,7 +533,7 @@
 
           <li>
             <p>
-              <m>f(x) = a^x</m> (<m>a&gt;0</m>)
+              <m>f(x) = a^x</m> (<m>a\gt 0</m>)
             </p>
           </li>
 
@@ -618,9 +618,9 @@
         <caption>A graph of <m>f</m></caption>
           <!-- START figures/fig_continuous3.tex -->
         <image xml:id="img_continuous3" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-.4,xmax=5.4,
           ymin=-.4,ymax=3.2,]
@@ -628,7 +628,7 @@
           \addplot[soliddot] coordinates {(1,2) (5,2)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_continuous3.tex END -->
@@ -708,9 +708,9 @@
   <figure xml:id="fig_intermediate_value">
     <caption>Illustration of the Intermediate Value Theorem: the output <m>3</m> is in between <m>-10</m> and <m>5</m>, and therefore any continuous function on <m>[1,2]</m> with <m>f(1) = -10</m> and <m>f(2) = 5</m> will achieve the output <m>3</m> somewhere in <m>[1,2]</m>.</caption>
     <image xml:id="img_intermediate_value" width="47%">
-      <description/>
+      <description></description>
       <latex-image>
-      <![CDATA[
+      
       \begin{tikzpicture}
       \begin{axis}[xmin=0.5,xmax=2.5,
       ymin=-15,ymax=10,
@@ -726,7 +726,7 @@
       \addplot[guideline] coordinates {(1.6,0) (1.6,3) (0.5,3)};
       \end{axis}
       \end{tikzpicture}
-      ]]>
+      
       </latex-image>
     </image>
 
@@ -762,7 +762,7 @@
     These roots may be very difficult to find exactly.
     Good approximations can be found through successive applications of this theorem.
     Suppose through direct computation we find that
-    <m>f(a) \lt 0</m> and <m>f(b)&gt;0</m>, where <m>a\lt b</m>.
+    <m>f(a) \lt 0</m> and <m>f(b)\gt 0</m>, where <m>a\lt b</m>.
     The <xref ref="thm_IVT" text="title"/> states that there is at least one <m>c</m> in <m>(a,b)</m> such that <m>f(c) = 0</m>.
     The theorem does not give us any clue as to where to find such a value in the interval <m>(a,b)</m>,
     just that at least one such value exists.
@@ -792,7 +792,7 @@
 
       <li>
         <p>
-          <m>f(d) &gt;0</m>: Then we know there is a root of <m>f</m> on the interval <m>[a,d]</m> <mdash/> again,we have halved the size of our interval,
+          <m>f(d) \gt 0</m>: Then we know there is a root of <m>f</m> on the interval <m>[a,d]</m> <mdash/> again,we have halved the size of our interval,
           hence are closer to a good approximation of the root.
         </p>
       </li>
@@ -834,9 +834,9 @@
         <caption>Graphing a root of <m>f(x) = x-\cos(x)</m>.</caption>
           <!-- START figures/fig_xminuscosx.tex -->
         <image xml:id="img_xminuscosx" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[minor xtick={0,0.1,...,1},
           xmin=-.05,xmax=1.07,
@@ -846,7 +846,7 @@
           \addplot[guideline] coordinates {(0.9,0) (0.9,0.278)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
           <!-- figures/fig_xminuscosx.tex END -->
@@ -857,7 +857,7 @@
           <li>
             <title>Iteration 1:</title>
             <p>
-              <m>f(0.7) \lt 0</m>, <m>f(0.9) &gt; 0</m>, and <m>f(0.8) &gt;0</m>.
+              <m>f(0.7) \lt 0</m>, <m>f(0.9) \gt 0</m>, and <m>f(0.8) \gt 0</m>.
               So replace <m>0.9</m> with <m>0.8</m> and repeat.
             </p>
           </li>
@@ -865,9 +865,9 @@
           <li>
             <title>Iteration 2:</title>
             <p>
-              <m>f(0.7)\lt 0</m>, <m>f(0.8) &gt; 0</m>,
+              <m>f(0.7)\lt 0</m>, <m>f(0.8) \gt 0</m>,
               and at the midpoint, <m>0.75</m>,
-              we have <m>f(0.75) &gt;0</m>.
+              we have <m>f(0.75) \gt 0</m>.
               So replace <m>0.8</m> with <m>0.75</m> and repeat.
               Note that we don't need to continue to check the endpoints,
               just the midpoint.
@@ -886,19 +886,19 @@
             <cell>Midpoint Sign</cell>
           </row>
           <row bottom="minor">
-            <cell/>
-            <cell/>
-            <cell/>
+            <cell></cell>
+            <cell></cell>
+            <cell></cell>
           </row>
           <row>
             <cell><m>1</m></cell>
             <cell><m>[\highlight{0.7},0.9]</m></cell>
-            <cell><m>f(0.8) &gt;0</m></cell>
+            <cell><m>f(0.8) \gt 0</m></cell>
           </row>
           <row>
             <cell><m>2</m></cell>
             <cell><m>[\highlight{0.7},0.8]</m></cell>
-            <cell><m>f(0.75) &gt;0</m></cell>
+            <cell><m>f(0.75) \gt 0</m></cell>
           </row>
           <row>
             <cell><m>3</m></cell>
@@ -913,17 +913,17 @@
           <row>
             <cell><m>5</m></cell>
             <cell><m>[\highlight{0.7375},\highlight{0.75}]</m></cell>
-            <cell><m>f(0.7438)&gt;0</m></cell>
+            <cell><m>f(0.7438)\gt </m></cell>
           </row>
           <row>
             <cell><m>6</m></cell>
             <cell><m>[\highlight{0.7375},0.7438]</m></cell>
-            <cell><m>f(0.7407)&gt;0</m></cell>
+            <cell><m>f(0.7407)\gt 0</m></cell>
           </row>
           <row>
             <cell><m>7</m></cell>
             <cell><m>[\highlight{0.7375},0.7407]</m></cell>
-            <cell><m>f(0.7391)&gt;0</m></cell>
+            <cell><m>f(0.7391)\gt 0</m></cell>
           </row>
           <row>
             <cell><m>8</m></cell>
@@ -948,10 +948,10 @@
           <row>
             <cell><m>12</m></cell>
             <cell><m>[0.7390,\highlight{0.7391}]</m></cell>
-            <cell/>
+            <cell></cell>
           </row>
           <row>
-            <cell/>
+            <cell></cell>
           </row>
         </tabular>
 
@@ -1300,7 +1300,7 @@
                 Is <m>f</m> in the graph below continuous at <m>a=<var name="$a"/></m>?
               </p>
 
-              <image pg-name="$graph" width="67%"/>
+              <image pg-name="$graph" width="50%"/>
 
               <p>
                 <var name="$answer" form="popup"/>
@@ -1349,7 +1349,7 @@
                 Is <m>f</m> in the graph below continuous at <m>a=<var name="$a"/></m>?
               </p>
 
-              <image pg-name="$graph" width="67%"/>
+              <image pg-name="$graph" width="50%"/>
 
               <p>
                 <var name="$answer" form="popup"/>
@@ -1400,7 +1400,7 @@
                 Is <m>f</m> in the graph below continuous at <m>a=<var name="$a"/></m>?
               </p>
 
-              <image pg-name="$graph" width="67%"/>
+              <image pg-name="$graph" width="50%"/>
 
               <p>
                 <var name="$answer" form="popup"/>
@@ -1446,7 +1446,7 @@
                 Is <m>f</m> in the graph below continuous at <m>a=<var name="$a"/></m>?
               </p>
 
-              <image pg-name="$graph" width="67%"/>
+              <image pg-name="$graph" width="50%"/>
 
               <p>
                 <var name="$answer" form="popup"/>
@@ -1495,7 +1495,7 @@
                 Is <m>f</m> in the graph below continuous at <m>a=<var name="$a"/></m>?
               </p>
 
-              <image pg-name="$graph" width ="67%"/>
+              <image pg-name="$graph" width ="50%"/>
 
               <p>
                 <var name="$answer" form="popup"/>
@@ -1544,7 +1544,7 @@
                 Is <m>f</m> in the graph below continuous at <m>a=<var name="$a"/></m>?
               </p>
 
-              <image pg-name="$graph" width ="67%"/>
+              <image pg-name="$graph" width="50%"/>
 
               <p>
                 <var name="$answer" form="popup"/>
@@ -1603,7 +1603,7 @@
                 <m>a=0</m>, and <m>a=2</m>?
               </p>
 
-              <image pg-name="$graph" width ="67%"/>
+              <image pg-name="$graph" width="50%"/>
 
               <p>
                 At <m>a=-2</m>: <var name="$answer[0]" form="popup"/>
@@ -1632,43 +1632,36 @@
             </solution>
         </webwork>
       </exercise>
+<!--TODO: fix WeBWorK code in this problem-->
+      <!-- <exercise> -->
+        <!-- <webwork seed="1"> -->
+          <!-- <setup> -->
+          <!-- <pg-code> -->
+            <!-- $a=3*pi/2; -->
+            <!-- $g=Formula("1+sin(x)"); -->
+            <!-- @choices=('?','Yes.',"No; the limit of f(x) as x goes to $a does not exist.","No; f($a) is not defined.","No; the limit of f(x) as x goes to $a does not equal f($a) even though both exist."); -->
+            <!-- $correct=$choices[1]; -->
+            <!-- $answer=PopUp(~~@choices,$correct); -->
+            <!-- $graph=init_graph(-0.5,-0.5,2.5,2.5,axes=>[0,0],size=>[400,400]); -->
+            <!-- $graph->h_ticks(0,"black",0.5,1,1.5,2); -->
+            <!-- $graph->v_ticks(0,"black",0.5,1,1.5,2); -->
+            <!-- for my$i(0.5,1,1.5,2){$graph->lb(new Label($i,-0.05,"$i",'black','center','top'));$graph->lb(new Label(-0.05,$i,"$i",'black','right','middle'))}; -->
+            <!-- add_functions($graph,"$g for x in &lt;0,2*pi> using color:blue and weight:2"); -->
+          <!-- </pg-code> -->
+          <!-- </setup> -->
+          <!-- <statement> -->
+            <!-- <p> -->
+              <!-- Is <m>f</m> in the graph below continuous at <m>a = <var name="$a"/></m>? -->
+            <!-- </p> -->
 
-      <exercise>
-        <webwork seed="1">
-          <setup>
+            <!-- <image pg-name="$graph" width="50%"/> -->
 
-
-          <pg-code>
-            $a=3*pi/2;
-            $g=Formula("1+sin(x)");
-            @choices=('?','Yes.',"No; the limit of f(x) as x goes to $a does not exist.","No; f($a) is not defined.","No; the limit of f(x) as x goes to $a does not equal f($a) even though both exist.");
-            $correct=$choices[1];
-            $answer=PopUp(~~@choices,$correct);
-            $graph=init_graph(-0.5,-0.5,2.5,2.5,axes=>[0,0],size=>[400,400]);
-            $graph->h_ticks(0,"black",0.5,1,1.5,2);
-            $graph->v_ticks(0,"black",0.5,1,1.5,2);
-            for my$i(0.5,1,1.5,2){$graph->lb(new Label($i,-0.05,"$i",'black','center','top'));$graph->lb(new Label(-0.05,$i,"$i",'black','right','middle'))};
-            add_functions($graph,"$g for x in &lt;0,2*pi> using color:blue and weight:2");
-          </pg-code>
-          </setup>
-          <statement>
-            <p>
-              Is <m>f</m> in the graph below continuous at <m>a = <var name="$a"/></m>?
-            </p>
-
-            <image pg-name="$graph" width ="67%"/>
-
-            <p>
-              <var name="$answer" form="popup"/>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <var name="$answer"/>
-            </p>
-          </solution>
-        </webwork>
-      </exercise>
+            <!-- <p> -->
+              <!-- <var name="$answer" form="popup"/> -->
+            <!-- </p> -->
+          <!-- </statement> -->
+        <!-- </webwork> -->
+      <!-- </exercise> -->
 
     </exercisegroup>
     <exercisegroup>
@@ -1828,11 +1821,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
-
-
-
             <pg-code>
               @a=map{$_-12}NchooseK(24,6);
               Context("PiecewiseFunction");
@@ -1891,8 +1879,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               $a=random(-9,9,1);
               $b=non_zero_random(-9,9,1);
@@ -1953,11 +1939,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
-
-
-
             <pg-code>
               $a=random(1,5,1);
               $b=random(1,5,1);
@@ -2069,8 +2050,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               $b=list_random(2..9,Formula("e"),Formula("pi"));
               if($envir{problemSeed}==1){$b=Formula("e");};
@@ -2118,8 +2097,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               Context()->variables->are(t=>'Real');
               $f=list_random(Formula("cos(t)"),Formula("sin(t)"));
@@ -2167,8 +2144,6 @@
       <exercise>
         <webwork seed="1">
             <setup>
-
-
             <pg-code>
               $a=list_random('sin','cos');
               $b=list_random(2,3,'e');
@@ -2377,7 +2352,7 @@
                   <row>
                     <cell>8</cell>
                     <cell><var name="$in[7]" width="20"/></cell>
-                    <cell/>
+                    <cell></cell>
                   </row>
                 </tabular>
 
@@ -2412,7 +2387,7 @@
             </setup>
             <statement>
               <p>
-                Use the Bisection Method to zero in on the root for <m>f(x)=<var name="$f" /></m> in the interval <m><var name="$in[0]" /></m>.
+                Use the Bisection Method to zero in on the root for <m>f(x)=<var name="$f"/></m> in the interval <m><var name="$in[0]"/></m>.
               </p>
 
               <sidebyside>
@@ -2461,7 +2436,7 @@
                   <row>
                     <cell>8</cell>
                     <cell><var name="$in[7]" width="20"/></cell>
-                    <cell/>
+                    <cell></cell>
                   </row>
                 </tabular>
 
@@ -2545,7 +2520,7 @@
                   <row>
                     <cell>8</cell>
                     <cell><var name="$in[7]" width="20"/></cell>
-                    <cell/>
+                    <cell></cell>
                   </row>
                 </tabular>
 
@@ -2628,7 +2603,7 @@
                   <row>
                     <cell>8</cell>
                     <cell><var name="$in[7]" width="20"/></cell>
-                    <cell/>
+                    <cell></cell>
                   </row>
                 </tabular>
 

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -135,8 +135,8 @@
         <me>
           \lim_{x\to c} f(x) = L
         </me>,
-        and means that given any <m>\varepsilon &gt; 0</m>,
-        there exists <m>\delta &gt; 0</m> such that for all <m>x</m> in <m>I</m>,
+        and means that given any <m>\varepsilon  \gt  0</m>,
+        there exists <m>\delta  \gt  0</m> such that for all <m>x</m> in <m>I</m>,
         where <m>x \neq c</m>,
         if <m>\abs{x - c} \lt  \delta</m>,
         then <m>\abs{f(x) - L} \lt  \varepsilon</m>.
@@ -153,7 +153,7 @@
     <md>
       <mrow>\lim_{x\to c} f(x) = L</mrow>
       <mrow>\iff</mrow>
-      <mrow>\forall \, \varepsilon &gt; 0, \exists \, \delta &gt; 0 \text{ s.t. }0\lt \abs{x - c} \lt  \delta \implies \abs{f(x) - L} \lt  \varepsilon</mrow>
+      <mrow>\forall \, \varepsilon \gt 0, \exists \, \delta \gt 0 \text{ s.t. }0\lt \abs{x - c} \lt  \delta \implies \abs{f(x) - L} \lt  \varepsilon</mrow>
     </md>.
   </p>
 
@@ -216,56 +216,56 @@
       <sidebyside widths="47% 47%">
           <!-- START figures/fig_limit_proof1a.tex -->
           <image xml:id="img_limit_proof1a">
-            <description/>
+            <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-.1,xmax=7.1,
             ymin=-.1,ymax=3.1,
             xtick={2,4,6},
             ytick={1,2},]
-            \addplot+[->,domain=0:2.64575] ({x^2},{x});
+            \addplot+[-&gt;,domain=0:2.64575] ({x^2},{x});
             \addplot[soliddot] coordinates {(4,2)};
             \addplot[guideline] coordinates {(0,1.5) (2.25,1.5)};
             \addplot[guideline] coordinates {(0,2.5) (6.25,2.5)};
-            \addplot[guideline,|->] coordinates {(0.2,2) (0.2,2.5)} node [below right]{$\varepsilon=0.5$} ;
-            \addplot[guideline,|->] coordinates {(0.2,2) (0.2,1.5)} node [above right]{$\varepsilon=0.5$} ;
+            \addplot[guideline,|-&gt;] coordinates {(0.2,2) (0.2,2.5)} node [below right]{$\varepsilon=0.5$} ;
+            \addplot[guideline,|-&gt;] coordinates {(0.2,2) (0.2,1.5)} node [above right]{$\varepsilon=0.5$} ;
             \addplot[soliddot] coordinates {(2.25,1.5)};
             \addplot[soliddot] coordinates {(6.25,2.5)};
-            \addplot[mark=none] coordinates {(0,2.5)} node [above right]{Choose $\varepsilon>0$. Then \ldots} ;
+            \addplot[mark=none] coordinates {(0,2.5)} node [above right]{Choose $\varepsilon&gt;0$. Then \ldots} ;
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_limit_proof1a.tex END -->
 
             <!-- START figures/fig_limit_proof1b.tex -->
           <image xml:id="img_limit_proof1b">
-            <description/>
+            <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-.1,xmax=7.1,
             ymin=-.1,ymax=3.1,
             xtick={2,4,6},
             ytick={1,2},]
-            \addplot+[->,domain=0:2.64575] ({x^2},{x});
+            \addplot+[-&gt;,domain=0:2.64575] ({x^2},{x});
             \addplot[soliddot] coordinates {(4,2)};
             \addplot[guideline] coordinates {(0,1.5) (2.25,1.5)};
             \addplot[guideline] coordinates {(0,2.5) (6.25,2.5)};
             \addplot[guideline] coordinates {(2.25,0) (2.25,1.5)};
             \addplot[guideline] coordinates {(6.25,0) (6.25,2.5)};
-            \addplot[guideline,|->] coordinates {(0.2,2) (0.2,2.5)} node [below right]{$\varepsilon=0.5$} ;
-            \addplot[guideline,|->] coordinates {(0.2,2) (0.2,1.5)} node [above right]{$\varepsilon=0.5$} ;
-            \addplot[guideline,<-|] coordinates {(2.25,0.2) (4,0.2)} node [above left]{width 1.75} ;
-            \addplot[guideline,<-|] coordinates {(6.25,0.2) (4,0.2)} node [above right]{width 2.25} ;
+            \addplot[guideline,|-&gt;] coordinates {(0.2,2) (0.2,2.5)} node [below right]{$\varepsilon=0.5$} ;
+            \addplot[guideline,|-&gt;] coordinates {(0.2,2) (0.2,1.5)} node [above right]{$\varepsilon=0.5$} ;
+            \addplot[guideline,&lt;-|] coordinates {(2.25,0.2) (4,0.2)} node [above left]{width 1.75} ;
+            \addplot[guideline,&lt;-|] coordinates {(6.25,0.2) (4,0.2)} node [above right]{width 2.25} ;
             \addplot[soliddot] coordinates {(2.25,1.5)};
             \addplot[soliddot] coordinates {(6.25,2.5)};
             \addplot[mark=none] coordinates {(4,1)} node{\parbox{9em}{\ldots choose $\delta$ smaller than each of these}};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
             <!-- figures/fig_limit_proof1a.tex END -->
@@ -331,7 +331,7 @@
       </p>
 
       <p>
-        Since <m>\varepsilon &gt; 0</m>,
+        Since <m>\varepsilon  \gt  0</m>,
         we have <m>4\varepsilon - \varepsilon^2 \lt 4\varepsilon + \varepsilon^2</m>,
         the minimum is <m>\delta \leq 4\varepsilon - \varepsilon^2</m>.
         That's the formula: given an <m>\varepsilon</m>,
@@ -346,7 +346,7 @@
       </p>
 
       <p>
-        So given any <m>\varepsilon &gt;0</m>,
+        So given any <m>\varepsilon  \gt 0</m>,
         set <m>\delta \lt 4\varepsilon - \varepsilon^2</m>.
         Then if <m>\abs{x-4}\lt \delta</m>
         (and <m>x\neq 4</m>),
@@ -384,7 +384,7 @@
     <solution>
       <p>
         Let's do this example symbolically from the start.
-        Let <m>\varepsilon &gt; 0</m> be given;
+        Let <m>\varepsilon  \gt  0</m> be given;
         we want <m>\abs{y-4} \lt \varepsilon</m>,
         i.e., <m>\abs{x^2-4} \lt \varepsilon</m>.
         How do we find <m>\delta</m> such that when <m>\abs{x-2} \lt \delta</m>,
@@ -473,7 +473,7 @@
             <!-- START figures/fig_limit_proof2a.tex -->
         <image xml:id="img_limit_eover5" width="47%">
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=0,xmax=4,
           ymin=2,ymax=6,
@@ -490,18 +490,18 @@
           \addplot[guideline,dashed] coordinates {(1.73,0) (1.73,3)};
           \addplot[guideline,dotted] coordinates {(2.2,0) (2.2,4.84)};
           \addplot[guideline,dotted] coordinates {(1.8,0) (1.8,3.24)};
-          \addplot[guideline,|->] coordinates {(0.2,4) (0.2,5)} node [below right]{$\varepsilon$};
-          \addplot[guideline,<-|] coordinates {(2.2,2.2) (2,2.2)} node [above right]{$\delta=\varepsilon/5$};
+          \addplot[guideline,|-&gt;] coordinates {(0.2,4) (0.2,5)} node [below right]{$\varepsilon$};
+          \addplot[guideline,&lt;-|] coordinates {(2.2,2.2) (2,2.2)} node [above right]{$\delta=\varepsilon/5$};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
             <!-- figures/fig_limit_proof2a.tex END -->
       </figure>
 
       <p>
-        In summary, given <m>\varepsilon &gt; 0</m>,
+        In summary, given <m>\varepsilon  \gt  0</m>,
         set <m>\delta=\varepsilon/5</m>.
         Then <m>\abs{x-2} \lt \delta</m> implies
         <m>\abs{x^2 - 4}\lt\varepsilon</m> (<ie/> <m>\abs{y-4}\lt\varepsilon</m>) as desired.
@@ -700,14 +700,14 @@
           <mrow>-\delta \amp \lt  x \lt  \delta \amp\amp   \text{(Definition of absolute value)}</mrow>
           <mrow>-\ln(1+\varepsilon) \amp \lt  x \lt  \ln(1+\varepsilon)</mrow>
           <mrow>\ln(1-\varepsilon) \amp \lt  x \lt  \ln(1+\varepsilon)\text{.}\amp \amp  \text{(since \(\ln(1-\varepsilon) \lt  -\ln(1+\varepsilon)\)) }</mrow>
-          <intertext>The above line is true by our choice of <m>\delta</m> and by the fact that since <m>\abs{\ln(1-\varepsilon)}&gt;\ln(1+\varepsilon)</m> and <m>\ln(1-\varepsilon)\lt 0</m>, we know <m>\ln(1-\varepsilon) \lt  -\ln(1+\varepsilon )</m>.</intertext>
+          <intertext>The above line is true by our choice of <m>\delta</m> and by the fact that since <m>\abs{\ln(1-\varepsilon)} \gt \ln(1+\varepsilon)</m> and <m>\ln(1-\varepsilon)\lt 0</m>, we know <m>\ln(1-\varepsilon) \lt  -\ln(1+\varepsilon )</m>.</intertext>
           <mrow>1-\varepsilon \amp \lt  e^x \lt  1+\varepsilon \amp \amp  \text{(Exponentiate)}</mrow>
           <mrow>-\varepsilon \amp \lt  e^x - 1 \lt  \varepsilon \amp\amp   \text{(Subtract 1)}</mrow>
         </md>
       </p>
 
       <p>
-        In summary, given <m>\varepsilon &gt; 0</m>,
+        In summary, given <m>\varepsilon  \gt  0</m>,
         let <m>\delta = \ln(1+\varepsilon)</m>.
         Then <m>\abs{x - 0} \lt \delta</m> implies <m>\abs{e^x - 1}\lt \varepsilon</m> as desired.
         We have shown that <m>\lim\limits_{x\to 0} e^x = 1</m>.
@@ -768,8 +768,8 @@
               <blockquote>
                 <p>
                   <q>The limit of <m>f(x)</m>, as <m>x</m> approaches <m>a</m>,
-                  is <m>K</m></q> means that given any <m>\delta&gt;0</m> there exists
-                  <m>\varepsilon&gt;0</m> such that whenever <m>\abs{f(x)-K}\lt\varepsilon</m>,
+                  is <m>K</m></q> means that given any <m>\delta \gt 0</m> there exists
+                  <m>\varepsilon \gt 0</m> such that whenever <m>\abs{f(x)-K}\lt\varepsilon</m>,
                   we have <m>\abs{x-a}\lt \delta</m>.
                 </p>
               </blockquote>
@@ -886,8 +886,8 @@
         </statement>
         <solution>
           <p>
-            Let <m>\varepsilon &gt;0</m> be given.
-            We wish to find <m>\delta &gt;0</m> such that when <m>|x-4|\lt \delta</m>,
+            Let <m>\varepsilon  \gt 0</m> be given.
+            We wish to find <m>\delta  \gt 0</m> such that when <m>|x-4|\lt \delta</m>,
             <m>\abs{f(x)-13}\lt \epsilon</m>.
           </p>
 
@@ -935,8 +935,8 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-5}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-5}\lt\delta</m>,
                 <m>\abs{f(x)-(-2)}\lt\varepsilon</m>.
               </p>
 
@@ -987,8 +987,8 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-3}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-3}\lt\delta</m>,
                 <m>\abs{f(x)-6}\lt\varepsilon</m>.
               </p>
 
@@ -1048,8 +1048,8 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-4}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-4}\lt\delta</m>,
                 <m>\abs{f(x)-15}\lt\varepsilon</m>.
               </p>
 
@@ -1109,8 +1109,8 @@
           </statement>
           <solution>
             <p>
-              Let <m>\varepsilon &gt;0</m> be given.
-              We wish to find <m>\delta &gt;0</m> such that when <m>\abs{x-1}\lt \delta</m>,
+              Let <m>\varepsilon  \gt 0</m> be given.
+              We wish to find <m>\delta  \gt 0</m> such that when <m>\abs{x-1}\lt \delta</m>,
               <m>\abs{f(x)-6}\lt \varepsilon</m>.
             </p>
 
@@ -1179,8 +1179,8 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-2}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-2}\lt\delta</m>,
                 <m>\abs{f(x)-7}\lt\varepsilon</m>.
               </p>
 
@@ -1240,8 +1240,8 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-2}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-2}\lt\delta</m>,
                 <m>\abs{f(x)-5}\lt\varepsilon</m>.
               </p>
 
@@ -1288,8 +1288,8 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-0}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-0}\lt\delta</m>,
                 <m>\abs{f(x)-0}\lt\varepsilon</m>.
               </p>
 
@@ -1344,8 +1344,8 @@
           </statement>
           <solution>
             <p>
-              Let <m>\epsilon &gt;0</m> be given.
-              We wish to find <m>\delta &gt;0</m> such that when <m>|x-1|\lt \delta</m>,
+              Let <m>\epsilon  \gt 0</m> be given.
+              We wish to find <m>\delta  \gt 0</m> such that when <m>|x-1|\lt \delta</m>,
               <m>|f(x)-1|\lt \epsilon</m>.
             </p>
 
@@ -1419,8 +1419,8 @@
             </hint>
             <solution>
               <p>
-                Let <m>\varepsilon&gt;0</m> be given.
-                We wish to find <m>\delta&gt;0</m> such that when <m>\abs{x-0}\lt\delta</m>,
+                Let <m>\varepsilon \gt 0</m> be given.
+                We wish to find <m>\delta \gt 0</m> such that when <m>\abs{x-0}\lt\delta</m>,
                 <m>\abs{f(x)-0}\lt\varepsilon</m>.
               </p>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1283,8 +1283,8 @@
               $e=1/50**(1/$n);
               $below=$a-$e;
               $above=$a+$e;
-              add_functions($gr, "$f for x in &lt;$xmin,$below &gt; using color:blue and weight:2");
-              add_functions($gr, "$f for x in &lt;$above,$xmax &gt; using color:blue and weight:2");
+              add_functions($gr, "$f for x in &lt;$xmin,$below > using color:blue and weight:2");
+              add_functions($gr, "$f for x in &lt;$above,$xmax > using color:blue and weight:2");
               $gr->moveTo($a,-50);
               $gr->lineTo($a,50,'gray',1,'dashed');
             </pg-code>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -572,7 +572,7 @@
           gives values of <m>f(x)</m> for large magnitude values of <m>x</m>.
           It seems reasonable to conclude from both of these sources that <m>f</m> has a horizontal asymptote at <m>y=1</m>.
         </p>
-<!--TODO: update referencing. References to tab_hzasy1 should become fig_hzasy1b-->
+
         <figure xml:id="fig_hzasy1">
           <caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1">Example</xref>.</caption>
     <sidebyside widths="47% 47%" margins="auto">

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1304,9 +1304,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <sidebyside width="67%">
-                <image pg-name="$gr"/>
-              </sidebyside>
+              <image pg-name="$gr" width="67%"/>
 
               <p>
                 Use the graph of <m>f</m> to find:

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -576,7 +576,7 @@
         <figure xml:id="fig_hzasy1">
           <caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1">Example</xref>.</caption>
     <sidebyside widths="47% 47%" margins="auto">
-
+          <figure xml:id="fig_hzasy1a">
             <image xml:id="img_hzasy1a">
               <description></description>
               <latex-image>
@@ -592,7 +592,9 @@
               </latex-image>
             </image>
             <!-- figures/fig_hzasy1.tex END -->
+          </figure>
 
+          <figure xml:id="fig_hzasy1b">
             <tabular>
               <row bottom="minor">
                 <cell><m>x</m></cell>
@@ -623,7 +625,7 @@
                 <cell><m>0.999996</m></cell>
               </row>
             </tabular>
-
+          </figure>
         </sidebyside>
       </figure>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -33,9 +33,9 @@
       <caption>Graphing <m>f(x) = 1/x^2</m> for values of <m>x</m> near 0.</caption>
       <!-- START figures/fig_oneoverxsquared.tex -->
       <image xml:id="img_oneoverxsquared" width="47%">
-        <description/>
+        <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-1.1,xmax=1.1,
         ymin=-.1,ymax=110,]
@@ -43,7 +43,7 @@
         \addplot[firstcurvestyle,domain=0.1:1] {1/x^2};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_oneoverxsquared.tex END -->
@@ -70,10 +70,10 @@
                 <me>
                   \lim\limits_{x\rightarrow c} f(x) = \infty
                 </me>,
-                if given any <m>N &gt; 0</m>,
-                there exists <m>\delta &gt; 0</m> such that for all <m>x</m> in <m>I</m>,
+                if given any <m>N \gt 0</m>,
+                there exists <m>\delta  \gt  0</m> such that for all <m>x</m> in <m>I</m>,
                 where <m>x\neq c</m>,
-                if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x) &gt;N</m>.
+                if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x)  \gt N</m>.
               </p>
             </li>
 
@@ -86,7 +86,7 @@
                   \lim\limits_{x\rightarrow c} f(x) = -\infty
                 </me>,
                 if given any <m>N \lt  0</m>,
-                there exists <m>\delta &gt; 0</m> such that for all <m>x</m> in <m>I</m>,
+                there exists <m>\delta  \gt  0</m> such that for all <m>x</m> in <m>I</m>,
                 where <m>x\neq c</m>,
                 if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x)  \lt  N</m>.
               </p>
@@ -145,16 +145,16 @@
               <me>
                 \lim\limits_{x\rightarrow c^-} f(x) = \infty
               </me>,
-              if  given any <m>N &gt; 0</m>,
-              there exists <m>\delta &gt; 0</m> such that for all
+              if  given any <m>N  \gt  0</m>,
+              there exists <m>\delta  \gt  0</m> such that for all
               <m>a\lt x\lt c</m>,
-              if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x) &gt;N</m>.
+              if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x)  \gt N</m>.
             </p>
           </li>
 
           <li>
             <p>
-              Let <m>f</m> be a function defined on <m>(c,b)</m> for some <m>b&gt;c</m>.
+              Let <m>f</m> be a function defined on <m>(c,b)</m> for some <m>b \gt c</m>.
 
               We say the <term>limit of <m>f(x)</m>,
               as <m>x</m> approaches <m>c</m> from the right, is infinity</term>, or,
@@ -163,10 +163,10 @@
               <me>
                 \lim\limits_{x\rightarrow c^+} f(x) = \infty
               </me>,
-              if  given any <m>N &gt; 0</m>,
-              there exists <m>\delta &gt; 0</m> such that for all
+              if  given any <m>N  \gt  0</m>,
+              there exists <m>\delta  \gt  0</m> such that for all
               <m>c\lt x\lt b</m>,
-              if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x) &gt;N</m>.
+              if  <m>\abs{x - c} \lt  \delta</m>, then <m>f(x)  \gt N</m>.
             </p>
           </li>
 
@@ -193,9 +193,9 @@
           <caption>Observing infinite limit as <m>x\to 1</m> in <xref ref="ex_inflim1">Example</xref>.</caption>
           <!-- START figures/fig_nolimit2.tex -->
           <image xml:id="img_inflim1" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-.1,xmax=2.1,
             ymin=-1,ymax=110,]
@@ -204,7 +204,7 @@
             \addplot[asymptote,rightarrow] coordinates {(1,1) (1,100)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_nolimit2.tex END -->
@@ -234,7 +234,7 @@
           <md>
             <mrow>\abs{x-1} \amp \lt  \frac{1}{\sqrt{N}}</mrow>
             <mrow>(x-1)^2 \amp \lt  \frac{1}{N}</mrow>
-            <mrow>\frac{1}{(x-1)^2} \amp &gt; N</mrow>
+            <mrow>\frac{1}{(x-1)^2} \amp \gt N</mrow>
           </md>,
           which is what we wanted to show.
           So we may say <m>\lim\limits_{x\to 1}1/{(x-1)^2}=\infty</m>.
@@ -265,9 +265,9 @@
           <caption>Evaluating <m>\lim\limits_{x\to 0}\frac1x</m>.</caption>
           <!-- START figures/fig_oneoverx.tex -->
           <image xml:id="img_oneoverx" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-1.1,xmax=1.1,
             ymin=-55,ymax=55,]
@@ -277,7 +277,7 @@
             \addplot[firstcurvestyle,domain=8:50,rightarrow] ({1/x},{x});
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_oneoverx.tex END -->
@@ -341,9 +341,9 @@
           <caption>Graphing <m>f(x) = \frac{3x}{x^2-4}</m>.</caption>
           <!-- START figures/fig_multipleasymptotes.tex -->
           <image xml:id="img_multipleasymptotes" width="47%">
-            <description/>
+            <description></description>
             <latex-image>
-            <![CDATA[
+            
             \begin{tikzpicture}
             \begin{axis}[xmin=-6.1,xmax=6.1,
             ymin=-16,ymax=16,]
@@ -358,7 +358,7 @@
             \addplot[asymptote] coordinates {(2,-16) (2,16)};
             \end{axis}
             \end{tikzpicture}
-            ]]>
+            
             </latex-image>
           </image>
           <!-- figures/fig_multipleasymptotes.tex END -->
@@ -392,9 +392,9 @@
       <caption>Graphically showing that <m>f(x) = \frac{x^2-1}{x-1}</m> does not have an asymptote at <m>x=1</m>.</caption>
       <!-- START figures/fig_noasy.tex -->
       <image xml:id="img_noasy" width="47%">
-        <description/>
+        <description></description>
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-1.2,xmax=2.2,
         ymin=-.2,ymax=3.2,]
@@ -402,7 +402,7 @@
         \addplot[hollowdot] coordinates {(1,2)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_noasy.tex END -->
@@ -515,7 +515,7 @@
                 <m>(a,\infty)</m> for some number <m>a</m>.
                 The <term>limit of <m>f</m> at infinity is <m>L</m></term>,
                 denoted <m>\lim\limits_{x\to\infty} f(x)=L</m>,
-                if for every <m>\epsilon&gt;0</m> there exists <m>M&gt;a</m> such that if <m>x &gt; M</m>,
+                if for every <m>\epsilon \gt 0</m> there exists <m>M \gt a</m> such that if <m>x  \gt  M</m>,
                 then <m>\abs{f(x)-L}\lt \epsilon</m>.
                 <idx><h>limit</h><h>at infinity</h></idx>
                 <idx><h>asymptote</h><h>horizontal</h></idx>
@@ -529,7 +529,7 @@
                 <m>(-\infty,b)</m> for some number <m>b</m>.
                 The <term>limit of <m>f</m> at negative infinity is <m>L</m></term>,
                 denoted <m>\lim\limits_{x\to-\infty} f(x)=L</m>,
-                if for every <m>\epsilon&gt;0</m> there exists <m>M\lt b</m> such that if <m>x \lt M</m>,
+                if for every <m>\epsilon \gt 0</m> there exists <m>M\lt b</m> such that if <m>x \lt M</m>,
                 then <m>\abs{f(x)-L}\lt \epsilon</m>.
               </p>
             </li>
@@ -567,24 +567,20 @@
         </p>
 
         <p>
-          <xref ref="fig_hzasy1">Figure</xref> shows a sketch of <m>f</m>,
-          and the table in <xref ref="tab_hzasy1">Figure</xref>
+          <xref ref="fig_hzasy1a">Figure</xref> shows a sketch of <m>f</m>,
+          and the table in <xref ref="fig_hzasy1b">Figure</xref>
           gives values of <m>f(x)</m> for large magnitude values of <m>x</m>.
           It seems reasonable to conclude from both of these sources that <m>f</m> has a horizontal asymptote at <m>y=1</m>.
         </p>
-
-        <figure>
-<caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1">Example</xref>.</caption>
+<!--TODO: update referencing. References to tab_hzasy1 should become fig_hzasy1b-->
+        <figure xml:id="fig_hzasy1">
+          <caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1">Example</xref>.</caption>
     <sidebyside widths="47% 47%" margins="auto">
-          
-          <figure xml:id="fig_hzasy1">
-<!-- START figures/fig_hzasy1.tex -->
-            <caption/>
 
             <image xml:id="img_hzasy1a">
-              <description/>
+              <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-21,xmax=21,
               ymin=-.2,ymax=1.1,]
@@ -592,14 +588,10 @@
               \addplot[asymptote] coordinates {(-21,1) (21,1)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_hzasy1.tex END -->
-          </figure>
-
-          <table xml:id="tab_hzasy1">
-            <title/>
 
             <tabular>
               <row bottom="minor">
@@ -632,10 +624,8 @@
               </row>
             </tabular>
 
-          </table>
-
         </sidebyside>
-</figure>
+      </figure>
 
         <p>
           Later, we will show how to determine this analytically.
@@ -672,16 +662,16 @@
         <caption/>
         <!-- START figures/fig_hzasy2.tex -->
         <image xml:id="img_hzasya">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-21,xmax=21,
           ymin=-1.1,ymax=1.1,]
           \addplot+[domain=-87:87,samples=100] ({tan(x)},{sin(x)*cos(x)});
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/fig_hzasy2.tex END -->
@@ -691,16 +681,16 @@
         <caption/>
         <!-- START figures/fig_hzasy3.tex -->
         <image xml:id="img_hzasyb">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-21,xmax=21,
           ymin=-1.1,ymax=1.1,]
           \addplot+[domain=-87:87,samples=100] ({tan(x)},{sin(x)});
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/fig_hzasy3.tex END -->
@@ -710,16 +700,16 @@
         <caption/>
         <!-- START figures/fig_hzasy4.tex -->
         <image xml:id="img_hzasy4">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[declare function = {func(\x) = (\x != 0) * (sin(x*180/pi)/x) + (\x == 0) * (1);}]
           \begin{axis}[xmin=-21,xmax=21,
           ymin=-.3,ymax=1.1]
           \addplot+[domain=-20:20,samples=100] {func(x)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/fig_hzasy4.tex END -->
@@ -734,7 +724,7 @@
       We can, in fact,
       make <m>1/x</m> as small as we want by choosing a large enough value of <m>x</m>.
       Given <m>\varepsilon</m>,
-      we can make <m>1/x\lt \varepsilon</m> by choosing <m>x&gt;1/\varepsilon</m>.
+      we can make <m>1/x\lt \varepsilon</m> by choosing <m>x \gt 1/\varepsilon</m>.
       Thus we have <m>\lim_{x\to\infty} 1/x=0</m>.
     </p>
 
@@ -812,7 +802,7 @@
 
             <li>
               <p>
-                If <m>n&gt;m</m>,
+                If <m>n \gt m</m>,
                 then <m>\lim\limits_{x\to\infty} f(x)</m> and <m>\lim\limits_{x\to-\infty} f(x)</m> are both infinite.
               </p>
             </li>
@@ -831,7 +821,7 @@
       If <m>n\lt m</m>, then after dividing through by <m>x^m</m>,
       all the terms in the numerator will approach <m>0</m> in the limit,
       leaving us with <m>0/b_m</m> or <m>0</m>.
-      If <m>n&gt;m</m>, and we try dividing through by <m>x^m</m>,
+      If <m>n \gt m</m>, and we try dividing through by <m>x^m</m>,
       we end up with the denominator tending to <m>b_m</m> while the numerator tends to <m>\infty</m>.
     </p>
 
@@ -844,7 +834,7 @@
       This reduces to <m>a_n/b_m</m>.
       If <m>n\lt m</m>, the function behaves like <m>a_n/(b_mx^{m-n})</m>,
       which tends toward <m>0</m>.
-      If <m>n&gt;m</m>, the function behaves like <m>a_nx^{n-m}/b_m</m>,
+      If <m>n \gt m</m>, the function behaves like <m>a_nx^{n-m}/b_m</m>,
       which will tend to either <m>\infty</m> or <m>-\infty</m> depending on the values of <m>n</m>,
       <m>m</m>,
       <m>a_n</m>,
@@ -954,9 +944,9 @@
             <caption/>
             <!-- START figures/fig_hzasy5.tex -->
             <image xml:id="img_hzasy3a">
-              <description/>
+              <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-41,xmax=2,
               ymin=-.6,ymax=.6,]
@@ -964,7 +954,7 @@
               \addplot[firstcurvestyle,domain=-8:-2,rightarrow] {(x^2+2*x-1)/(x^3+1)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_hzasy5.tex END -->
@@ -974,9 +964,9 @@
             <caption/>
             <!-- START figures/fig_hzasy6.tex -->
             <image xml:id="img_hzasy3b">
-              <description/>
+              <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-1,xmax=41,
               ymin=-.55,ymax=.55,]
@@ -985,7 +975,7 @@
               \addplot[asymptote] coordinates {(-1,-0.33333) (41,-0.33333)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_hzasy6.tex END -->
@@ -995,9 +985,9 @@
             <caption/>
             <!-- START figures/fig_hzasy7.tex -->
             <image xml:id="img_hzasy3c">
-              <description/>
+              <description></description>
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-5,xmax=41,
               ymin=-50,ymax=5]
@@ -1005,7 +995,7 @@
               \addplot[firstcurvestyle,domain=8:40,rightarrow] {(x^2-1)/(3-x)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_hzasy7.tex END -->
@@ -1293,8 +1283,8 @@
               $e=1/50**(1/$n);
               $below=$a-$e;
               $above=$a+$e;
-              add_functions($gr, "$f for x in &lt;$xmin,$below> using color:blue and weight:2");
-              add_functions($gr, "$f for x in &lt;$above,$xmax> using color:blue and weight:2");
+              add_functions($gr, "$f for x in &lt;$xmin,$below &gt; using color:blue and weight:2");
+              add_functions($gr, "$f for x in &lt;$above,$xmax &gt; using color:blue and weight:2");
               $gr->moveTo($a,-50);
               $gr->lineTo($a,50,'gray',1,'dashed');
             </pg-code>
@@ -1304,7 +1294,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <image pg-name="$gr" width="67%"/>
+              <image pg-name="$gr" width="50%"/>
 
               <p>
                 Use the graph of <m>f</m> to find:
@@ -1377,7 +1367,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1453,7 +1443,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1518,7 +1508,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1581,7 +1571,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1635,7 +1625,7 @@
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -2504,7 +2494,7 @@
             </statement>
             <solution>
               <p>
-                Let <m>\varepsilon>0</m> be given.
+                Let <m>\varepsilon \gt 0</m> be given.
                 We wish to find <m>\delta>0</m> such that when <m>\abs{x-1}\lt\delta</m>,
                 <m>\abs{f(x)-3}\lt\varepsilon</m>.
               </p>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -576,7 +576,7 @@
         <figure xml:id="fig_hzasy1">
           <caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1">Example</xref>.</caption>
     <sidebyside widths="47% 47%" margins="auto">
-          <figure xml:id="fig_hzasy1a">
+          <figure xml:id="fig_hzasy1a"><caption/>
             <image xml:id="img_hzasy1a">
               <description></description>
               <latex-image>
@@ -594,7 +594,7 @@
             <!-- figures/fig_hzasy1.tex END -->
           </figure>
 
-          <figure xml:id="fig_hzasy1b">
+          <figure xml:id="fig_hzasy1b"><caption/>
             <tabular>
               <row bottom="minor">
                 <cell><m>x</m></cell>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -306,7 +306,7 @@
             <!-- START figures/fig_limit1.tex -->
             <image xml:id="img_limit1">
               <latex-image>
-              <![[CDATA[
+              <![CDATA[
               \begin{tikzpicture}
               \begin{axis}[xmin=2.3,xmax=3.7,
               ymin=0.2,ymax=.35,

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -172,8 +172,8 @@
       we are only concerned with the values of the function when <m>x</m> is <em>near</em> 1.
     </p>
 
-    <table xml:id="table_sinx_1">
-      <title>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>1</m>.</title>
+    <figure xml:id="table_sinx_1">
+      <caption>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>1</m>.</caption>
       <tabular>
         <row bottom="medium">
           <cell><m>x</m></cell>
@@ -209,7 +209,7 @@
         </row>
       </tabular>
 
-    </table>
+    </figure>
 
     <p>
       Now approximate <m>\lim_{x\to 0} \sin(x)/x</m> numerically.
@@ -222,8 +222,8 @@
       only on the behavior of the function <em>near</em> <m>0</m>.
     </p>
 
-    <table xml:id="table_sinx_2">
-      <title>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>0</m>.</title>
+    <figure xml:id="table_sinx_2">
+      <caption>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>0</m>.</caption>
       <tabular>
         <row bottom="medium">
           <cell><m>x</m></cell>
@@ -259,7 +259,7 @@
         </row>
       </tabular>
 
-    </table>
+    </figure>
 
     <p>
       This numerical method gives confidence to say that <m>1</m> is a good approximation of <m>\lim_{x\to 0} \sin(x)/x</m>; that is,
@@ -327,7 +327,7 @@
           </figure>
 
           <figure xml:id="table_limit1">
-            <title>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref>.</title>
+            <caption>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref>.</caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -470,7 +470,7 @@
           </figure>
 
           <figure xml:id="table_limit2">
-            <title>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref>.</title>
+            <caption>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref>.</caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -611,7 +611,7 @@
           </figure>
 
           <figure xml:id="table_nolimit1">
-            <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref>.</title>
+            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref>.</caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -687,7 +687,7 @@
           </figure>
 
           <figure xml:id="table_nolimit2">
-            <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref>.</title>
+            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref>.</caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -896,8 +896,8 @@
         </sidebyside>
         </figure>
 
-        <table xml:id="table_nolimit3c">
-          <title>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref>.</title>
+        <figure xml:id="table_nolimit3c">
+          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref>.</caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -933,7 +933,7 @@
             </row>
           </tabular>
 
-        </table>
+        </figure>
 
         <p>
           It can be shown that in reality,
@@ -1139,8 +1139,8 @@
       The table gives us reason to assume the value of the limit is about <m>8.5</m>.
     </p>
 
-    <table xml:id="table_diff_quot_smallh">
-      <title>The difference quotient evaluated at values of <m>h</m> near <m>0</m>.</title>
+    <figure xml:id="table_diff_quot_smallh">
+      <caption>The difference quotient evaluated at values of <m>h</m> near <m>0</m>.</caption>
       <tabular>
         <row bottom="medium">
           <cell><m>h</m></cell>
@@ -1172,7 +1172,7 @@
         </row>
       </tabular>
 
-    </table>
+    </figure>
 
     <p>
       Proper understanding of limits is key to understanding calculus.

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -32,14 +32,14 @@
         <caption><m>\sin(x)/x</m>.</caption>
         <image xml:id="img_sinx_over_x_full">
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}[declare function = {func(\x) = (\x != 0) * (sin(x*180/pi)/x) + (\x == 0) * (1);}]
           \begin{axis}[]
           \addplot+[domain=-7:7,samples=50] {func(x)};
           \addplot[hollowdot] coordinates {(0,1)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
 
@@ -50,7 +50,7 @@
         <!-- START figures/sinx_over_x_1.tex -->
         <image xml:id="img_zoom_sinx_over_x">
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=.3, xmax=1.6,
           ymin=.4, ymax=1.1,
@@ -63,7 +63,7 @@
           \addplot+[domain=0.5:1.5] {sin(x*180/pi)/x};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/sinx_over_x_1.tex END -->
@@ -97,7 +97,7 @@
             <!-- START figures/sinx_over_x_2.tex -->
       <image xml:id="img_sinx_over_x_2" width="47%">
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}[declare function = {func(\x) = (\x != 0) * (sin(x*180/pi)/x) + (\x == 0) * (1);}]
         \begin{axis}[xmin=-1.1,xmax=1.2,
         ymin=.75,ymax=1.05,
@@ -109,7 +109,7 @@
         \addplot[hollowdot] coordinates {(0,1)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
             <!-- figures/sinx_over_x_2.tex END -->
@@ -306,7 +306,7 @@
             <!-- START figures/fig_limit1.tex -->
             <image xml:id="img_limit1">
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=2.3,xmax=3.7,
               ymin=0.2,ymax=.35,
@@ -320,13 +320,13 @@
 
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_limit1.tex END -->
           </figure>
 
-          <table xml:id="table_limit1">
+          <figure xml:id="table_limit1">
             <title>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref>.</title>
             <tabular>
               <row bottom="medium">
@@ -363,7 +363,7 @@
               </row>
             </tabular>
 
-          </table>
+          </figure>
 
         </sidebyside>
 
@@ -433,7 +433,7 @@
         <p>
           Graphically and numerically approximate the limit of <m>f(x)</m> as <m>x</m> approaches <m>0</m>, where
           <me>
-            f(x) = \begin{cases}x+1 \amp  x\lt  0 \\ -x^2+1 \amp  x &gt; 0\end{cases}
+            f(x) = \begin{cases}x+1 \amp  x\lt  0 \\ -x^2+1 \amp  x \gt 0\end{cases}
           </me>.
         </p>
       </statement>
@@ -454,8 +454,8 @@
             <!-- START figures/fig_limit2.tex -->
             <image xml:id="img_limit2">
               <latex-image>
-              <![CDATA[
-              \begin{tikzpicture}[declare function = {func(\x) = (\x<0) * (x+1) + (\x>0) * (-x^2+1);}]
+              
+              \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 0) * (x+1) + (\x &gt; 0) * (-x^2+1);}]
               \begin{axis}[xmin=-1.1,xmax=1.1,
               ymin=-.1,ymax=1.1,
               ]
@@ -463,13 +463,13 @@
               \addplot[hollowdot] coordinates {(0,1)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_limit2.tex END -->
           </figure>
 
-          <table xml:id="table_limit2">
+          <figure xml:id="table_limit2">
             <title>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref>.</title>
             <tabular>
               <row bottom="medium">
@@ -502,7 +502,7 @@
               </row>
             </tabular>
 
-          </table>
+          </figure>
 
         </sidebyside>
 
@@ -564,7 +564,7 @@
         <p>
           Explore why <m>\lim\limits_{x\to 1} f(x)</m> does not exist, where
           <me>
-            f(x) = \begin{cases}x^2-2x+3 \amp  x\leq 1 \\ x \amp  x&gt;1\end{cases}
+            f(x) = \begin{cases}x^2-2x+3 \amp  x\leq 1 \\ x \amp  x \gt 1\end{cases}
           </me>.
         </p>
       </statement>
@@ -593,7 +593,7 @@
             <!-- START figures/fig_nolimit1.tex -->
             <image xml:id="img_nolimit1">
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-.1,xmax=2.1,
               ymin=-.1,ymax=3.2,
@@ -604,13 +604,13 @@
               \addplot[hollowdot] coordinates {(1,1)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_nolimit1.tex END -->
           </figure>
 
-          <table xml:id="table_nolimit1">
+          <figure xml:id="table_nolimit1">
             <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref>.</title>
             <tabular>
               <row bottom="medium">
@@ -643,7 +643,7 @@
               </row>
             </tabular>
 
-          </table>
+          </figure>
 
         </sidebyside>
       </solution>
@@ -670,7 +670,7 @@
             <!-- START figures/fig_nolimit2.tex -->
             <image xml:id="img_nolimit2">
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-.1,xmax=2.1,
               ymin=-1,ymax=110
@@ -680,13 +680,13 @@
               \addplot[asymptote,rightarrow] coordinates {(1,1) (1,100)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_nolimit2.tex END -->
           </figure>
 
-          <table xml:id="table_nolimit2">
+          <figure xml:id="table_nolimit2">
             <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref>.</title>
             <tabular>
               <row bottom="medium">
@@ -719,7 +719,7 @@
               </row>
             </tabular>
 
-          </table>
+          </figure>
 
         </sidebyside>
 
@@ -774,7 +774,7 @@
             <caption/><!-- START figures/fig_nolimit3a.tex -->
             <image xml:id="img_nolimit3a">
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-1.1,xmax=1.1,
               ymin=-1.1,ymax=1.1,
@@ -822,7 +822,7 @@
               ] {sin(1/x * 180 / pi)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_nolimit3a.tex END -->
@@ -832,7 +832,7 @@
             <caption/><!-- START figures/fig_nolimit3b.tex -->
             <image xml:id="img_nolimit3b">
               <latex-image>
-              <![CDATA[
+              
               \begin{tikzpicture}
               \begin{axis}[xmin=-.11,xmax=.11,
               ymin=-1.1,ymax=1.1
@@ -888,7 +888,7 @@
               %        ] {sin(1/x * 180 / pi)};
               \end{axis}
               \end{tikzpicture}
-              ]]>
+              
               </latex-image>
             </image>
             <!-- figures/fig_nolimit3b.tex END -->
@@ -1006,7 +1006,7 @@
       <!-- START figures/fig_diff_quot1.tex -->
       <image xml:id="img_diffquot1" width="47%">
         <latex-image>
-        <![CDATA[
+        
         \begin{tikzpicture}
         \begin{axis}[xmin=-1,xmax=6.5,
         ymin=-1,ymax=25,
@@ -1016,7 +1016,7 @@
         \addplot[soliddot] coordinates {(1,10) (5,20)};
         \end{axis}
         \end{tikzpicture}
-        ]]>
+        
         </latex-image>
       </image>
       <!-- figures/fig_diff_quot1.tex END -->
@@ -1069,7 +1069,7 @@
         <!-- START figures/fig_diff_quot_smallha.tex -->
         <image xml:id="img_diff_quot_smallha">
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-1,xmax=6.5,
           ymin=-1,ymax=25,
@@ -1079,7 +1079,7 @@
           \addplot[soliddot] coordinates {(1,10) (3,21)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/fig_diff_quot_smallha.tex END -->
@@ -1090,7 +1090,7 @@
         <!-- START figures/fig_diff_quot_smallhb.tex -->
         <image xml:id="img_diff_quot_smallhb">
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-1,xmax=6.5,
           ymin=-1,ymax=25,
@@ -1100,7 +1100,7 @@
           \addplot[soliddot] coordinates {(1,10) (2,17)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/fig_diff_quot_smallhb.tex END -->
@@ -1111,7 +1111,7 @@
         <!-- START figures/fig_diff_quot_smallhc.tex -->
         <image xml:id="img_diff_quot_smallhc">
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-1,xmax=6.5,
           ymin=-1,ymax=25,
@@ -1121,7 +1121,7 @@
           \addplot[soliddot] coordinates {(1,10) (1.5,13.875)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+          
           </latex-image>
         </image>
         <!-- figures/fig_diff_quot_smallhc.tex END -->
@@ -1432,7 +1432,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -1544,7 +1544,7 @@
                 For a graphical approximation:
               </p>
 
-                <image pg-name="$solgr" width="67%"/>
+                <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -1567,19 +1567,19 @@
               }until($b!=$c);
               $a=0;
               if ($envir{problemSeed}==1){$a=0;$b=1;$c=3};
-              $f=Formula("(x+$b)/(x^2+$c x)")-&gt;reduce;
+              $f=Formula("(x+$b)/(x^2+$c x)")->reduce;
               $l=Compute("DNE");
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
-              $solgr=init_graph(-2,-1000,2,1000,axes=&gt;[0,0],grid=&gt;[4,10],size=&gt;[400,400]);
+              @tabout=map{$f->eval(x=>$_)} @tabin;
+              $solgr=init_graph(-2,-1000,2,1000,axes=>[0,0],grid=>[4,10],size=>[400,400]);
               if(0&lt;-$c){
-              add_functions($solgr,"$f for x in &lt;-2,-0.0001&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;-2,-0.0001> using color:blue and weight:2");
               add_functions($solgr,"$f for x in &lt;0.0001,-$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in (-$c,2&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in (-$c,2> using color:blue and weight:2");
               }else{
               add_functions($solgr,"$f for x in &lt;-2,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,-0.0001&gt; using color:blue and weight:2");
-              add_functions($solgr,"$f for x in &lt;0.0001,2&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,-0.0001> using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;0.0001,2> using color:blue and weight:2");
               };
             </pg-code>
             </setup>
@@ -1658,7 +1658,7 @@
                 For a graphical approximation:
               </p>
 
-                <image pg-name="$solgr" width="67%"/>
+                <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -1681,21 +1681,21 @@
               }until($b!=$c);
               do{$a=non_zero_random(-5,5,1);}until($a!=$b and $a!=$c);
               if ($envir{problemSeed}==1){$a=3;$b=-1;$c=1};
-              $f=Formula("(x^2-($a+$b)x+$a*$b)/(x^2-($a+$c)x+$a*$c)")-&gt;reduce;
+              $f=Formula("(x^2-($a+$b)x+$a*$b)/(x^2-($a+$c)x+$a*$c)")->reduce;
               Context("Fraction");
               $l=Fraction(($a-$b)/($a-$c));
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
+              @tabout=map{$f->eval(x=>$_)} @tabin;
               $xmin=-abs($a)-2;$xmax=abs($a)+2;$xmid1=$c-0.01;$xmid2=$c+0.01;$ymin=-ceil(abs(Real($l)))-2;$ymax=ceil(abs(Real($l)))+2;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
               if($a&lt;$c){
-              add_functions($solgr,"$f for x in &lt;$xmin,$xmid1&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;$xmin,$xmid1> using color:blue and weight:2");
               add_functions($solgr,"$f for x in &lt;$xmid2,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,$xmax> using color:blue and weight:2");
               }else{
               add_functions($solgr,"$f for x in &lt;$xmin,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,$xmid1&gt; using color:blue and weight:2");
-              add_functions($solgr,"$f for x in &lt;$xmid2,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,$xmid1> using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;$xmid2,$xmax> using color:blue and weight:2");
               };
             </pg-code>
             </setup>
@@ -1776,7 +1776,7 @@
                 For a graphical approximation:
               </p>
 
-                              <image pg-name="$solgr" width="67%"/>
+                              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -1799,21 +1799,21 @@
               }until($b!=$c);
               do{$a=non_zero_random(-5,5,1);}until($a!=$c);
               if ($envir{problemSeed}==1){$a=-1;$b=-7;$c=-5};
-              $f=Formula("(x^2-($a+$b)x+$a*$b)/(x^2-($a+$c)x+$a*$c)")-&gt;reduce;
+              $f=Formula("(x^2-($a+$b)x+$a*$b)/(x^2-($a+$c)x+$a*$c)")->reduce;
               Context("Fraction");
               $l=Fraction(($a-$b)/($a-$c));
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
+              @tabout=map{$f->eval(x=>$_)} @tabin;
               $xmin=-abs($a)-2;$xmax=abs($a)+2;$xmid1=$c-0.01;$xmid2=$c+0.01;$ymin=-ceil(abs(Real($l)))-2;$ymax=ceil(abs(Real($l)))+2;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
               if($a&lt;$c){
-              add_functions($solgr,"$f for x in &lt;$xmin,$xmid1&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;$xmin,$xmid1> using color:blue and weight:2");
               add_functions($solgr,"$f for x in &lt;$xmid2,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,$xmax> using color:blue and weight:2");
               }else{
               add_functions($solgr,"$f for x in &lt;$xmin,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,$xmid1&gt; using color:blue and weight:2");
-              add_functions($solgr,"$f for x in &lt;$xmid2,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,$xmid1> using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;$xmid2,$xmax> using color:blue and weight:2");
               };
             </pg-code>
             </setup>
@@ -1893,7 +1893,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -1916,20 +1916,20 @@
               }until($b!=$c);
               $a=non_zero_random(-5,5,1);
               if ($envir{problemSeed}==1){$a=2;$b=-5;$c=2};
-              $f=Formula("(x^2-(-$a+$b)x-$a*$b)/(x^2-($a+$c)x+$a*$c)")-&gt;reduce;
+              $f=Formula("(x^2-(-$a+$b)x-$a*$b)/(x^2-($a+$c)x+$a*$c)")->reduce;
               $l=Compute("DNE");
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
+              @tabout=map{$f->eval(x=>$_)} @tabin;
               $xmin=-abs($a)-2;$xmax=abs($a)+2;$xmid1=$c-0.01;$xmid2=$c+0.01;$ymin=-1000;$ymax=1000;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,10],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,10],size=>[400,400]);
               if($a&lt;$c){
-              add_functions($solgr,"$f for x in &lt;$xmin,$xmid1&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;$xmin,$xmid1> using color:blue and weight:2");
               add_functions($solgr,"$f for x in &lt;$xmid2,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,$xmax> using color:blue and weight:2");
               }else{
               add_functions($solgr,"$f for x in &lt;$xmin,$c) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in ($c,$xmid1&gt; using color:blue and weight:2");
-              add_functions($solgr,"$f for x in &lt;$xmid2,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in ($c,$xmid1> using color:blue and weight:2");
+              add_functions($solgr,"$f for x in &lt;$xmid2,$xmax> using color:blue and weight:2");
               };
             </pg-code>
             </setup>
@@ -2010,7 +2010,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -2034,17 +2034,17 @@
               $a=non_zero_random(-5,5,1);
               $d=$a+$b-($c*$a)-$diff;
               if ($envir{problemSeed}==1){$a=2;$b=2;$c=3;$d=-5;};
-              $f1=Formula("x+$b")-&gt;reduce;$f2=Formula("$c*x+$d")-&gt;reduce;
+              $f1=Formula("x+$b")->reduce;$f2=Formula("$c*x+$d")->reduce;
               Context("PiecewiseFunction");
-              Context()-&gt;flags-&gt;set(tolType=&gt;"absolute",tolerance=&gt;0.00001);
-              $f=PiecewiseFunction("x &lt;= $a" =&gt; "$f1", "x &gt; $a" =&gt; "$f2");
+              Context()->flags->set(tolType=>"absolute",tolerance=>0.00001);
+              $f=PiecewiseFunction("x &lt;= $a" => "$f1", "x > $a" => "$f2");
               $l=Compute("DNE");
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
+              @tabout=map{$f->eval(x=>$_)} @tabin;
               $xmin=-abs($a)-2;$xmax=abs($a)+2;$ymin=min($a+$b,$c*$a+$d)-2;$ymax=max($a+$b,$c*$a+$d)+2;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
               add_functions($solgr,"$f1 for x in &lt;$xmin,$a) using color:blue and weight:2");
-              add_functions($solgr,"$f2 for x in [$a,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f2 for x in [$a,$xmax> using color:blue and weight:2");
             </pg-code>
             </setup>
             <statement>
@@ -2126,7 +2126,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -2151,18 +2151,18 @@
               $d=non_zero_random(-3,3,1);
               $e=$a**2+$b*$a+$c-$d*$a;
               if ($envir{problemSeed}==1){$a=3;$b=-1;$c=1;$d=2;$e=1};
-              $f1=Formula("x^2+$b*x+$c")-&gt;reduce;$f2=Formula("$d*x+$e")-&gt;reduce;
+              $f1=Formula("x^2+$b*x+$c")->reduce;$f2=Formula("$d*x+$e")->reduce;
               Context("PiecewiseFunction");
-              Context()-&gt;flags-&gt;set(tolType=&gt;"absolute",tolerance=&gt;0.00001);
-              $f=PiecewiseFunction("x &lt;= $a" =&gt; "$f1", "x &gt; $a" =&gt; "$f2");
-              $l=$f1-&gt;eval(x=&gt;$a);
+              Context()->flags->set(tolType=>"absolute",tolerance=>0.00001);
+              $f=PiecewiseFunction("x &lt;= $a" => "$f1", "x > $a" => "$f2");
+              $l=$f1->eval(x=>$a);
               }until($l!=0);
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
+              @tabout=map{$f->eval(x=>$_)} @tabin;
               $xmin=-4;$xmax=4;$ymin=-abs($l)-2;$ymax=abs($l)+2;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
               add_functions($solgr,"$f1 for x in &lt;$xmin,$a) using color:blue and weight:2");
-              add_functions($solgr,"$f2 for x in [$a,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f2 for x in [$a,$xmax> using color:blue and weight:2");
             </pg-code>
             </setup>
             <statement>
@@ -2244,7 +2244,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -2265,17 +2265,17 @@
               $a=0;
               $b=non_zero_random(-5,5,1);
               if ($envir{problemSeed}==1){$a=0;$b=3;};
-              $f1=Formula("cos(x)")-&gt;reduce;$f2=Formula("x^2+$b*x+1")-&gt;reduce;
+              $f1=Formula("cos(x)")->reduce;$f2=Formula("x^2+$b*x+1")->reduce;
               Context("PiecewiseFunction");
-              Context()-&gt;flags-&gt;set(tolType=&gt;"absolute",tolerance=&gt;0.00001);
-              $f=PiecewiseFunction("x &lt;= $a" =&gt; "$f1", "x &gt; $a" =&gt; "$f2");
-              $l=$f1-&gt;eval(x=&gt;$a);
+              Context()->flags->set(tolType=>"absolute",tolerance=>0.00001);
+              $f=PiecewiseFunction("x &lt;= $a" => "$f1", "x > $a" => "$f2");
+              $l=$f1->eval(x=>$a);
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
+              @tabout=map{$f->eval(x=>$_)} @tabin;
               $xmin=-3;$xmax=3;$ymin=-3;$ymax=3;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
               add_functions($solgr,"$f1 for x in &lt;$xmin,$a) using color:blue and weight:2");
-              add_functions($solgr,"$f2 for x in [$a,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f2 for x in [$a,$xmax> using color:blue and weight:2");
             </pg-code>
             </setup>
             <statement>
@@ -2357,7 +2357,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -2375,21 +2375,21 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->flags->set(reduceConstants=>0);
               $a=list_random(Formula("pi/2"),Formula("pi/3"),Formula("pi/6"));
               if ($envir{problemSeed}==1){$a=Formula("pi/2")};
-              $f1=Formula("sin(x)")-&gt;reduce;$f2=Formula("cos(x)")-&gt;reduce;
+              $f1=Formula("sin(x)")->reduce;$f2=Formula("cos(x)")->reduce;
               Context("PiecewiseFunction");
-              Context()-&gt;flags-&gt;set(tolType=&gt;"absolute",tolerance=&gt;0.00001);
-              $areal=$a-&gt;eval(x=&gt;0);
-              $f=PiecewiseFunction("x &lt;= $areal" =&gt; "$f1", "x &gt; $areal" =&gt; "$f2");
+              Context()->flags->set(tolType=>"absolute",tolerance=>0.00001);
+              $areal=$a->eval(x=>0);
+              $f=PiecewiseFunction("x &lt;= $areal" => "$f1", "x > $areal" => "$f2");
               $l=Compute("DNE");
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_-&gt;eval(x=&gt;0))} @tabin;
+              @tabout=map{$f->eval(x=>$_->eval(x=>0))} @tabin;
               $xmin=-1;$xmax=3;$ymin=-2;$ymax=2;
-              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+              $solgr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
               add_functions($solgr,"$f1 for x in &lt;$xmin,$areal) using color:blue and weight:2");
-              add_functions($solgr,"$f2 for x in [$areal,$xmax&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f2 for x in [$areal,$xmax> using color:blue and weight:2");
             </pg-code>
             </setup>
             <statement>
@@ -2469,7 +2469,7 @@
                 For a graphical approximation:
               </p>
 
-              <image pg-name="$solgr" width="67%"/>
+              <image pg-name="$solgr" width="50%"/>
 
               <p>
                 It appears that when <m>x</m> is close to <m><var name="$a"/></m>,
@@ -2491,10 +2491,10 @@
               $a=0;
               $l=1;
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
-              $solgr=init_graph(-2,-2,2,2,axes=&gt;[0,0],grid=&gt;[4,4],size=&gt;[400,400]);
+              @tabout=map{$f->eval(x=>$_)} @tabin;
+              $solgr=init_graph(-2,-2,2,2,axes=>[0,0],grid=>[4,4],size=>[400,400]);
               add_functions($solgr,"$f for x in &lt;-2,0) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in (0,2&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in (0,2> using color:blue and weight:2");
             </pg-code>
           </setup>
           <statement>
@@ -2563,7 +2563,7 @@
 
             <p>For a graphical approximation:</p>
 
-            <image pg-name="$solgr" width="67%"/>
+            <image pg-name="$solgr" width="50%"/>
 
             <p>It appears that when <m>x</m> is close to <m>0</m>, that <m>\lvert x \rvert^x</m> is close to <m>1</m>. So
               <me>
@@ -2582,10 +2582,10 @@
               $a=0;
               $l=Compute("DNE");
               @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
-              @tabout=map{$f-&gt;eval(x=&gt;$_)} @tabin;
-              $solgr=init_graph(-2,-2,2,2,axes=&gt;[0,0],grid=&gt;[4,4],size=&gt;[400,400]);
+              @tabout=map{$f->eval(x=>$_)} @tabin;
+              $solgr=init_graph(-2,-2,2,2,axes=>[0,0],grid=>[4,4],size=>[400,400]);
               add_functions($solgr,"$f for x in &lt;-2,-0.0001) using color:blue and weight:2");
-              add_functions($solgr,"$f for x in (0.0001,2&gt; using color:blue and weight:2");
+              add_functions($solgr,"$f for x in (0.0001,2> using color:blue and weight:2");
             </pg-code>
           </setup>
           <statement>
@@ -2655,7 +2655,7 @@
 
             <p>For a graphical approximation:</p>
 
-            <image pg-name="$solgr" width="67%"/>
+            <image pg-name="$solgr" width="50%"/>
 
             <p>It appears that when <m>x</m> is close to <m>0</m>, that <m>e^{-e^{1/x}}</m> approaches different values from the left and right. So
               <me>
@@ -2688,27 +2688,27 @@
               do {$b=non_zero_random(-9,9,1);}until(abs($m)!=abs($b));
               $a=random(1,5,1);
               if ($envir{problemSeed}==1){$a=3;$m=-7;$b=2};
-              $f=Formula("$m*x+$b")-&gt;reduce;
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a)))/Formula("h");
+              $f=Formula("$m*x+$b")->reduce;
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a)))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -2806,27 +2806,27 @@
               $b=random(0.01,0.09,0.01)+random(0.1,0.9,0.1)+random(-9,9,1);
               $a=random(-5,5,1);
               if ($envir{problemSeed}==1){$a=-1;$m=9;$b=0.06};
-              $f=Formula("$m*x+$b")-&gt;reduce;
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a)))/Formula("h");
+              $f=Formula("$m*x+$b")->reduce;
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a)))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -2924,29 +2924,29 @@
               $c=non_zero_random(-9,9,1);
               $a=random(-5,5,1);
               if ($envir{problemSeed}==1){$a=1;$b=3;$c=-7};
-              $f=Formula("x^2+$b*x+$c")-&gt;reduce;
-              $m=$f-&gt;D('x')-&gt;eval(x=&gt;$a);
+              $f=Formula("x^2+$b*x+$c")->reduce;
+              $m=$f->D('x')->eval(x=>$a);
               }until($m!=0);
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a)))/Formula("h");
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a)))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -3042,28 +3042,28 @@
               do{$b=non_zero_random(-5,5,1);
               $a=random(-5,5,1);} until ($a + $b!= 0);
               if ($envir{problemSeed}==1){$a=2;$b=1;};
-              $f=Formula("1/(x+$b)")-&gt;reduce;
-              $m=$f-&gt;D('x')-&gt;eval(x=&gt;$a)-&gt;with(tolerance =&gt; .01);
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a)))/Formula("h");
+              $f=Formula("1/(x+$b)")->reduce;
+              $m=$f->D('x')->eval(x=>$a)->with(tolerance => .01);
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a)))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -3164,29 +3164,29 @@
               }until(gcd($d,gcd($b,$c))==1);
               $a=random(-5,5,1);
               if ($envir{problemSeed}==1){$a=-3;$d=-4;$b=5;$c=-1};
-              $f=Formula("$d*x^2+$b*x+$c")-&gt;reduce;
-              $m=$f-&gt;D('x')-&gt;eval(x=&gt;$a);
+              $f=Formula("$d*x^2+$b*x+$c")->reduce;
+              $m=$f->D('x')->eval(x=>$a);
               }until($m!=0);
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a)))/Formula("h");
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a)))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -3282,27 +3282,27 @@
               $a=random(2,9,1);
               if ($envir{problemSeed}==1){$a=5;};
               $f=Formula("ln(x)");
-              $m=$f-&gt;D('x')-&gt;eval(x=&gt;$a)-&gt;with(tolerance =&gt; .01);
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a)))/Formula("h");
+              $m=$f->D('x')->eval(x=>$a)->with(tolerance => .01);
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a)))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -3395,31 +3395,31 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->flags->set(reduceConstants=>0);
               $a=list_random(Formula("pi/3"),Formula("2pi/3"),Formula("pi"),Formula("4pi/3"),Formula("5pi/3"),);
               if ($envir{problemSeed}==1){$a=Formula("pi");};
               $f=Formula("sin(x)");
-              $m=$f-&gt;D('x')-&gt;eval(x=&gt;$a-&gt;eval(x=&gt;0))-&gt;with(tolerance =&gt; .01);
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a-&gt;eval(x=&gt;0))))/Formula("h");
+              $m=$f->D('x')->eval(x=>$a->eval(x=>0))->with(tolerance => .01);
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a->eval(x=>0))))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });
@@ -3512,31 +3512,31 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;flags-&gt;set(reduceConstants=&gt;0);
+              Context()->flags->set(reduceConstants=>0);
               $a=list_random(Formula("pi/3"),Formula("2pi/3"),Formula("pi"),Formula("4pi/3"),Formula("5pi/3"),);
               if ($envir{problemSeed}==1){$a=Formula("pi");};
               $f=Formula("cos(x)");
-              $m=$f-&gt;D('x')-&gt;eval(x=&gt;$a-&gt;eval(x=&gt;0))-&gt;with(tolerance =&gt; .01);
-              Context()-&gt;variables-&gt;add(h=&gt;'Real');
-              $dq=($f-&gt;substitute(x=&gt;Formula("$a+h"))-($f-&gt;eval(x=&gt;$a-&gt;eval(x=&gt;0))))/Formula("h");
+              $m=$f->D('x')->eval(x=>$a->eval(x=>0))->with(tolerance => .01);
+              Context()->variables->add(h=>'Real');
+              $dq=($f->substitute(x=>Formula("$a+h"))-($f->eval(x=>$a->eval(x=>0))))/Formula("h");
               @tabin=(Real(-0.1),Real(-0.01),Real(0.01),Real(0.1));
-              @tabout=map{$dq-&gt;eval(h=&gt;$_,x=&gt;1)} @tabin;
+              @tabout=map{$dq->eval(h=>$_,x=>1)} @tabin;
               @table=map{($tabin[$_],$tabout[$_])}(0 .. $#tabin);
-              $tableanswers=MultiAnswer(@table)-&gt;with(allowBlankAnswers=&gt;1,checker=&gt;sub{
+              $tableanswers=MultiAnswer(@table)->with(allowBlankAnswers=>1,checker=>sub{
                   my ($correct,$student,$self)=@_;
                   my @cor=@{$correct};my @stu=@{$student};
                   my @return=(1,1,1,1,1,1,1,1);
                   for my $i (0,2,4,6) {
-                      do {$return[$i+1]=0;$self-&gt;setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
-                      unless($stu[$i] ne "" and $dq-&gt;eval(h=&gt;$stu[$i]) == $stu[$i+1]);
-                      do {$return[$i]=0;$self-&gt;setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
+                      do {$return[$i+1]=0;$self->setMessage($i+2,'This is not the difference quotient when h='."$stu[$i]".'.');}
+                      unless($stu[$i] ne "" and $dq->eval(h=>$stu[$i]) == $stu[$i+1]);
+                      do {$return[$i]=0;$self->setMessage($i+1,'You should use h-values '."$cor[0]".', '."$cor[2]".', '."$cor[4]".', and '."$cor[6]".'.');}
                       unless($stu[$i]==$cor[0] or $stu[$i]==$cor[2] or $stu[$i]==$cor[4] or $stu[$i]==$cor[6]);
                   };
-                  do {$return[2]=0;$self-&gt;setMessage(3,'You already used this h-value.');}
+                  do {$return[2]=0;$self->setMessage(3,'You already used this h-value.');}
                   unless($stu[2]!=$stu[0] or $stu[2] eq "");
-                  do {$return[4]=0;$self-&gt;setMessage(5,'You already used this h-value.');}
+                  do {$return[4]=0;$self->setMessage(5,'You already used this h-value.');}
                   unless($stu[4]!=$stu[0] and $stu[4]!=$stu[2] or $stu[2] eq "");
-                  do {$return[6]=0;$self-&gt;setMessage(7,'You already used this h-value.');}
+                  do {$return[6]=0;$self->setMessage(7,'You already used this h-value.');}
                   unless($stu[6]!=$stu[0] and $stu[6]!=$stu[2] and $stu[6]!=$stu[4] or $stu[2] eq "");
                   return [@return];
               });

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -48,7 +48,7 @@
     We begin with formal definitions that are very similar to the
     definition of the limit given in <xref ref="sec_limit_def">Section</xref>,
     but the notation is slightly different and <q><m>x\neq c</m></q>
-    is replaced with either <q><m>x\lt c</m></q> or <q><m>x&gt;c</m>.</q>
+    is replaced with either <q><m>x\lt c</m></q> or <q><m>x \gt c</m>.</q>
   </p>
   <p>
     There is a slighlty different definition for a left-hand limit,
@@ -91,7 +91,7 @@
 
             <p>
               Let <m>f</m> be a function defined on <m>(c,b)</m>
-              for some <m>b&gt;c</m> and let <m>L</m> be a real number.
+              for some <m>b \gt c</m> and let <m>L</m> be a real number.
               The statement that the <term>limit of <m>f(x)</m>,
               as <m>x</m> approaches <m>c</m> from the right,
               is <m>L</m></term>, (alternatively,
@@ -124,7 +124,7 @@
     <m>c</m> to get values for <m>x</m>.
     A similar statement holds for evaluating right-hand limits;
     there we consider only values of <m>x</m> to the right of <m>c</m>,
-    i.e., <m>x&gt;c</m>.
+    i.e., <m>x \gt c</m>.
     We can use the theorems from previous sections to help us evaluate these limits;
     we just restrict our view to one side of <m>c</m>.
   </p>
@@ -202,9 +202,9 @@
         </caption>
           <!-- START figures/fig_one_sidedlimit1.tex -->
         <image xml:id="img_onesided1" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
+          
           \begin{tikzpicture}
           \begin{axis}[xmin=-.4,xmax=2.4,
           ymin=-.4,ymax=2.4,]
@@ -214,7 +214,7 @@
           \addplot[hollowdot] coordinates {(1,2) (2,1)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+
           </latex-image>
         </image>
           <!-- figures/fig_one_sidedlimit1.tex END -->
@@ -421,17 +421,17 @@
         <caption>A graph of <m>f</m> from <xref ref="ex_onesideb">Example</xref></caption>
           <!-- START figures/fig_one_sidedlimit2.tex -->
         <image xml:id="img_onesidedb" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
-          \begin{tikzpicture}[declare function = {func(\x) = (\x&lt;1) * (2 - x) + (\x &gt;= 1) * ((x - 2)^2);}]
+
+          \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1) * (2 - x) + (\x &gt; = 1) * ((x - 2)^2);}]
           \begin{axis}[xmin=-.4,xmax=2.4,
           ymin=-.4,ymax=2.4]
           \addplot+[domain=0:2,-] {func(x)};
           \addplot[hollowdot] coordinates {(0,2) (1,1) (2,0)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+
           </latex-image>
         </image>
           <!-- figures/fig_one_sidedlimit2.tex END -->
@@ -547,9 +547,8 @@
         <caption>Graphing <m>f</m> in <xref ref="ex_onesidec">Example</xref></caption>
           <!-- START figures/fig_one_sidedlimit3.tex -->
         <image xml:id="img_onesidedc" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
           \begin{tikzpicture}
           \begin{axis}[xmin=-.4,xmax=2.4,
           ymin=-.4,ymax=1.4]
@@ -558,7 +557,6 @@
           \addplot[hollowdot] coordinates {(1,0)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
           </latex-image>
         </image>
           <!-- figures/fig_one_sidedlimit3.tex END -->
@@ -614,17 +612,17 @@
         <caption>Graphing <m>f</m> in <xref ref="ex_onesided">Example</xref></caption>
           <!-- START figures/fig_one_sidedlimit4.tex -->
         <image xml:id="img_onesidedd" width="47%">
-          <description/>
+          <description></description>
           <latex-image>
-          <![CDATA[
-          \begin{tikzpicture}[declare function = {func(\x) = (\x&lt;1) * (x^2) + (\x&gt;1) * (2-x);}]
+
+          \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1) * (x^2) + (\x &gt; 1) * (2-x);}]
           \begin{axis}[xmin=-.4,xmax=2.4,
           ymin=-.4,ymax=1.4]
           \addplot+[domain=0:2,-] {func(x)};
           \addplot[soliddot] coordinates {(0,0) (1,1) (2,0)};
           \end{axis}
           \end{tikzpicture}
-          ]]>
+
           </latex-image>
         </image>
           <!-- figures/fig_one_sidedlimit4.tex END -->
@@ -641,7 +639,7 @@
   </example>
 
   <p>
-    In <xref ref="ex_onesidea">Examples</xref><ndash /><xref ref="ex_onesided"></xref>
+    In <xref ref="ex_onesidea">Examples</xref><ndash/><xref ref="ex_onesided"/>
     we were asked to find both <m>\lim\limits_{x\to 1}f(x)</m> and <m>f(1)</m>.
     Consider the following table:
   </p>
@@ -650,7 +648,7 @@
 
     <tabular>
       <row bottom="medium">
-        <cell/>
+        <cell></cell>
         <cell><m>\lim\limits_{x\to 1}f(x)</m></cell>
         <cell><m>f(1)</m></cell>
       </row>
@@ -814,10 +812,10 @@
                 $f=Formula("($y[1]-$y[0])/($x[1]-$x[0])*(x-$x[0])+$y[0]");
                 $g=Formula("($y[1]-$y[2])/($x[1]-$x[2])^2*(x-$x[2])^2+$y[2]");
                 $xmin=min(@x)-1;$xmax=max(@x)+1;$ymin=min(@y,$z)-1;$ymax=max(@y,$z)+1;
-                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
                 add_functions($gr,"$f for x in [$x[0],$x[1]) using color:blue and weight:2");
                 add_functions($gr,"$g for x in ($x[1],$x[2]] using color:blue and weight:2");
-                $gr-&gt;stamps(closed_circle($x[1],$z,'blue'));
+                $gr->stamps(closed_circle($x[1],$z,'blue'));
                 @L=($y[1],$y[1],$y[1],$z);
                 ($L[4],$L[5])=($b==0)?(Compute("DNE"),$y[0]):($y[2],Compute("DNE"));
             </pg-code>
@@ -827,7 +825,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -888,7 +886,7 @@
                 $f=Formula("($y[1]-$y[0])/($x[1]-$x[0])*(x-$x[0])+$y[0]");
                 $g=Formula("($z-$y[2])/($x[1]-$x[2])*(x-$x[2])+$y[2]");
                 $xmin=min(@x)-1;$xmax=max(@x)+1;$ymin=min(@y,$z)-1;$ymax=max(@y,$z)+1;
-                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
                 add_functions($gr,"$f for x in [$x[0],$x[1]) using color:blue and weight:2");
                 add_functions($gr,"$g for x in [$x[1],$x[2]] using color:blue and weight:2");
                 @L=($y[1],$z,Compute("DNE"),$z);
@@ -900,7 +898,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -961,11 +959,11 @@
                 $f=Formula("sec((x-$x[0])/($x[1]-$x[0])*pi/2)-1+$y[0]");
                 $g=Formula("sec((x-$x[2])/($x[1]-$x[2])*pi/2)-1+$y[2]");
                 $xmin=min(@x)-1;$xmax=max(@x)+1;$ymin=-1;$ymax=max($y[0],$y[2])+4;
-                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
                 $xmidlow=$x[1]-0.1;$xmidhigh=$x[1]+0.1;
                 add_functions($gr,"$f for x in [$x[0],$xmidlow) using color:blue and weight:2");
                 add_functions($gr,"$g for x in ($xmidhigh,$x[2]] using color:blue and weight:2");
-                $gr-&gt;moveTo($x[1],$ymin);$gr-&gt;lineTo($x[1],$ymax,'gray',2,'dashed');
+                $gr->moveTo($x[1],$ymin);$gr->lineTo($x[1],$ymax,'gray',2,'dashed');
                 @L=(OneOf(Compute("DNE"),Compute("INF")),OneOf(Compute("DNE"),Compute("INF")),OneOf(Compute("DNE"),Compute("INF")),Compute("DNE"));
                 ($L[4],$L[5])=($b==0)?(Compute("DNE"),Compute("DNE")):($y[2],$y[0]);
             </pg-code>
@@ -975,7 +973,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1036,10 +1034,10 @@
                 $f=Formula("($z-$y[0])/($x[1]-$x[0])*(x-$x[0])+$y[0]");
                 $g=Formula("($y[2]-$y[1])/($x[2]-$x[1])^2*(x-$x[1])^2+$y[1]");
                 $xmin=min(@x)-1;$xmax=max(@x)+1;$ymin=min(@y,$z,$w)-1;$ymax=max(@y,$z,$w)+1;
-                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
                 add_functions($gr,"$f for x in [$x[0],$x[1]) using color:blue and weight:2");
                 add_functions($gr,"$g for x in ($x[1],$x[2]] using color:blue and weight:2");
-                $gr-&gt;stamps(closed_circle($x[1],$w,'blue'));
+                $gr->stamps(closed_circle($x[1],$w,'blue'));
                 @L=($z,$y[1],Compute("DNE"),$w);
             </pg-code>
             </setup>
@@ -1048,7 +1046,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1096,7 +1094,7 @@
                 $f=Formula("($y[0]-$y[1])/($x[0]-$x[1])^2*(x-$x[1])^2+$y[1]");
                 $g=Formula("($y[2]-$y[1])/($x[2]-$x[1])*(x-$x[1])+$y[1]");
                 $xmin=min(@x)-1;$xmax=max(@x)+1;$ymin=min(@y)-1;$ymax=max(@y)+1;
-                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
                 add_functions($gr,"$f for x in [$x[0],$x[1]] using color:blue and weight:2");
                 add_functions($gr,"$g for x in [$x[1],$x[2]] using color:blue and weight:2");
                 @L=($y[1],$y[1],$y[1],$y[1]);
@@ -1107,7 +1105,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1157,10 +1155,10 @@
                 $f=Formula("($y[1]-$y[0])/2*cos((x-$x[1])/($x[0]-$x[1])*pi)+($y[0]+$y[1])/2");
                 $g=Formula("($y[4]-$y[3])/2*cos((x-$x[2])/($x[1]-$x[2])*pi)+($y[3]+$y[4])/2");
                 $xmin=min(@x)-1;$xmax=max(@x)+1;$ymin=min(@y)-1;$ymax=max(@y)+1;
-                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=&gt;[0,0],grid=&gt;[$xmax-$xmin,$ymax-$ymin],size=&gt;[400,400]);
+                $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],grid=>[$xmax-$xmin,$ymax-$ymin],size=>[400,400]);
                 add_functions($gr,"$f for x in [$x[0],$x[1]) using color:blue and weight:2");
                 add_functions($gr,"$g for x in ($x[1],$x[2]] using color:blue and weight:2");
-                $gr-&gt;stamps(closed_circle($x[1],$y[2],'blue'));
+                $gr->stamps(closed_circle($x[1],$y[2],'blue'));
                 @L=($y[1],$y[3],Compute("DNE"),$y[2]);
             </pg-code>
             </setup>
@@ -1169,7 +1167,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1208,12 +1206,12 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-                $gr=init_graph(-5,-4,5,4,axes=&gt;[0,0],grid=&gt;[10,8],size=&gt;[400,400]);
+                $gr=init_graph(-5,-4,5,4,axes=>[0,0],grid=>[10,8],size=>[400,400]);
                 add_functions($gr,"x+4 for x in [-4,-2) using color:blue and weight:2");
                 add_functions($gr,"-x for x in (-2,0] using color:blue and weight:2");
                 add_functions($gr,"x for x in [0,2) using color:blue and weight:2");
                 add_functions($gr,"4-x for x in (2,4] using color:blue and weight:2");
-                $gr-&gt;stamps(closed_circle(-2,0,'blue'));
+                $gr->stamps(closed_circle(-2,0,'blue'));
                 @L=(2,2,2,0,2,2,2,Compute("DNE"));
             </pg-code>
             </setup>
@@ -1222,7 +1220,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1285,9 +1283,9 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-                $gr=init_graph(-5,-5,5,5,axes=&gt;[0,0],grid=&gt;[10,10],size=&gt;[400,400]);
+                $gr=init_graph(-5,-5,5,5,axes=>[0,0],grid=>[10,10],size=>[400,400]);
                 for my $i(-4..3) {$ip1=$i+1;add_functions($gr,"$i for x in [$i,$ip1) using color:blue and weight:2");};
-                Context()-&gt;variables-&gt;are(a=&gt;'Real');
+                Context()->variables->are(a=>'Real');
                 @L=(Formula("a-1"),Formula("a"),Compute("DNE"),Formula("a"));
             </pg-code>
             </setup>
@@ -1296,7 +1294,7 @@
                 Evaluate each expression using the given graph of <m>f</m>.
               </p>
 
-              <sidebyside width="67%">
+              <sidebyside width="50%">
                 <image pg-name="$gr"/>
               </sidebyside>
 
@@ -1353,12 +1351,12 @@
               $b=non_zero_random(-5,5,1);
               do{$c=non_zero_random(-5,5,1);}until($a+$b!=$a**2+$c);
               if($envir{problemSeed}==1){$a=1;$b=1;$c=-5};
-              @f=(Formula("x+$b")-&gt;reduce,Formula("x^2+$c")-&gt;reduce);
+              @f=(Formula("x+$b")->reduce,Formula("x^2+$c")->reduce);
               Context("PiecewiseFunction");
-              $g=PiecewiseFunction("x &lt;= $a" =&gt; "$f[0]", "x &gt; $a" =&gt; "$f[1]");
-              @L=($f[0]-&gt;eval(x=&gt;$a),$f[1]-&gt;eval(x=&gt;$a));
+              $g=PiecewiseFunction("x &lt;= $a" => "$f[0]", "x > $a" => "$f[1]");
+              @L=($f[0]->eval(x=>$a),$f[1]->eval(x=>$a));
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
-              $L[3]=$g-&gt;eval(x=&gt;$a);
+              $L[3]=$g->eval(x=>$a);
             </pg-code>
             </setup>
             <statement>
@@ -1410,12 +1408,12 @@
               $c=non_zero_random(-5,5,1);
               $d=non_zero_random(-5,5,1);
               if($envir{problemSeed}==1){$a=0;$b=2;$c=5;$d=-1;};
-              @f=(Formula("$b x^2 + $c x+$d")-&gt;reduce,Formula("sin(x-$a)")-&gt;reduce);
+              @f=(Formula("$b x^2 + $c x+$d")->reduce,Formula("sin(x-$a)")->reduce);
               Context("PiecewiseFunction");
-              $g=PiecewiseFunction("x &lt; $a" =&gt; "$f[0]", "x &gt;= $a" =&gt; "$f[1]");
-              @L=($f[0]-&gt;eval(x=&gt;$a),$f[1]-&gt;eval(x=&gt;$a));
+              $g=PiecewiseFunction("x &lt; $a" => "$f[0]", "x >= $a" => "$f[1]");
+              @L=($f[0]->eval(x=>$a),$f[1]->eval(x=>$a));
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
-              $L[3]=$g-&gt;eval(x=&gt;$a);
+              $L[3]=$g->eval(x=>$a);
             </pg-code>
             </setup>
             <statement>
@@ -1465,15 +1463,15 @@
               $a=random(-3,-1,1);
               $b=$a+random(4,5,1);
               if($envir{problemSeed}==1){$a=-1;$b=1;};
-              @f=(Formula("x^2 + ($a+1) x+($a)^3+1-($a)^2-($a+1)*$a")-&gt;reduce,Formula("x^3+1")-&gt;reduce,Formula("x^2 + ($b-1) x+($b)^3+1-($b)^2-($b-1)*$b")-&gt;reduce);
+              @f=(Formula("x^2 + ($a+1) x+($a)^3+1-($a)^2-($a+1)*$a")->reduce,Formula("x^3+1")->reduce,Formula("x^2 + ($b-1) x+($b)^3+1-($b)^2-($b-1)*$b")->reduce);
               Context("PiecewiseFunction");
-              $g=PiecewiseFunction("x &lt; $a" =&gt; "$f[0]", "$a &lt;= x &lt;= $b" =&gt; "$f[1]", "x &gt; $b" =&gt; $f[2]);
-              @L=($f[0]-&gt;eval(x=&gt;$a),$f[1]-&gt;eval(x=&gt;$a));
+              $g=PiecewiseFunction("x &lt; $a" => "$f[0]", "$a &lt;= x &lt;= $b" => "$f[1]", "x > $b" => $f[2]);
+              @L=($f[0]->eval(x=>$a),$f[1]->eval(x=>$a));
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
-              $L[3]=$g-&gt;eval(x=&gt;$a);
-              ($L[4],$L[5])=($f[1]-&gt;eval(x=&gt;$b),$f[2]-&gt;eval(x=&gt;$b));
+              $L[3]=$g->eval(x=>$a);
+              ($L[4],$L[5])=($f[1]->eval(x=>$b),$f[2]->eval(x=>$b));
               $L[6]=($L[4]==$L[5])?$L[4]:Compute("DNE");
-              $L[7]=$g-&gt;eval(x=&gt;$b);
+              $L[7]=$g->eval(x=>$b);
             </pg-code>
             </setup>
             <statement>
@@ -1545,7 +1543,7 @@
             <setup>
             <pg-code>
               @f=($envir{problemSeed}%2==1)?(Formula("cos(x)"),Formula("sin(x)")):(Formula("sin(x)"),Formula("cos(x)"));
-              @L=($f[0]-&gt;eval(x=&gt;pi),$f[1]-&gt;eval(x=&gt;pi));
+              @L=($f[0]->eval(x=>pi),$f[1]->eval(x=>pi));
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
               $L[3]=$L[1];
             </pg-code>
@@ -1594,7 +1592,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;add(a=&gt;'Real');
+              Context()->variables->add(a=>'Real');
               @L=(Formula("1-cos^2(a)"),Formula("sin^2(a)"),OneOf(Formula("1-cos^2(a)"),Formula("sin^2(a)")),Formula("sin^2(a)"));
             </pg-code>
             </setup>
@@ -1649,12 +1647,12 @@
               $a=random(-3,3,1);
               @y=map{$_-2}NchooseK(5,3);
               if($envir{problemSeed}==1){$a=1;@y=(1,0,-1);};
-              @f=(Formula("x+$y[0]")-&gt;reduce,Formula("x+$y[1]")-&gt;reduce,Formula("x+$y[2]")-&gt;reduce);
+              @f=(Formula("x+$y[0]")->reduce,Formula("x+$y[1]")->reduce,Formula("x+$y[2]")->reduce);
               Context("PiecewiseFunction");
-              $g=PiecewiseFunction("x &lt; $a" =&gt; "$f[0]", "x = $a" =&gt; "$f[1]", "x &gt; $a" =&gt; $f[2]);
-              @L=($f[0]-&gt;eval(x=&gt;$a),$f[2]-&gt;eval(x=&gt;$a));
+              $g=PiecewiseFunction("x &lt; $a" => "$f[0]", "x = $a" => "$f[1]", "x > $a" => $f[2]);
+              @L=($f[0]->eval(x=>$a),$f[2]->eval(x=>$a));
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
-              $L[3]=$g-&gt;eval(x=&gt;$a);
+              $L[3]=$g->eval(x=>$a);
             </pg-code>
             </setup>
             <statement>
@@ -1704,12 +1702,12 @@
               $a=random(-3,3,1);
               @y=map{$_-2}NchooseK(5,2);
               if($envir{problemSeed}==1){$a=2;@y=(4,3);};
-              @f=(Formula("x^2+($y[0]-2*$a)x+($y[0]-($a)^2-($y[0]-2*$a)*$a)")-&gt;reduce-&gt;reduce,Formula("x+($y[1]-$a)")-&gt;reduce,Formula("-x^2+$a*x+$y[0]")-&gt;reduce);
+              @f=(Formula("x^2+($y[0]-2*$a)x+($y[0]-($a)^2-($y[0]-2*$a)*$a)")->reduce->reduce,Formula("x+($y[1]-$a)")->reduce,Formula("-x^2+$a*x+$y[0]")->reduce);
               Context("PiecewiseFunction");
-              $g=PiecewiseFunction("x &lt; $a" =&gt; "$f[0]", "x = $a" =&gt; "$f[1]", "x &gt; $a" =&gt; $f[2]);
-              @L=($f[0]-&gt;eval(x=&gt;$a),$f[2]-&gt;eval(x=&gt;$a));
+              $g=PiecewiseFunction("x &lt; $a" => "$f[0]", "x = $a" => "$f[1]", "x > $a" => $f[2]);
+              @L=($f[0]->eval(x=>$a),$f[2]->eval(x=>$a));
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
-              $L[3]=$g-&gt;eval(x=&gt;$a);
+              $L[3]=$g->eval(x=>$a);
             </pg-code>
             </setup>
             <statement>
@@ -1756,7 +1754,7 @@
         <webwork seed="1">
             <setup>
             <pg-code>
-              Context()-&gt;variables-&gt;add(c=&gt;'Real');
+              Context()->variables->add(c=>'Real');
               $L=Formula("c");
             </pg-code>
             </setup>
@@ -1862,8 +1860,8 @@
             <pg-code>
               ($a,$b,$c)=map{($_+1)*random(-1,1,2)}NchooseK(9,3);
               if($envir{problemSeed}==1){$a=-1;$b=-4;$c=4;};
-              $f=Formula("x^2-($a+$b)x+$a*$b")-&gt;reduce;
-              $g=Formula("x^2-($a+$c)x+$a*$c")-&gt;reduce;
+              $f=Formula("x^2-($a+$b)x+$a*$b")->reduce;
+              $g=Formula("x^2-($a+$c)x+$a*$c")->reduce;
               $r=$f/$g;
               Context("Fraction");
               $L=Fraction($a-$b,$a-$c);
@@ -1891,8 +1889,8 @@
             <pg-code>
               ($a,$b,$c)=map{($_+1)*random(-1,1,2)}NchooseK(9,3);
               if($envir{problemSeed}==1){$a=-4;$b=4;$c=8;};
-              $f=Formula("x^2-($a+$b)x+$a*$b")-&gt;reduce;
-              $g=Formula("x^2-($a+$c)x+$a*$c")-&gt;reduce;
+              $f=Formula("x^2-($a+$b)x+$a*$b")->reduce;
+              $g=Formula("x^2-($a+$c)x+$a*$c")->reduce;
               $r=$f/$g;
               Context("Fraction");
               $L=Fraction($a-$b,$a-$c);
@@ -1920,8 +1918,8 @@
             <pg-code>
               @a=map{($_-9)}NchooseK(18,4);
               if($envir{problemSeed}==1){@a=(-6,6,9,0)};
-              $f=Formula("x^2-($a[1]+$a[2])x+$a[1]*$a[2]")-&gt;reduce;
-              $g=Formula("x^2-($a[1]+$a[3])x+$a[1]*$a[3]")-&gt;reduce;
+              $f=Formula("x^2-($a[1]+$a[2])x+$a[1]*$a[2]")->reduce;
+              $g=Formula("x^2-($a[1]+$a[3])x+$a[1]*$a[3]")->reduce;
               $r=$f/$g;
               Context("Fraction");
               $L=Fraction($a[0]-$a[2],$a[0]-$a[3]);
@@ -1949,8 +1947,8 @@
             <pg-code>
               ($a,$b,$c)=map{$_*random(-1,1,2)/10}NchooseK(99,3);
               if($envir{problemSeed}==1){$a=0.4;$b=4;$c=0;};
-              $f=Formula("x^2-($a+$b)x+$a*$b")-&gt;reduce;
-              $g=Formula("x^2-($a+$c)x+$a*$c")-&gt;reduce;
+              $f=Formula("x^2-($a+$b)x+$a*$b")->reduce;
+              $g=Formula("x^2-($a+$c)x+$a*$c")->reduce;
               $r=$f/$g;
               $L=Real(($a-$b)/($a-$c));
             </pg-code>
@@ -1977,8 +1975,8 @@
             <pg-code>
               ($a,$b,$c)=map{$_*random(-1,1,2)/10}NchooseK(99,3);
               if($envir{problemSeed}==1){$a=0.2;$b=-6;$c=4;};
-              $f=Formula("x^2-($a+$b)x+$a*$b")-&gt;reduce;
-              $g=Formula("x^2-($a+$c)x+$a*$c")-&gt;reduce;
+              $f=Formula("x^2-($a+$b)x+$a*$b")->reduce;
+              $g=Formula("x^2-($a+$c)x+$a*$c")->reduce;
               $r=$f/$g;
               $L=Real(($a-$b)/($a-$c));
             </pg-code>


### PR DESCRIPTION
Running the fix-deprecations script on files in chapters 1 - 3
- Cleans up '<' and '>'
- Removes CDATA sections since above fix made them obsolete 
- Fixes spacing in some places
-  Checking the rare case in which xml:id gets removed in a figure within a sidebyside and that reference is lost and has to be added back

Other general small validation fixes
- Width for images in webwork exercises

Chapter 3 still needs to be done so this is very much a work in progress.