### PR TITLE
edited sec_limits_onesided.ptx to remove reference to figure

### DIFF
--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -363,7 +363,8 @@
                        2-x \amp 0\lt x\lt 1 \\
                        (x-2)^2 \amp 1\lt x\lt 2
                     \end{cases}</m>
-                    as shown in <xref ref="fig_onesidedb">Figure</xref>.
+                   .
+									<!-- as shown in <xref ref="fig_onesidedb">Figure</xref>.--> 
         Evaluate the following:
 
         <ol cols="2">
@@ -417,7 +418,94 @@
         </ol>
       </p>
 
-      <figure xml:id="fig_onesidedb">
+      
+    </statement>
+    <solution>
+      <p>
+        In this example, we evaluate each expression using just the definition of <m>f</m>, without using a graph as we did in the previous example.
+      </p>
+
+      <p>
+        <ol>
+          <li>
+            <p>
+              As <m>x</m> approaches <m>1</m> from the left, we consider a limit where all <m>x</m>-values are less than <m>1</m>. This means we use the <m>2-x</m> piece of the piecewise function <m>f</m> as the domain for that piece is <m>(0,1)</m>. As the <m>x</m>-values near <m>1</m>, <m>2-x</m> approaches <m>1</m>; that is, <m>f(x)</m> approaches <m>1</m>. Therefore <m>\ds \lim_{x\to 1^-} f(x)=1.</m>
+							
+							<!--As <m>x</m> approaches <m>1</m> from the left,
+              we see that <m>f(x)</m> approaches <m>1</m>.
+              Therefore <m>\lim\limits_{x\to 1^-} f(x)=1</m>.--> 
+            </p>
+          </li>
+
+          <li>
+            <p>
+						As <m>x</m> approaches <m>1</m> from the right, we consider a limit where all <m>x</m>-values are greater than <m>1</m>. This means we use the <m>(x-2)^2</m> piece of <m>f</m> as the domain for that piece is <m>(1,2)</m>. As the <m>x</m>-values near <m>1</m>, <m>(x-2)^2</m> approaches <m>1</m>; that is, we see that again <m>f(x)</m> approaches <m>1</m>. Therefore <m>\ds \lim_{x\to 1+} f(x)=1</m>.
+						
+              <!-- As <m>x</m> approaches <m>1</m> from the right,
+              we see that again <m>f(x)</m> approaches <m>1</m>.
+              Therefore <m>\lim\limits_{x\to 1+} f(x)=1</m>. -->
+            </p>
+          </li>
+
+          <li>
+            <p>
+						<em>The</em> limit of <m>f</m> as <m>x</m> approaches <m>1</m> exists and is <m>1</m>,
+              as <m>f</m> approaches <m>1</m> from both the right and left.
+              Therefore <m>\lim\limits_{x\to 1} f(x)=1</m>.
+						</p>
+          </li>
+
+          <li>
+            <p>
+						  Neither piece of <m>f</m> is defined for the <m>x</m>-value of <m>1</m>; in other words, <m>1</m> is not in the domain of <m>f</m>. Therefore <m>f(1)</m> is not defined.
+              <!--
+							<m>f(1)</m> is not defined.
+              Note that <m>1</m> is not in the domain of <m>f</m> as defined by the problem,
+              which is indicated on the graph by an open circle when <m>x=1</m>.
+							-->
+            </p>
+          </li>
+
+          <li>
+            <p>
+              As <m>x</m> approaches  <m>0</m> from the right, we consider a limit where all <m>x</m>-values are greater than <m>0</m>. This means we use the <m>2-x</m> piece of <m>f</m>. As the <m>x</m>-values near <m>0</m>, <m>2-x</m> approaches <m>2</m>; that is, <m>f(x)</m> approaches <m>2</m>. So <m>\ds \lim_{x\to 0^+} f(x)=2</m>.
+							<!--
+							As <m>x</m> goes to <m>0</m> from the right,
+              <m>f(x)</m> approaches <m>2</m>.
+              So <m>\lim\limits_{x\to 0^+} f(x)=2</m>.
+							-->
+            </p>
+          </li>
+
+          <li>
+            <p>
+              <m>f(0)</m> is not defined as <m>0</m> is not in the domain of <m>f</m>.
+            </p>
+          </li>
+
+          <li>
+            <p>
+						As <m>x</m> approaches  <m>2</m> from the left, we consider a limit where all <m>x</m>-values are less than <m>2</m>. This means we use the <m>(x-2)^2</m> piece of <m>f</m>. As the <m>x</m>-values near <m>2</m>, <m>(x-2)^2</m> nears <m>0</m>; that is, <m>f(x)</m> approaches <m>0</m>. So <m>\ds \lim_{x\to 2^-} f(x)=0</m>.
+						<!--
+              As <m>x</m> goes to <m>2</m> from the left,
+              <m>f(x)</m> approaches <m>0</m>.
+              So <m>\lim\limits_{x\to 2^-} f(x)=0</m>.
+							-->
+            </p>
+          </li>
+
+          <li>
+            <p>
+              <m>f(2)</m> is not defined as <m>2</m> is not in the domain of <m>f</m>.
+            </p>
+          </li>
+        </ol>
+      </p>
+			
+			<p>
+			We can confirm our analytic result by consulting the graph of <m>f</m> shown in <xref ref="fig_onesidedb">Figure</xref>.	Note the open circles on the graph at <m>x=0</m>, <m>1</m> and <m>2</m>, where <m>f</m> is not defined.
+			</p>
+			<figure xml:id="fig_onesidedb">
         <caption>A graph of <m>f</m> from <xref ref="ex_onesideb">Example</xref></caption>
           <!-- START figures/fig_one_sidedlimit2.tex -->
         <image xml:id="img_onesidedb" width="47%">
@@ -436,75 +524,6 @@
         </image>
           <!-- figures/fig_one_sidedlimit2.tex END -->
       </figure>
-    </statement>
-    <solution>
-      <p>
-        Again we will evaluate each using both the definition of <m>f</m> and its graph.
-      </p>
-
-      <p>
-        <ol>
-          <li>
-            <p>
-              As <m>x</m> approaches <m>1</m> from the left,
-              we see that <m>f(x)</m> approaches <m>1</m>.
-              Therefore <m>\lim\limits_{x\to 1^-} f(x)=1</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              As <m>x</m> approaches <m>1</m> from the right,
-              we see that again <m>f(x)</m> approaches <m>1</m>.
-              Therefore <m>\lim\limits_{x\to 1+} f(x)=1</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              <em>The</em> limit of <m>f</m> as <m>x</m> approaches <m>1</m> exists and is <m>1</m>,
-              as <m>f</m> approaches <m>1</m> from both the right and left.
-              Therefore <m>\lim\limits_{x\to 1} f(x)=1</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              <m>f(1)</m> is not defined.
-              Note that <m>1</m> is not in the domain of <m>f</m> as defined by the problem,
-              which is indicated on the graph by an open circle when <m>x=1</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              As <m>x</m> goes to <m>0</m> from the right,
-              <m>f(x)</m> approaches <m>2</m>.
-              So <m>\lim\limits_{x\to 0^+} f(x)=2</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              <m>f(0)</m> is not defined as <m>0</m> is not in the domain of <m>f</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              As <m>x</m> goes to <m>2</m> from the left,
-              <m>f(x)</m> approaches <m>0</m>.
-              So <m>\lim\limits_{x\to 2^-} f(x)=0</m>.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              <m>f(2)</m> is not defined as <m>2</m> is not in the domain of <m>f</m>.
-            </p>
-          </li>
-        </ol>
-      </p>
     </solution>
   </example>
 


### PR DESCRIPTION
Edited the one-sided limits section, second example, to remove references to the figure when evaluating the limits. The figure is shown at the end of the example as a reference.