### PR TITLE
Added differential equations content

### DIFF
--- a/ptx/chapter_differential_equations.ptx
+++ b/ptx/chapter_differential_equations.ptx
@@ -1,0 +1,26 @@
+<chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_differential_equations">
+  <title>Differential Equations</title>
+  <introduction>
+    <p>
+      One of the strengths of calculus is its ability to describe real-world phenomena.
+      We have seen hints of this in our discussion of the applications of derivatives and integrals in the previous chapters.
+      The process of formulating an equation or multiple equations to describe a physical phenomenon is called
+      <em>mathematical modeling.</em> As a simple example,
+      populations of bacteria are often described as
+      <q>growing exponentially.</q>
+      Looking in a biology text, we might see <m>P(t) = P_0e^{kt}</m>,
+      where <m>P(t)</m> is the bacteria population at time <m>t</m>,
+      <m>P_0</m> is the initial population at time <m>t=0</m>,
+      and the constant <m>k</m> describes how quickly the population grows.
+      This equation for exponential growth arises from the assumption that the population of bacteria grows at a rate proportional to its size.
+      Recalling that the derivative gives the rate of change of a function,
+      we can describe the growth assumption precisely using the equation <m>P' = kP</m>.
+      This equation is called a <em>differential equation</em>,
+      and these equations are the subject of the current chapter.
+    </p>
+  </introduction>
+  <xi:include  href="sec_Graphical_Numerical.ptx" />
+  <xi:include  href="sec_Separable.ptx" />
+  <xi:include  href="sec_Linear.ptx" />
+  <xi:include  href="sec_Modeling.ptx" />
+</chapter>

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -291,6 +291,8 @@
 
     <xi:include href="./chapter_app_of_int.ptx" />
 
+    <xi:include href="./chapter_differential_equations.ptx"/>
+
     <!-- <xi:include href="./chapter_sequences_series.ptx" /> -->
 
     <!-- <xi:include href="./chapter9.ptx" /> -->

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -98,7 +98,7 @@
           A differential equation paired with an initial condition
           (or initial conditions)
           is called an <term>initial value problem.</term>
-              <idx><h>initial value problem</h><h>for differential equations</idx>
+              <idx><h>initial value problem</h><h>for differential equations</h></idx>
               <idx><h>initial condition</h></idx>
         </p>
         <p>
@@ -182,15 +182,36 @@
           and a different function.
           We emphasize the particular solution corresponding to the initial condition <m>y(0)=3/2</m>.
         </p>
+        <figure xml:id="fig_general_particular">
+          <caption>A representation of some of the members of general solution to the differential equation <m>\yp = 2y</m>,
+          including the particular solution to the initial value problem with <m>y(0)=\displaystyle 3/2</m>,
+          from <xref ref="ex_simple_de">Example</xref></caption>
+          <image xml:id="img_general_particular" width="47%">
+            <description></description>
+            <latex-image>
+              \begin{tikzpicture}
+
+              \begin{axis}[
+              ymin=-10.5,ymax=10.75,
+              xmin=-2,xmax=2.15%
+              ]
+
+              \foreach \n in {-6,...,6}
+                {
+                \addplot[secondcurvestyle,-,domain=-2:2,samples=50] {\n/2*exp(2*x)};
+                }
+              \addplot[firstcurvestyle,-,domain=-2:2,samples=50] {3/2*exp(2*x)};
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </solution>
     </example>
-
-    <figure xml:id="fig_general_particular">
-      <caption>A representation of some of the members of general solution to the differential equation <m>\yp = 2y</m>,
-      including the particular solution to the initial value problem with <m>y(0)=\displaystyle 3/2</m>,
-      from <xref ref="ex_simple_de">Example</xref></caption>
-      <img src="figures/fig20_01_general_particular"/>
-    </figure>
 
     <example xml:id="ex_simple_de2">
       <title>A second-order differential equation</title>
@@ -374,7 +395,29 @@
 
     <figure xml:id="fig_20_01_intersection">
       <caption>Graphically finding an approximate solution to <m>\cos x = x</m>.</caption>
-      <img src="figures/fig20_01_intersection"/>
+      <image xml:id="fig_de_intersection" width="47%">
+        <description></description>
+        <latex-image>
+          \begin{tikzpicture}
+
+          \begin{axis}[
+            minor x tick num=1,
+            %extra x ticks={.25,.75},
+            ymin=-.1,ymax=1.1,%
+            xmin=-.1,xmax=1.1%
+          ]
+
+          \addplot [firstcurvestyle,-,domain=0:1] {cos(deg(x))};
+          \addplot [secondcurvestyle,-] coordinates {(0,0) (1,1)};
+
+          \end{axis}
+
+          %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+          %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+          \end{tikzpicture}
+        </latex-image>
+      </image>
     </figure>
     <p>
       Consider the first-order differential equation
@@ -464,13 +507,34 @@
           There are also various online tools that can make the drawings.
           The slope field for <m>\yp = x+y</m> is shown in <xref ref="fig_20_01_slopefield1">Figure</xref>.
         </p>
+        <figure xml:id="fig_20_01_slopefield1">
+          <caption>Slope field for <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref>.</caption>
+          <image xml:id="img_slopefield1" width="47%">
+            <description></description>
+            <latex-image>
+              \def\length{sqrt(1+(x+y)^2)}
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                view={0}{90},
+                domain = -2:2,
+                ytick={-2,-1,0,1,2},
+              ]
+
+              \addplot3 [secondcolor,quiver = {u = {1/(\length)}, v = {(x+y)/(\length)},scale arrows=.25},samples=9]{0};
+
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+
+          </image>
+        </figure>
       </solution>
     </example>
-
-    <figure xml:id="fig_20_01_slopefield1">
-      <caption>Slope field for <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref>.</caption>
-      <img src="figures/fig20_01_slopefield1"/>
-    </figure>
 
     <example xml:id="ex_IVP_graphical">
       <title>A graphical solution to an initial value problem</title>
@@ -507,18 +571,38 @@
           in either direction.
           A sketch of the solution is shown in <xref ref="fig_20_01_slopefield1solution">Figure</xref>.
         </p>
+        <figure xml:id="fig_20_01_slopefield1solution">
+          <caption>Solution to the initial value problem <m>\yp = x+y</m>, with <m>y(1)=-1</m> from <xref ref="ex_IVP_graphical">Example</xref></caption>
+          <image xml:id="img_slopefield1solution" width="47%">
+            <description></description>
+            <latex-image>
+              \def\length{sqrt(1+(x+y)^2)}
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                view={0}{90},
+                domain = -2:2,
+                xtick={-2,-1,0,1,2},
+                ytick={-2,-1,0,1,2},
+                xmin=-2,xmax=2.3
+              ]
+
+              \addplot3 [secondcolor,quiver = {u = {1/(\length)}, v = {(x+y)/(\length)},scale arrows=.25},samples=9]{0};
+              \addplot [firstcurvestyle,-,domain=-2.5:2.2,samples=51] {-(x+1)+exp(x-1)};
+
+              \fill[black,draw=black] (axis cs:1,-1) circle (1.5pt);
+
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </solution>
     </example>
-
-    <figure xml:id="fig_20_01_slopefield1solution">
-      <caption>Solution to the initial value problem <m>\yp = x+y</m>, with <m>y(1)=-1</m> from <xref ref="ex_IVP_graphical">Example</xref></caption>
-      <img src="figures/fig20_01_slopefield1solution"/>
-    </figure>
-
-    <figure xml:id="fig_20_01_slopefield2">
-      <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref>.</caption>
-      <img src="figures/fig20_01_slopefield2"/>
-    </figure>
 
     <example xml:id="ex_logistic_slope_field">
       <title>Using a slope field to predict long term behavior</title>
@@ -528,6 +612,36 @@
           shown in <xref ref="fig_20_01_slopefield2">Figure</xref>,
           to predict long term behavior of solutions to the equation.
         </p>
+        <figure xml:id="fig_20_01_slopefield2">
+          <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref>.</caption>
+          <image xml:id="img_slopefield2" width="47%">
+            <description></description>
+            <latex-image>
+              \def\length{sqrt(1+(y*(1-y))^2)}
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                view={0}{90},
+                domain = -1:3,
+                y domain=-.5:1.5,
+                xtick={-1,0,1,2,3},
+                ytick={-.5,0,.5,1},
+                ymin=-0.5,ymax=1.5,
+                xmin=-1,xmax=3,
+                xlabel={$t$}
+              ]
+
+              \addplot3 [secondcolor,quiver = {u = {1/(\length)}, v = {(y*(1-y))/(\length)},scale arrows=.1},samples=20]{0};
+
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $t$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </statement>
       <solution>
         <p>
@@ -573,13 +687,43 @@
           We call this the <em>carrying capacity.</em>
           <idx><h>carrying capacity</h></idx>
         </p>
+        <figure xml:id="fig_20_01_slopefield2solution">
+          <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref>
+          with a few representative solution curves.</caption>
+          <image xml:id="img_slopefield2solution" width="47%">
+            <description></description>
+            <latex-image>
+              \def\length{sqrt(1+(y*(1-y))^2)}
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                view={0}{90},
+                domain = -1:3,
+                y domain=-.5:1.5,
+                xtick={-1,0,1,2,3},
+                ytick={-.5,0,.5,1},
+                xlabel={$t$},
+                ymin=-0.5,ymax=1.5,
+                xmin=-1,xmax=3
+              ]
+
+              \addplot3 [secondcolor,quiver = {u = {1/(\length)}, v = {(y*(1-y))/(\length)},scale arrows=.1},samples=20]{0};
+              \addplot [firstcurvestyle,-,domain = -1:2, samples=50] {1/(1-10*exp(-x)};
+              \addplot [firstcurvestyle,-,domain = -1:3, samples=50] {1/(1+1*exp(-x)};
+              \addplot [firstcurvestyle,-,domain = -1:3, samples=50] {1/(1-.3*exp(-x)};
+
+              \end{axis}
+              %\node [right] at (myplot.right of origin) {\scriptsize $t$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </solution>
     </example>
 
-    <figure xml:id="fig_20_01_slopefield2solution">
-      <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref> with a few representative solution curves.</caption>
-      <img src="figures/fig20_01_slopefield2solution"/>
-    </figure>
+
   </subsection>
 
   <subsection>
@@ -735,13 +879,35 @@
           (connected by line segments)
           are plotted along with the analytical solution to the initial value problem in <xref ref="fig_20_01_euler1">Figure</xref>.
         </p>
+        <figure xml:id="fig_20_01_euler1">
+          <caption>Euler's Method approximation to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Example</xref>,
+          along with the analytical solution to the initial value problem.</caption>
+          <image xml:id="img-euler1" width="47%">
+            <description></description>
+            <latex-image>
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                xtick={1,1.5,2},
+                ytick={-1,-.5,0},
+                ymin=-1.25,ymax=0.1,
+                xmin=.9,xmax=2.1
+              ]
+
+              \addplot [secondcurvestyle,-,solid,domain=1:2,samples = 51] {-(x+1)+exp(x-1)};
+              \addplot [firstcolor, mark = *] coordinates{ (1,-1) (1.5,-1) (2,-0.75)};
+
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </solution>
     </example>
-
-    <figure xml:id="fig_20_01_euler1">
-      <caption>Euler's Method approximation to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Example</xref>, along with the analytical solution to the initial value problem.</caption>
-      <img src="figures/fig20_01_euler1"/>
-    </figure>
 
     <p>
       This approximation doesn't appear terrific,
@@ -786,13 +952,41 @@
           along with the points from <xref ref="ex_euler1">Example</xref> and the analytic solution,
           are plotted in <xref ref="fig_20_01_euler2">Figure</xref>.
         </p>
+        <figure xml:id="fig_20_01_euler2">
+          <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Examples</xref>
+          and <xref ref="ex_euler2"></xref>, along with the analytical solution.</caption>
+          <image xml:id="img-euler2" width="47%">
+            <description></description>
+            <latex-image>
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                xtick={1,1.5,2},
+                ytick={-1,-.5,0},
+                ymin=-1.25,ymax=0.1,
+                xmin=.9,xmax=2.35
+              ]
+
+              \addplot [secondcolor,thick,domain=1:2,samples = 51] {-(x+1)+exp(x-1)};
+              \addplot [firstcolor, mark = *] coordinates{ (1,-1) (1.5,-1) (2,-0.75)};
+              \addplot [firstcolor, mark = *,dashed] coordinates{ (1,-1) (1.25,-1) (1.5,-.9375) (1.75,-.7969) (2,-.5586)};
+
+              \node [right] at (axis cs:2,-0.75) {\scriptsize $h = 0.5$};
+              \node [right] at (axis cs:2,-0.5586) {\scriptsize $h = 0.25$};
+
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </solution>
     </example>
 
-    <figure xml:id="fig_20_01_euler2">
-      <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Examples</xref> and <xref ref="ex_euler2"></xref>, along with the analytical solution.</caption>
-      <img src="figures/fig20_01_euler2"/>
-    </figure>
+
 
     <p>
       Using the results from <xref ref="ex_euler1">Examples</xref>
@@ -883,13 +1077,38 @@
           are plotted in <xref ref="fig_20_01_euler3">Figure</xref>.
           Notice how well they seem to match the true solution.
         </p>
+        <figure xml:id="fig_20_01_euler3">
+          <caption>Euler's Method approximation to <m>\yp = y(1-y)</m> with <m>y(0) = 0.25</m> from <xref ref="ex_euler3">Example</xref>,
+          along with the analytical solution.</caption>
+          <image xml:id="img_euler3" width="47%">
+            <description></description>
+            <latex-image>
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                xtick={0,1,2,3,4},
+                ytick={0,0.5,1},
+                xlabel={$t$},
+                ymin=-.1,ymax=1.1,
+                xmin=-.1,xmax=4.1
+              ]
+
+              \addplot [firstcurvestyle,-,domain = 0:4, samples=50] {1/(1+3*exp(-x)};
+              \addplot [firstcolor, mark = *] coordinates{(0,.25)(0.4,.325)(0.8,.41275)(1.2,.50970)(1.6,.60966)(2.0,.70485)(2.4,.78806)(2.8,.85487)(3.2,.90450)(3.6,.93905)(4.0,.96194)};
+
+              \end{axis}
+
+              %\node [right] at (myplot.right of origin) {\scriptsize $t$};
+              %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
       </solution>
     </example>
 
-    <figure xml:id="fig_20_01_euler3">
-      <caption>Euler's Method approximation to <m>\yp = y(1-y)</m> with <m>y(0) = 0.25</m> from <xref ref="ex_euler3">Example</xref>, along with the analytical solution.</caption>
-      <img src="figures/fig20_01_euler3"/>
-    </figure>
+
 
     <p>
       The study of differential equations is a natural extension of the study of derivatives and integrals.
@@ -1105,9 +1324,29 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_11ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_11ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  domain = -2:2,
+                	ytick={-2,-1,0,1,2},
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(y-x)^2))}, v = {(y-x)/(sqrt(1+(y-x)^2))},scale arrows=.25},samples=9]{0};
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
       <exercise>
@@ -1117,9 +1356,28 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_12ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_12ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  domain = -2:2,
+                	ytick={-2,-1,0,1,2},
+                ]
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(x/(2*y))^2))}, v = {(x/(2*y))/(sqrt(1+(x/(2*y))^2))},scale arrows=.2},samples=10]{0};
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
       <exercise>
@@ -1129,9 +1387,29 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_13ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_13ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  domain = -2:2,
+                	ytick={-2,-1,0,1,2},
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(sin(deg pi*y))^2))}, v = {(sin(deg pi*y))/(sqrt(1+(sin(deg pi*y))^2))},scale arrows=.15},samples=20]{0};
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
       <exercise>
@@ -1141,9 +1419,29 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_30ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_30ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  domain = -2:2,
+                	ytick={-2,-1,0,1,2},
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(y/4)^2))}, v = {(y/4)/(sqrt(1+(y/4)^2))},scale arrows=.2},samples=10]{0};
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
     </exercisegroup>
@@ -1153,32 +1451,117 @@
           Match each slope field in <xref ref="fig_slopefield_exercise"/> with the appropriate differential equation.
         </p>
         <figure xml:id="fig_slopefield_exercise">
+          <caption>Slope fields for <xref first="ex_slopefield_first" last="ex_slopefield_last">Exercises</xref></caption>
           <sbsgroup>
-            <sidebyside widths="40%">
+            <sidebyside widths="40% 40%">
               <figure>
                 <caption/>
-                <img src="figures/fig20_01_ex_14_a"/>
+                <image xml:id="img_slopefield_exercise_a">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+
+                    \begin{axis}[
+                      view={0}{90},
+                      domain = -2:2,
+                      y domain = -2:2,
+                    	ytick={-3,-2,-1,0,1,2,3},
+                    ]
+
+                    \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(x*(1-x))^2))}, v = {(x*(1-x))/(sqrt(1+(x*(1-x))^2))},scale arrows=.1},samples=15]{0};
+
+                    \end{axis}
+
+                    %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                    %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
               </figure>
               <figure>
                 <caption/>
-                <img src="figures/fig20_01_ex_14_b"/>
+                <image xml:id="img_slopefield_exercise_b">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+
+                    \begin{axis}[
+                      view={0}{90},
+                      domain = -2:2,
+                      y domain = -2:2,
+                    	ytick={-3,-2,-1,0,1,2,3},
+                    ]
+
+                    \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(x*y)^2))}, v = {(x*y)/(sqrt(1+(x*y)^2))},scale arrows=.1},samples=15]{0};
+
+                    \end{axis}
+
+                    %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                    %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
               </figure>
             </sidebyside>
-            <sidebyside widths="40%">
+            <sidebyside widths="40% 40%">
               <figure>
                 <caption/>
-                <img src="figures/fig20_01_ex_14_c"/>
+                <image xml:id="img_slopefield_exercise_c">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+
+                    \begin{axis}[
+                      view={0}{90},
+                      domain = -2:2,
+                      y domain = -2:2,
+                    	ytick={-3,-2,-1,0,1,2,3},
+                    ]
+
+                    \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(-y)^2))}, v = {(-y)/(sqrt(1+(-y)^2))},scale arrows=.1},samples=15]{0};
+
+                    \end{axis}
+
+                    %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                    %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
               </figure>
               <figure>
                 <caption/>
-                <img src="figures/fig20_01_ex_14_d"/>
+                <image xml:id="img_slopefield_exercise_d">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+
+                    \begin{axis}[
+                      view={0}{90},
+                      domain = -2:2,
+                      y domain = -2:2,
+                    	ytick={-3,-2,-1,0,1,2,3},
+                    ]
+
+                    \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(-x)^2))}, v = {(-x)/(sqrt(1+(-x)^2))},scale arrows=.1},samples=15]{0};
+
+                    \end{axis}
+
+                    %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                    %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
               </figure>
             </sidebyside>
           </sbsgroup>
         </figure>
       </introduction>
 
-      <exercise>
+      <exercise xml:id="ex_slopefield_first">
         <statement>
           <p>
             <m>\yp = xy</m>
@@ -1214,7 +1597,7 @@
           </p>
         </answer>
       </exercise>
-      <exercise>
+      <exercise xml:id="ex_slopefield_last">
         <statement>
           <p>
             <m>\yp = x(1-x)</m>
@@ -1242,9 +1625,35 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_18ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_18ans">
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                view={0}{90},
+                y domain = -.5:1.5,
+                domain = -.5:5,
+                  minor x tick num=1,
+                  extra x ticks={1,3,5},
+                  ymin=-.1,ymax=1.6,
+                  xmin=-.1,xmax=5.2
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(y/x-y)^2))}, v = {(y/x-y)/(sqrt(1+(y/x-y)^2))},scale arrows=.15},samples=15]{0};
+                \addplot [firstcurvestyle,-,domain=0.5:5.1,samples = 51] {2*x*exp(1/2-x)};
+
+                \fill[black,draw=black] (axis cs:.5,1) circle (1.5pt);
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
       <exercise>
@@ -1254,9 +1663,35 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_19ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_ex20_01_ex_19ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  domain = -.5:10,
+                  minor x tick num=1,
+                  extra x ticks={2.5,7.5},
+                  minor y tick num=1,
+                  extra y ticks={2.5,7.5},
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(y*sin(deg x))^2))}, v = {(y*sin(deg x))/(sqrt(1+(y*sin(deg x))^2))},scale arrows=.4},samples=15]{0};
+                \addplot [firstcurvestyle,-,domain=0:10,samples = 100] {exp(1-cos(deg x))};
+
+                \fill[black,draw=black] (axis cs:0,1) circle (1.5pt);
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
       <exercise>
@@ -1266,9 +1701,34 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_20ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_20ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  y domain = -.15:3,
+                  domain = -.15:4,
+                			minor x tick num=1,
+                			extra x ticks={1,3},
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(y^2-3*y+2)^2))}, v = {(y^2-3*y+2)/(sqrt(1+(y^2-3*y+2)^2))},scale arrows=.2},samples=15]{0};
+                \addplot [firstcurvestyle,-] coordinates {(0,2) (4.1,2)};
+
+                \fill[black,draw=black] (axis cs:0,2) circle (1.5pt);
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
       <exercise>
@@ -1278,9 +1738,34 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_01_ex_31ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_01_ex_31ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  y domain = -.15:3,
+                  domain = -.15:4,
+                  minor x tick num=1,
+                  extra x ticks={1,3},
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(-x*y/(1+x^2))^2))}, v = {(-x*y/(1+x^2))/(sqrt(1+(-x*y/(1+x^2))^2))},scale arrows=.2},samples=15]{0};
+                \addplot [firstcurvestyle,-,domain=0:4,samples=50] {1/sqrt(1+x^2)};
+
+                \fill[black,draw=black] (axis cs:0,1) circle (1.5pt);
+
+                \end{axis}
+
+                %\node [right] at (myplot.right of origin) {\scriptsize $x$};
+                %\node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </answer>
       </exercise>
     </exercisegroup>
@@ -1310,12 +1795,12 @@
         <answer>
           <p>
             <md>
-              <mrow> x_i \amp y_i</mrow>
-              <mrow> 0.00 \amp 1.0000 </mrow>
-              <mrow>  0.25 \amp 1.5000 </mrow>
-              <mrow> 0.50 \amp 2.3125 </mrow>
-              <mrow> 0.75 \amp 3.5938</mrow>
-              <mrow> 1.00 \amp 5.5781 </mrow>
+              <mrow> x_i \amp \quad \amp \quad \amp y_i</mrow>
+              <mrow> 0.00 \amp \quad \amp \quad \amp 1.0000 </mrow>
+              <mrow>  0.25 \amp \quad \amp \quad \amp 1.5000 </mrow>
+              <mrow> 0.50 \amp \quad \amp \quad \amp 2.3125 </mrow>
+              <mrow> 0.75 \amp \quad \amp \quad \amp 3.5938</mrow>
+              <mrow> 1.00 \amp \quad \amp \quad \amp 5.5781 </mrow>
             </md>
           </p>
         </answer>
@@ -1338,13 +1823,13 @@
         <answer>
           <p>
             <md>
-              <mrow> x_i \amp y_i </mrow>
-              <mrow>  0.0 \amp 1.0000 </mrow>
-              <mrow> 0.1 \amp 1.0000 </mrow>
-              <mrow> 0.2 \amp 1.0037 </mrow>
-              <mrow> 0.3 \amp 1.0110 </mrow>
-              <mrow> 0.4 \amp 1.0219 </mrow>
-              <mrow> 0.5 \amp 1.0363 </mrow>
+              <mrow> x_i \amp \quad \amp \quad \amp y_i </mrow>
+              <mrow>  0.0 \amp \quad \amp \quad \amp 1.0000 </mrow>
+              <mrow> 0.1 \amp \quad \amp \quad \amp 1.0000 </mrow>
+              <mrow> 0.2 \amp \quad \amp \quad \amp 1.0037 </mrow>
+              <mrow> 0.3 \amp \quad \amp \quad \amp 1.0110 </mrow>
+              <mrow> 0.4 \amp \quad \amp \quad \amp 1.0219 </mrow>
+              <mrow> 0.5 \amp \quad \amp \quad \amp 1.0363 </mrow>
             </md>
           </p>
         </answer>
@@ -1367,13 +1852,13 @@
         <answer>
           <p>
             <md>
-              <mrow> x_i \amp y_i </mrow>
-              <mrow> 0.0 \amp 2.0000 </mrow>
-              <mrow> 0.2 \amp 2.4000 </mrow>
-              <mrow> 0.4 \amp 2.9197 </mrow>
-              <mrow> 0.6 \amp 3.5816 </mrow>
-              <mrow> 0.8 \amp 4.4108 </mrow>
-              <mrow> 1.0 \amp 5.4364 </mrow>
+              <mrow> x_i \amp \quad \amp \quad \amp y_i </mrow>
+              <mrow> 0.0 \amp \quad \amp \quad \amp 2.0000 </mrow>
+              <mrow> 0.2 \amp \quad \amp \quad \amp 2.4000 </mrow>
+              <mrow> 0.4 \amp \quad \amp \quad \amp 2.9197 </mrow>
+              <mrow> 0.6 \amp \quad \amp \quad \amp 3.5816 </mrow>
+              <mrow> 0.8 \amp \quad \amp \quad \amp 4.4108 </mrow>
+              <mrow> 1.0 \amp \quad \amp \quad \amp 5.4364 </mrow>
             </md>
           </p>
         </answer>
@@ -1396,12 +1881,12 @@
         <answer>
           <p>
             <md>
-              <mrow> x_i \amp y_i </mrow>
-              <mrow> 0.0 \amp 0.0000 </mrow>
-              <mrow> 0.5 \amp 0.5000 </mrow>
-              <mrow>  1.0 \amp 1.8591 </mrow>
-              <mrow> 1.5 \amp 10.5824 </mrow>
-              <mrow> 2.0 \amp 88378.1190 </mrow>
+              <mrow> x_i \amp \quad \amp \quad \amp y_i </mrow>
+              <mrow> 0.0 \amp \quad \amp \quad \amp 0.0000 </mrow>
+              <mrow> 0.5 \amp \quad \amp \quad \amp 0.5000 </mrow>
+              <mrow>  1.0 \amp \quad \amp \quad \amp 1.8591 </mrow>
+              <mrow> 1.5 \amp \quad \amp \quad \amp 10.5824 </mrow>
+              <mrow> 2.0 \amp \quad \amp \quad \amp 88378.1190 </mrow>
             </md>
           </p>
         </answer>
@@ -1415,6 +1900,13 @@
         </p>
         <sidebyside>
           <tabular>
+            <col right="minor"/>
+            <col right="minor"/>
+            <col right="minor"/>
+            <col right="minor"/>
+            <col right="minor"/>
+            <col right="minor"/>
+            <col right="minor"/>
             <row bottom="minor">
               <cell><m> x</m></cell><cell><m> 0.0</m></cell><cell> <m>0.2</m></cell><cell><m>0.4</m></cell><cell> <m>0.6</m> </cell><cell> <m>0.8</m> </cell><cell> <m>1.0</m></cell>
             </row>
@@ -1429,7 +1921,6 @@
             </row>
           </tabular>
         </sidebyside>
-        </p>
       </introduction>
 
       <exercise>
@@ -1445,17 +1936,30 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <md>
-              <mrow> x_i \amp y(x) \amp <m>h=0.2</m> \amp h = 0.1 </mrow>
-              <mrow> 0.0 \amp 1.0000 \amp 1.0000 \amp 1.0000 </mrow>
-              <mrow> 0.2 \amp 1.0204 \amp 1.0000 \amp 1.0100 </mrow>
-              <mrow> 0.4 \amp 1.0870 \amp 1.0400 \amp 1.0623 </mrow>
-              <mrow> 0.6 \amp 1.2195 \amp 1.1265 \amp 1.1687 </mrow>
-              <mrow> 0.8 \amp 1.4706 \amp 1.2788 \amp 1.3601 </mrow>
-              <mrow> 1.0 \amp 2.0000 \amp 1.5405 \amp 1.7129 </mrow>
-            </md>
-          </p>
+          <sidebyside>
+            <tabular>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <row bottom="minor">
+                <cell><m> x</m></cell><cell><m> 0.0</m></cell><cell> <m>0.2</m></cell><cell><m>0.4</m></cell><cell> <m>0.6</m> </cell><cell> <m>0.8</m> </cell><cell> <m>1.0</m></cell>
+              </row>
+              <row bottom="minor">
+                <cell><m> y(x)</m></cell><cell>1.0000</cell><cell>1.0204</cell><cell>1.0870</cell><cell>1.2195</cell><cell>1.4706</cell><cell>2.0000</cell>
+              </row>
+              <row bottom="minor">
+                <cell><m>h = 0.2</m></cell><cell>1.0000</cell><cell>1.0000</cell><cell>1.0400</cell><cell>1.1265</cell><cell>1.2788</cell><cell>1.5405</cell>
+              </row>
+              <row>
+                <cell><m>h = 0.1</m></cell><cell>1.0000</cell><cell>1.0100</cell><cell>1.0623</cell><cell>1.1687</cell><cell>1.3601</cell><cell>1.7129</cell>
+              </row>
+            </tabular>
+          </sidebyside>
+
         </answer>
       </exercise>
       <exercise>
@@ -1471,17 +1975,29 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <md>
-              <mrow> x_i \amp y(x) \amp h = 0.2 \amp h = 0.1 </mrow>
-              <mrow> 0.0 \amp 0.5000 \amp 0.5000 \amp 0.5000 </mrow>
-              <mrow> 0.2 \amp 0.5412 \amp 0.5000 \amp 0.5201 </mrow>
-              <mrow> 0.4 \amp 0.6806 \amp 0.5816 \amp 0.6282 </mrow>
-              <mrow> 0.6 \amp 0.9747 \amp 0.7686 \amp 0.8622 </mrow>
-              <mrow> 0.8 \amp 1.5551 \amp 1.1250 \amp 1.3132 </mrow>
-              <mrow> 1.0 \amp 2.7183 \amp 1.7885 \amp 2.1788 </mrow>
-            </md>
-          </p>
+          <sidebyside>
+            <tabular>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <col right="minor"/>
+              <row bottom="minor">
+                <cell><m> x</m></cell><cell><m> 0.0</m></cell><cell> <m>0.2</m></cell><cell><m>0.4</m></cell><cell> <m>0.6</m> </cell><cell> <m>0.8</m> </cell><cell> <m>1.0</m></cell>
+              </row>
+              <row bottom="minor">
+                <cell><m> y(x)</m></cell><cell>0.5000</cell><cell>0.5412</cell><cell>0.6806</cell><cell>0.9747</cell><cell>1.5551</cell><cell>2.7183</cell>
+              </row>
+              <row bottom="minor">
+                <cell><m>h = 0.2</m></cell><cell>0.5000</cell><cell>0.5000</cell><cell>0.5816</cell><cell>0.7686</cell><cell>1.1250</cell><cell>1.7885</cell>
+              </row>
+              <row>
+                <cell><m>h = 0.1</m></cell><cell>0.5000</cell><cell>0.5201</cell><cell>0.6282</cell><cell>0.8622</cell><cell>1.3132</cell><cell>2.1788</cell>
+              </row>
+            </tabular>
+          </sidebyside>
         </answer>
       </exercise>
     </exercisegroup>

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -1,0 +1,1489 @@
+<section xml:id="sec_Graphical_Numerical">
+  <title>Graphical and Numerical Solutions to Differential Equations</title>
+  <introduction>
+    <p>
+      In <xref ref="sec_antider">Section</xref>,
+      we were introduced to the idea of a differential equation.
+      Given a function <m>y = f(x)</m>,
+      we defined a <em>differential equation</em>
+      as an equation involving <m>y,
+      x</m>, and derivatives of <m>y</m>.
+      We explored the simple differential equation <m>\yp = 2x</m>,
+      and saw that a <em>solution</em>
+      to a differential equation is simply a function that satisfies the differential equation.
+    </p>
+  </introduction>
+  <subsection>
+    <title>Introduction and Terminology</title>
+    <definition xml:id="def_ODE">
+      <title>Differential Equation</title>
+      <statement>
+        <p>
+          Given a function <m>y=f(x)</m>,
+          a <term>differential equation</term> is an equation relating
+          <m>x,
+          y</m>, and derivatives of <m>y</m>.
+          <ul>
+            <li>
+              <p>
+                The variable <m>x</m> is called the
+                <em>independent variable</em>.
+              </p>
+            </li>
+            <li>
+              <p>
+                The variable <m>y</m> is called the
+                <em>dependent variable</em>.
+              </p>
+            </li>
+            <li>
+              <p>
+                The <em>order</em> of the differential equation is the order of the highest derivative of <m>y</m> that appears in the equation.
+              </p>
+            </li>
+          </ul>
+          <idx><h>differential equation</h><h>definition</h></idx>
+          <idx><h>order</h><h>of a differential equation</h></idx>
+          <idx><h>differential equation</h><h>order of</h></idx>
+        </p>
+      </statement>
+    </definition>
+    <p>
+      Let us return to the simple differential equation
+      <me>
+        \yp = 2x
+      </me>.
+    </p>
+    <p>
+      To find a solution,
+      we must find a function whose derivative is <m>2x</m>.
+      In other words, we seek an antiderivative of <m>2x</m>.
+      The function
+      <me>
+        y = x^2
+      </me>
+      is an antiderivative of <m>2x</m>,
+      and solves the differential equation.
+      So do the functions
+      <me>
+        y = x^2 + 1
+      </me>
+      and
+      <me>
+        y = x^2 - 2346
+      </me>.
+    </p>
+    <p>
+      We call the function
+      <me>
+        y = x^2 +  C
+      </me>,
+      with <m>C</m> an arbitrary constant of integration,
+      the <em>general solution</em> to the differential equation.
+      <idx><h>general solution</h><h>of a differential equation</h></idx>
+      <idx><h>differential equation</h><h>general solution</h></idx>
+    </p>
+    <p>
+      In order to specify the value of the integration constant <m>C</m>,
+      we require additional information.
+      For example, if we know that <m>y(1) = 3</m>,
+      it follows that <m>C=2</m>.
+      This additional information is called an
+      <em>initial condition.</em>
+    </p>
+    <definition xml:id="def_IVP">
+      <title>Initial Value Problem</title>
+      <statement>
+        <p>
+          A differential equation paired with an initial condition
+          (or initial conditions)
+          is called an <term>initial value problem.</term>
+              <idx><h>initial value problem</h><h>for differential equations</idx>
+              <idx><h>initial condition</h></idx>
+        </p>
+        <p>
+          The solution to an initial value problem is called a
+          <term>particular solution</term>.
+              <idx><h>differential equation</h><h>particular solution</h></idx>
+          A particular solution does not include arbitrary constants.
+        </p>
+        <p>
+          The family of solutions to a differential equation that encompasses all possible solutions is called the
+          <term>general solution</term> to the differential equation.
+          <idx><h>differential equation</h><h>general solution</h></idx>
+        </p>
+      </statement>
+    </definition>
+
+    <aside>
+      <p>
+        <em>Note:</em>
+        A general solution typically includes one or more arbitrary constants.
+        Different values of the constant(s) specify different members in the family of solutions.
+        The particular solution to an initial value problem is the specific member in the family of solutions that corresponds to the given initial condition(s).
+      </p>
+    </aside>
+
+    <example xml:id="ex_simple_de">
+      <title>A simple first-order differential equation</title>
+      <statement>
+        <p>
+          Solve the differential equation <m>\yp = 2y</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The solution is a function <m>y</m> such that differentiation yields twice the original function.
+          Unlike our starting example,
+          finding the solution here does not involve computing an antiderivative.
+          Notice that
+          <q>integrating both sides</q>
+          would yield the result <m>y = \int 2y\,dx</m>, which is not useful.
+          Without knowledge of the function <m>y</m>,
+          we can't compute the indefinite integral.
+          Later sections will explore systematic ways to find analytic solutions to simple differential equations.
+          For now, a bit of thought might let us guess the solution
+          <me>
+            y = e^{2x}
+          </me>.
+        </p>
+        <p>
+          Notice that application of the chain rule yields <m>\yp = 2e^{2x} = 2y</m>.
+          Another solution is given by
+          <me>
+            y = -3e^{2x}
+          </me>.
+        </p>
+        <p>
+          In fact,
+          <me>
+            y = Ce^{2x}
+          </me>,
+          where <m>C</m> is any constant,
+          is the <em>general solution</em>
+          to the differential equation because <m>\yp = 2Ce^{2x} = 2y</m>.
+        </p>
+        <p>
+          If we are provided with a single initial condition,
+          say <m>y(0) = 3/2</m>, we can identify <m>C=3/2</m> so that
+          <me>
+            y = \frac{3}{2}e^{2x}
+          </me>
+          is the <em>particular solution</em>
+          to the initial value problem
+          <me>
+            \yp = 2y, \text{ with }  y(0) = \frac{3}{2}
+          </me>.
+        </p>
+        <p>
+          <xref ref="fig_general_particular">Figure</xref>
+          shows various members of the general solution to the differential equation <m>\displaystyle \yp = 2y</m>.
+          Each <m>C</m> value yields a different member of the family,
+          and a different function.
+          We emphasize the particular solution corresponding to the initial condition <m>y(0)=3/2</m>.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_general_particular">
+      <caption>A representation of some of the members of general solution to the differential equation <m>\yp = 2y</m>,
+      including the particular solution to the initial value problem with <m>y(0)=\displaystyle 3/2</m>,
+      from <xref ref="ex_simple_de">Example</xref></caption>
+      <img src="figures/fig20_01_general_particular"/>
+    </figure>
+
+    <example xml:id="ex_simple_de2">
+      <title>A second-order differential equation</title>
+      <statement>
+        <p>
+          Solve the differential equation <m>\yp' + 9y = 0</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We seek a function whose second derivative is negative 9 multiplied by the original function.
+          Both <m>\sin(3x)</m> and <m>\cos(3x)</m> have this feature.
+          The general solution to the differential equation is given by
+          <me>
+            y = C_1\sin(3x) + C_2\cos(3x)
+          </me>,
+          where <m>C_1</m> and <m>C_2</m> are arbitrary constants.
+          To fully specify a particular solution,
+          we require two additional conditions.
+          For example, the initial conditions <m>y(0)=1</m> and
+          <m>\yp(0)=3</m> yield <m>C_1 = C_2 = 1</m>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      The differential equation in <xref ref="ex_simple_de2">Example</xref>
+      is <em>second order</em>, because the equation involves a second derivative.
+      In general, the number of initial conditions required to specify a particular solution depends on the order of the differential equation.
+      For the remainder of the chapter,
+      we restrict our attention to first order differential equations and first order initial value problems.
+    </p>
+
+    <example xml:id="ex_verify_solutions">
+      <title>Verifying a solution to the differential equation</title>
+      <statement>
+        <p>
+          Which of the following is a solution to the differential equation
+          <me>
+            \yp + \frac{y}{x} - \sqrt{y} = 0
+          </me>?
+        </p>
+        <p>
+          <ol label="a">
+            <li><m>y = C \left ( 1 + \ln x \right )^2</m></li>
+            <li><m>y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m></li>
+            <li><m>y = C e^{-3x} + \sqrt{\sin x}</m></li>
+          </ol>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Verifying a solution to a differential equation is simply an exercise in differentiation and simplification.
+          We substitute each potential solution into the differential equation to see if it satisfies the equation.
+        </p>
+        <p>
+          <ol label="a">
+            <li>
+              <p>
+                Testing the potential solution <m>y = C \left ( 1 + \ln x \right )^2</m>:
+              </p>
+              <p>
+                Differentiating,
+                we have <m>\displaystyle \yp = \frac{2C(1 + \ln x)}{x}</m>.
+                Substituting into the differential equation,
+                <md>
+                  <mrow>\amp \ \frac{2C(1+\ln x)}{x} + \frac{C(1+\ln x)^2}{x} -\sqrt{C}(1+\ln x)</mrow>
+                  <mrow>=\amp \ (1+\ln x)\left( \frac{2C}{x} + \frac{C(1+\ln x)}{x} - \sqrt{C}\right)</mrow>
+                  <mrow>\neq \amp \ 0</mrow>
+                </md>.
+              </p>
+              <p>
+                Since it doesn't satisfy the differential equation,
+                <m>y = C(1 + \ln x)^2</m> is <em>not</em> a solution.
+              </p>
+            </li>
+
+            <li>
+              <p>
+                Testing the potential solution <m>\displaystyle y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m>:
+              </p>
+              <p>
+                Differentiating,
+                we have <m>\displaystyle \yp = 2\left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )\left ( \frac{1}{3} - \frac{C}{2x^{3/2}}\right )</m>.
+                Substituting into the differential equation,
+                <md>
+                  <mrow>\amp \ 2\left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )\left ( \frac{1}{3} - \frac{C}{2x^{3/2}}\right ) + \frac{1}{x}\left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2 - \left (\frac{1}{3}x + \frac{C}{\sqrt{x}}\right)</mrow>
+                  <mrow>=\amp \ \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right ) \left ( \frac{2}{3} - \frac{C}{x^{3/2}} + \frac{1}{3} + \frac{C}{x^{3/2}} - 1 \right )</mrow>
+                  <mrow>=\amp \ 0. \text{ (Note how the second parenthetical grouping above reduces to 0.) }</mrow>
+                </md>
+              </p>
+              <p>
+                Thus <m>\displaystyle y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m> <em>is</em>
+                a solution to the differential equation.
+              </p>
+            </li>
+
+            <li>
+              <p>
+                Testing the potential solution <m>\displaystyle y = C e^{-3x} + \sqrt{\sin x}</m>:
+              </p>
+              <p>
+                Differentiating,
+                <m>\displaystyle \yp = -3Ce^{-3x} + \frac{\cos x}{2\sqrt{\sin x}}</m>.
+                Substituting into the differential equation,
+                <md>
+                  <mrow>\amp \ -3Ce^{-3x} + \frac{\cos x}{2\sqrt{\sin x}} + \frac{C e^{-3x} + \sqrt{\sin x}}{x} - \sqrt{C e^{-3x} + \sqrt{\sin x}} \neq 0</mrow>
+                </md>.
+              </p>
+              <p>
+                The function <m>\displaystyle y = C e^{-3x} + \sqrt{\sin x}</m> is <em>not</em>
+                a solution to the differential equation.
+              </p>
+            </li>
+          </ol>
+        </p>
+      </solution>
+    </example>
+
+    <example xml:id="ex_verify_solutions2">
+      <title>Verifying a solution to a differential equation</title>
+      <statement>
+        <p>
+          Verify that <m>x^2+y^2 = Cy</m> is a solution to <m>\displaystyle \yp = \frac{2xy}{x^2-y^2}</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The solution in this example is called an
+          <em>implicit solution.</em>
+          That means the dependent variable <m>y</m> is a function of <m>x</m>,
+          but has not been explicitly solved for.
+          Verifying the solution still involves differentiation,
+          but we must take the derivatives implicitly.
+          Differentiating, we have
+          <me>
+            2x + 2y\yp = C\yp
+          </me>.
+          <idx><h>differential equation</h><h>implicit soution</h></idx>
+        </p>
+        <p>
+          Solving for <m>\yp</m>, we have
+          <me>
+            \yp = \frac{2x}{C-2y}
+          </me>.
+        </p>
+        <p>
+          From the solution,
+          we know that <m>\displaystyle C = \frac{x^2+y^2}{y}</m>.
+          Then
+          <md>
+            <mrow>\yp \amp = \frac{2x}{\displaystyle \frac{x^2+y^2}{y} - 2y}</mrow>
+            <mrow>\amp =\frac{2xy}{x^2+y^2-2y^2}</mrow>
+            <mrow>\amp = \frac{2xy}{x^2-y^2}</mrow>
+          </md>.
+        </p>
+        <p>
+          We have verified that <m>x^2+y^2 = Cy</m> is a solution to <m>\displaystyle \yp = \frac{2xy}{x^2-y^2}</m>.
+        </p>
+      </solution>
+    </example>
+  </subsection>
+
+  <subsection>
+    <title>Graphical Solutions to Differential Equations</title>
+    <p>
+      In the examples we have explored so far,
+      we have found exact forms for the functions that solve the differential equations.
+      Solutions of this type are called
+      <em>analytic solutions.</em>
+      Many times a differential equation has a solution,
+      but it is difficult or impossible to find the solution analytically.
+      This is analogous to algebraic equations.
+      The algebraic equation <m>x^2 + 3x - 1 = 0</m> has two real solutions that can be found analytically by using the quadratic formula.
+      The equation <m>\cos x = x</m> has one real solution,
+      but we can't find it analytically.
+      As shown in <xref ref="fig_20_01_intersection">Figure</xref>,
+      we can find an approximate solution graphically by plotting <m>\cos x</m> and <m>x</m> and observing the <m>x</m>-value of the intersection.
+      We can similarly use graphical tools to understand the qualitative behavior of solutions to a first order-differential equation.
+    </p>
+
+    <figure xml:id="fig_20_01_intersection">
+      <caption>Graphically finding an approximate solution to <m>\cos x = x</m>.</caption>
+      <img src="figures/fig20_01_intersection"/>
+    </figure>
+    <p>
+      Consider the first-order differential equation
+      <me>
+        \yp = f(x,y)
+      </me>.
+    </p>
+    <p>
+      The function <m>f</m> could be any function of the two variables <m>x</m> and <m>y</m>.
+      Written in this way,
+      we can think of the function <m>f</m> as providing a formula to find the slope of a solution at a given point in the <m>xy</m>-plane.
+      In other words,
+      suppose a solution to the differential equation passes through the point <m>(x_0,y_0)</m>.
+      At the point <m>(x_0,y_0)</m>,
+      the slope of the solution curve will be <m>f(x_0,y_0)</m>.
+      Since this calculation of the slope is possible at any point <m>(x,y)</m> where the function <m>f(x,y)</m> is defined,
+      we can produce a plot called a <em>slope field</em>
+      (or direction field)
+      that shows the slope of a solution at any point in the <m>xy</m>-plane where the solution is defined.
+      Further, this process can be done purely by working with the differential equation itself.
+      In other words,
+      we can draw a slope field and use it to determine the qualitative behavior of solutions to a differential equation without having to solve the differential equation.
+      <idx><h>differential equation</h><h>graphical solution</h></idx>
+      <idx><h>direction field</h><see>slope field</see></idx>
+    </p>
+
+    <definition xml:id="def_slope_field">
+      <title>Slope Field</title>
+      <statement>
+        <p>
+          A <term>slope field</term>
+          for a first-order differential equation
+          <m>\yp = f(x,y)</m> is a plot in the <m>xy</m>-plane made up of short line segments or arrows.
+          At each point <m>(x_0,y_0)</m> where <m>f(x,y)</m> is defined,
+          the slope of the line segment is given by <m>f(x_0,y_0)</m>.
+          Plots of solutions to a differential equation are tangent to the line segments in the slope field.
+            <idx><h>slope field</h></idx>
+        </p>
+      </statement>
+    </definition>
+
+    <example xml:id="ex_slope_field">
+      <title>Sketching a slope field</title>
+      <statement>
+        <p>
+          Find a slope field for the differential equation <m>\displaystyle \yp = x+y</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Because the function <m>f(x,y) = x+y</m> is defined for all points <m>(x,y)</m>,
+          every point in the <m>xy</m>-plane has an associated line segment.
+          It is not practical to draw an entire slope field by hand,
+          but many tools exist for drawing slope fields on a computer.
+          Here, we explicitly calculate a few of the line segments in the slope field.
+        </p>
+
+        <p>
+          <ul>
+            <li>
+              <p>
+                The slope of the line segment at <m>(0,0)</m> is <m>f(0,0) = 0 + 0 = 0</m>.
+              </p>
+            </li>
+            <li>
+              <p>
+                The slope of the line segment at <m>(1,1)</m> is <m>f(1,1) = 1 + 1 = 2</m>.
+              </p>
+            </li>
+            <li>
+              <p>
+                The slope of the line segment at <m>(1,-1)</m> is <m>f(1,-1) = 1 - 1 = 0</m>.
+              </p>
+            </li>
+            <li>
+              <p>
+                The slope of the line segment at <m>(-2,3)</m> is <m>f(-2,-1) = -2 - 1 = -3</m>.
+              </p>
+            </li>
+          </ul>
+        </p>
+
+        <p>
+          Though it is possible to continue this process to sketch a slope field,
+          we usually use a computer to make the drawing.
+          Most popular computer algebra systems can draw slope fields.
+          There are also various online tools that can make the drawings.
+          The slope field for <m>\yp = x+y</m> is shown in <xref ref="fig_20_01_slopefield1">Figure</xref>.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_01_slopefield1">
+      <caption>Slope field for <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref>.</caption>
+      <img src="figures/fig20_01_slopefield1"/>
+    </figure>
+
+    <example xml:id="ex_IVP_graphical">
+      <title>A graphical solution to an initial value problem</title>
+      <statement>
+        <p>
+          Approximate, with a sketch,
+          the solution to the initial value problem
+          <m>\displaystyle \yp = x+y</m>, with <m>y(1)=-1</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The solution to the initial value problem should be a continuous smooth curve.
+          Using the slope field,
+          we can draw of a sketch of the solution using the following two criteria:
+          <ol>
+            <li>
+              <p>
+                The solution must pass through the point <m>(1,-1)</m>.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the solution passes through a point
+                <m>(x_0,y_0)</m> it must be tangent to the line segment at <m>(x_0,y_0)</m>.
+              </p>
+            </li>
+          </ol>
+        </p>
+        <p>
+          Essentially,
+          we sketch a solution to the initial value problem by starting at the point <m>(1,-1)</m> and
+          <q>following the lines</q>
+          in either direction.
+          A sketch of the solution is shown in <xref ref="fig_20_01_slopefield1solution">Figure</xref>.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_01_slopefield1solution">
+      <caption>Solution to the initial value problem <m>\yp = x+y</m>, with <m>y(1)=-1</m> from <xref ref="ex_IVP_graphical">Example</xref></caption>
+      <img src="figures/fig20_01_slopefield1solution"/>
+    </figure>
+
+    <figure xml:id="fig_20_01_slopefield2">
+      <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref>.</caption>
+      <img src="figures/fig20_01_slopefield2"/>
+    </figure>
+
+    <example xml:id="ex_logistic_slope_field">
+      <title>Using a slope field to predict long term behavior</title>
+      <statement>
+        <p>
+          Use the slope field for the differential equation <m>\yp = y(1-y)</m>,
+          shown in <xref ref="fig_20_01_slopefield2">Figure</xref>,
+          to predict long term behavior of solutions to the equation.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          This differential equation,
+          called the <em>logistic differential equation</em>, often appears in population biology to describe the size of a population.
+          For that reason,
+          we use <m>t</m> (time) as the independent variable instead of <m>x</m>.
+          We also often restrict attention to non-negative <m>y</m>-values because negative values correspond to a negative population.
+          <idx><h>differential equation</h><h>logistic</h></idx>
+        </p>
+
+        <p>
+          Looking at the slope field in <xref ref="fig_20_01_slopefield2">Figure</xref>,
+          we can predict long term behavior for a given initial condition.
+          <ul>
+            <li>
+              <p>
+                If the initial <m>y</m>-value is negative (<m>y(0)\lt 0</m>),
+                the solution curve must pass though the point
+                <m>(0,y(0))</m> and follow the slope field.
+                We expect the solution <m>y</m> to become more and more negative as time increases.
+                Note that this result is not physically relevant when considering a population.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the initial <m>y</m>-value is greater than 0 but less than 1, we expect the solution <m>y</m> to increase and level off at <m>y=1</m>.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the initial <m>y</m>-value is greater than 1, we expect the solution <m>y</m> to decrease and level off at <m>y=1</m>.
+              </p>
+            </li>
+          </ul>
+        </p>
+
+        <p>
+          The slope field for the logistic differential equation,
+          along with representative solution curves,
+          is shown in <xref ref="fig_20_01_slopefield2solution">Figure</xref>.
+          Notice that any solution curve with positive initial value will tend towards the value <m>y=1</m>.
+          We call this the <em>carrying capacity.</em>
+          <idx><h>carrying capacity</h></idx>
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_01_slopefield2solution">
+      <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref> with a few representative solution curves.</caption>
+      <img src="figures/fig20_01_slopefield2solution"/>
+    </figure>
+  </subsection>
+
+  <subsection>
+    <title>Numerical Solutions to Differential Equations: Euler's Method</title>
+    <p>
+      While the slope field is an effective way to understand the qualitative behavior of solutions to a differential equation,
+      it is difficult to use a slope field to make quantitative predictions.
+      For example,
+      if we have the slope field for the differential equation
+      <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref>
+      along with the initial condition <m>y(0)=1</m>,
+      we can understand the qualitative behavior of the solution to the initial value problem,
+      but will struggle to predict a specific value,
+      <m>y(2)</m> for example, with any degree of confidence.
+      The most straightforward way to predict <m>y(2)</m> is to find the analytic solution to the the initial value problem and evaluate it at <m>x=2</m>.
+      Unfortunately,
+      we have already mentioned that it is impossible to find analytic solutions to many differential equations.
+      In the absence of an analytic solution,
+      a <em>numerical solution</em> can serve as an effective tool to make quantitative predictions about the solution to an initial value problem.
+    </p>
+    <p>
+      There are many techniques for computing numerical solutions to initial value problems.
+      A course in numerical analysis will discuss various techniques along with their strengths and weaknesses.
+      The simplest technique is called
+      <em>Euler's Method</em>.
+      <idx><h>differential equation</h><h>numerical solution</h></idx>
+    </p>
+
+    <aside>
+      <p>
+        Euler's Method is named for Leonhard Euler,
+        a prolific Swiss mathematician during the 1700's.
+        His last name is properly pronounced
+        <q>oil-er</q>, not
+        <q>you-ler.</q>
+      </p>
+    </aside>
+
+    <p>
+      Consider the first-order initial value problem
+      <me>
+        \yp = f(x,y), \text{ with }  y(x_0) = y_0
+      </me>.
+    </p>
+    <p>
+      Using the definition of the derivative,
+      <me>
+        \yp(x) = \lim_{h \to 0} \frac{y(x+h) - y(x)}{h}
+      </me>.
+    </p>
+    <p>
+      This notation can be confusing at first, but
+      <q><m>y(x)</m></q>
+      simply means
+      <q>the <m>y</m>-value of the solution when the <m>x</m>-value is <m>x</m></q>, and
+      <q><m>y(x+h)</m></q>
+      means
+      <q>the <m>y</m>-value of the solution when the <m>x</m>-value is <m>x+h</m></q>.
+    </p>
+    <p>
+      If we remove the limit but restrict <m>h</m> to be
+      <q>small,</q>
+      we have
+      <me>
+        \yp(x) \approx \frac{y(x+h) - y(x)}{h}
+      </me>,
+      so that
+      <me>
+        f(x,y) \approx \frac{y(x+h)-y(x)}{h}
+      </me>,
+      because <m>\yp = f(x,y)</m> according to the differential equation.
+      Rearranging terms,
+      <me>
+        y(x + h) \approx y(x) + h\,f(x,y)
+      </me>.
+    </p>
+    <p>
+      This statement says that if we know the solution (<m>y</m>-value) to the initial value problem for some given <m>x</m>-value,
+      we can find an approximation for the solution at the value <m>x+h</m> by taking our <m>y</m>-value and adding <m>h</m> times the function <m>f</m> evaluated at the <m>x</m> and <m>y</m> values.
+      Euler's method uses the initial condition of an initial value problem as the starting point,
+      and then uses the above idea to find approximate values for the solution <m>y</m> at later <m>x</m>-values.
+      The algorithm is summarized in <xref ref="idea_Euler">Key Idea</xref>.
+    </p>
+    <insight xml:id="idea_Euler">
+      <title>Euler's Method</title>
+      <p>
+        Consider the initial value problem
+        <me>
+          \yp = f(x,y) \text{ with }  y(x_0)=y_0
+        </me>.
+      </p>
+      <p>
+        Let <m>h</m> be a small positive number and <m>N</m> be an integer.
+        <ol>
+          <li>
+            <p>
+              For <m>i = 0, 1, 2, \ldots, N</m>, define
+              <me>
+                x_i = x_0 + ih
+              </me>.
+            </p>
+          </li>
+          <li>
+            <p>
+              The value <m>y_0</m> is given by the initial condition.
+              For <m>i = 0, 1, 2, \ldots, N-1</m>, define
+              <me>
+                y_{i+1} = y_i + hf(x_i,y_i)
+              </me>.
+            </p>
+          </li>
+        </ol>
+      </p>
+      <p>
+        This process yields a sequence of <m>N+1</m> points
+        <m>(x_i,y_i)</m> for <m>i= 0,1,2,\ldots,N</m>,
+        where <m>(x_i, y_i)</m> is an approximation for <m>(x_i,y(x_i))</m>.
+            <idx><h>Euler's Method</h></idx>
+      </p>
+    </insight>
+
+    <p>
+      Let's practice Euler's Method using a few concrete examples.
+    </p>
+    <example xml:id="ex_euler1">
+      <title>Using Euler's Method 1</title>
+      <statement>
+        <p>
+          Find an approximation at <m>x=2</m> for the solution to
+          <m>\yp = x + y</m> with <m>y(1)=-1</m> using Euler's Method with <m>h=0.5</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Our initial condition yields the starting values <m>x_0 = 1</m> and <m>y_0 = -1</m>.
+          With <m>h = 0.5</m>, it takes <m>N=2</m> steps to get to <m>x=2</m>.
+          Using steps 1 and 2 from the Euler's Method algorithm,
+          <md>
+            <mrow> x_0  \amp = 1      \amp    y_0  \amp = -1</mrow>
+            <mrow> x_1   \amp = x_0 + h   \amp    y_1   \amp = y_0 + hf(x_0,y_0)</mrow>
+            <mrow>\amp = 1 + 0.5     \amp     \amp = -1 + 0.5(1 - 1)</mrow>
+            <mrow>\amp = 1.5    \amp     \amp = -1</mrow>
+            <mrow> x_2  \amp = x_0 + 2h  \amp   y_2  \amp = y_1 + hf(x_1,y_1)</mrow>
+            <mrow>\amp = 1 + 2(0.5)  \amp     \amp = -1 + 0.5(1.5 -1)</mrow>
+            <mrow> \amp = 2      \amp     \amp = -0.75 </mrow>
+          </md>.
+        </p>
+        <p>
+          Using Euler's method, we find the approximate <m>y(2) \approx -0.75</m>.
+        </p>
+        <p>
+          To help visualize the Euler's method approximation, these three points
+          (connected by line segments)
+          are plotted along with the analytical solution to the initial value problem in <xref ref="fig_20_01_euler1">Figure</xref>.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_01_euler1">
+      <caption>Euler's Method approximation to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Example</xref>, along with the analytical solution to the initial value problem.</caption>
+      <img src="figures/fig20_01_euler1"/>
+    </figure>
+
+    <p>
+      This approximation doesn't appear terrific,
+      though it is better than merely guessing.
+      Let's repeat the previous example using a smaller <m>h</m>-value.
+    </p>
+
+    <example xml:id="ex_euler2">
+      <title>Using Euler's Method 2</title>
+      <statement>
+        <p>
+          Find an approximation on the interval <m>[1,2]</m> for the solution to
+          <m>\yp = x + y</m> with <m>y(1)=-1</m> using Euler's Method with <m>h=0.25</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Our initial condition yields the starting values <m>x_0 = 1</m> and <m>y_0 = -1</m>.
+          With <m>h = 0.25</m>,
+          we need <m>N=4</m> steps on the interval <m>[1,2]</m> Using steps 1 and 2 from the Euler's Method algorithm
+          (and rounding to 4 decimal points),
+          we have
+          <md>
+            <mrow> x_0  \amp = 1      \amp    y_0  \amp = -1 </mrow>
+            <mrow> x_1   \amp = 1.25    \amp   y_1   \amp = -1 + 0.25(1 - 1) </mrow>
+            <mrow> \amp       \amp     \amp = -1 </mrow>
+            <mrow> x_2   \amp = 1.5     \amp    y_2   \amp = -1 + 0.25(1.25-1) </mrow>
+            <mrow> \amp       \amp     \amp = -0.9375 </mrow>
+            <mrow> x_3  \amp = 1.75    \amp   y_3   \amp = -0.9375 + 0.25(1.5-0.9375) </mrow>
+            <mrow> \amp       \amp     \amp = -0.7969 </mrow>
+            <mrow> x_4  \amp = 2      \amp   y_4  \amp = -0.7969 + 0.25(1.75 - 0.7969) </mrow>
+            <mrow> \amp       \amp     \amp = -0.5586 </mrow>
+          </md>.
+        </p>
+
+        <p>
+          Using Euler's method, we find <m>y(2) \approx -0.5586</m>.
+        </p>
+
+        <p>
+          These five points,
+          along with the points from <xref ref="ex_euler1">Example</xref> and the analytic solution,
+          are plotted in <xref ref="fig_20_01_euler2">Figure</xref>.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_01_euler2">
+      <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Examples</xref> and <xref ref="ex_euler2"></xref>, along with the analytical solution.</caption>
+      <img src="figures/fig20_01_euler2"/>
+    </figure>
+
+    <p>
+      Using the results from <xref ref="ex_euler1">Examples</xref>
+      and <xref ref="ex_euler2"></xref>,
+      we can make a few observations about Euler's method.
+      First, the Euler approximation generally gets worse as we get farther from the initial condition.
+      This is because Euler's method involves two sources of error.
+      The first comes from the fact that we're using a positive <m>h</m>-value in the derivative approximation instead of using a limit as <m>h</m> approaches zero.
+      Essentially,
+      we're using a linear approximation to the solution <m>y</m>
+      (similar to the process described in <xref ref="sec_differentials">Section</xref> on Differentials.)
+      This error is often called the <em>local truncation error.</em>
+      The second source of error comes from the fact that every step in Euler's method uses the result of the previous step.
+      That means we're using an approximate <m>y</m>-value to approximate the next <m>y</m>-value.
+      Doing this repeatedly causes the errors to build on each other.
+      This second type of error is often called the <em>propagated</em>
+      or <em>accumulated error.</em>
+      <idx><h>accumulated error</h><h>using Euler's method</h></idx>
+      <idx><h>Euler's method</h><h>accumulated error</h></idx>
+    </p>
+    <p>
+      A second observation is that the Euler approximation is more accurate for smaller <m>h</m>-values.
+      This accuracy comes at a cost, though.
+      <xref ref="ex_euler2">Example</xref>
+      is more accurate than <xref ref="ex_euler1">Example</xref>,
+      but takes twice as many computations.
+      In general, numerical algorithms
+      (even when performed by a computer program)
+      require striking a balance between a desired level of accuracy and the amount of computational effort we are willing to undertake.
+    </p>
+    <p>
+      Let's do one final example of Euler's Method.
+    </p>
+
+    <example xml:id="ex_euler3">
+      <title>Using Euler's Method 3</title>
+      <statement>
+        <p>
+          Find an approximation for the solution to the logistic differential equation
+        </p>
+        <p>
+          <m>\yp = y(1-y)</m> with <m>y(0) = 0.25</m>,
+          for <m>0 \leq y \leq 4</m>.
+          Use <m>N = 10</m> steps.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The logistic differential equation is what is called an
+          <em>autonomous equation</em>.
+          An autonomous differential equation has no explicit dependence on the independent variable
+          (<m>t</m> in this case).
+          This has no real effect on the application of Euler's method other than the fact that the function <m>f(t,y)</m> is really just a function of <m>y</m>.
+          To take steps in the <m>y</m> variable, we use
+          <me>
+            y_{i+1} = y_i + hf(t_i,y_i) = y_i + hy_i(1-y_i)
+          </me>.
+        </p>
+        <p>
+          Using <m>N=10</m> steps requires <m>\displaystyle h = \frac{4-0}{10} = 0.4</m>.
+          Implementing Euler's Method, we have
+          <md>
+            <mrow> x_0  \amp = 0      \amp    y_0  \amp = 0.25 </mrow>
+            <mrow> x_1   \amp = 0.4    \amp   y_1   \amp = 0.25 + 0.4(0.25)(1-0.25) </mrow>
+            <mrow> \amp       \amp     \amp = 0.325 </mrow>
+            <mrow> x_2   \amp = 0.8     \amp    y_2   \amp = 0.325 + 0.4(0.325)(1-0.325) </mrow>
+            <mrow>  \amp       \amp     \amp = 0.41275 </mrow>
+            <mrow> x_3  \amp = 1.2    \amp   y_3   \amp = 0.41275 + 0.4(0.41275)(1-0.41275)</mrow>
+            <mrow>  \amp       \amp     \amp = 0.50970 </mrow>
+            <mrow>  x_4  \amp = 1.6    \amp   y_4  \amp = 0.50970 + 0.4(0.50970)(1 - 0.50970) </mrow>
+            <mrow> \amp       \amp     \amp = 0.60966 </mrow>
+            <mrow>  x_5  \amp = 2.0    \amp    y_5  \amp = 0.60966 + 0.4(0.60966)(1-0.60966)</mrow>
+            <mrow> \amp       \amp     \amp =  0.70485 </mrow>
+            <mrow> x_6   \amp = 2.4    \amp   y_6   \amp = 0.70485 + 0.4(0.70485)(1 - 0.70485) </mrow>
+            <mrow> \amp       \amp     \amp = 0.78806</mrow>
+            <mrow> x_7   \amp = 2.8     \amp    y_7   \amp = 0.78806 + 0.4(0.78806)(1-0.78806) </mrow>
+            <mrow> \amp       \amp     \amp = 0.85487 </mrow>
+            <mrow> x_8  \amp = 3.2    \amp   y_8   \amp = 0.85487 + 0.4(0.85487)(1-0.85487)</mrow>
+            <mrow>  \amp       \amp     \amp = 0.90450</mrow>
+            <mrow> x_9  \amp = 3.6    \amp   y_9  \amp = 0.90450 + 0.4(0.90450)(1 - 0.90450)</mrow>
+            <mrow> \amp       \amp     \amp = 0.93905 </mrow>
+            <mrow> x_{10}\amp = 4.0    \amp   y_{10}\amp = 0.93905 + 0.4(0.93905)(1 - 0.93905) </mrow>
+            <mrow> \amp       \amp     \amp = 0.96194 </mrow>
+          </md>.
+        </p>
+        <p>
+          These 11 points, along with the the analytic solution,
+          are plotted in <xref ref="fig_20_01_euler3">Figure</xref>.
+          Notice how well they seem to match the true solution.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_01_euler3">
+      <caption>Euler's Method approximation to <m>\yp = y(1-y)</m> with <m>y(0) = 0.25</m> from <xref ref="ex_euler3">Example</xref>, along with the analytical solution.</caption>
+      <img src="figures/fig20_01_euler3"/>
+    </figure>
+
+    <p>
+      The study of differential equations is a natural extension of the study of derivatives and integrals.
+      The equations themselves involve derivatives,
+      and methods to find analytic solutions often involve finding antiderivatives.
+      In this section,
+      we focus on graphical and numerical techniques to understand solutions to differential equations.
+      We restrict our examples to relatively simple initial value problems that permit analytic solutions to the equations,
+      but we should remember that this is only for comparison purposes.
+      In reality, many differential equations,
+      even some that appear straightforward,
+      do not have solutions we can find analytically.
+      Even so, we can use the techniques presented in this section to understand the behavior of solutions.
+      In the next two sections,
+      we explore two techniques to find analytic solutions to two different classes of differential equations.
+    </p>
+  </subsection>
+
+  <exercises>
+    <exercisegroup>
+      <introduction>
+        <p>
+          Terms and Concepts
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            In your own words, what is an initial value problem,
+            and how is it different than a differential equation?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            An initial value problems is a differential equation that is paired with one or more initial conditions.
+            A differential equation is simply the equation without the initial conditions.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            In your own words,
+            describe what it means for a function to be a solution to a differential equation.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Answers will vary.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            How can we verify that a function is a solution to a differential equation?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Substitute the proposed function into the differential equation,
+            and show the the statement is satisfied.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Describe the difference between a particular solution and a general solution.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            A particular solution is one specifica member of a family of solutions,
+            and has no arbitrary constants.
+            A general solution is a family of solutions,
+            includes all possible solutions to the differential equation,
+            and typically includes one or more arbitrary constants.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Why might we use a graphical or numerical technique to study solutions to a differential equation instead of simply solving the differential equation to find an analytic solution?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Many differential equations are impossible to solve analytically.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Describe the considerations that should be made when choosing an <m>h</m> value to use in a numerical method like Euler's Method.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            A smaller <m>h</m> value leads to a numerical solution that is closer to the true solution,
+            but decreasing the <m>h</m> value leads to more computational effort.
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          verify that the given function is a solution to the differential equation or initial value problem.
+        </p>
+      </introduction>
+
+      <exercise>
+        <statement>
+          <p>
+            <m>y = Ce^{-6x^2}</m>; <m>\yp = -12xy</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Answers will vary.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>y = x\sin x</m>;
+            <m>\yp - x\cos x= (x^2+1)\sin x - xy</m>, with <m>y(\pi) = 0</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Answers will vary.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>2x^2-y^2=C</m>; <m>y\yp-2x = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Answers will vary.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>y=xe^x</m>; <m>\yp' - 2\yp + y = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Answers will vary.
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          verify that the given function is a solution to the differential equation and find the <m>C</m> value required to make the function satisfy the initial condition.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>y = 4e^{3x}\sin x + Ce^{3x}</m>;
+            <m>\yp - 3y = 4e^{3x}\cos x</m>, with <m>y(0)=2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>C = 2</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>y(x^2+y) = C</m>; <m>2xy + (x^2+2y)\yp= 0</m>, with <m>y(1)=2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>C = 6</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          sketch a slope field for the given differential equation.
+          Let <m>x</m> and <m>y</m> range between <m>-2</m> and <m>2</m>.
+        </p>
+      </introduction>
+
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = y-x</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_11ans"/>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = \displaystyle \frac{x}{2y}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_12ans"/>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = \sin(\pi y)</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_13ans"/>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = \frac{y}{4}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_30ans"/>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          Match each slope field in <xref ref="fig_slopefield_exercise"/> with the appropriate differential equation.
+        </p>
+        <figure xml:id="fig_slopefield_exercise">
+          <sbsgroup>
+            <sidebyside widths="40%">
+              <figure>
+                <caption/>
+                <img src="figures/fig20_01_ex_14_a"/>
+              </figure>
+              <figure>
+                <caption/>
+                <img src="figures/fig20_01_ex_14_b"/>
+              </figure>
+            </sidebyside>
+            <sidebyside widths="40%">
+              <figure>
+                <caption/>
+                <img src="figures/fig20_01_ex_14_c"/>
+              </figure>
+              <figure>
+                <caption/>
+                <img src="figures/fig20_01_ex_14_d"/>
+              </figure>
+            </sidebyside>
+          </sbsgroup>
+        </figure>
+      </introduction>
+
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = xy</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            b
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = -y</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            c
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = -x</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            d
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = x(1-x)</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            a
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          sketch the slope field for the differential equation,
+          and use it to draw a sketch of the solution to the initial value problem.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = \displaystyle \frac{y}{x} - y</m>, with <m>y(0.5)=1</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_18ans"/>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = y\sin x</m>, with <m>y(0)=1</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_19ans"/>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = y^2-3y+2</m>, with <m>y(0)=2</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_20ans"/>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = -\frac{xy}{1+x^2}</m>, with <m>y(0)=1</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_01_ex_31ans"/>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          use Euler's Method to make a table of values that approximates the solution to the initial value problem on the given interval.
+          Use the specified <m>h</m> or <m>N</m> value.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = x+2y</m>
+          </p>
+          <p>
+            <m>y(0)=1</m>
+          </p>
+          <p>
+            interval: <m>[0,1]</m>
+          </p>
+          <p>
+            <m>h=0.25</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <md>
+              <mrow> x_i \amp y_i</mrow>
+              <mrow> 0.00 \amp 1.0000 </mrow>
+              <mrow>  0.25 \amp 1.5000 </mrow>
+              <mrow> 0.50 \amp 2.3125 </mrow>
+              <mrow> 0.75 \amp 3.5938</mrow>
+              <mrow> 1.00 \amp 5.5781 </mrow>
+            </md>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = xe^{-y}</m>
+          </p>
+          <p>
+            <m>y(0)=1</m>
+          </p>
+          <p>
+            interval: <m>[0,0.5]</m>
+          </p>
+          <p>
+            <m>N=5</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <md>
+              <mrow> x_i \amp y_i </mrow>
+              <mrow>  0.0 \amp 1.0000 </mrow>
+              <mrow> 0.1 \amp 1.0000 </mrow>
+              <mrow> 0.2 \amp 1.0037 </mrow>
+              <mrow> 0.3 \amp 1.0110 </mrow>
+              <mrow> 0.4 \amp 1.0219 </mrow>
+              <mrow> 0.5 \amp 1.0363 </mrow>
+            </md>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = y + \sin x</m>
+          </p>
+          <p>
+            <m>y(0)=2</m>
+          </p>
+          <p>
+            interval: <m>[0,1]</m>
+          </p>
+          <p>
+            <m>h = 0.2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <md>
+              <mrow> x_i \amp y_i </mrow>
+              <mrow> 0.0 \amp 2.0000 </mrow>
+              <mrow> 0.2 \amp 2.4000 </mrow>
+              <mrow> 0.4 \amp 2.9197 </mrow>
+              <mrow> 0.6 \amp 3.5816 </mrow>
+              <mrow> 0.8 \amp 4.4108 </mrow>
+              <mrow> 1.0 \amp 5.4364 </mrow>
+            </md>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = e^{x-y}</m>
+          </p>
+          <p>
+            <m>y(0)=0</m>
+          </p>
+          <p>
+            interval: <m>[0,2]</m>
+          </p>
+          <p>
+            <m>h = 0.5</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <md>
+              <mrow> x_i \amp y_i </mrow>
+              <mrow> 0.0 \amp 0.0000 </mrow>
+              <mrow> 0.5 \amp 0.5000 </mrow>
+              <mrow>  1.0 \amp 1.8591 </mrow>
+              <mrow> 1.5 \amp 10.5824 </mrow>
+              <mrow> 2.0 \amp 88378.1190 </mrow>
+            </md>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          use the provided solution <m>y(x)</m> and Euler's Method with the <m>h=0.2</m> and <m>h=0.1</m> to complete the following table.
+        </p>
+        <sidebyside>
+          <tabular>
+            <row bottom="minor">
+              <cell><m> x</m></cell><cell><m> 0.0</m></cell><cell> <m>0.2</m></cell><cell><m>0.4</m></cell><cell> <m>0.6</m> </cell><cell> <m>0.8</m> </cell><cell> <m>1.0</m></cell>
+            </row>
+            <row bottom="minor">
+              <cell><m> y(x)</m></cell><cell></cell><cell></cell><cell></cell><cell></cell><cell></cell><cell></cell>
+            </row>
+            <row bottom="minor">
+              <cell><m>h = 0.2</m></cell><cell></cell><cell></cell><cell></cell><cell></cell><cell></cell><cell></cell>
+            </row>
+            <row>
+              <cell><m>h = 0.1</m></cell><cell></cell><cell></cell><cell></cell><cell></cell><cell></cell><cell></cell>
+            </row>
+          </tabular>
+        </sidebyside>
+        </p>
+      </introduction>
+
+      <exercise>
+        <statement>
+          <p>
+            <m>\yp = xy^2</m>
+          </p>
+          <p>
+            <m>y(0)=1</m>
+          </p>
+          <p>
+            Solution: <m>\displaystyle y(x) = \frac{2}{1-x^2}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <md>
+              <mrow> x_i \amp y(x) \amp <m>h=0.2</m> \amp h = 0.1 </mrow>
+              <mrow> 0.0 \amp 1.0000 \amp 1.0000 \amp 1.0000 </mrow>
+              <mrow> 0.2 \amp 1.0204 \amp 1.0000 \amp 1.0100 </mrow>
+              <mrow> 0.4 \amp 1.0870 \amp 1.0400 \amp 1.0623 </mrow>
+              <mrow> 0.6 \amp 1.2195 \amp 1.1265 \amp 1.1687 </mrow>
+              <mrow> 0.8 \amp 1.4706 \amp 1.2788 \amp 1.3601 </mrow>
+              <mrow> 1.0 \amp 2.0000 \amp 1.5405 \amp 1.7129 </mrow>
+            </md>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = xe^{x^2}+\frac{1}{2}xy</m>
+          </p>
+          <p>
+            <m>\displaystyle y(0)=\frac{1}{2}</m>
+          </p>
+          <p>
+            Solution: <m>\displaystyle y(x) = \frac{1}{2}(x^2+1)e^{x^2}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <md>
+              <mrow> x_i \amp y(x) \amp h = 0.2 \amp h = 0.1 </mrow>
+              <mrow> 0.0 \amp 0.5000 \amp 0.5000 \amp 0.5000 </mrow>
+              <mrow> 0.2 \amp 0.5412 \amp 0.5000 \amp 0.5201 </mrow>
+              <mrow> 0.4 \amp 0.6806 \amp 0.5816 \amp 0.6282 </mrow>
+              <mrow> 0.6 \amp 0.9747 \amp 0.7686 \amp 0.8622 </mrow>
+              <mrow> 0.8 \amp 1.5551 \amp 1.1250 \amp 1.3132 </mrow>
+              <mrow> 1.0 \amp 2.7183 \amp 1.7885 \amp 2.1788 </mrow>
+            </md>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+  </exercises>
+</section>

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -1,0 +1,946 @@
+<section xml:id="sec_Linear">
+  <title>First Order Linear Differential Equations</title>
+  <introduction>
+    <p>
+      In the previous section,
+      we explored a specific techique to solve a specific type of differential equation called a separable differential equation.
+      In this section,
+      we develop and practice a technique to solve a type of differential equation called a
+      <em>first order linear</em> differential equation.
+    </p>
+    <p>
+      Recall than a linear algebraic equation in one variable is one that can be written <m>ax + b = 0</m>,
+      where <m>a</m> and <m>b</m> are real numbers.
+      Notice that the variable <m>x</m> appears to the first power.
+      The equations <m>\sqrt{x}+1=0</m> and <m>\sin(x)-3x = 0</m> are both nonlinear.
+      A linear differential equation is one in which the dependent variable and its derivatives appear only to the first power.
+      We focus on first order equations, which involve first
+      (but not higher order)
+      derivatives of the dependent variable.
+    </p>
+  </introduction>
+  <subsection>
+    <title>Solving First Order Linear Equations</title>
+
+    <definition xml:id="def_Linear">
+      <title>First Order Linear Differential Equation</title>
+      <statement>
+        <p>
+          A <term>first order linear differential equation</term> is a differential equation that can be written in the form
+          <me>
+            \frac{dy}{dx} + p(x)y = q(x)
+          </me>,
+          where <m>p</m> and <m>q</m> are arbitrary functions of the independent variable <m>x</m>.
+          <idx><h>differential equation</h><h>first order linear</h></idx>
+        </p>
+      </statement>
+    </definition>
+
+    <example xml:id="ex_identify_linear">
+      <title>Classifying Differential Equations</title>
+      <statement>
+        <p>
+          Classify each differential equation as first order linear,
+          separable, both, or neither.
+        </p>
+        <p>
+          <ol label="a" cols="2">
+            <li><m>\displaystyle \yp = xy</m></li>
+            <li><m>\displaystyle \yp = e^y + 3x</m></li>
+            <li><m>\displaystyle \yp - (\cos x)y = \cos x</m></li>
+            <li><m>\displaystyle y\yp -3xy = 4\ln x</m></li>
+          </ol>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          <ol label="a">
+            <li>
+              <p>Both.
+                We identify <m>p(x) = -x</m> and <m>q(x) = 0</m>.
+                The separated form of the equation is <m>\displaystyle \frac{dy}{y} = x\,dx</m>.
+              </p>
+            </li>
+            <li>
+              <p>
+                Neither.
+                The <m>e^y</m> term makes the equation nonlinear.
+                Because of the addition,
+                it is not possible to write the equation in separated form.
+              </p>
+            </li>
+            <li>
+              <p>
+                First order linear.
+                We identify <m>p(x) = -\cos x</m> and <m>q(x) = \cos x</m>.
+                The equation cannot be written in separated form.
+              </p>
+            </li>
+            <li>
+              <p>
+                Neither.
+                Notice that dividing by <m>y</m> results in the nonlinear term <m>\displaystyle \frac{4\ln x}{y}</m>.
+                It is not possible to write the equation in separated form.
+              </p>
+            </li>
+          </ol>
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      Notice that linearity depends on the dependent variable <m>y</m>,
+      not the independent variable <m>x</m>.
+      The functions <m>p(x)</m> and <m>q(x)</m> need not be linear,
+      as demonstrated in part (c) of <xref ref="ex_identify_linear">Example</xref>.
+      Neither <m>\cos x</m> nor <m>\sin x</m> are linear functions of <m>x</m>,
+      but the differential equation is still linear.
+    </p>
+
+    <p>
+      Before working out a general technique for solving first order linear differential equations,
+      we look at a specific example.
+      Consider the differential equation
+      <me>
+        \frac{d}{dx}\bigl(xy\bigr) = \sin x \cos x
+      </me>.
+    </p>
+    <p>
+      This is an easy differential equation to solve.
+      On the left,
+      the antiderivative of the derivative is simply the function <m>xy</m>.
+      Using the substitution <m>u = \sin x</m> on the right and integrating results in the implicit solution
+      <me>
+        xy = \frac{1}{2}\sin^2 x + C
+      </me>.
+    </p>
+    <p>
+      Solving for <m>y</m> yields the explicit solution
+      <me>
+        y = \frac{\sin^2 x}{2x} + \frac{C}{x}
+      </me>.
+    </p>
+    <p>
+      Though not obvious,
+      the differential equation above is actually a linear differential equation.
+      Using the product rule and implicit differentiation,
+      we can write <m>\displaystyle \frac{d}{dx}\big(xy\big) = x\frac{dy}{dx} + y</m>.
+      Our original differential equation can be written
+      <me>
+        x\frac{dy}{dx} + y = \sin x \cos x
+      </me>.
+    </p>
+    <p>
+      If we divide by <m>x</m>, we have
+      <me>
+        \frac{dy}{dx} + \frac{1}{x} y = \frac{\sin x \cos x}{x}
+      </me>,
+      which matches the form in <xref ref="def_Linear">Definition</xref>.
+      Reversing our steps would lead us back to the original form our our differential equation.
+    </p>
+    <aside>
+      <p>
+        In the examples in the previous section,
+        we performed operations on the arbitrary constant <m>C</m>,
+        but still called the result <m>C</m>.
+        The justification is that the result after the operation is
+        <em>still</em> an arbitrary contant.
+        Here, we divide <m>C</m> by <m>x</m>,
+        so the result depends explicitly on the independent variable <m>x</m>.
+        Since <m>C/x</m> is <em>not</em> contant,
+        we can't just call it <m>C</m>.
+      </p>
+    </aside>
+
+    <p>
+      As motivated by the problem we just explored,
+      the basic idea behind solving first order linear differential equations is to multiply both sides of the differential equation by a function,
+      called an <em>integrating factor</em>,
+      that makes the left hand side of the equation look like an expanded Product Rule.
+      We then condense the left hand side into the derivative of a product and integrate both sides.
+      An obvious question is,
+      <q>How do you find this integrating factor?</q>
+      <idx><h>differential equation</h><h>integrating factor</h></idx>
+    </p>
+    <p>
+      Consider the first order linear equation
+      <me>
+        \frac{dy}{dx} + p(x)y = q(x)
+      </me>.
+    </p>
+    <p>
+      Let's call the integrating factor <m>\mu(x)</m>.
+      We multiply both sides of the differential equation by <m>\mu(x)</m> to get
+      <me>
+        \mu(x) \left ( \frac{dy}{dx} + p(x)y \right ) = \mu(x)q(x)
+      </me>.
+    </p>
+    <p>
+      Our goal is to choose <m>\mu(x)</m> so that the left hand side of the differential equation looks like the result of a Product Rule.
+      The left hand side of the equation is
+      <me>
+        \mu(x) \frac{dy}{dx} + \mu(x)p(x)y
+      </me>.
+    </p>
+    <p>
+      Using the Product Rule and Implicit Differentiation,
+      <me>
+        \frac{d}{dx} \bigl( \mu(x) y \bigr) = \frac{d\mu}{dx}y + \mu(x)\frac{dy}{dx}
+      </me>.
+    </p>
+    <aside>
+      <p>
+        Though we use <m>\mu(x)</m> for our integrating factor,
+        the symbol is unimportant.
+        The notation <m>\mu(x)</m> is a common choice,
+        but other texts my use <m>\alpha(x), I(x)</m>,
+        or some other symbol to designate the integrating factor.
+      </p>
+    </aside>
+
+    <p>
+      Equating
+      <m>\frac{d}{dx} \big ( \mu(x) y \big )</m> and <m>\mu(x) \left ( \frac{dy}{dx} + p(x)y \right )</m> gives
+      <me>
+        \frac{d\mu}{dx}y + \mu(x)\frac{dy}{dx} = \mu(x) \frac{dy}{dx} + \mu(x)p(x)y
+      </me>,
+      which is equivalent to
+      <me>
+        \frac{d\mu}{dx} = \mu(x)p(x)
+      </me>.
+    </p>
+
+    <aside>
+      <p>
+        Following the steps outlined in the previous section,
+        we should technically end up with <m>\mu(x) = Ce^{\int p(x)\,dx}</m>,
+        where <m>C</m> is an arbitrary constant.
+        Because we multiply both sides of the differential equation by <m>\mu(x)</m>,
+        the arbitrary constant cancels,
+        and we omit it when finding the integrating factor.
+      </p>
+    </aside>
+
+    <p>
+      In order for the integrating factor <m>\mu(x)</m> to perform its job,
+      it must solve the differential equation above.
+      But that differential equation is separable, so we can solve it.
+      The separated form is
+      <me>
+        \frac{d\mu}{\mu} = p(x)\,dx
+      </me>.
+    </p>
+    <p>
+      Integrating,
+      <me>
+        \ln \mu = \int p(x)\,dx
+      </me>,
+      or
+      <me>
+        \mu(x) = e^{\int p(x)\,dx}
+      </me>.
+    </p>
+    <p>
+      If <m>\mu(x)</m> is chosen this way,
+      after multiplying by <m>\mu(x)</m>,
+      we can always write the differential equation in the form
+      <me>
+        \frac{d}{dx} \bigl( \mu(x)y \bigr) = \mu(x)q(x)
+      </me>.
+    </p>
+    <p>
+      Integrating and solving for <m>y</m>, the explicit solution is
+      <me>
+        y = \frac{1}{\mu(x)}\int \bigl( \mu(x)q(x) \bigr)\,dx
+      </me>.
+    </p>
+    <p>
+      Though this formula can be used to write down the solution to a first order linear equation,
+      we shy away from simply memorizing a formula.
+      The process is lost, and it's easy to forget the formula.
+      Rather, we always always follow the steps outlined in <xref ref="idea_solving_linear">Key Idea</xref>
+      when solving equations of this type.
+    </p>
+
+    <insight xml:id="idea_solving_linear">
+      <title>Solving First Order Linear Equations</title>
+      <p>
+        <ol>
+          <li>
+            <p>
+              Write the differential equation in the form
+              <me>
+                \frac{dy}{dx} + p(x)y = q(x)
+              </me>.
+            </p>
+          </li>
+          <li>
+            <p>
+              Compute the integrating factor
+              <me>
+                \mu(x) = e^{\int p(x)\,dx}
+              </me>.
+            </p>
+          </li>
+          <li>
+            <p>
+              Multiply both sides of the differential equation by <m>\mu(x)</m>,
+              and condense the left hand side to get
+              <me>
+                \frac{d}{dx}\big( \mu(x)y \big) = \mu(x)q(x)
+              </me>.
+            </p>
+          </li>
+          <li>
+            <p>
+              Integrate both sides of the differential equation with respect to <m>x</m>,
+              taking care to remember the arbitrary constant.
+            </p>
+          </li>
+          <li>
+            <p>
+              Solve for <m>y</m> to find the explicit solution to the differential equation.
+            </p>
+          </li>
+        </ol>
+      </p>
+    </insight>
+
+    <p>
+      Let's practice the process by solving the two first order linear differential equations from <xref ref="ex_identify_linear">Example</xref>.
+    </p>
+
+    <example xml:id="ex_linear1">
+      <title>Solving a First Order Linear Equation</title>
+      <statement>
+        <p>
+          Find the general solution to <m>\yp = xy</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We solve by following the steps in <xref ref="idea_solving_linear">Key Idea</xref>.
+          Unlike the process for solving separable equations,
+          we need not worry about losing constant solutions.
+          The answer we find <em>will</em>
+          be the general solution to the differential equation.
+          We first write the equation in the form
+          <me>
+            \frac{dy}{dx} - xy = 0
+          </me>.
+        </p>
+        <p>
+          By identifying <m>p(x) = -x</m>,
+          we can compute the integrating factor
+          <me>
+            \mu(x) = e^{\int -x\,dx} = e^{-\frac{1}{2}x^2}
+          </me>.
+        </p>
+        <p>
+          Multiplying both side of the differential equation by <m>\mu(x)</m>, we have
+          <me>
+            e^{-\frac{1}{2}x^2}\left( \frac{dy}{dx} - xy\right) = 0
+          </me>.
+        </p>
+        <p>
+          The left hand side of the differential equation condenses to yield
+          <me>
+            \frac{d}{dx} \left ( e^{-\frac{1}{2}x^2}y\right ) = 0
+          </me>.
+        </p>
+        <p>
+          We integrate both sides with respect to <m>x</m> to find the implicit solution
+          <me>
+            e^{-\frac{1}{2}x^2}y = C
+          </me>,
+          or the explicit solution
+          <me>
+            y  = Ce^{\frac{1}{2}x^2}
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <aside>
+      <p>
+        The step where the left hand side of the differential equation condenses to the derivative of a product can feel a bit magical.
+        The reality is that we choose <m>\mu(x)</m> so that we can get exactly this condensing behavior.
+        It's not magic, it's math!
+        If you're still skeptical,
+        try using the Product Rule and Implicit Differentiation to evaluate <m>\displaystyle \frac{d}{dx}\left (e^{-\frac{1}{2}x^2}y\right)</m>,
+        and verify that it becomes <m>e^{-\frac{1}{2}x^2}\left(\displaystyle \frac{dy}{dx} - xy\right)</m>.
+      </p>
+    </aside>
+
+    <example xml:id="ex_linear2">
+      <title>Solving a First Order Linear Equation</title>
+      <statement>
+        <p>
+          Find the general solution to <m>\yp -(\cos x)y = \cos x</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The differential equation is already in the correct form.
+          The integrating factor is given by
+          <me>
+            \mu(x) = e^{-\int\cos x\,dx} = e^{-\sin x}
+          </me>.
+        </p>
+        <p>
+          Multiplying both sides of the equation by the integrating factor and condensing,
+          <me>
+            \frac{d}{dx}\left(e^{-\sin x}y \right) = (\cos x) e^{-\sin x}
+          </me>
+        </p>
+        <p>
+          Using the substitution <m>u = -\sin x</m>,
+          we can integrate to find the implicit solution
+          <me>
+            e^{-\sin x} y = -e^{-\sin x} + C
+          </me>.
+        </p>
+        <p>
+          The explicit form of the general solution is
+          <me>
+            y = -1 + Ce^{\sin x}
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      We continue our practice by finding the particular solution to an initial value problem.
+    </p>
+
+    <example xml:id="ex_linear_ivp">
+      <title>Solving a First Order Linear Initial Value Problem</title>
+      <statement>
+        <p>
+          Solve the initial value problem <m>\displaystyle x\yp - y = x^3\ln x</m>,
+          with <m>y(1)=0</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We first divide by <m>x</m> to get
+          <me>
+            \frac{dy}{dx}-\frac{1}{x}y = x^2\ln x
+          </me>.
+        </p>
+        <p>
+          The integrating factor is given by
+          <md>
+            <mrow>\mu(x) \amp = e^{\int-\frac{1}{x}\,dx}</mrow>
+            <mrow>\amp = e^{-\ln x}</mrow>
+            <mrow>\amp = e^{\ln x^{-1}}</mrow>
+            <mrow>\amp = x^{-1}</mrow>
+          </md>.
+        </p>
+        <p>
+          Multiplying both sides of the differential equation by the integrating factor and condensing the left hand side, we have
+          <me>
+            \frac{d}{dx} \left( \frac{y}{x}\right) = x\ln x
+          </me>.
+        </p>
+        <p>
+          Using Integrating by Parts to find the antiderivative of <m>x\ln x</m>,
+          we find the implicit solution
+          <me>
+            \frac{y}{x} = \frac{1}{2}x^2\ln x - \frac{1}{4}x^2 + C
+          </me>.
+        </p>
+        <p>
+          Solving for <m>y</m>, the explicit solution is
+          <me>
+            y = \frac{1}{2}x^3\ln x - \frac{1}{4}x^3 + Cx
+          </me>.
+        </p>
+        <p>
+          The initial condition <m>y(1) = 0</m> yields <m>C = 1/4</m>.
+          The solution to the initial value problem is
+          <me>
+            y = \frac{1}{2}x^3\ln x - \frac{1}{4}x^3 + \frac{1}{4}x
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      Differential equations are a valuable tool for exploring various physical problems.
+      This process of using equations to describe real world situations is called mathematical modeling,
+      and is the topic of the next section.
+      The last two examples in this section begin our discussion of mathematical modeling.
+    </p>
+
+    <example xml:id="ex_falling_object">
+      <title>A Falling Object Without Air Resistance</title>
+      <statement>
+        <p>
+          Suppose an object with mass <m>m</m> is dropped from an airplane.
+          Find and solve a differential equation describing the vertical velocity of the object assuming no air resistance.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The basic physical law at play is Newton's second law,
+          <me>
+            \text{ mass }  \times \text{ acceleration }  = \text{ the sum of the forces }
+          </me>.
+        </p>
+
+        <p>
+          Using the fact that acceleration is the derivative of velocity,
+          mass <times/> acceleration can be writting <m>mv'</m>.
+          In the absence of air resistance,
+          the only force of interest is the force due to gravity.
+          This force is approximately constant,
+          and is given by <m>mg</m>, where <m>g</m> is the gravitational constant.
+          The word equation above can be written as the differential equation
+          <me>
+            m\frac{dv}{dt} = mg
+          </me>.
+        </p>
+
+        <p>
+          Because <m>g</m> is constant,
+          this differential equation is simply an integration problem,
+          and we find
+          <me>
+            v = gt + C
+          </me>.
+        </p>
+
+        <p>
+          Since <m>v = C</m> with <m>t=0</m>,
+          we see that the arbitrary constant here corresponds to the initial vertical velocity of the object.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      The process of mathematical modeling does not stop simply because we have found an answer.
+      We must examine the answer to see how well it can describe real world observations.
+      In the previous example,
+      the answer may be somewhat useful for short times,
+      but intuition tells us that something is missing.
+      Our answer says that a falling object's velocity will increase linearly as a function of time,
+      but we know that a falling object does not speed up indefinitely.
+      In order to more fully describe real world behavior,
+      our mathematical model must be revised.
+    </p>
+
+    <example xml:id="ex_falling_object1">
+      <title>A Falling Object with Air Resistance</title>
+      <statement>
+        <p>
+          Suppose an object with mass <m>m</m> is dropped from an airplane.
+          Find and solve a differential equation describing the vertical velocity of the object,
+          taking air resistance into account.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We still begin with Newon's second law,
+          but now we assume that the forces in the object come both from gravity and from air resistance.
+          The gravitational force is still given by <m>mg</m>.
+          For air resistance,
+          we assume the force is related to the velocity of the object.
+          A simple way to describe this assumption might be <m>kv^{p}</m>,
+          where <m>k</m> is a proportionality constant and <m>p</m> is a positive real number.
+          The value <m>k</m> depends on various factors such as the density of the object,
+          surface area of the object, and density of the air.
+          The value <m>p</m> affects how changes in the velocity affect the force.
+          Taken together,
+          a function of the form <m>kv^{p}</m> is often called a <em>power law</em>.
+          The differential equation for the velocity is given by
+          <me>
+            m\frac{dv}{dt} = mg - kv^{p}
+          </me>.
+        </p>
+
+        <p>
+          (Notice that the force from air resistance opposes motion,
+          and points in the opposite direction as the force from gravity.) This differential equation is separable,
+          and can be written in the separated form
+          <me>
+            \frac{m}{mg - kv^{p}}\,dv = dt
+          </me>.
+        </p>
+
+        <p>
+          For arbitrary positive <m>p</m>,
+          the integration is difficult,
+          making this problem hard to solve analytically.
+          In the case that <m>p=1</m>, the differential equation becomes linear,
+          and is easy to solve either using either separation of variables or integrating factor techniques.
+          We assume <m>p=1</m>,
+          and proceed with an integrating factor so we can continue practicing the process.
+          Writing
+          <me>
+            \frac{dv}{dt} + \frac{k}{m}v = g
+          </me>,
+          we identify the integrating factor
+          <me>
+            \mu(t) = e^{\int \frac{k}{m}\,dt} = e^{\frac{k}{m}t}
+          </me>.
+        </p>
+
+        <p>
+          Then
+          <me>
+            \frac{d}{dt}\left(e^{\frac{k}{m}t}v \right) = ge^{\frac{k}{m}t}
+          </me>,
+          so
+          <me>
+            e^{\frac{k}{m}t}v = \frac{mg}{k}e^{\frac{k}{m}t} + C
+          </me>,
+          or
+          <me>
+            v = \frac{mg}{k}+ Ce^{-\frac{k}{m}t}
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <figure xml:id="fig_20_03_falling_object">
+      <caption>The velocity functions from <xref ref="ex_falling_object">Examples</xref> (dashed) and <xref ref="ex_falling_object1"></xref> (solid) under the assumption that <m>v(0)=0</m>, with <m>g=9.8, m=1</m>, and <m>k=1</m>.</caption>
+      <img src="figures/fig20_03_falling_object"/>
+    </figure>
+
+    <p>
+      In the solution above, the exponential term decays as time increases,
+      causing the velocity to approach the constant value <m>mg/k</m> in the limit as <m>t</m> approaches infinity.
+      This value is called the <em>terminal velocity</em>.
+      If we assume a zero initial velocity
+      (the object is dropped, not thrown from the plane),
+      the velocities from <xref ref="ex_falling_object">Examples</xref>
+      and <xref ref="ex_falling_object1"></xref>
+      are given by <m>v = gt</m> and <m>v = \displaystyle \frac{mg}{k}\left (1 - e^{-\frac{k}{m}t}\right )</m>,
+      respectively.
+      These two functions are shown in <xref ref="fig_20_03_falling_object">Figure</xref>,
+      with <m>g = 9.8, m=1</m>, and <m>k=1</m>.
+      Notice that the two curves agree well for short times,
+      but have dramatically different behaviors as <m>t</m> increases.
+      Part of the art in mathematical modeling is deciding on the level of detail required to answer the question of interest.
+      If we are only interested in the initial behavior of the falling object,
+      the simple model in <xref ref="ex_falling_object">Example</xref> may be sufficient.
+      If we are interested in the longer term behavior of the object,
+      the simple model is not sufficient,
+      and we should consider a more complicated model.
+    </p>
+  </subsection>
+
+  <exercises>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises, Find the general solution to the first order linear differential equation.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = 2y - 3</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{3}{2} + Ce^{2x}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x^2\yp + xy = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{\ln |x| + C}{x}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x^2\yp - xy = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle -\frac{1}{2x} + Cx</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x\yp +4y = x^3-x</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{x^3}{7} - \frac{x}{5} + \frac{C}{x^4}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (\cos^2 x \sin x)\yp + (\cos^3 x)y = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \sec x + C(\csc x)</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \frac{\yp}{x} = 1-2y</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{1}{2} + Ce^{-x^2}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x^3\yp-3x^3y=x^4e^{2x}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle Ce^{3x}-(x+1)e^{2x}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp + y = 5\sin(2x)</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = sin(2x) - 2\cos(2x) + Ce^{-x}</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises, Find the particular solution to the initial value problem.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = y + 2xe^x</m>, <m>y(0) = 2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = (x^2+2)e^x</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x\yp + 2y = x^2 - x + 1</m>, <m>y(1) = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{1}{4}x^2-\frac{1}{3}x+\frac{1}{2}+\frac{7}{12x^2}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x\yp + (x+2)y = x</m>, <m>y(1) = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle 1 - \frac{2}{x} + \frac{2-e^{1-x}}{x^2}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp + 2y = 0</m>, <m>y(0) = 3</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle 3e^{-2x}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (x+1)\yp + (x+2)y = 2xe^{-x}</m>, <m>y(0) = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{x^2+1}{x+1}e^{-x}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (\cos x)\yp + (\sin x)y = 1</m>, <m>y(0) = -3</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \sin x - 3\cos x</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (x^2-1)\yp + 2y = (x+1)^2</m>, <m>y(0) = 2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle \frac{(x-2)(x+1)}{x-1}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x\yp-2y = \frac{x^3}{1+x^2}</m>, <m>y(1) = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle x^2\left (\arctan x - \frac{\pi}{4}\right )</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          classify the differential equation as separable,
+          first order linear, or both,
+          and solve the initial value problem using an appropriate method.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = y + yx^2</m>, <m>y(0) = -5</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Both; <m>\displaystyle y = -5e^{x + \frac{1}{3}x^3}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle xe^y \yp = x^2\sin x</m>, <m>y(0) = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            separable; <m>\displaystyle e^y = \sin x - x\cos x + 1</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (x-1)\yp+y = x^2-1</m>, <m>y(0) = 2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            linear; <m>\displaystyle y = \frac{x^3-3x-6}{3(x-1)}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = y^2+y-2</m>, <m>y(0) = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            separable; <m>\displaystyle y = 1</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises, draw a slope field for the differential equation.
+          Use the slope field to predict the behavior of the solution to the initial value problem for large <m>x</m> values.
+          Solve the initial value problem,
+          and verify your prediction.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = x-y</m>, <m>y(0) = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_03_ex_21ans"/>
+          </p>
+          <p>
+            The solution will increase and begin to follow the line <m>y=x-1</m>.
+          </p>
+          <p>
+            <m>y = x-1 + e^{-x}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (X+1)\yp + y = \frac{1}{x+1}</m>, <m>y(0) = 2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <img src="figures/fig20_03_ex_22ans"/>
+          </p>
+          <p>
+            The solution will decrease and approach <m>y=0</m>.
+          </p>
+          <p>
+            <m>\displaystyle y = \frac{2 + \ln(x+1)}{x+1}</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+  </exercises>
+</section>

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -605,7 +605,28 @@
 
     <figure xml:id="fig_20_03_falling_object">
       <caption>The velocity functions from <xref ref="ex_falling_object">Examples</xref> (dashed) and <xref ref="ex_falling_object1"></xref> (solid) under the assumption that <m>v(0)=0</m>, with <m>g=9.8, m=1</m>, and <m>k=1</m>.</caption>
-      <img src="figures/fig20_03_falling_object"/>
+      <image xml:id="img_falling_object" width="47%">
+        <description></description>
+        <latex-image>
+          \begin{tikzpicture}
+
+          \begin{axis}[
+            xtick={0,2,...,10},
+            ymin=-.1,ymax=10.5,
+            xmin=-.1,xmax=10.5
+          ]
+
+          \addplot [firstcurvestyle,-,domain = 0:10, samples=50] {9.8-9.8*exp(-x)};
+          \addplot [secondcurvestyle,domain = 0:10, samples=50] {9.8*x};
+
+          \end{axis}
+
+          \node [right] at (myplot.right of origin) {\scriptsize $t$};
+          \node [above] at (myplot.above origin) {\scriptsize $v$};
+            
+          \end{tikzpicture}
+        </latex-image>
+      </image>
     </figure>
 
     <p>
@@ -658,7 +679,7 @@
         </statement>
         <answer>
           <p>
-            <m>y = \displaystyle \frac{\ln |x| + C}{x}</m>
+            <m>y = \displaystyle \frac{\ln \abs{x} + C}{x}</m>
           </p>
         </answer>
       </exercise>
@@ -912,9 +933,30 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_03_ex_21ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_03_ex_21ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  y domain = -.15:4,
+                  domain = -.15:4,
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(x - y)^2))}, v = {(x-y)/(sqrt(1+(x - y)^2))},scale arrows=.2},samples=15]{0};
+                \addplot [firstcurvestyle,-,domain=0:4.1,samples=50] {x-1+exp(-x)};
+
+                \end{axis}
+
+                \node [right] at (myplot.right of origin) {\scriptsize $x$};
+                \node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
           <p>
             The solution will increase and begin to follow the line <m>y=x-1</m>.
           </p>
@@ -930,9 +972,30 @@
           </p>
         </statement>
         <answer>
-          <p>
-            <img src="figures/fig20_03_ex_22ans"/>
-          </p>
+          <sidebyside width="47%">
+            <image xml:id="img_20_03_ex_22ans">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+
+                \begin{axis}[
+                  view={0}{90},
+                  y domain = -.15:3,
+                  domain = -.15:4,
+                ]
+
+                \addplot3 [secondcolor,quiver = {u = {1/(sqrt(1+(-y/(x+1)+1/(x+1)^2)^2))}, v = {(-y/(x+1)+1/(x+1)^2)/(sqrt(1+(-y/(x+1)+1/(x+1)^2)^2))},scale arrows=.2},samples=15]{0};
+                \addplot [firstcurvestyle,-,domain=0:4.15,samples=50] {(2+ln(x+1))/(x+1)};
+
+                \end{axis}
+                
+                \node [right] at (myplot.right of origin) {\scriptsize $x$};
+                \node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
           <p>
             The solution will decrease and approach <m>y=0</m>.
           </p>

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -1,0 +1,919 @@
+<section xml:id="sec_Modeling">
+  <title>Modeling with Differential Equations</title>
+  <introduction>
+    <p>
+      In the first three sections of this chapter,
+      we focused on the basic ideas behind differential equations and the mechanics of solving certain types of differential equations.
+      We have only hinted at their practical use.
+      In this section,
+      we use differential equations for mathematical modeling,
+      the process of using equations to describe real world processes.
+      We explore a few different mathematical models with the goal of gaining an introduction to this large field of applied mathematics.
+      <idx><h>differential equation</h><h>modeling</h></idx>
+    </p>
+  </introduction>
+  <subsection xml:id="fig_20_translation">
+    <title>Models Involving Proportional Change</title>
+    <p>
+      Some of the simplest differential equation models involve one quantity that changes at a rate proportional to another quantity.
+      In the introduction to this chapter,
+      we considered a population that grows at a rate proportional to the current population.
+      The words in this assumption can be directly translated into a differential equation as shown below.
+    </p>
+
+    <figure>
+      <caption>Translating words into a differential equation</caption>
+      <image xml:id="img_20_04_translation" width="40%">
+        <description></description>
+        <latex-image>
+          \begin{tikzpicture}
+
+          \draw  (1,1) node {$\displaystyle \frac{dp}{dt} = kp$};
+
+          \draw [firstcolor] (-1,0) node [text width=60pt,align=center] (a) {\scriptsize \centering The rate of change of the population};
+          \draw [firstcolor,-&gt;] (a) -- (.3,.7);
+
+          \draw [firstcolor] (2,.25) node [text width=60pt,align=center] (b) {\scriptsize \centering the population.};
+          \draw [firstcolor,-&gt;] (b) -- (1.6,.8);
+
+          \draw [firstcolor] (.5,2) node [text width=32pt,align=center] (c) {\scriptsize \centering is};
+          \draw [firstcolor,-&gt;] (c) -- (1,1.2);
+
+          \draw [firstcolor] (2,2) node [text width=60pt,align=center] (d) {\scriptsize \centering proportional to};
+          \draw [firstcolor,-&gt;] (d) -- (1.4,1.2);
+
+          \end{tikzpicture}
+        </latex-image>
+      </image>
+    </figure>
+
+    <p>
+      There are some key ideas that can be helpful when translating words into a differential equation.
+      Any time we see something about rates or changes,
+      we should think about derivatives.
+      The word
+      <q>is</q>
+      usually corresponds to an equal sign in the equation.
+      The words
+      <q>proportional to</q>
+      mean we have a constant multiplied by something.
+    </p>
+    <p>
+      The differential equation in <xref ref="fig_20_translation">Figure</xref>
+      is easily solved using separation of variables.
+      We find
+      <me>
+        p = Ce^{kt}
+      </me>.
+    </p>
+    <p>
+      Notice that we need values for both <m>C</m> and <m>k</m> before we can use this formula to predict population size.
+      We require information about the population at two different times in order to fully determine the population model.
+    </p>
+    <example xml:id="ex_ecoli">
+      <title>Bacterial Growth</title>
+      <statement>
+        <p>
+          Suppose a population of <em>e-coli</em>
+          bacteria grows at a rate proportional to the current population.
+          If an initial popluation of 200 bacteria has grown to 1600 three hours later,
+          find a function for the size of the population at time <m>t</m>,
+          and use it to predict when the population size will reach 10,000.
+          <idx><h>bacterial growth</h></idx>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We already know that the population at time <m>t</m> is given by
+          <m>p = Ce^{kt}</m> for some <m>C</m> and <m>k</m>.
+          The information about the initial size of the population means that <m>p(0)=200</m>.
+          Thus <m>C=200</m>.
+          Our knowledge of the population size after three hours allows us to solve for <m>k</m> via the equation
+          <me>
+            1600 = 200e^{3k}
+          </me>.
+        </p>
+        <p>
+          Solving this exponential equation yields <m>k =\ln(8)/3 \approx 0.6931</m>.
+          The popluation at time <m>t</m> is given by
+          <me>
+            p = 200 e^{(\ln(8)/3)t}
+          </me>.
+        </p>
+        <p>
+          Solving
+          <me>
+            10000 = 200e^{(\ln(8)/3)t}
+          </me>
+          yields <m>t =(3\ln 50)/\ln 8 \approx 5.644</m>.
+          The population is predicted to reach 10,000 bacteria in slightly more than five and a half hours.
+        </p>
+      </solution>
+    </example>
+    <p>
+      Another example of porportional change is
+      <em>Newton's Law of Cooling.</em>
+      The laws of thermodynamics state that heat flows from areas of higher temperature to areas of lower temperature.
+      A simple example is a hot object that cools down when placed in a cool room.
+      Newton's Law of Cooling is the simple assumption that the temperature of the object changes at a rate proportional to the difference between the temperature of the object and the ambient temperature of the room.
+      If <m>T</m> is the temperature of the object and <m>A</m> is the constant ambient temperature,
+      Newton's Law of Cooling can be expressed as the differential equation
+      <me>
+        \frac{dT}{dt} = k(A - T)
+      </me>.
+      <idx><h>Newton's Law of Cooling</h></idx>
+    </p>
+    <p>
+      This differential equation is both linear and separable.
+      The separated form is
+      <me>
+        \frac{1}{A-T}\,dT = k\,dt
+      </me>.
+    </p>
+    <p>
+      Then an implicit definition of the temperature is given by
+      <me>
+        -\ln\abs{A-T} = kt + C
+      </me>.
+    </p>
+    <p>
+      If we solve for <m>T</m>, we find the explicit temperature
+      <me>
+        T = A-Ce^{-kt}
+      </me>.
+    </p>
+    <p>
+      Though we didn't show the steps,
+      the explicit solution involves the typical process of renaming the constant <m>\pm e^{-C}</m> as <m>C</m>,
+      and allowing <m>C</m> to be positive, negative,
+      or zero to account for both cases of the absolution value and to catch the constant solution <m>T=A</m>.
+      Notice that the temperature of the object approaches the ambient temperature in the limit as <m>t\to\infty</m>.
+    </p>
+
+    <aside>
+      <p>
+        The equation <m>\displaystyle \frac{dT}{dt} = k(T-A)</m> is also a valid representation of Newton's Law of Cooling.
+        Intuition tells us that <m>T</m> will increase if <m>T</m> is less than <m>A</m> and decrease if <m>T</m> is greater then <m>A</m>.
+        The form we use in the text follows this intuition with a positive <m>k</m> value.
+        The form above will require that <m>k</m> take on a negative value.
+        In the end, both forms result in the same function.
+      </p>
+    </aside>
+
+    <example xml:id="ex_coffee">
+      <title>Hot Coffee</title>
+      <statement>
+        <p>
+          A freshly brewed cup of coffee is set on the counter and has a temperature of 200<m>^\circ</m> Fahrenheit.
+          After 3 minutes, it has cooled to 190<m>^\circ</m>,
+          but is still too hot to drink.
+          If the room is 72<m>^\circ</m> and the coffee cools according to Newton's Law of Cooling,
+          how long will the impatient coffee drinker have to wait until the coffee has cooled to 165<m>^\circ</m>?
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Since we have already solved the differential equation for Newton's Law of Cooling,
+          we can immediately use the function
+          <me>
+            T = A - Ce^{-kt}
+          </me>.
+        </p>
+        <p>
+          Since the room is 72<m>^\circ</m>, we know <m>A = 72</m>.
+          The initial temperature is 200<m>^\circ</m>,
+          which means <m>C = -128</m>.
+          At this point, we have
+          <me>
+            T = 72 + 128e^{-kt}
+          </me>
+        </p>
+        <p>
+          The information about the coffee cooling to 190<m>^\circ</m> in 3 minutes leads to the equation
+          <me>
+            190 = 72 + 128e^{-3k}
+          </me>.
+        </p>
+        <p>
+          Solving the exponential equation for <m>k</m>, we have
+          <me>
+            k = -\frac{1}{3}\ln \left(\frac{59}{64}\right) \approx 0.0271
+          </me>.
+        </p>
+        <p>
+          Finally, we finish the problem by solving the exponential equation
+          <me>
+            165 = 72 + 128e^{\frac{1}{3}\ln \left(\frac{59}{64}\right)t}
+          </me>.
+        </p>
+        <p>
+          The coffee drinker must wait <m>\displaystyle t = \frac{3 \ln \left(\frac{93}{128}\right)}{\ln \left(\frac{59}{64}\right)} \approx 11.78</m> minutes.
+        </p>
+      </solution>
+    </example>
+    <p>
+      We finish our discussion of models of proportional change by exploring three different models of disease spread through a population.
+      In all of the models,
+      we let <m>y</m> denote the proportion of the population that is sick
+      (<m>0 \leq y \leq 1</m>).
+      We assume a proportion of <m>0.05</m> is initially sick and that a proportion of <m>0.1</m> is sick 1 week later.
+    </p>
+    <example xml:id="ex_disease_exponential">
+      <title>Disease Spread 1</title>
+      <statement>
+        <p>
+          Suppose a disease spreads through a population at a rate proportional to the number of individuals who are sick.
+          If 5% of the population is sick initially and 10% of the population is sick one week later,
+          find a formula for the proportion of the popoulation that is sick at time <m>t</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The assumption here seems to have some merit because it matches our intuition that a disease should spread more rapidly when more individuals are sick.
+          The differential equation is simply
+          <me>
+            \frac{dy}{dt} = ky
+          </me>,
+          with solution
+          <me>
+            y = Ce^{kt}
+          </me>.
+        </p>
+        <p>
+          The conditions <m>y(0)=0.05</m> and <m>y(1) = 0.1</m> lead to
+          <m>C = 0.05</m> a and <m>k = \ln 2</m>, so the function is
+          <me>
+            y = 0.05e^{(\ln 2)t}
+          </me>.
+        </p>
+        <p>
+          We should point out a glaring problem with this model.
+          The variable <m>y</m> is a proportion and should take on values between 0 and 1, but the function <m>y = 0.05e^{2t}</m> grows without bound.
+          After <m>t \approx 4.32</m> weeks,
+          <m>y</m> exceeds 1, and the model ceases to make physical sense.
+        </p>
+      </solution>
+    </example>
+    <example xml:id="ex_disease_newton">
+      <title>Disease Spread 2</title>
+      <statement>
+        <p>
+          Suppose a disease spreads through a population at a rate proportional to the number of individuals who are not sick.
+          If 5% of the population is sick initially and 10% of the population is sick one week later,
+          find a formula for the proportion of the popoulation that is sick at time <m>t</m>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The intuition behind the assumption here is that a disease can only spread if there are individuals who are susceptible to the infection.
+          As fewer and fewer people are able to be infected,
+          the disease spread should slow down.
+          Since <m>y</m> is proportion of the population that is sick,
+          <m>1-y</m> is the proportion who are not sick,
+          and the differential equation is
+          <me>
+            \frac{dy}{dt} = k(1-y)
+          </me>.
+        </p>
+        <p>
+          Though the context is quite different,
+          the differential equation is identical to the differential equation for Newton's Law of Cooling,
+          with <m>A=1</m>.
+          The solution is
+          <me>
+            y = 1 - Ce^{-kt}
+          </me>.
+        </p>
+        <p>
+          The conditions <m>y(0)=0.05</m> and
+          <m>y(1) = 0.1</m> yield <m>C = 0.95</m> and
+          <m>k = -\ln\left(\frac{18}{19}\right) \approx 0.0541</m>,
+          so the final function is
+          <me>
+            y = 1-.95e^{\ln\left(\frac{18}{19}\right)t}
+          </me>.
+        </p>
+        <p>
+          Notice that this function approaches <m>y=1</m> in the limit as <m>t \to \infty</m>,
+          and does not suffer from the non-physical behavior described in <xref ref="ex_disease_exponential">Example</xref>.
+        </p>
+      </solution>
+    </example>
+    <p>
+      In <xref ref="ex_disease_exponential">Example</xref>,
+      we assumed disease spread depends on the number of infected individuals.
+      In <xref ref="ex_disease_newton">Example</xref>,
+      we assumed disease spread depends on the number of susceptible individuals who are able to become infected.
+      In reality, we would expect many diseases to require the interaction of both infected and susceptible individuals in order to spread.
+      One of the simplest ways to model this required interaction is to assume disease spread depends on the product of the proportions of infected and uninfected individuals.
+      This assumption
+      (regularly seen in the context of chemical reactions)
+      is often called the <em>law of mass action.</em>
+    </p>
+
+
+    <example xml:id="ex_disease_logistic">
+      <title>Disease Spread 3</title>
+      <statement>
+        <p>
+          Suppose a disease spreads through a population at a rate proportional to the product of the number of infected and uninfected individuals.
+          If 5% of the population is sick initially and 10% of the population is sick one week later,
+          find a formula for the proportion of the population that is sick at time <m>t</m>.
+          <idx><h>differential equation</h><h>logistic</h></idx>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The differential equation is
+          <me>
+            \frac{dy}{dt} = ky(1-y)
+          </me>.
+        </p>
+        <p>
+          This is exactly the logistic equation with <m>M = 1</m>.
+          We solved this differential equation in <xref ref="ex_logistic">Example</xref>,
+          and found
+          <me>
+            y = \frac{1}{1 + be^{-kt}}
+          </me>.
+        </p>
+        <p>
+          The conditions <m>y(0)=0.05</m> and
+          <m>y(1) = 0.1</m> yield <m>b = 19</m> and <m>k = -\ln\left(\frac{9}{19}\right) \approx 0.7472</m>.
+          The final function is
+          <me>
+            y = \frac{1}{1+19e^{\ln\left(\frac{9}{19}\right)t}}
+          </me>.
+        </p>
+        <p>
+          Based on the three different assumptions about the rate of disease spread explored in the last three examples,
+          we now have three different functions giving the proportion of a population that is sick at time <m>t</m>.
+          Each of the three functions meets the conditions
+          <m>y(0)=0.05</m> and <m>y(1) = 0.1</m>.
+          The three functions are shown in <xref ref="fig_disease">Figure</xref>.
+          Notice that the logistic function mimics specific parts of the functions from <xref ref="ex_disease_exponential">Examples</xref>
+          and <xref ref="ex_disease_newton"></xref>.
+          We see in <xref ref="fig_diseasea">Figure</xref> that the logistic and exponential functions are virtually indistinguishable for small <m>t</m> values.
+          When there are few infected individuals and lots of susceptible individuals,
+          the spread of a disease is largely determined by the number of sick people.
+          The logistic curve captures this feature, and is
+          <q>almost exponential</q>
+          early on.
+          In <xref ref="fig_diseaseb">Figure</xref>,
+          we see that the logistic curve leaves the exponential curve from <xref ref="ex_disease_exponential">Example</xref>
+          and approaches the curve from <xref ref="ex_disease_newton">Example</xref>.
+          This result implies that when most of the population is sick,
+          the spread of the disease is largely dependent on the number of susceptible individuals.
+          Though there are much more sophisticated mathematical models describing the spread of infections,
+          we could argue that the logistic model presented in this example is the
+          <q>best</q>
+          of the three.
+        </p>
+        <figure xml:id="fig_disease">
+          <caption>Plots of the functions from <xref ref="ex_disease_exponential">Example</xref> (dotted),
+          <xref ref="ex_disease_newton">Example</xref> (dashed),
+          and <xref ref="ex_disease_logistic">Example</xref> (solid)</caption>
+          <sidebyside width="45%">
+            <figure xml:id="fig_diseasea">
+              <caption/>
+              <image xml:id="img_disease_a">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+
+                  \begin{axis}[
+                    ytick={0,0.05,.1},
+                    yticklabels = {0,0.05,0.1},
+                    ymin=-.01,ymax=.11,
+                    xmin=-.1,xmax=1.25
+                  ]
+
+                  \addplot [firstcurvestyle,-,domain = 0:10, samples=50] {1/(1+19*exp(ln(9/19)*x)};
+                  \addplot [firstcurvestyle,-,dashed,domain = 0:10, samples=50] {1-.95*exp(ln(18/19)*x)};
+                  \addplot [firstcurvestyle,-,dotted,domain = 0:2, samples=50] {.05*exp(ln(2)*x)};
+
+                  \fill[black,draw=black](axis cs:0,.05) circle (1.5pt);
+                  \fill[black,draw=black](axis cs:1,.1) circle (1.5pt);
+
+                  \end{axis}
+
+                  \node [right] at (myplot.right of origin) {\scriptsize $t$};
+                  \node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
+            </figure>
+            <figure xml:id="fig_diseaseb">
+              <caption/>
+              <image xml:id="img_disease_b">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+
+                  \begin{axis}[
+                    ymin=-.01,ymax=1.1,
+                    xmin=-.1,xmax=50.1%
+                  ]
+
+                  \addplot [firstcurvestyle,-,domain = 0:50, samples=100] {1/(1+19*exp(ln(9/19)*x)};
+                  \addplot [firstcurvestyle,-,dashed,domain = 0:50, samples=50] {1-.95*exp(ln(18/19)*x)};
+                  \addplot [firstcurvestyle,-,dotted,domain = 0:5, samples=50] {.05*exp(ln(2)*x)};
+
+                  \fill[black,draw=black](axis cs:0,.05) circle (1.5pt);
+                  \fill[black,draw=black](axis cs:1,.1) circle (1.5pt);
+
+                  \end{axis}
+
+                  \node [right] at (myplot.right of origin) {\scriptsize $t$};
+                  \node [above] at (myplot.above origin) {\scriptsize $y$};
+
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
+            </figure>
+          </sidebyside>
+        </figure>
+
+      </solution>
+    </example>
+  </subsection>
+  <subsection>
+    <title>Rate-in Rate-out Problems</title>
+    <p>
+      One of the classic ways to build a mathematical model involves tracking the way the amount of something can change.
+      We sometimes say these models are based on
+      <em>conservation laws</em>.
+      Consider a box with some amount of a specific type of material inside.
+      (Some type of chemical, for example.)
+      The amount of material of the specific type in the box can only change in four ways;
+      we can add more to the box, we can remove some from the box,
+      some of the material can change into material of a different type,
+      or some other type of material can turn into the type we're tracking.
+      In the examples that follow, we assume material doesn't change type,
+      so we only need to keep track of material coming into the box and material leaving the box.
+      To derive a differential equation, we track rates:
+      <me>
+        \text{ rate of change of some quantity }  = \text{ rate in }  - \text{ rate out }
+      </me>.
+    </p>
+    <p>
+      Though we stick to relatively simple examples,
+      this basic idea can be used to derive some very important differential equations in mathematics and physics.
+    </p>
+    <p>
+      The examples to follow involve tracking the amount of a chemical in solution.
+      We assume liquid containing some chemical flows into a container at some rate.
+      That liquid mixes instantaneously with the liquid already in the container.
+      Then the liquid from the container flows out at some
+      (potentially different)
+      rate.
+    </p>
+
+    <aside>
+      <p>
+        The assumption about instantaneous mixing,
+        though not physically accurate,
+        leads to a differential equation we have hope of solving.
+        In reality, the amount of chemical at a specific location in the container depends both on the location and how long we have been waiting.
+        This dependence on both space and time leads to a type of differential equation called a
+        <em>partial differential equation.</em>
+        Differential equations of this type are more interesting,
+        but significantly harder to study.
+        Instantaneous mixing removes any spatial dependence from the problem,
+        and leaves us with an <em>ordinary differential equation</em>.
+      </p>
+    </aside>
+
+    <example xml:id="ex_equal_flow">
+      <title>Equal Flow Rates</title>
+      <statement>
+        <p>
+          Suppose a 10 liter tank has 5 liters of salt solution in it.
+          The initial concentration of the salt solution is 1 gram per liter.
+          A salt solution with concentration
+          <quantity><mag>3</mag><unit base="gram"/><per base="liter"/></quantity> flows into the tank at a rate of
+          <quantity><mag>2</mag><unit base="liter"/><per base="minute"/></quantity>.
+          Suppose the salt solution mixes instantaneously with the solution already in the tank,
+          and that the mixed solution from the tank flows out at a rate of
+          <quantity><mag>2</mag><unit base="liter"/><per base="minute"/></quantity>.
+          Find a function that gives the amount of salt in the tank at time <m>t</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We use the rate in <ndash/> rate out setup described above.
+          The quantity here is the amount
+          (in grams)
+          of salt in the tank at time <m>t</m>.
+          Let <m>y</m> denote the amount of salt.
+          In words, the differential equation is given by
+          <me>
+            \frac{dy}{dt} = \text{ rate in }  - \text{ rate out }
+          </me>.
+        </p>
+        <p>
+          Thinking in terms of units can help fill in the details of the differential equation.
+          Since <m>y</m> has units of grams,
+          the left hand side of the equation has units g/min.
+          Both terms on the right hand side must have these same units.
+          Notice that the product of a concentration
+          (with units g/L)
+          and a flow rate
+          (with units L/min)
+          results in a quantity with units g/min.
+          Both terms on the right hand side of the equation will include a concentration multiplied by a flow rate.
+        </p>
+        <p>
+          For the rate in,
+          we multiply the inflow concentration by the rate that fluid is flowing into the bucket.
+          This is <m>\displaystyle \left(3 \frac{\text{g} }{\text{L} }\right)\left(2 \frac{\text{L} }{\text{ min } }\right) = 6</m> g/min.
+        </p>
+        <p>
+          The rate out is more complicated.
+          The flow rate is still <quantity><mag>2</mag><unit base="liter"/><per base="minute"/></quantity>,
+          meaning that the overall volume of the fluid in the bucket is the constant
+          <quantity><mag>5</mag><unit base="liter"/></quantity>.
+          The salt concentration in the bucket is not constant though,
+          meaning that the outflow concentration is not constant.
+          In particular, the outflow concentration is <em>not</em>
+          the constant <quantity><mag>1</mag><unit base="liter"/><per base="minute"/></quantity>.
+          This is simply the initial concentration.
+          To find the concentration at any time,
+          we need the amount of salt in the bucket at that time and the volume of liquid in the bucket at that time.
+          The volume of liquid is the constant <quantity><mag>5</mag><unit base="liter"/></quantity>,
+          and the amount of salt is given by the dependent variable <m>y</m>.
+          Thus, the outflow concentration is
+          <m>\displaystyle \frac{y}{5}</m> g/L, yielding a rate out given by
+          <me>
+            \left(\frac{y}{5}\frac{\text{ g } }{\text{ L } }\right)\left(2 \frac{\text{ L } }{\text{ min } }\right) = \frac{2y}{5}\text{ g/min }
+          </me>.
+        </p>
+        <p>
+          The differential equation we wish to solve is given by
+          <me>
+            \frac{dy}{dt} = 6 - \frac{2y}{5}
+          </me>.
+        </p>
+        <p>
+          To furnish an initial condition,
+          we must convert the initial salt concentration into an initial amount of salt.
+          This is <m>\left(1\displaystyle \frac{\text{ g } }{\text{ L } }\right)(5 \text{ L } ) = 5</m> g, so
+          <m>y(0) = 5</m> is our initial condition.
+        </p>
+        <p>
+          Our differential equation is both separable and linear.
+          We solve using separation of variables.
+          The separated form of the differential equation is
+          <me>
+            \frac{5}{30 - 2y}\,dy = dt
+          </me>.
+        </p>
+        <p>
+          Integration yields the implicit solution
+          <me>
+            -\frac{5}{2}\ln\abs{30 - 2y} = t+C
+          </me>.
+        </p>
+        <p>
+          Solving for <m>y</m>
+          (and redefining the arbitrary constant <m>C</m> as necessary)
+          yields the explicit solution
+          <me>
+            y = 15 + Ce^{-\frac{2}{5}t}
+          </me>.
+        </p>
+        <p>
+          The initial condition <m>y(0) = 5</m> means that <m>C = -10</m> so that
+          <me>
+            y = 15 - 10e^{-\frac{2}{5}t}
+          </me>
+          is the particular solution to our initial value problem.
+        </p>
+        <p>
+          This function is plotted in <xref ref="fig_equal_flow">Figure</xref>.
+          Notice that in the limit as <m>t\to\infty</m>,
+          <m>y</m> approaches <m>15</m>.
+          This corresponds to a bucket concentration of
+          <m>15/5 = 3</m> g/L. It should not be surprising that salt concentration inside the tank will move to match the inflow salt concentration.
+        </p>
+        <figure xml:id="fig_equal_flow">
+          <caption>Salt concentration at time <m>t</m>, from <xref ref="ex_equal_flow">Example</xref>.</caption>
+          <image xml:id="img_equal_flow" width="47%">
+            <description></description>
+            <latex-image>
+              \begin{tikzpicture}
+
+              \begin{axis}[
+                ymin=-.1,ymax=15.5,
+                xmin=-.1,xmax=10.3
+              ]
+
+              \addplot [firstcurvestyle,-,domain = 0:10, samples=50] {15-10*exp(-2/5*x)};
+
+              \end{axis}
+
+              \node [right] at (myplot.right of origin) {\scriptsize $t$};
+              \node [above] at (myplot.above origin) {\scriptsize $y$};
+
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
+      </solution>
+    </example>
+
+
+
+    <example xml:id="ex_unequal_flow">
+      <title>Unequal Flow Rates</title>
+      <statement>
+        <p>
+          Suppose the setup is identical to the setup in <xref ref="ex_equal_flow">Example</xref>
+          except that now liquid flows out of the bucket at a rate of 1 L/min.
+          Find a function that gives the amount of salt in the bucket at time <m>t</m>.
+          What is the salt concentration when the solution ceases to be valid?
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Because the inflow and outflow rates no longer match,
+          the volume of liquid in the bucket is not the constant 5 L. In general,
+          we can find the volume of liquid via the equation
+          <me>
+            \text{ volume }  = \text{ initial volume }  + \text{ (inflow rate - outflow rate) } t
+          </me>.
+        </p>
+        <p>
+          In this example,
+          the volume at time <m>t</m> is <m>5 + t</m> liters.
+          Because the total volume of the bucket is only 10 L, it follows that our solution will only be valid for <m>0 \leq t \leq 5</m>.
+          At that point it is no longer possible to have liquid flow into a the bucket at a rate of 2 L/min and out of the bucket at a rate of 1 L/min.
+        </p>
+        <p>
+          To update the differential equation,
+          we must modify the rate out.
+          Since the volume is <m>5 + t</m>,
+          the concentration at time <m>t</m> is given by
+          <m>\frac{y}{5+t}</m> g/L. Thus for rate out,
+          we must use <m>\left( \frac{y}{5+t}\right)(1)</m> g/min.
+          The initial value problem is
+          <me>
+            \frac{dy}{dt} = 6 - \frac{y}{5+t}, \text{ with }  y(0)=5
+          </me>.
+        </p>
+        <p>
+          Unlike <xref ref="ex_equal_flow">Example</xref>,
+          where we had equal flow rates,
+          this differential equation is no longer separable.
+          We must proceed with an integrating factor.
+          Writing the differential equation in the form
+          <me>
+            \frac{dy}{dt} + \frac{1}{5+t}y = 6
+          </me>,
+          we identify the integrating factor
+          <me>
+            \mu(t) = e^{\int \frac{1}{5+t}\,dt} = e^{\ln(5+t)} = 5+t
+          </me>.
+        </p>
+        <p>
+          Then
+          <me>
+            \frac{d}{dt}\big((5+t)y\big) = 6(5+t)
+          </me>,
+          yielding the implicit solution
+          <me>
+            (5+t)y = 30t + 3t^2 + C
+          </me>.
+        </p>
+        <p>
+          The initial condition <m>y(0) = 5</m> implies <m>C = 25</m>,
+          so the explicit solution to our initial value problem is given by
+          <me>
+            y = \frac{3t^2 + 30t + 25}{5+t}
+          </me>.
+        </p>
+        <p>
+          This solution ceases to be valid at <m>t=5</m>.
+          At that time, there are 25 g of salt in the tank.
+          The volume of liquid is 10 L, resulting in a salt concentration of <m>2.5</m> g/L.
+        </p>
+      </solution>
+    </example>
+    <p>
+      Differential equations are powerful tools that can be used to help describe the world around us.
+      Though relatively simple in concept,
+      the ideas of proportional change and matching rates can serve as building blocks in the development of more sophisticated mathematical models.
+      As we saw in this section,
+      some simple mathematical models can be solved analytically using the techniques developed in this chapter.
+      Most sophisticated mathematical models don't allow for analytic solutions.
+      Even so, there are an array of graphical and numerical techniques that can be used to analyze the model to make predictions and infer information about real world phenomena.
+    </p>
+  </subsection>
+
+  <exercises>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          use the tools in the section to answer the questions presented.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            Suppose the rate of change of <m>y</m> with respect to <m>x</m> is proportional to <m>10 - y</m>.
+            Write down and solve a differential equation for <m>y</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = 10 + Ce^{-kx}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A rumor is spreading through a middle school with 250 students.
+            Suppose the rumor spreads at a rate proportional to the number of students who haven't heard the rumor yet.
+            If 1 person starts the rumor,
+            and 75 students have heard the rumor 3 days later,
+            how many days will it take until 80% of the students in the school have heard the rumor?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            13.66 days
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A rumor is spreading through a middle school with 250 students.
+            Suppose the rumor spreads at a rate proportional to the product of number of students who have heard the rumor and the number who haven't heard the rumor.
+            If 1 person starts the rumor,
+            and 75 students have heard the rumor 3 days later,
+            how many days will it take until 80% of the students in the school have heard the rumor?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            4.43 days
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A feature of radioactive decay is that the amount of a radioactive substance decreases at a rate proportional to the current amount of the substance.
+            The <em>half life</em>
+                <idx><h>half life</h></idx>
+            of a substance is the amount of time it takes for half of a given amount of substance to decay.
+            The half life of carbon-14 is approximately 5730 years.
+            If an ancient object has a carbon-14 amount that is 20% of the original amount,
+            how old is the object?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            13,304.65 years old
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Consider a chemical reaction where molecules of type A combine with molecules of type B to form molecules of type C. Suppose one molecule of type A combines with one molecule of type B to form one molecule of type C, and that type C is produced at a rate proportional the product of the remaining number of molecules of types A and B. Let <m>x</m> denote moles of molecules of type <m>C</m>.
+            Find a function giving the number of moles of type C at time <m>t</m> if there are originally <m>a</m> moles of type A, <m>b</m> moles of type B, and zero moles of type C.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>x = \begin{cases}\displaystyle\frac{ab(1 - e^{(a-b)kt})}{b-ae^{(a-b)kt}} \amp \text{ if } a \neq b\\ \displaystyle \frac{a^2kt}{1+akt} \amp \text{ if } a = b \end{cases}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Suppose an object with a temperature of 100<m>^\circ</m> is introduced into a room with an ambient temperature of 70<m>^\circ</m>.
+            Suppose the temperature of the object changes at a rate proportional to the difference between the temperature of the object and the temperature of the room (Newton's Law of Cooling).
+            If the object has cooled to 92<m>^\circ</m> in 10 minutes,
+            how long until the object has cooled to 84<m>^\circ?</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            24.57 minutes
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Suppose an object with a temperature of 100<m>^\circ</m> is introduced into a room with an ambient temperature given by <m>60 + 20e^{-\frac{1}{4}t}</m> degrees.
+            Suppose the temperature of the object changes at a rate proportional to the difference between the temperature of the object and the temperature of the room (Newton's Law of Cooling).
+            If the object is 80<m>^\circ</m> after 20 minutes,
+            find a formula giving the temperature of the object at time <m>t</m>.
+            (Note: This problem requires a numerical technique to solve for the unknown constants.)
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\displaystyle y = 60 - 3.69858e^{-\frac{1}{4}t} + 43.69858e^{-0.0390169 t}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A tank contains 5 gallons of salt solution with concentration 0.5 g/gal.
+            Pure water flows into the tank at a rate of 1 gallon per minute.
+            Salt solution flows out of the tank at a rate of 1 gallon per minute.
+            (Assume instantaneous mixing.)
+            Find the concentration of the salt solution at 10 minutes.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            0.06767 g/gal
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Dead leaves accumulate on the ground at a rate of 4 grams per square centimeter per year.
+            The dead leaves on the ground decompose at a rate of 50% per year.
+            Find a formula giving grams per square centimeter on the ground if there are no leaves on the ground at time <m>t=0</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = 8(1-e^{-\frac{1}{2}t})</m> g/cm<m>^2</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A pond initially contains 10 million gallons of fresh water.
+            Water containing an undesirable chemical flows into the pond at a rate of 5 million gallons per year,
+            and fluid from the pond flows out at the same rate.
+            (Assume instantaneous mixing.)
+            If the concentration
+            (in grams per million gallons)
+            of the incoming chemical varies periodically according to the expression <m>2 + \sin(2t)</m>,
+            find a formula giving the amount of chemical in the pond at time <m>t</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = \displaystyle 20 - \frac{10}{17}\left (4\cos(2t)- \sin(2t)\right) - \frac{300}{17}e^{-\frac{1}{2}t}</m> g
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A large tank contains 1 gallon of a salt solution with concentration 2 g/gal.
+            A salt solution with concentration 1 g/gal flows into the tank at a rate of 4 gal/min.
+            Salt solution flows out of the tank at a rate of 3 gal/min.
+            (Assume instantaneous mixing.)
+            Find the amount of salt in the tank at 10 minutes.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            11.00075 g
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            A stream flows into a pond containing 2 million gallons of fresh water at a rate of 1 million gallons per day.
+            The stream flows out of the first pond and into a second pond containing 3 million gallons of fresh water.
+            The stream then flows out of the second pond.
+            Suppose the inflow and outflow rates are the same so that both ponds maintain their volumes.
+            A factory upstream of the first pond starts polluting the stream.
+            Directly below the factory,
+            pollutant has a concentration of 55 grams per million gallons,
+            and this concentration starts to flow into the first pond.
+            Find the concentration of pollutant in the first and second ponds at 5 days.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            pond 1: 50.4853 grams per million gallons
+          </p>
+          <p>
+            pond 2: 32.8649 grams per million gallons
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+  </exercises>
+</section>

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -1,0 +1,635 @@
+<section xml:id="sec_Separable">
+  <title>Separable Differential Equations</title>
+  <introduction>
+    <p>
+      There are specific techniques that can be used to solve specific types of differential equations.
+      This is similar to solving algebraic equations.
+      In algebra, we can use the quadratic formula to solve a quadratic equation,
+      but not a linear or cubic equation.
+      In the same way,
+      techniques that can be used for a specific type of differential equation are often ineffective for a differential equation of a different type.
+      In this section,
+      we describe and practice a technique to solve a class of differential equations called
+      <em>separable equations.</em>
+    </p>
+    <definition xml:id="def_Separable">
+      <title>Separable Differential Equation</title>
+      <statement>
+        <p>
+          A <term>separable differential equation</term> is one that can be written in the form
+          <me>
+            \displaystyle n(y) \frac{dy}{dx} = m(x)
+          </me>,
+          where <m>n</m> is a function that depends only on the dependent variable <m>y</m>,
+          and <m>m</m> is a function that depends only on the independent variable <m>x</m>.
+          <idx><h>differential equation</h><h>separable</h></idx>
+        </p>
+      </statement>
+    </definition>
+    <p>
+      Below, we show a few examples of separable differential equations,
+      along with similar looking equations that are not separable.
+    </p>
+    <sidebyside>
+      <list xml:id="list_separable_examples">
+        <title>Separable</title>
+        <ol>
+          <li><m>\displaystyle \frac{dy}{dx} = x^2y</m></li>
+          <li><m>\displaystyle y\sqrt{y^2-5} \frac{dy}{dx} - \sin x \cos x = 0</m></li>
+          <li><m>\displaystyle \frac{dy}{dx} = \frac{(x^2 + 1)e^{y}}{y}</m></li>
+        </ol>
+      </list>
+      <list xml:id="list_nonseparable_examples">
+        <title>Not Separable</title>
+        <ol>
+          <li xml:id="item-not-sep"><m>\displaystyle \frac{dy}{dx} = x^2 + y</m></li>
+          <li><m>\displaystyle y\sqrt{y^2-1} \frac{dy}{dx} - \sin x \cos y = 0</m></li>
+          <li><m>\displaystyle \frac{dy}{dx} = \frac{(xy + 1)e^{y}}{y}</m></li>
+        </ol>
+      </list>
+    </sidebyside>
+    <p>
+      Notice that a separable equation requires that the functions of the dependent and independent variables be multiplied,
+      not added
+      (like <xref ref="item-not-sep">item</xref> in <xref ref="list_nonseparable_examples">List</xref>).
+      An alternate definition of a separable differential equation states that an equation is separable if it can be written in the form
+      <me>
+        \frac{dy}{dx} = f(x)g(y)
+      </me>,
+      for some functions <m>f</m> and <m>g</m>.
+    </p>
+  </introduction>
+  <subsection>
+    <title>Separation of Variables</title>
+    <p>
+          <idx><h>separation of variables</h></idx>
+      Let's find a formal solution to the separable equation
+      <me>
+        \displaystyle n(y) \frac{dy}{dx} = m(x)
+      </me>.
+    </p>
+    <p>
+      Since the functions on the left and right hand sides of the equation are equal,
+      their antiderivatives should be equal up to an arbitrary constant of integration.
+      That is
+      <me>
+        \displaystyle \int n(y) \frac{dy}{dx}\,dx = \int m(x)\, dx + C
+      </me>.
+    </p>
+    <p>
+      Though the integral on the left may look a bit strange,
+      recall that <m>y</m> itself is a function of <m>x</m>.
+      Consider the substitution <m>u = y(x)</m>.
+      The differential is <m>du = \displaystyle \frac{dy}{dx}\,dx</m>.
+      Using this substitution, the above equation becomes
+      <me>
+        \int n(u)\,du = \int m(x)\,dx + C
+      </me>.
+    </p>
+    <p>
+      Let <m>N(u)</m> and <m>M(x)</m> be antiderivatives of <m>n(u)</m> and <m>m(x)</m>,
+      respectively.
+      Then
+      <me>
+        N(u) = M(x) + C
+      </me>.
+    </p>
+    <p>
+      Since <m>u = y(x)</m>, this is
+      <me>
+        N(y) = M(x) + C
+      </me>.
+    </p>
+    <p>
+      This relationship between <m>y</m> and <m>x</m> is an implicit form of the solution to the differential equation.
+      Sometimes (but not always) it is possible to solve for <m>y</m> to find an explicit version of the solution.
+    </p>
+    <p>
+      Though the technique outlined above is formally correct,
+      what we did essentially amounts to integrating the function <m>n</m> with respect to its variable and integrating the function
+      <m>m</m> with respect to its variable.
+      The informal way to solve a separable equation is to treat the derivative
+      <m>\displaystyle \frac{dy}{dx}</m> as if it were a fraction.
+      The separated form of the equation is
+      <me>
+        n(y)\,dy = m(x)\, dx
+      </me>.
+    </p>
+    <p>
+      To solve, we integrate the left hand side with respect to <m>y</m> and the right hand side with respect to <m>x</m> and add a constant of integration.
+      As long as we are able to find the antiderivatives,
+      we can find an implicit form for the solution.
+      Sometimes we are able to solve for <m>y</m> in the implicit solution to find an explicit form of the solution to the differential equation.
+      We practice the technique by solving the three differential equations listed in the separable column above,
+      and conclude by revisiting and finding the general solution to the logistic differential equation from <xref ref="sec_Graphical_Numerical">Section</xref>.
+    </p>
+    <example xml:id="ex_separable_DE">
+      <title>Solving a Separable Differential Equation</title>
+      <statement>
+        <p>
+          Find the general solution to the differential equation <m>\yp = x^2y</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Using the informal solution method outlined above,
+          we treat <m>\displaystyle \frac{dy}{dx}</m> as a fraction,
+          and write the separated form of the differential equation as
+          <me>
+            \frac{dy}{y} = x^2 dx
+          </me>.
+        </p>
+        <p>
+          Integrating the left hand side of the equation with respect to <m>y</m> and the right hand side of the equation with respect to <m>x</m> yields
+          <me>
+            \ln \abs{y} = \frac{1}{3}x^3 + C
+          </me>.
+        </p>
+        <p>
+          This is an implicit form of the solution to the differential equation.
+          Solving for <m>y</m> yields an explicit form for the solution.
+          Exponentiating both sides, we have
+          <me>
+            \abs{y} = e^{x^3/3 + C} = e^{x^3/3}e^C
+          </me>.
+        </p>
+
+        <aside>
+          <p>
+            The indefinite integrals <m>\int \frac{dy}{y}</m> and
+            <m>\int x^2\, dx</m> both produce arbitrary constants.
+            Since both constants are arbitrary,
+            we combine them into a single constant of integration.
+          </p>
+        </aside>
+
+        <p>
+          This solution is a bit problematic.
+          First, the absolute value makes the solution difficult to understand.
+          The second issue comes from our desire to find the
+          <em>general solution.</em>
+          Recall that a general solution includes all possible solutions to the differential equation.
+          In other words, for any given initial condition,
+          the general solution must include the solution to that specific initial value problem.
+          We can often satisfy any given initial condition by choosing an appropriate <m>C</m> value.
+          When solving separable equations, though,
+          it is possible to lose solutions that have the form <m>y = \text{ constant}</m>.
+          Notice that <m>y=0</m> solves the differential equation,
+          but it is not possible to choose a finite <m>C</m> to make our solution look like <m>y=0</m>.
+          Our solution cannot solve the initial value problem
+          <m>\displaystyle \frac{dy}{dx} = x^2y</m>, with <m>y(a) = 0</m>
+          (where <m>a</m> is any value).
+          Thus, we haven't actually found a general solution to the problem.
+          We can clean up the solution and recover the missing solution with a bit of clever thought.
+        </p>
+        <p>
+          Recall the formal definition of the absolute value:
+          <m>\abs{y} = y</m> if <m>y \geq 0</m> and <m>\abs{y} =  -y</m> if <m>y \lt  0</m>.
+          Our solution is either <m>y = e^C e^{\frac{x^3}{3}}</m> or <m>y = - e^C e^{{\frac{x^3}{3}}}</m>.
+          Further, note that <m>C</m> is constant,
+          so <m>e^C</m> is also constant.
+          If we write our solution as <m>y = Ae^{\frac{x^3}{3}}</m>,
+          and allow the constant <m>A</m> to take on either positive or negative values,
+          we incorporate both cases of the absolute value.
+          Finally, if we allow <m>A</m> to be zero,
+          we recover the missing solution discussed above.
+          The best way to express the general solution to our differential equation is
+          <me>
+            y = Ae^{\frac{x^3}{3}}
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <aside>
+      <p>
+        Missing constant solutions can't always be recovered by cleverly redefining the arbitrary constant.
+        The differential equation <m>\yp = y^2 - 1</m> is an example of this fact.
+        Both <m>y=1</m> and <m>y=-1</m> are constant solutions to this differential equation.
+        Separation of variables yields a solution where <m>y=1</m> can be attained by choosing an appropriate <m>C</m> value,
+        but <m>y=-1</m> can't.
+        The general solution is the set containing the solution produced by separation of variables <em>and</em>
+        the missing solution <m>y=-1</m>.
+        We should always be careful to look for missing constant solutions when seeking the general solution to a separable differential equation.
+      </p>
+    </aside>
+
+    <example xml:id="ex_separable_IVP">
+      <title>Solving a Separable Initial Value Problem</title>
+      <statement>
+        <p>
+          Solve the initial value problem
+          <m>\displaystyle (y\sqrt{y^2-5}) \yp - \sin x \cos x = 0</m>,
+          with <m>y(0) = -3</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We first put the differential equation in separated form
+          <me>
+            y\sqrt{y^2-5}\,dy = \sin x \cos x\, dx
+          </me>.
+        </p>
+        <p>
+          The indefinite integral <m>\displaystyle \int y\sqrt{y^2-5}\,dy</m> requires the substitution <m>u = y^2-5</m>.
+          Using this substitute yields the antiderivative <m>\displaystyle \frac{1}{3} (y^2-5)^{3/2}</m>.
+          The indefinite integral <m>\displaystyle \int \sin x \cos x\,dx</m> requires the substitution <m>u = \sin x</m>.
+          Using this substitution yields the antiderivative <m>\displaystyle \frac{1}{2} \sin^2 x</m>.
+          Thus, we have an implicit form of the solution to the differential equation given by
+          <me>
+            \frac{1}{3} (y^2-5)^{3/2} = \frac{1}{2} \sin^2 x + C
+          </me>.
+        </p>
+        <p>
+          The initial condition says that <m>y</m> should be <m>-3</m> when <m>x</m> is <m>0</m>, or
+          <me>
+            \frac{1}{3} ((-3)^2 - 5)^{3/2} = \frac{1}{2} \sin^2 0 + C
+          </me>.
+        </p>
+        <p>
+          Evaluating the line above, we find <m>C = 8/3</m>,
+          yielding the particular solution to the initial value problem
+          <me>
+            \frac{1}{3} (y^2-5)^{3/2} = \frac{1}{2} \sin^2 x + \frac{8}{3}
+          </me>.
+        </p>
+      </solution>
+    </example>
+    <example xml:id="ex_separable_DE2">
+      <title>Solving a Separable Differential Equation</title>
+      <statement>
+        <p>
+          Find the general solution to the differential equation <m>\displaystyle \frac{dy}{dx} = \frac{(x^2 + 1)e^{y}}{y}</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We start by observing that there are no constant solutions to this differential equation because there are no constant <m>y</m>
+          values that make the right hand side of the equation identically zero.
+          Thus, we need not worry about losing solutions during the separation of variables process.
+          The separated form of the equation is given by
+          <me>
+            ye^{-y}\,dy = (x^2+1)\,dx
+          </me>.
+        </p>
+        <p>
+          The antiderivative of the left hand side requires Integration by Parts.
+          Evaluating both indefinite integrals yields the implicit solution
+          <me>
+            -(y+1)e^{-y} = \frac{1}{3}x^3 + x + C
+          </me>.
+        </p>
+        <p>
+          Since we cannot solve for <m>y</m>,
+          we cannot find an explicit form of the solution.
+        </p>
+      </solution>
+    </example>
+    <example xml:id="ex_logistic">
+      <title>Solving the Logistic Differential Equation</title>
+      <statement>
+        <p>
+          Solve the logistic differential equation <m>\displaystyle \frac{dy}{dt} = ky\left( 1 - \frac{y}{M}\right)</m>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We looked at a slope field for this equation in <xref ref="sec_Graphical_Numerical">Section</xref>
+          in the specific case of <m>k = M = 1</m>.
+          Here, we use separation of variables to find an analytic solution to the more general equation.
+          Notice that the independent variable <m>t</m> does not explicitly appear in the differential equation.
+          We mentioned that an equation of this type is called <em>autonomous</em>.
+          All autonomous first order differential equations are separable.
+        </p>
+        <p>
+          We start by making the observation that both <m>y=0</m> and <m>y = M</m> are constant solutions to the differential equation.
+          We must check that these solutions are not lost during the separation of variables process.
+          The separated form of the equation is
+          <me>
+            \frac{1}{y \left(1-\displaystyle\frac{y}{M}\right)}\,dy = k\,dt
+          </me>.
+        </p>
+        <p>
+          The antiderivative of the left hand side of the equation can be found by making use of partial fractions.
+          Using the techniques discussed in <xref ref="sec_partial_fraction">Section</xref>, we write
+          <me>
+            \frac{1}{y\left(1-\frac{y}{M}\right)} = \frac{1}{y} + \frac{1}{M-y}
+          </me>.
+        </p>
+        <p>
+          Then an implicit form of the solution is given by
+          <me>
+            \ln \abs{y} - \ln \abs{M-y} = kt + C
+          </me>.
+        </p>
+        <p>
+          Combining the logarithms,
+          <me>
+            \ln \abs{\frac{y}{M-y}} = kt + C
+          </me>.
+        </p>
+        <p>
+          Similarly to <xref ref="ex_separable_DE">Example</xref>,
+          we can write
+          <me>
+            \frac{y}{M-y} = Ae^{kt}
+          </me>.
+        </p>
+        <p>
+          Letting <m>A</m> take on positive values or negative values incorporates both cases of the absolute value.
+          This is another implicit form of the solution.
+          Solving for <m>y</m> gives the explicit form
+          <me>
+            y = \frac{M}{1 + be^{-kt}}
+          </me>,
+          where <m>b</m> is an arbitrary constant.
+          Notice that <m>b=0</m> recovers the constant solution <m>y = M</m>.
+          The constant solution <m>y=0</m> cannot be produced with a finite <m>b</m> value,
+          and has been lost.
+          The general solution the logistic differential equation is the set containing <m>\displaystyle y = \frac{M}{1 + be^{-kt}}</m> and <m>y=0</m>.
+        </p>
+      </solution>
+    </example>
+
+    <aside>
+      <p>
+        Solving for <m>y</m> initially yields the explicit solution <m>\displaystyle y = \frac{AMe^{kt}}{1+Ae^{kt}}</m>.
+        Dividing numerator and denominator by <m>Ae^{kt}</m> and defining <m>b = 1/A</m>
+        yields the commonly presented form of the solution given in <xref ref="ex_logistic">Example</xref>.
+      </p>
+    </aside>
+  </subsection>
+
+  <exercises>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          decide whether the differential equation is separable or not separable.
+          If the equation is separable. write it in separated form.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = y^2 - y</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Separable.
+            <m>\displaystyle \frac{1}{y^2-y}\,dy = dx</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x\yp + x^2y = \frac{\sin x}{x-y}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Not separable.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (y + 3)\yp + (\ln x) \yp - x\sin y = (y+3)\ln x</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Not separable.
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp -x^2\cos y + y = \cos y - x^2 y</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Separable.
+            <m>\displaystyle \frac{1}{\cos y - y}\,dy = (x^2+1)\,dx</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          find the general solution to the separable differential equation.
+          Be sure to check for missing constant solutions.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp +1 - y^2 = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\left \{ \displaystyle y = \frac{1 + Ce^{2x}}{1 - Ce^{2x}}, y = -1\right \}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = y-2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = 2 + Ce^x</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x \yp = 4y</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y = Cx^4</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle y\yp = 4x</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y^2 - 4x^2 = C</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle e^xy \yp = e^{-y} + e^{-2x - y}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\displaystyle (y-1)e^y = -e^{-x} - \frac{1}{3}e^{-3x} + C</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (x^2 + 1) \yp = \frac{x}{y-1}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\displaystyle (y-1)^2 = \ln(x^2+1) + C</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = \frac{x\sqrt{1-4y^2}}{x^4 + 2x^2 + 2}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\left \{ \arcsin{2y} - \arctan(x^2+1) = C, y = \pm \displaystyle \frac{1}{2} \right \}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle (e^x + e^{-x})\yp = y^2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\left \{ \displaystyle y = \frac{1}{C - \arctan x}, y = 0 \right \}</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+    <exercisegroup>
+      <introduction>
+        <p>
+          In the following exercises,
+          find the particular solution to the separable initial value problem.
+        </p>
+      </introduction>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = \frac{\sin x}{\cos y}</m>,
+            with <m>y(0) = \displaystyle \frac{\pi}{2}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\sin y + \cos x = 2</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = \frac{x^2}{1-y^2}</m>, with <m>y(0) = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>-x^3 + 3y - y^3 = 2</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = \frac{2x}{y+x^2y}</m>, with <m>y(0) = -4</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\frac{1}{2}y^2 - \ln(1+x^2) = 8</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle x + ye^{-x}\yp = 0</m>, with <m>y(0) = -2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>y^2+2xe^x - 2e^x = 2</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = \frac{x\ln(x^2+1)}{y-1}</m>, with <m>y(0) = 2</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\displaystyle \frac{1}{2}y^2 - y = \frac{1}{2}\big ( (x^2+1)\ln(x^2+1) - (x^2 + 1)\big) + \frac{1}{2}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \sqrt{1-x^2}\,\yp - \frac{\arcsin x}{y\cos(y^2)}= 0</m>,
+            with <m>y(0) = \sqrt{\displaystyle\frac{7\pi}{6}}</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>\sin(y^2)-(\arcsin x)^2 = -\frac{1}{2}</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = (\cos^2x)(\cos^2 2y)</m>, with <m>y(0) = 0</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>2\tan 2y = 2x + \sin 2x</m>
+          </p>
+        </answer>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            <m>\displaystyle \yp = \frac{y^2\sqrt{1-y^2}}{x}</m>, with <m>y(0) = 1</m>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>x = exp \displaystyle \left ( -\frac{\sqrt{1-y^2}}{y}\right )</m>
+          </p>
+        </answer>
+      </exercise>
+    </exercisegroup>
+  </exercises>
+</section>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -181,7 +181,7 @@
     <sbsgroup>
       <sidebyside>
         <figure xml:id="fig_derivfalling">
-        <caption>The function <m>f(x)</m> and its secant line corresponding to <m>t=2</m> and <m>  t=3</m>.</caption>
+        <caption>The function <m>f(t)</m> and its secant line corresponding to <m>t=2</m> and <m>  t=3</m>.</caption>
           <image xml:id="img_derivfalling">
           <!-- START figures/fig_derivfalling.tex -->
             <description></description>
@@ -203,7 +203,7 @@
         </figure>
 
         <figure xml:id="fig_derivfalling2">
-          <caption>The function <m>f(x)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m>.</caption>
+          <caption>The function <m>f(t)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m>.</caption>
           <image xml:id="img_derivfalling2">
           <!-- START figures/fig_derivfalling2.tex -->
             <description></description>
@@ -228,7 +228,7 @@
 
       <sidebyside>
         <figure xml:id="fig_derivfalling3">
-          <caption>The function <m>f(x)</m> with the same secant line, zoomed in further.</caption>
+          <caption>The function <m>f(t)</m> with the same secant line, zoomed in further.</caption>
           <image xml:id="img_derivfalling3">
           <!-- START figures/fig_derivfalling3.tex -->
             <description></description>
@@ -251,7 +251,7 @@
         </figure>
 
         <figure xml:id="fig_derivfalling4">
-          <caption>The function <m>f(x)</m> with its tangent line at <m>t=2</m>.</caption>
+          <caption>The function <m>f(t)</m> with its tangent line at <m>t=2</m>.</caption>
           <!-- START figures/fig_derivfalling4.tex -->
           <image xml:id="img_derivfalling4">
             <description></description>


### PR DESCRIPTION
@davidfarmer did a machine conversion of the differential equations appendix for APEX for me earlier this week, and here is the result after some hand editing.

Adding new content, so no changes other than adding a line to the index file to include the content.

To do/deal with: obviously there is no WeBWorK code at this point. Figures are done, text is done, and it looked pretty good to me when I built the HTML. One schema non-compliant item: in the first section there's an exercise (or set of exercises) that asks the user to match differential equations to slope fields.

I tried to follow the way this was originally, done, with the slope fields labelled a,b,c,d and then 4 exercises following, each with one equation to be matched. But labeling was done by auto-captioning of figures, and figures aren't allowed in exercises.

On the forum, Rob suggested putting the captions into the images themselves, and dropping the figures for simply sidebyside+image. If anyone has a better idea for the markup on this, suggestions are welcome.