### PR TITLE
Update last chapter and add tangent planes

### DIFF
--- a/apex.xml
+++ b/apex.xml
@@ -54,4 +54,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     </html>
 
+    <!-- WeBWorK problem merging  -->
+    <!-- Replace path accordingly -->
+    <source webwork-problems="/home/sean/github/APEXCalculusPTX/webwork-extraction/webwork-representations.ptx"/>
+
 </publication>

--- a/ptx/bibliography.ptx
+++ b/ptx/bibliography.ptx
@@ -1,6 +1,5 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <references>
   <title>Bibliography</title>
 </references>
-

--- a/ptx/chapter_deriv_apps.ptx
+++ b/ptx/chapter_deriv_apps.ptx
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_deriv_apps">
   <title>Applications of the Derivative</title>

--- a/ptx/chapter_derivatives.ptx
+++ b/ptx/chapter_derivatives.ptx
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_derivatives">
   <title>Derivatives</title>
@@ -19,5 +19,5 @@
   <xi:include  href="sec_deriv_prodquot.ptx" />
   <xi:include  href="sec_deriv_chainrule.ptx" />
   <xi:include  href="sec_deriv_implicit.ptx" />
-  <!-- <xi:include  href="sec_deriv_inverse_function.ptx" /> -->
+  <xi:include  href="sec_deriv_inverse_function.ptx" />
 </chapter>

--- a/ptx/chapter_differential_equations.ptx
+++ b/ptx/chapter_differential_equations.ptx
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_differential_equations">
   <title>Differential Equations</title>
   <introduction>

--- a/ptx/chapter_vector_calc.ptx
+++ b/ptx/chapter_vector_calc.ptx
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_vector_calc">
   <title>Vector Analysis</title>
@@ -16,82 +16,81 @@
       and how that relates to the notation we use to describe it.
     </p>
 
-    <p>
-      <em>Integration review</em>
-    </p>
-    
-    <p>
-      Recall from <xref ref="sec_iterated_integrals">Section</xref>
-      that when <m>R</m> is a region in the <m>x</m>-<m>y</m> plane,
-      <m>\iint_R dA</m> gives the area of the region <m>R</m>.
-      The integral symbols are <q>elongated esses</q> meaning <q>sum</q>
-      and <m>dA</m> represents <q>a small amount of area.</q> Taken together,
-      <m>\iint_R dA</m> means <q>sum up, over <m>R</m>,
-      small amounts of area.</q> This sum then gives the total area of <m>R</m>.
-      We use two integral symbols since <m>R</m> is a two<ndash />dimensional region.
-    </p>
+    <paragraphs xml:id="pars-integration-review">
+      <title>Integration review</title>
+      <p>
+        Recall from <xref ref="sec_iterated_integrals">Section</xref>
+        that when <m>R</m> is a region in the <m>x</m>-<m>y</m> plane,
+        <m>\iint_R dA</m> gives the area of the region <m>R</m>.
+        The integral symbols are <q>elongated esses</q> meaning <q>sum</q>
+        and <m>dA</m> represents <q>a small amount of area.</q> Taken together,
+        <m>\iint_R dA</m> means <q>sum up, over <m>R</m>,
+        small amounts of area.</q> This sum then gives the total area of <m>R</m>.
+        We use two integral symbols since <m>R</m> is a two<ndash />dimensional region.
+      </p>
 
-    <p>
-      Now let <m>z=f(x,y)</m> represent a surface.
-      The double integral <m>\iint_R f(x,y)\, dA</m> means
-      <q>sum up, over <m>R</m>,
-      function values (heights) given by <m>f</m> times small amounts of area.</q>
-      Since <q>height <times /> area = volume,</q>
-      we are summing small amounts of volume over <m>R</m>,
-      giving the total signed volume under the surface
-      <m>z=f(x,y)</m> and above the <m>x</m>-<m>y</m> plane.
-    </p>
+      <p>
+        Now let <m>z=f(x,y)</m> represent a surface.
+        The double integral <m>\iint_R f(x,y)\, dA</m> means
+        <q>sum up, over <m>R</m>,
+        function values (heights) given by <m>f</m> times small amounts of area.</q>
+        Since <q>height <times /> area = volume,</q>
+        we are summing small amounts of volume over <m>R</m>,
+        giving the total signed volume under the surface
+        <m>z=f(x,y)</m> and above the <m>x</m>-<m>y</m> plane.
+      </p>
 
-    <p>
-      This notation does not directly inform us <em>how</em>
-      to evaluate the double integrals to find an area or a volume.
-      With additional work,
-      we recognize that a small amount of area <m>dA</m> can be measured as the area of a small rectangle,
-      with one side length a small change in <m>x</m> and the other side length a small change in <m>y</m>.
-      That is, <m>dA = dx\,dy</m> or <m>dA = dy\,dx</m>.
-      We could also compute a small amount of area by thinking in terms of polar coordinates,
-      where <m>dA = r\,dr\,d\theta</m>.
-      These understandings lead us to the iterated integrals we used in <xref ref="chapter_mult_int">Chapter</xref>.
-    </p>
+      <p>
+        This notation does not directly inform us <em>how</em>
+        to evaluate the double integrals to find an area or a volume.
+        With additional work,
+        we recognize that a small amount of area <m>dA</m> can be measured as the area of a small rectangle,
+        with one side length a small change in <m>x</m> and the other side length a small change in <m>y</m>.
+        That is, <m>dA = dx\,dy</m> or <m>dA = dy\,dx</m>.
+        We could also compute a small amount of area by thinking in terms of polar coordinates,
+        where <m>dA = r\,dr\,d\theta</m>.
+        These understandings lead us to the iterated integrals we used in <xref ref="chapter_mult_int">Chapter</xref>.
+      </p>
 
-    <p>
-      Let us back our review up farther.
-      Note that <m>\int_1^3\, dx = x\big|_1^3 = 3-1 = 2</m>.
-      We have simply measured the length of the interval <m>[1,3]</m>.
-      We could rewrite the above integral using syntax similar to the double integral syntax above:
-      <me>
-        \int_1^3\, dx = \int_Idx, \text{ where \(I\) = \([1,3]\) }
-      </me>.
-    </p>
+      <p>
+        Let us back our review up farther.
+        Note that <m>\int_1^3\, dx = x\big|_1^3 = 3-1 = 2</m>.
+        We have simply measured the length of the interval <m>[1,3]</m>.
+        We could rewrite the above integral using syntax similar to the double integral syntax above:
+        <me>
+          \int_1^3\, dx = \int_Idx, \text{ where \(I\) = \([1,3]\) }
+        </me>.
+      </p>
 
-    <p>
-      We interpret <q><m>\int_I dx</m></q> as meaning <q>sum up,
-      over the interval <m>I</m>,
-      small changes in <m>x</m>.</q>
-      A change in <m>x</m> is a length along the <m>x</m>-axis,
-      so we are adding up along <m>I</m> small lengths,
-      giving the total length of <m>I</m>.
-    </p>
+      <p>
+        We interpret <q><m>\int_I dx</m></q> as meaning <q>sum up,
+        over the interval <m>I</m>,
+        small changes in <m>x</m>.</q>
+        A change in <m>x</m> is a length along the <m>x</m>-axis,
+        so we are adding up along <m>I</m> small lengths,
+        giving the total length of <m>I</m>.
+      </p>
 
-    <p>
-      We could also write <m>\int_1^3f(x)\, dx</m> as <m>\int_I f(x)\, dx</m>,
-      interpreted as <q>sum up, over <m>I</m>,
-      heights given by <m>y = f(x)</m> times small changes in <m>x</m>.</q>
-      Since <q>height<times />length = area,</q>
-      we are summing up areas and finding the total signed area between
-      <m>y = f(x)</m> and the <m>x</m>-axis.
-    </p>
+      <p>
+        We could also write <m>\int_1^3f(x)\, dx</m> as <m>\int_I f(x)\, dx</m>,
+        interpreted as <q>sum up, over <m>I</m>,
+        heights given by <m>y = f(x)</m> times small changes in <m>x</m>.</q>
+        Since <q>height<times />length = area,</q>
+        we are summing up areas and finding the total signed area between
+        <m>y = f(x)</m> and the <m>x</m>-axis.
+      </p>
 
-    <p>
-      This method of referring to the process of integration can be very powerful.
-      It is the core of our notion of the Riemann Sum.
-      When faced with a quantity to compute,
-      if one can think of a way to approximate its value through a sum,
-      the one is well on their way to constructing an integral (or,
-      double or triple integral) that computes the desired quantity.
-      We will demonstrate this process throughout this chapter,
-      starting with the next section.
-    </p>
+      <p>
+        This method of referring to the process of integration can be very powerful.
+        It is the core of our notion of the Riemann Sum.
+        When faced with a quantity to compute,
+        if one can think of a way to approximate its value through a sum,
+        the one is well on their way to constructing an integral (or,
+        double or triple integral) that computes the desired quantity.
+        We will demonstrate this process throughout this chapter,
+        starting with the next section.
+      </p>
+    </paragraphs>
   </introduction>
 
   <xi:include  href="sec_line_int_intro.ptx" />

--- a/ptx/chapter_vectors.ptx
+++ b/ptx/chapter_vectors.ptx
@@ -30,4 +30,3 @@
   <xi:include href="sec_lines.ptx" />
   <xi:include href="sec_planes.ptx" />
 </chapter>
-

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -6,6 +6,9 @@
         <package>cancel</package>
     </latex-preamble>
 
+    <brandlogo url="http://www.apexcalculus.com" source="images/aa_website_favicon.png"/>
+    <initialism>APEX</initialism>
+
     <macros>
       \newcommand{\highlight}[1]{{\color{blue}{#1}}}
       \newcommand{\apex}{A\kern -1pt \lower -2pt\mbox{P}\kern -4pt \lower .7ex\mbox{E}\kern -1pt X}

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -109,7 +109,7 @@
     <p>
       Now repeat the first two columns after the original three:
       <me>
-        \begin{matrix \veci\amp \vecj\amp \veck\amp \veci\amp \vecj \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
+        \begin{matrix} \veci\amp \vecj\amp \veck\amp \veci\amp \vecj \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
         \end{matrix}
       </me>
       This gives three full <q>upper left to lower right</q> diagonals,
@@ -342,6 +342,8 @@
     </theorem>
 
     <aside xml:id="aside-cross-orthogonal">
+      <title>Parallel vectors and the cross product</title>
+
       <p>
         We could rewrite <xref ref="def_orthogonal">Definition</xref>
         and <xref ref="thm_cross_product">Theorem</xref> to include <m>\vec 0</m>,
@@ -350,7 +352,7 @@
         this would mean that <m>\vec 0</m> is both parallel <em>and</em>
         orthogonal to all vectors.
         Apparent paradoxes such as this are not uncommon in mathematics and can be very useful.
-        (See also <xref ref="aside-def-orthogonal">aside</xref> in <xref ref="sec_vector_intro">Section</xref>.)
+        (See also the <xref ref="aside-def-orthogonal" text="custom">aside</xref> in <xref ref="sec_vector_intro">Section</xref>.)
       </p>
     </aside>
     <p>
@@ -563,7 +565,7 @@
 
       <figure xml:id="fig_crossp_parallelogram">
         <caption>Using the cross product to find the area of a parallelogram.</caption>
-        <sidebyside widths="47% 47%">
+        <sidebyside widths="47% 47%" margins="0%">
           <figure xml:id="fig_crossp_parallelograma">
             <caption/>
             <!-- START figures/fig_crossp_parallelogram1.tex -->
@@ -653,7 +655,7 @@
 
                 <figure xml:id="fig_crossp4">
                   <caption>Sketching the parallelograms in <xref ref="ex_crossp4">Example</xref>.</caption>
-                  <sidebyside widths="47% 47%">
+                  <sidebyside widths="47% 47%" valign="bottom">
                     <figure xml:id="fig_crossp4a">
                       <caption/>
                     <!-- START figures/fig_crossp4b.tex -->
@@ -807,7 +809,7 @@
           <figure xml:id="fig_crossp5">
             <caption>Finding the area of a triangle in <xref ref="ex_crossp5">Example</xref>.</caption>
             <!-- START figures/fig_crossp5.tex -->
-            <image xml:id="img_crossp5">
+            <image xml:id="img_crossp5" width="47%">
               <description></description>
               <latex-image>
 
@@ -1336,12 +1338,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 The cross product of two vectors is a <fillin/>, not a scalar.
@@ -1356,12 +1355,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 One can visualize the direction of <m>\vec u\times\vec v</m> using the
@@ -1380,12 +1376,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Give a synonym for <q>orthogonal.</q>
@@ -1400,15 +1393,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -1421,12 +1412,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <fillin/> is a measure of the turning force applied to an object.
@@ -1465,14 +1453,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;12, -15, 3>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 3,2,-2\ra</m>,
@@ -1491,14 +1477,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;11, 1, -17>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 5, -4, 3\ra</m>,
@@ -1517,14 +1501,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;-5, -31, 27>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 4, -5, -5\ra</m>,
@@ -1543,14 +1525,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;47, -36, -44>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la -4, 7, -10\ra</m>,
@@ -1569,14 +1549,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;0, -2, 0>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 1, 0, 1\ra</m>,
@@ -1595,14 +1573,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;0, 0, 0>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 1, 5, -4\ra</m>,
@@ -1636,15 +1612,13 @@
 
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(ijk=>1);
               $cp=Vector("k");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \hat\imath</m>,
@@ -1663,15 +1637,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(ijk=>1);
               $cp=Vector("-j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \hat\imath</m>, <m>\vec v = \hat{k}</m>.
@@ -1689,15 +1661,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(ijk=>1);
               $cp=Vector("i");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \hat\jmath</m>, <m>\vec v = \hat{k}</m>.
@@ -1717,12 +1687,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Pick any vectors <m>\vec u</m>,
@@ -1739,12 +1706,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Pick any vectors <m>\vec u</m>,
@@ -1772,14 +1736,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 2</m>, <m>\vnorm{v} = 5</m>,
@@ -1791,14 +1753,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("21");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 3</m>, <m>\vnorm{v} = 7</m>,
@@ -1810,14 +1770,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 3</m>, <m>\vnorm{v} = 4</m>,
@@ -1829,14 +1787,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 2</m>, <m>\vnorm{v} = 5</m>,
@@ -1858,14 +1814,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("sqrt(14)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la 1,1,2\ra</m>,
@@ -1880,14 +1834,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("sqrt(230)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la -2,1,5\ra</m>,
@@ -1902,14 +1854,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la 1,2\ra</m>,
@@ -1924,14 +1874,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("6");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la 2,0\ra</m>,
@@ -1956,14 +1904,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("5sqrt(2)/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(0,0,0)</m>,
@@ -1978,14 +1924,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("3sqrt(30)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(5,2,-1)</m>,
@@ -2000,14 +1944,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("1");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(1,1)</m>,
@@ -2022,14 +1964,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("5/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(3,1)</m>,
@@ -2055,14 +1995,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("7");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the quadrilateral with vertices <m>(0,0)</m>,
@@ -2083,14 +2021,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("4sqrt(14)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the quadrilateral with vertices <m>(0,0,0)</m>,
@@ -2120,13 +2056,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $volume=Compute("2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the volume of the parallelepiped defined by <m>\vec u = \la 1,1,1\ra</m>,
@@ -2141,13 +2075,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $volume=Compute("15");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the volume of the parallelepiped defined by <m>\vec u = \la -1,2,1\ra</m>,
@@ -2172,16 +2104,14 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $w=Compute("&lt;1/sqrt(6),1/sqrt(6),-2/sqrt(6)>");
               $w=OneOf("$w,-$w");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 1,1,1\ra</m>,
@@ -2196,16 +2126,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $w=Compute("&lt;-2/sqrt(21),1/sqrt(21),4/sqrt(21)>");
               $w=OneOf("$w,-$w");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 1,-2,1\ra</m>,
@@ -2220,16 +2148,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $w=Compute("&lt;0,1,0>");
               $w=OneOf("$w,-$w");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 5,0,2\ra</m>,
@@ -2244,9 +2170,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
@@ -2257,7 +2181,7 @@
                       return 1 if (($student . $student == 1) and ($student . $u == 0));
                    });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 1,-2,1\ra</m>,
@@ -2281,12 +2205,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A bicycle rider applies 150lb of force, straight down,
@@ -2303,12 +2224,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A bicycle rider applies 150lb of force,
@@ -2326,12 +2244,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               To turn a stubborn bolt, 80lb of force is applied to a 10in wrench.
@@ -2347,12 +2262,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               To turn a stubborn bolt, 80lb of force is applied to a 10in wrench in a confined space,
@@ -2370,12 +2282,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Show, using the definition of the Cross Product,
@@ -2397,12 +2306,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Show, using the definition of the Cross Product,

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -135,7 +135,7 @@
   <p>
     We now generalize this concept.
     Given <m>f(x)</m> and an <m>x</m>-value <m>c</m>,
-    the tangent line is <m>\ell(x) = \fp(c)(x-c)+f(c)</m>.
+    the tangent line is <m>y=\ell(x)</m>, where <m>\ell(x) = \fp(c)(x-c)+f(c)</m>.
     Clearly, <m>f(c) = \ell(c)</m>.
     Let <m>\dx</m> be a small number,
     representing a small change in the <m>x</m>-value.
@@ -144,7 +144,21 @@
       f(c+\dx) \approx \ell(c+\dx)
     </me>,
     since the tangent line to a function approximates well the values of that function near <m>x=c</m>.
+    This tangent line approximation is used frequently enough in applications that we give it a name.
   </p>
+
+  <definition xml:id="def-linearization">
+    <statement>
+      <p>
+        The function <m>\ell(x)</m> is often referred to as the <term>linearization</term>,
+        or <term>linear approximation</term> of <m>f</m> at <m>c</m>.
+        It is the linear function that best approximates the value of <m>f(x)</m> when <m>x</m> is close to <m>c</m>.
+        <idx><h>linearization</h></idx>
+        <idx><h>approximation</h><h>tangent line</h></idx>
+        <idx><h>approximation</h><h>linear</h></idx>
+      </p>
+    </statement>
+  </definition>
 
   <p>
     As the <m>x</m>-value changes from <m>c</m> to <m>c+\dx</m>,
@@ -218,6 +232,23 @@
   <p>
     It is helpful to organize our new concepts and notations in one place.
   </p>
+
+  <aside>
+    <title>Differentials and linearization</title>
+    <p>
+      The relationship between the differential and the linearization given in
+      <xref ref="def-linearization"/> is as follows:
+      <me>
+        \ell(x) = f(c)+dy
+      </me>,
+      if we take <m>dy</m> to be evaluated at <m>x=c</m>.
+    </p>
+
+    <p>
+      It is often useful to think of <m>dy</m> is the <em>linear change</em> in <m>f</m>,
+      while <m>\dy</m> represents the true change in <m>f</m>.
+    </p>
+  </aside>
 
   <insight xml:id="idea_differential">
     <title>Differential Notation</title>

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1436,7 +1436,7 @@
 
       <introduction>
         <p>
-          In the following exercises, a function <m>z=f(x,y)</m> is given.
+          In the following exercises, a function <m>f(x,y)</m> is given.
           Find <m>\nabla f</m>.
         </p>
       </introduction>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -171,7 +171,7 @@
 
     <figure xml:id="fig_dotpangle">
       <caption>Illustrating the angle formed by two vectors with the same initial point.</caption>
-      <sidebyside widths="37% 47%" valign="bottom">
+      <sidebyside widths="47% 47%" valign="bottom">
         <figure xml:id="fig_dotpanglea">
           <caption/>
         <!-- START figures/fig_dotpangle.tex -->
@@ -875,7 +875,7 @@
       <statement>
         <p>
           <ol>
-            <li>
+            <li xml:id="ex_dotp4_part1">
               <p>
                 Let <m>\vec u= \la -2,1\ra</m> and <m>\vec v=\la 3,1\ra</m>.
                 Find <m>\proj uv</m>,
@@ -883,7 +883,7 @@
               </p>
             </li>
 
-            <li>
+            <li xml:id="ex_dotp4_part2">
               <p>
                 Let <m>\vec w = \la 2,1,3\ra</m> and <m>\vec x = \la 1,1,1\ra</m>.
                 Find <m>\proj wx</m>,
@@ -912,249 +912,34 @@
                 That is because the angle between <m>\vec u</m> and <m>\vec v</m> is obtuse (i.e., greater than <m>90^\circ</m>).
               </p>
 
-              <figure xml:id="fig_dotp4">
-                <caption>Graphing the vectors used in <xref ref="ex_dotp4">Example</xref>.</caption>
-                <sidebyside widths="33% 33% 33%">
-                  <figure xml:id="fig_dotp4a">
-                    <caption/>
-                      <image xml:id="img_dotp4a">
-                        <description></description>
-                        <latex-image>
+              <figure xml:id="fig_dotp4a">
+                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part1">Part</xref> of <xref ref="ex_dotp4">Example</xref></caption>
+                <image xml:id="img_dotp4a" width="47%">
+                  <description></description>
+                  <latex-image>
 
-                        \begin{tikzpicture}[&gt;=stealth]
+                  \begin{tikzpicture}[&gt;=stealth]
 
-                        \begin{axis}[
-                        axis on top,
-                        xtick={-3,-2,-1,1,2,3},
-                        ytick={1,2,-1,-2},
-                        ymin=-2.8,ymax=2.8,
-                        xmin=-2.9,xmax=3.9,
-                        ]
+                  \begin{axis}[
+                  axis on top,
+                  xtick={-3,-2,-1,1,2,3},
+                  ytick={1,2,-1,-2},
+                  ymin=-2.8,ymax=2.8,
+                  xmin=-2.9,xmax=3.9,
+                  ]
 
-                        \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: -2,1) node [above] {\scriptsize$\vec u$};
-                        \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: 3,1) node [above] {\scriptsize$\vec v$};
-                        \draw [thick,-&gt;,gray] (axis cs:0,0) -- (axis cs: -1.5,-.5) node [below,black] {\scriptsize$\text{proj}_{\, \vec v}\, \vec u$};
+                  \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: -2,1) node [above] {\scriptsize$\vec u$};
+                  \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: 3,1) node [above] {\scriptsize$\vec v$};
+                  \draw [thick,-&gt;,gray] (axis cs:0,0) -- (axis cs: -1.5,-.5) node [below,black] {\scriptsize$\text{proj}_{\, \vec v}\, \vec u$};
 
-                        \draw [dotted,thick] (axis cs: -2,1) -- (axis cs:-1.5,-.5);
+                  \draw [dotted,thick] (axis cs: -2,1) -- (axis cs:-1.5,-.5);
 
-                        \end{axis}
+                  \end{axis}
 
-                        \end{tikzpicture}
+                  \end{tikzpicture}
 
-                        </latex-image>
-                      </image>
-                  </figure>
-
-                  <figure xml:id="figdotp4b_3D">
-                    <caption/>
-                    <!--
-                      \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
-                    3Droll=0,
-                    3Dortho=0.0046,
-                    3Dc2c=.9 .12 .42,
-                    3Dcoo=0 50 30,
-                    3Droo=250,
-                    3Dlights=Headlamp,add3Djscript=asylabels.js]
-                      -->
-                      <image xml:id="img_dotp4b_3D">
-                        <description></description>
-                        <asymptote>
-
-                          import graph3;
-
-                          //ASY file for figdotp4b.asy in Chapter 10
-
-                          size(200,200,IgnoreAspect);
-                          //currentprojection=perspective(7,2,1);
-
-                          // The text calls for two viewpoints of this picture to show orthogonality
-                          // The two projections below give those two views
-                          //  view "b", saved as figdotp4b_3D
-                          currentprojection=orthographic(8,2,5);
-
-                          //  view "c", saved as figdotp4c_3D
-                          //currentprojection=orthographic(2,8,6);
-                          defaultrender.merge=true;
-
-                          // setup and draw the axes
-                          real[] myxchoice={2};
-                          real[] myychoice={2};
-                          real[] myzchoice={2};
-                          defaultpen(0.5mm);
-                          pair xbounds=(-0.5,2.5);
-                          pair ybounds=(-1,2.5);
-                          pair zbounds=(-0.5,3);
-
-                          xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-                          yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-                          zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-                          label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-                          label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-                          label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-                          // Draw the lines for vec{x}=&lt;1,1,1&gt;
-                          //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
-                          draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
-                          label("$\vec{x}$",(1,1,1),N);
-                          //dotfactor=3;  dot((2,1,1),blue);
-
-                          // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
-                          //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
-                          //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
-                          draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
-                          label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
-
-                          // Draw the lines for \vec{w}=&lt;2,1,3&gt;
-                          //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
-                          draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
-                          label("$\vec{w}$",(2,1,3),N);
-
-                          // ////////////////////////////////////
-                          //    SAMPLE CODE
-
-                          // defaultpen(fontsize(10pt));
-
-                          //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
-                          //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
-
-                          //triple f(pair t) {
-                          //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
-                          //}
-                          //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
-
-                          //draw(s,paleblue);
-                          //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
-                          //draw(mypath,2bp+blue);
-
-                          //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
-                          //path3 mypath=graph(g,-1,1,operator ..);
-
-                          //pen p=rgb(0,0,1);
-                          //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
-
-                        </asymptote>
-                      </image>
-                  <!-- figures/figdotp4b_3D.asy END -->
-                    </figure>
-
-                    <figure xml:id="figdotp4c_3D">
-                      <caption/>
-                  <!--
-                      \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
-                    3Droll=0,
-                    3Dortho=0.0046,
-                    3Dc2c=.29 .77 .56,
-                    3Dcoo=50 0 40,
-                    3Droo=250,
-                    3Dlights=Headlamp,add3Djscript=asylabels.js]
-                      -->
-                    <!-- START figures/figdotp4c_3D.asy -->
-                      <image xml:id="img_dotp4c_3D">
-                        <description></description>
-                        <asymptote>
-
-                          import graph3;
-
-                          //ASY file for figdotp4b.asy in Chapter 10
-
-                          size(200,200,IgnoreAspect);
-                          //currentprojection=perspective(7,2,1);
-
-                          // The text calls for two viewpoints of this picture to show orthogonality
-                          // The two projections below give those two views
-                          //  view "b", saved as figdotp4b_3D
-                          //currentprojection=orthographic(8,2,5);
-
-                          //  view "c", saved as figdotp4c_3D
-                          currentprojection=orthographic(2,8,6);
-                          defaultrender.merge=true;
-
-                          // setup and draw the axes
-                          real[] myxchoice={2};
-                          real[] myychoice={2};
-                          real[] myzchoice={2};
-                          defaultpen(0.5mm);
-                          pair xbounds=(-0.5,2.5);
-                          pair ybounds=(-1,2.5);
-                          pair zbounds=(-0.5,3);
-
-                          xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-                          yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-                          zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-                          label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-                          label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-                          label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-                          // Draw the lines for vec{x}=&lt;1,1,1&gt;
-                          //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
-                          draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
-                          label("$\vec{x}$",(1,1,1),N);
-                          //dotfactor=3;  dot((2,1,1),blue);
-
-                          // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
-                          //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
-                          //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
-                          draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
-                          label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
-
-                          // Draw the lines for \vec{w}=&lt;2,1,3&gt;
-                          //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
-                          draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
-                          label("$\vec{w}$",(2,1,3),N);
-
-                          // ////////////////////////////////////
-                          //    SAMPLE CODE
-
-                          // defaultpen(fontsize(10pt));
-
-                          //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
-                          //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
-
-                          //triple f(pair t) {
-                          //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
-                          //}
-                          //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
-
-                          //draw(s,paleblue);
-                          //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
-                          //draw(mypath,2bp+blue);
-
-                          //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
-                          //path3 mypath=graph(g,-1,1,operator ..);
-
-                          //pen p=rgb(0,0,1);
-                          //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
-
-                        </asymptote>
-                      </image>
-                    <!-- figures/figdotp4c_3D.asy END -->
-                    </figure>
-                </sidebyside>
-
+                  </latex-image>
+                </image>
               </figure>
             </li>
 
@@ -1172,6 +957,220 @@
                 the sketch in <xref ref="figdotp4b_3D">Figure</xref> makes it difficult to recognize that the drawn projection has the geometric properties it should.
                 The graph shown in <xref ref="figdotp4c_3D">Figure</xref> illustrates these properties better.
               </p>
+
+              <figure xml:id="fig_dotp4bc">
+                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part2">Part</xref> of <xref ref="ex_dotp4">Example</xref></caption>
+                <sidebyside widths="47% 47%">
+                  <figure xml:id="figdotp4b_3D">
+                    <caption/>
+                    <!--
+                      \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
+                    3Droll=0,
+                    3Dortho=0.0046,
+                    3Dc2c=.9 .12 .42,
+                    3Dcoo=0 50 30,
+                    3Droo=250,
+                    3Dlights=Headlamp,add3Djscript=asylabels.js]
+                      -->
+                    <image xml:id="img_dotp4b_3D">
+                      <description></description>
+                      <asymptote>
+
+                        import graph3;
+
+                        //ASY file for figdotp4b.asy in Chapter 10
+
+                        size(200,200,IgnoreAspect);
+                        //currentprojection=perspective(7,2,1);
+
+                        // The text calls for two viewpoints of this picture to show orthogonality
+                        // The two projections below give those two views
+                        //  view "b", saved as figdotp4b_3D
+                        currentprojection=orthographic(8,2,5);
+
+                        //  view "c", saved as figdotp4c_3D
+                        //currentprojection=orthographic(2,8,6);
+                        defaultrender.merge=true;
+
+                        // setup and draw the axes
+                        real[] myxchoice={2};
+                        real[] myychoice={2};
+                        real[] myzchoice={2};
+                        defaultpen(0.5mm);
+                        pair xbounds=(-0.5,2.5);
+                        pair ybounds=(-1,2.5);
+                        pair zbounds=(-0.5,3);
+
+                        xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+                        yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+                        zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+                        label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+                        label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+                        label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+                        // Draw the lines for vec{x}=&lt;1,1,1&gt;
+                        //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
+                        draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
+                        label("$\vec{x}$",(1,1,1),N);
+                        //dotfactor=3;  dot((2,1,1),blue);
+
+                        // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
+                        //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
+                        //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
+                        draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
+                        label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
+
+                        // Draw the lines for \vec{w}=&lt;2,1,3&gt;
+                        //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
+                        draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
+                        label("$\vec{w}$",(2,1,3),N);
+
+                        // ////////////////////////////////////
+                        //    SAMPLE CODE
+
+                        // defaultpen(fontsize(10pt));
+
+                        //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
+                        //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
+
+                        //triple f(pair t) {
+                        //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
+                        //}
+                        //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
+
+                        //draw(s,paleblue);
+                        //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
+                        //draw(mypath,2bp+blue);
+
+                        //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
+                        //path3 mypath=graph(g,-1,1,operator ..);
+
+                        //pen p=rgb(0,0,1);
+                        //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
+
+                      </asymptote>
+                    </image>
+                <!-- figures/figdotp4b_3D.asy END -->
+                  </figure>
+
+                  <figure xml:id="figdotp4c_3D">
+                    <caption/>
+                <!--
+                    \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
+                  3Droll=0,
+                  3Dortho=0.0046,
+                  3Dc2c=.29 .77 .56,
+                  3Dcoo=50 0 40,
+                  3Droo=250,
+                  3Dlights=Headlamp,add3Djscript=asylabels.js]
+                    -->
+                  <!-- START figures/figdotp4c_3D.asy -->
+                    <image xml:id="img_dotp4c_3D">
+                      <description></description>
+                      <asymptote>
+
+                        import graph3;
+
+                        //ASY file for figdotp4b.asy in Chapter 10
+
+                        size(200,200,IgnoreAspect);
+                        //currentprojection=perspective(7,2,1);
+
+                        // The text calls for two viewpoints of this picture to show orthogonality
+                        // The two projections below give those two views
+                        //  view "b", saved as figdotp4b_3D
+                        //currentprojection=orthographic(8,2,5);
+
+                        //  view "c", saved as figdotp4c_3D
+                        currentprojection=orthographic(2,8,6);
+                        defaultrender.merge=true;
+
+                        // setup and draw the axes
+                        real[] myxchoice={2};
+                        real[] myychoice={2};
+                        real[] myzchoice={2};
+                        defaultpen(0.5mm);
+                        pair xbounds=(-0.5,2.5);
+                        pair ybounds=(-1,2.5);
+                        pair zbounds=(-0.5,3);
+
+                        xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+                        yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+                        zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+                        label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+                        label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+                        label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+                        // Draw the lines for vec{x}=&lt;1,1,1&gt;
+                        //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
+                        draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
+                        label("$\vec{x}$",(1,1,1),N);
+                        //dotfactor=3;  dot((2,1,1),blue);
+
+                        // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
+                        //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
+                        //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
+                        draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
+                        label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
+
+                        // Draw the lines for \vec{w}=&lt;2,1,3&gt;
+                        //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
+                        draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
+                        label("$\vec{w}$",(2,1,3),N);
+
+                        // ////////////////////////////////////
+                        //    SAMPLE CODE
+
+                        // defaultpen(fontsize(10pt));
+
+                        //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
+                        //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
+
+                        //triple f(pair t) {
+                        //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
+                        //}
+                        //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
+
+                        //draw(s,paleblue);
+                        //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
+                        //draw(mypath,2bp+blue);
+
+                        //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
+                        //path3 mypath=graph(g,-1,1,operator ..);
+
+                        //pen p=rgb(0,0,1);
+                        //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
+
+                      </asymptote>
+                    </image>
+                  <!-- figures/figdotp4c_3D.asy END -->
+                  </figure>
+                </sidebyside>
+              </figure>
             </li>
           </ol>
         </p>
@@ -1629,12 +1628,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 The dot product of two vectors is a <fillin/>, not a vector.
@@ -1649,12 +1645,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 How are the concepts of the dot product and vector magnitude related?
@@ -1670,12 +1663,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 How can one quickly tell if the angle between two vectors is acute or obtuse?
@@ -1692,12 +1682,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Give a synonym for <q>orthogonal.</q>
@@ -1721,14 +1708,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("-22");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 2,-4\ra</m>, <m>\vec v = \la 3,7\ra</m>
@@ -1742,14 +1727,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("33");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 5,3\ra</m>, <m>\vec v = \la 6,1\ra</m>
@@ -1763,14 +1746,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 1,-1,2\ra</m>,
@@ -1785,14 +1766,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 3,5,-1\ra</m>,
@@ -1807,12 +1786,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\vec u = \la 1,1\ra</m>, <m>\vec v = \la 1,2,3\ra</m>
@@ -1827,14 +1803,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 1,2,3\ra</m>,
@@ -1851,12 +1825,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Create your own vectors <m>\vec u</m>,
@@ -1873,12 +1844,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Create your own vectors <m>\vec u</m> and <m>\vec v</m> in
@@ -1903,14 +1871,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("arccos(3/sqrt(10))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la 1,1\ra</m> and
@@ -1921,14 +1887,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("arccos(-1/sqrt(170))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la -2,1\ra</m> and
@@ -1939,14 +1903,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("pi/4");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la 8,1,-4\ra</m> and
@@ -1957,14 +1919,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("pi/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la 1,7,2\ra</m> and
@@ -1985,9 +1945,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;4,7>");
@@ -2004,7 +1962,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la 4,7\ra</m>.
@@ -2024,9 +1982,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;-3,5>");
@@ -2043,7 +1999,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la -3,5\ra</m>.
@@ -2063,9 +2019,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;1,1,1>");
@@ -2082,7 +2036,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la 1,1,1\ra</m>.
@@ -2102,9 +2056,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;1,-2,3>");
@@ -2121,7 +2073,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la 1,-2,3\ra</m>.
@@ -2153,9 +2105,7 @@
       </introduction>
 
       <exercise xml:id="ex_10_03_ex_21">
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2167,7 +2117,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 1,2\ra</m> and <m>\vec v = \la -1,3\ra</m>,
@@ -2182,9 +2132,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2196,7 +2144,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 5,5\ra</m> and <m>\vec v = \la 1,3\ra</m>,
@@ -2211,9 +2159,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2225,7 +2171,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la -3,2\ra</m> and <m>\vec v = \la 1,1\ra</m>,
@@ -2240,9 +2186,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2254,7 +2198,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la -3,2\ra</m> and <m>\vec v = \la 2,3\ra</m>,
@@ -2269,9 +2213,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2283,7 +2225,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den,$nums[2]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 1,5,1\ra</m> and <m>\vec v = \la 1,2,3\ra</m>,
@@ -2298,9 +2240,7 @@
       </exercise>
 
       <exercise xml:id="ex_10_03_ex_24">
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2312,7 +2252,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den,$nums[2]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 3,-1,2\ra</m> and <m>\vec v = \la 2,2,1\ra</m>,
@@ -2342,9 +2282,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2397,7 +2335,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 1,2\ra</m> as the sum of two vectors,
@@ -2414,9 +2352,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2469,7 +2405,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 5,5\ra</m> as the sum of two vectors,
@@ -2486,9 +2422,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2541,7 +2475,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la -3,2\ra</m> as the sum of two vectors,
@@ -2558,9 +2492,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2613,7 +2545,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la -3,2\ra</m> as the sum of two vectors,
@@ -2630,9 +2562,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2685,7 +2615,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 1,5,1\ra</m> as the sum of two vectors,
@@ -2702,9 +2632,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2757,7 +2685,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 3,-1,2\ra</m> as the sum of two vectors,
@@ -2776,12 +2704,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A 10lb box sits on a ramp that rises 4ft over a distance of 20ft.
@@ -2797,12 +2722,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A 10lb box sits on a 15ft ramp that makes a
@@ -2819,12 +2741,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box horizontally 10ft with a force of 20lb applied at an angle of <m>45^\circ</m> to the horizontal?
@@ -2839,12 +2758,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box horizontally 10ft with a force of 20lb applied at an angle of <m>10^\circ</m> to the horizontal?
@@ -2859,12 +2775,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box up the length of a ramp that rises 2ft over a distance of 10ft,
@@ -2880,12 +2793,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box up the length of a ramp that rises 2ft over a distance of 10ft,
@@ -2901,12 +2811,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box up the length of a 10ft ramp that makes a <m>5^\circ</m> angle with the horizontal,

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -177,7 +177,7 @@
   <p>
     So to evaluate <m>\iint_Rf(x,y)\, dA</m>,
     replace <m>dA</m> with <m>r\, dr\, d\theta</m>.
-    Convert the function <m>z=f(x,y)</m> to a function with polar coordinates with the substitutions
+    Convert the function <m>f(x,y)</m> to a function with polar coordinates with the substitutions
     <m>x=r\cos(\theta)</m>, <m>y=r\sin(\theta)</m>.
     Finally, find bounds <m>g_1(\theta)\leq r\leq g_2(\theta)</m> and
     <m>\alpha\leq\theta\leq\beta</m> that describe <m>R</m>.

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -1762,7 +1762,7 @@
     Given a region <m>R</m> in the plane,
     we computed <m>\iint_R 1\, dA</m>;
     again, our understanding at the time was that we were finding the area of <m>R</m>.
-    However, we can now view the function <m>z=1</m> as a surface,
+    However, we can now view the graph <m>z=1</m> as a surface,
     a flat surface with constant <m>z</m>-value of 1.
     The double integral <m>\iint_R 1\, dA</m> finds the volume,
     under <m>z=1</m>, over <m>R</m>,

--- a/ptx/sec_greensthm.ptx
+++ b/ptx/sec_greensthm.ptx
@@ -15,7 +15,7 @@
 
     <figure xml:id="fig_flowfluxintro">
       <caption>Illustrating the principles of flow and flux.</caption>
-          <image xml:id="img_flowfluxintro">
+          <image xml:id="img_flowfluxintro" width="47%">
             <description></description>
             <asymptote>
 
@@ -161,7 +161,7 @@
 
     <figure xml:id="fig_fluxcounterclockwise">
       <caption>Determining <q>counterclockwise</q> is not always simple without a good definition.</caption>
-           <image xml:id="img_fluxcounterclockwise">
+           <image xml:id="img_fluxcounterclockwise" width="47%">
             <description></description>
             <asymptote>
 
@@ -313,11 +313,9 @@
           Find the flux across both curves for the vector fields
           <m>\vec F_1 = \la y, -x+1\ra</m> and <m>\vec F_2 = \la -x, 2y-x\ra</m>.
         </p>
-      </statement>
-      <solution>
         <figure xml:id="fig_flux1">
           <caption>Illustrating the curves and vector fields in <xref ref="ex_flux1">Example</xref>. In (a) the vector field is <m>\vec F_1</m>, and in (b) the vector field is <m>\vec F_2</m>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_flux1a">
               <caption/>
               <image xml:id="img_flux1a">
@@ -469,7 +467,8 @@
           </sidebyside>
 
         </figure>
-
+      </statement>
+      <solution>
         <p>
           We begin by finding parametrizations of <m>C_1</m> and <m>C_2</m>.
           As done in <xref ref="ex_livf3">Example</xref>,
@@ -618,7 +617,7 @@
 
         <figure xml:id="fig_green1">
           <caption>The vector field and planar region used in <xref ref="ex_green1">Example</xref>.</caption>
-          <image xml:id="img_green1">
+          <image xml:id="img_green1" width="47%">
             <description></description>
             <asymptote>
 
@@ -771,7 +770,7 @@
 
         <figure xml:id="fig_green2">
           <caption>The vector field and planar region used in <xref ref="ex_green2">Example</xref>.</caption>
-          <image xml:id="img_green2">
+          <image xml:id="img_green2" width="47%">
             <description></description>
             <asymptote>
 
@@ -863,7 +862,7 @@
           we can conclude that the circulation is 0 in two ways.
           One method is to employ Green's Theorem as done above.
           The second way is to recognize that <m>\vec F</m> is a conservative field,
-          hence there is a function <m>z=f(x,y)</m> wherein <m>\vec F = \nabla f</m>.
+          hence there is a function <m>f(x,y)</m> wherein <m>\vec F = \nabla f</m>.
           Let <m>A</m> be any point on the curve <m>C</m>;
           since <m>C</m> is closed,
           we can say that <m>C</m> <q>begins</q>
@@ -905,7 +904,7 @@
 
         <figure xml:id="fig_green3">
           <caption>The region <m>R</m>, whose area is found in <xref ref="ex_green3">Example</xref>.</caption>
-          <image xml:id="img_green3">
+          <image xml:id="img_green3" width="47%">
             <description></description>
             <latex-image>
 
@@ -989,7 +988,7 @@
 
         <figure xml:id="fig_div1">
           <caption>The region <m>R</m> used in <xref ref="ex_div1">Example</xref>.</caption>
-          <image xml:id="img_div1">
+          <image xml:id="img_div1" width="47%">
             <description></description>
             <asymptote>
 
@@ -1091,7 +1090,7 @@
     </example>
 
     <example xml:id="ex_div2">
-      <title>Flux when $\divv \vec F = 0$</title>
+      <title>Flux when <m>\divv \vec F = 0</m></title>
       <statement>
         <p>
           Let <m>\vec F</m> be any field where <m>\divv \vec F = 0</m>,
@@ -1121,7 +1120,7 @@
 
         <figure xml:id="fig_div2">
           <caption>As used in <xref ref="ex_div2">Example</xref>, the vector field has a divergence of 0 and the two paths only intersect at their initial and terminal points.</caption>
-          <image xml:id="img_div2">
+          <image xml:id="img_div2" width="47%">
             <description></description>
             <asymptote>
 

--- a/ptx/sec_line_int_intro.ptx
+++ b/ptx/sec_line_int_intro.ptx
@@ -7,7 +7,10 @@
       <q>area under a curve.</q> In this section,
       we learn to do this (again), but in a different context.
     </p>
+  </introduction>
 
+  <subsection xml:id="subsec-line-int-scalar">
+    <title>Line Integrals of Functions</title>
     <p>
       Consider the surface and curve shown in <xref ref="fig_line_integral_intro1a_3D">Figure</xref>.
       The surface is given by <m>f(x,y)=1-\cos(x)\sin(y)</m>.
@@ -32,7 +35,7 @@
 
     <figure xml:id="fig_line_integral_intro1">
       <caption>Finding area under a curve in space.</caption>
-      <sidebyside>
+      <sidebyside widths="33% 33% 33%">
         <figure xml:id="fig_line_integral_intro1a_3D">
           <caption/>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -366,11 +369,11 @@
       we can say that <m>f</m> is a function of <m>s</m>.
       Given a value <m>s</m>, we can compute <m>f(s)</m> and find a height.
       Thus
-      <md>
-        <mrow>\text{ area under \(f\) and above \(C\) } \amp \approx \sum (\text{ heights } \times\text{ widths } );</mrow>
-        <mrow>\text{ area under \(f\) and above \(C\) }               \amp =\lim_{||\Delta s||\to0}\sum f(c_i)\Delta s_i</mrow>
-        <mrow>\amp =\int_Cf(s)\, ds</mrow>
-      </md>.
+      <mdn>
+        <mrow number="no">\text{ area under \(f\) and above \(C\) } \amp \approx \sum (\text{ heights } \times\text{ widths } );</mrow>
+        <mrow number="no">\text{ area under \(f\) and above \(C\) }               \amp =\lim_{\norm{\Delta s}\to0}\sum f(c_i)\Delta s_i</mrow>
+        <mrow xml:id="eq_line0">\amp =\int_Cf(s)\, ds</mrow>
+      </mdn>.
     </p>
 
     <p>
@@ -405,12 +408,12 @@
           and let <m>f</m> be a continuous function of <m>s</m>.
           A <term>line integral</term> is an integral of the form
           <me>
-            \int_C f(s)\, ds = \lim_{||\Delta s||\to 0}\sum_{i=1}^n f(c_i)\Delta s_i
+            \int_C f(s)\, ds = \lim_{\norm{\Delta s}\to 0}\sum_{i=1}^n f(c_i)\Delta s_i
           </me>,
           where <m>s_1\lt s_2\lt \ldots\lt s_n</m> is any partition of the <m>s</m>-interval over which <m>C</m> is defined,
           <m>c_i</m> is any value in the <m>i</m>th subinterval,
           <m>\Delta s_i</m> is the width of the <m>i</m>th subinterval,
-          and <m>||\Delta s||</m> is the length of the longest subinterval in the partition.
+          and <m>\norm{\Delta s}</m> is the length of the longest subinterval in the partition.
               <idx><h>line integral</h><h>over scalar field</h></idx>
         </p>
       </statement>
@@ -550,7 +553,7 @@
     </p>
 
     <example xml:id="ex_linescalarfield2">
-      <title>Evaluating a line integral: area under a surface over a curve.</title>
+      <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
           Find the area under the surface
@@ -558,28 +561,9 @@
           which is the segment of the line <m>y=2x+1</m> on <m>-1\leq x\leq 1</m>,
           as shown in <xref ref="fig_linescalarfield2">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Our first step is to represent <m>C</m> with a vector<ndash/>valued function.
-          Since <m>C</m> is a simple line,
-          and we have a explicit relationship between <m>y</m> and <m>x</m> (namely,
-          that <m>y</m> is <m>2x+1</m>),
-          we can let <m>x = t</m>, <m>y = 2t+1</m>,
-          and write <m>\vrt = \langle t, 2t+1\rangle</m> for <m>-1\leq t\leq 1</m>.
-        </p>
-
-        <p>
-          We find the values of <m>f</m> over <m>C</m> as <m>f(x,y) = f(t,2t+1) = \cos(t)+\sin(2t+1) + 2</m>.
-          We also need <m>\norm{\vec r\,'(t)}</m>;
-          with <m>\vrp(t) = \langle 1,2\rangle</m>,
-          we have <m>\norm{\vrp(t)} = \sqrt{5}</m>.
-          Thus <m>ds = \sqrt{5}\, dt</m>.
-        </p>
-
         <figure xml:id="fig_linescalarfield2">
           <caption>Finding area under a curve in <xref ref="ex_linescalarfield2">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_linescalarfield2a_3D">
               <caption/>
               <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -759,6 +743,24 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Our first step is to represent <m>C</m> with a vector<ndash/>valued function.
+          Since <m>C</m> is a simple line,
+          and we have a explicit relationship between <m>y</m> and <m>x</m> (namely,
+          that <m>y</m> is <m>2x+1</m>),
+          we can let <m>x = t</m>, <m>y = 2t+1</m>,
+          and write <m>\vrt = \langle t, 2t+1\rangle</m> for <m>-1\leq t\leq 1</m>.
+        </p>
+
+        <p>
+          We find the values of <m>f</m> over <m>C</m> as <m>f(x,y) = f(t,2t+1) = \cos(t)+\sin(2t+1) + 2</m>.
+          We also need <m>\norm{\vec r\,'(t)}</m>;
+          with <m>\vrp(t) = \langle 1,2\rangle</m>,
+          we have <m>\norm{\vrp(t)} = \sqrt{5}</m>.
+          Thus <m>ds = \sqrt{5}\, dt</m>.
+        </p>
 
         <p>
           The area we seek is
@@ -777,24 +779,15 @@
     </p>
 
     <example xml:id="ex_linescalarfield3">
-      <title>Evaluating a line integral: area under a surface over a curve.</title>
+      <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
           Find the area over the unit circle in the <m>x</m>-<m>y</m> plane and under the surface <m>f(x,y) = x^2-y^2+3</m>,
           shown in <xref ref="fig_linescalarfield3">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          The curve <m>C</m> is the unit circle,
-          which we will describe with the parametrization
-          <m>\vrt = \langle \cos t, \sin t\rangle</m> for <m>0\leq t\leq 2\pi</m>.
-          We find <m>\norm{\vrp(t)} = 1</m>, so <m>ds = 1 dt</m>.
-        </p>
-
         <figure xml:id="fig_linescalarfield3">
           <caption>Finding area under a curve in <xref ref="ex_linescalarfield3">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_linescalarfield3a_3D">
               <caption/>
               <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -973,6 +966,14 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          The curve <m>C</m> is the unit circle,
+          which we will describe with the parametrization
+          <m>\vrt = \langle \cos t, \sin t\rangle</m> for <m>0\leq t\leq 2\pi</m>.
+          We find <m>\norm{\vrp(t)} = 1</m>, so <m>ds = 1 dt</m>.
+        </p>
 
         <p>
           We find the values of <m>f</m> over <m>C</m> as <m>f(x,y) = f(\cos t, \sin t) = \cos^2t-\sin^2t+3</m>.
@@ -997,7 +998,7 @@
     </p>
 
     <example xml:id="ex_linescalarfield5">
-      <title>Evaluating a line integral: area under a surface over a curve.</title>
+      <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
           Find the area under <m>f(x,y) = 1-\cos(x)\sin(y)</m> and over the parabola <m>y = x^2</m>,
@@ -1030,37 +1031,13 @@
     </p>
 
     <example xml:id="ex_linescalarfield4">
-      <title>Evaluating a line integral: area under a curve in space.</title>
+      <title>Evaluating a line integral: area under a curve in space</title>
       <statement>
         <p>
           Find the area above the <m>x</m>-<m>y</m> plane and below the helix parametrized by <m>\vrt = \langle \cos t,2\sin t,t/\pi\rangle</m>,
           for <m>0\leq t\leq 2\pi</m>,
           as shown in <xref ref="fig_linescalarfield4">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Note how this is problem is different than the previous examples:
-          here, the height is not given by a surface, but by the curve itself.
-        </p>
-
-        <p>
-          We use the given vector-valued function \vec r(t)<nbsp/>to determine the curve <m>C</m> in the <m>x</m>-<m>y</m> plane by simply using the first two components of \vec r(t):
-          <m>\vec c(t) = \langle \cos t,2\sin t\rangle</m>.
-          Thus <m>ds = \norm{\vec c\,'(t)}\,dt = \sqrt{\sin^2t + 4\cos^2t}\,dt</m>.
-        </p>
-
-        <p>
-          The height is not found by evaluating a surface over <m>C</m>,
-          but rather it is given directly by the third component of \vec r(t):
-          <m>t/\pi</m>.
-          Thus
-          <me>
-            \oint_C f(s)\, ds = \int_0^{2\pi} \frac{t}{\pi}\sqrt{\sin^2t + 4\cos^2t}\,dt \approx 9.69
-          </me>,
-          where the approximation was obtained using numerical methods.
-        </p>
-
         <figure xml:id="fig_linescalarfield4">
           <caption>Finding area under a curve in <xref ref="ex_linescalarfield4">Example</xref>.</caption>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1070,7 +1047,7 @@
           3Dcoo=1.7807315587997437 0.9528753757476807 54.982017517089844,
           3Droo=141.8977232410902,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_linescalarfield4_3D">
+          <image xml:id="img_linescalarfield4_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -1147,6 +1124,29 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Note how this is problem is different than the previous examples:
+          here, the height is not given by a surface, but by the curve itself.
+        </p>
+
+        <p>
+          We use the given vector-valued function \vec r(t)<nbsp/>to determine the curve <m>C</m> in the <m>x</m>-<m>y</m> plane by simply using the first two components of \vec r(t):
+          <m>\vec c(t) = \langle \cos t,2\sin t\rangle</m>.
+          Thus <m>ds = \norm{\vec c\,'(t)}\,dt = \sqrt{\sin^2t + 4\cos^2t}\,dt</m>.
+        </p>
+
+        <p>
+          The height is not found by evaluating a surface over <m>C</m>,
+          but rather it is given directly by the third component of \vec r(t):
+          <m>t/\pi</m>.
+          Thus
+          <me>
+            \oint_C f(s)\, ds = \int_0^{2\pi} \frac{t}{\pi}\sqrt{\sin^2t + 4\cos^2t}\,dt \approx 9.69
+          </me>,
+          where the approximation was obtained using numerical methods.
+        </p>
       </solution>
     </example>
 
@@ -1160,7 +1160,7 @@
       The figures show how the curve <m>C</m> defines another curve on the surface <m>z=f(x,y)</m>,
       and we are finding the area under that curve.
     </p>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Properties of Line Integrals</title>
@@ -1182,7 +1182,7 @@
 
     <figure xml:id="fig_line_int_prop">
       <caption>Illustrating properties of line integrals.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_line_int_propa">
           <caption/>
           <image xml:id="img_line_int_propa">
@@ -1384,7 +1384,7 @@
     </definition>
 
     <example xml:id="ex_linescalarfield6">
-      <title>Evaluating a line integral: calculating mass.</title>
+      <title>Evaluating a line integral: calculating mass</title>
       <statement>
         <p>
           A thin wire follows the path
@@ -1406,7 +1406,7 @@
           3Dcoo=85.21116638183594 55.206966400146484 50.90880584716797,
           3Droo=141.89772711774134,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_linescalarfield6">
+          <image xml:id="img_linescalarfield6" width="47%">
             <description></description>
             <asymptote>
 

--- a/ptx/sec_line_int_vf.ptx
+++ b/ptx/sec_line_int_vf.ptx
@@ -56,12 +56,16 @@
       <m>ds = \norm{\vrp(t)}\, dt</m>,
       and recall that <m>\vec T = \vrp(t)/\norm{\vrp(t)}</m>.
       Thus
-      <men xml:id="eq_line_integral">
-        W = \int_C \vec F\cdot\vec T\, ds = \int_C \vec F\cdot \frac{\vrp(t)}{\norm{\vrp(t)}}\norm{\vrp(t)}\, dt = \int_C\vec F\cdot \vrp(t)\, dt = \int_C \vec F\cdot d\vec r
-      </men>,
+      <mdn >
+        <mrow number="no">W \amp = \int_C \vec F\cdot\vec T\, ds = \int_C \vec F\cdot \frac{\vrp(t)}{\norm{\vrp(t)}}\norm{\vrp(t)}\, dt</mrow>
+        <mrow xml:id="eq_line_integral"> = \int_C\vec F\cdot \vrp(t)\, dt = \int_C \vec F\cdot d\vec r</mrow>
+      </mdn>,
       where the final integral uses the differential <m>d\vec r</m> for <m>\vrp(t)\,dt</m>.
     </p>
+  </introduction>
 
+  <subsection xml:id="subsec-line-int-vector-eval">
+    <title>Evaluating Line Integrals over Vector Fields</title>
     <p>
       These integrals are known as <em>line integrals over vector fields</em>.
       By contrast,
@@ -159,42 +163,9 @@
           Force is measured in newtons and distance is measured in meters.
           Find the work performed by each particle.
         </p>
-      </statement>
-      <solution>
-        <p>
-          To compute work, we need to parametrize each path.
-          We use <m>\vec r_1(t) = \langle t,t\rangle</m> to parametrize <m>y=x</m>,
-          and let <m>\vec r_2(t) =\langle t,t^4\rangle</m> parametrize <m>y=x^4</m>;
-          for each, <m>0\leq t\leq 1</m>.
-        </p>
-
-        <p>
-          Along the straight<ndash/>line path,
-          <m>\vec F\big(\vec r_1(t)\big) = \langle x, x+y\rangle = \langle t, t+t\rangle = \langle t,2t\rangle</m>.
-          We find <m>\vrp_1(t) =\langle 1,2\rangle</m>.
-          The integral that computes work is:
-          <md>
-            <mrow>\int_{C_1} \vec F\cdot d\vec r \amp = \int_0^1 \langle t,2t\rangle\cdot\la 1,1\ra\, dt</mrow>
-            <mrow>\amp = \int_0^1 3t\, dt</mrow>
-            <mrow>\amp = \frac32t^2\Big|_0^1 = 1.5 \text{ joules } </mrow>
-          </md>.
-        </p>
-
-        <p>
-          Along the curve <m>y = x^4</m>,
-          <m>\vec F\big(\vec r_2(t)\big) = \la x, x+y\ra = \la t, t+t^4\ra</m>.
-          We find <m>\vrp_2(t) = \la 1, 4t^3\ra</m>.
-          The work performed along this path is
-          <md>
-            <mrow>\int_{C_2} \vec F\cdot d\vec r \amp = \int_0^1 \la t,t+t^4\ra\cdot\la 1,4t^3\ra\, dt</mrow>
-            <mrow>\amp = \int_0^1 \big(t + 4t^4+ 4t^7\big)\, dt</mrow>
-            <mrow>\amp = \big(\frac12t^2 + \frac45t^5 + \frac12t^8\big)\Big|_0^1 =  1.8 \text{ joules } </mrow>
-          </md>.
-        </p>
-
         <figure xml:id="fig_livf1">
-          <caption>Paths through a vector field in <xref ref="ex_livf1">Example</xref>.</caption>
-          <image xml:id="img_livf1">
+          <caption>Paths through a vector field in <xref ref="ex_livf1">Example</xref></caption>
+          <image xml:id="img_livf1" width="47%">
             <description></description>
             <asymptote>
 
@@ -278,6 +249,38 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          To compute work, we need to parametrize each path.
+          We use <m>\vec r_1(t) = \langle t,t\rangle</m> to parametrize <m>y=x</m>,
+          and let <m>\vec r_2(t) =\langle t,t^4\rangle</m> parametrize <m>y=x^4</m>;
+          for each, <m>0\leq t\leq 1</m>.
+        </p>
+
+        <p>
+          Along the straight<ndash/>line path,
+          <m>\vec F\big(\vec r_1(t)\big) = \langle x, x+y\rangle = \langle t, t+t\rangle = \langle t,2t\rangle</m>.
+          We find <m>\vrp_1(t) =\langle 1,2\rangle</m>.
+          The integral that computes work is:
+          <md>
+            <mrow>\int_{C_1} \vec F\cdot d\vec r \amp = \int_0^1 \langle t,2t\rangle\cdot\la 1,1\ra\, dt</mrow>
+            <mrow>\amp = \int_0^1 3t\, dt</mrow>
+            <mrow>\amp = \frac32t^2\Big|_0^1 = 1.5 \text{ joules } </mrow>
+          </md>.
+        </p>
+
+        <p>
+          Along the curve <m>y = x^4</m>,
+          <m>\vec F\big(\vec r_2(t)\big) = \la x, x+y\ra = \la t, t+t^4\ra</m>.
+          We find <m>\vrp_2(t) = \la 1, 4t^3\ra</m>.
+          The work performed along this path is
+          <md>
+            <mrow>\int_{C_2} \vec F\cdot d\vec r \amp = \int_0^1 \la t,t+t^4\ra\cdot\la 1,4t^3\ra\, dt</mrow>
+            <mrow>\amp = \int_0^1 \big(t + 4t^4+ 4t^7\big)\, dt</mrow>
+            <mrow>\amp = \big(\frac12t^2 + \frac45t^5 + \frac12t^8\big)\Big|_0^1 =  1.8 \text{ joules } </mrow>
+          </md>.
+        </p>
 
         <p>
           Note how differing amounts of work are performed along the different paths.
@@ -300,19 +303,9 @@
           Force is measured in pounds and distances are measured in feet.
           Find the work performed by moving each particle along its path.
         </p>
-      </statement>
-      <solution>
-        <p>
-          We start by parametrizing <m>C_1</m>:
-          the parametrization <m>\vec r_1(t) = \la t, 2t^2-1\ra</m> is straightforward,
-          giving <m>\vrp_1 = \la 1,4t\ra</m>.
-          On <m>C_1</m>,
-          <m>\vec F\big(\vec r_1(t)\big) = \la y,x\ra = \la 2t^2-1,t\ra</m>.
-        </p>
-
         <figure xml:id="fig_livf2">
           <caption>Paths through a vector field in <xref ref="ex_livf2">Example</xref>.</caption>
-          <image xml:id="img_livf2">
+          <image xml:id="img_livf2" width="47%">
             <description></description>
             <asymptote>
 
@@ -382,6 +375,15 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          We start by parametrizing <m>C_1</m>:
+          the parametrization <m>\vec r_1(t) = \la t, 2t^2-1\ra</m> is straightforward,
+          giving <m>\vrp_1 = \la 1,4t\ra</m>.
+          On <m>C_1</m>,
+          <m>\vec F\big(\vec r_1(t)\big) = \la y,x\ra = \la 2t^2-1,t\ra</m>.
+        </p>
 
         <p>
           Computing the work along <m>C_1</m>, we have:
@@ -419,7 +421,7 @@
         </p>
       </solution>
     </example>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Properties of Line Integrals Over Vector Fields</title>
@@ -500,7 +502,7 @@
 
         <figure xml:id="fig_livf3">
           <caption>The vector field and curve in <xref ref="ex_livf3">Example</xref>.</caption>
-          <image xml:id="img_livf3">
+          <image xml:id="img_livf3" width="47%">
             <description></description>
             <asymptote>
 
@@ -647,7 +649,7 @@
           3Dcoo=12.9679536819458 12.412303924560547 19.615886688232422,
           3Droo=399.99998637870164,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_livf4_3D">
+          <image xml:id="img_livf4_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -828,7 +830,7 @@
 
     <figure xml:id="fig_simply_connected_plane">
       <caption><m>R_1</m> is simply connected; <m>R_2</m> is connected, but not simply connected; <m>R_3</m> is not connected.</caption>
-      <image xml:id="img_simply_connected_plane">
+      <image xml:id="img_simply_connected_plane" width="47%">
         <description></description>
         <latex-image>
 
@@ -870,7 +872,7 @@
 
     <figure xml:id="fig_simply_connected_space">
       <caption>The domains in (a) are simply connected, while the domains in (b) are not.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_simply_connected_spacea_3D">
           <caption/>
           <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -1005,7 +1005,7 @@
 
           size(200,200,IgnoreAspect);
           //currentprojection=perspective(7,2,1);
-          currentprojection=orthographic((-.14,-9.67,3.98),(0.003,0.01,0.026),(0,0,0),1.5,(-0.09,-0.2));
+          currentprojection=orthographic((-.14,-9.67,3.98),(0.003,0.01,0.026),(0,0,0),1,(-0.09,-0.2));
           defaultrender.merge=true;
 
 
@@ -1245,12 +1245,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 To find an equation of a line,
@@ -1266,12 +1263,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Two distinct lines in the plane can intersect or be <fillin/>.
@@ -1286,12 +1280,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Two distinct lines in space can intersect,
@@ -1307,12 +1298,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Use your own words to describe what it means for two lines in space to be skew.
@@ -1337,12 +1325,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(2,-4,1)</m>,
@@ -1366,8 +1351,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -1473,7 +1457,7 @@
               });
 
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through <m>P=(6,1,7)</m>,
@@ -1500,12 +1484,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(2,1,5)</m> and <m>Q = (7,-2,4)</m>.
@@ -1529,8 +1510,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -1645,7 +1625,7 @@
               });
 
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through
@@ -1672,12 +1652,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(0,1,2)</m> and orthogonal to both
@@ -1706,8 +1683,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -1767,7 +1743,7 @@
                return (3*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through
@@ -1795,8 +1771,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");Context()->variables->are(t=>"Real");
               $v=Compute("(7,2,-1)+t&lt;1,-1,2>");
@@ -1884,7 +1859,7 @@
                return(3*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through the intersection of
@@ -1912,8 +1887,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");Context()->variables->are(t=>"Real");
               $v=Compute("(2,2,3)+t&lt;5,-1,-3>");
@@ -2001,7 +1975,7 @@
                return(3*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through the intersection of
@@ -2029,12 +2003,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(1,1)</m>,
@@ -2058,8 +2029,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");Context()->variables->are(t=>"Real");
               $v=Compute("(-2,5)+t&lt;0,1>");
@@ -2110,7 +2080,7 @@
                return(2*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through <m>P=(-2,5)</m>,
@@ -2149,15 +2119,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("parallel");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \la 1,2,1\ra + t\la 2,-1,1\ra</m> and
@@ -2177,15 +2145,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("(12,3,7)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \la 2,1,1\ra + t\la 5,1,3\ra</m> and
@@ -2205,12 +2171,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\vec\ell_1(t) = \la 3,4,1\ra + t\la 2,-3,4\ra</m>,
@@ -2230,15 +2193,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("same");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \la 1,1,1\ra + t\la 3,1,3\ra</m> and
@@ -2258,15 +2219,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("skew");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \begin{cases}x\amp = 1+2t\\ y\amp = 3-2t\\ z\amp = t\end{cases}</m> and
@@ -2286,15 +2245,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("parallel");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \begin{cases}x\amp = 1.1+0.6t\\ y\amp = 3.77+0.9t\\ z\amp = -2.3+1.5t\end{cases}</m> and
@@ -2314,12 +2271,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ell_1 = \left\{\begin{aligned}x\amp = 0.2+0.6t\\ y\amp = 1.33-0.45t\\ z\amp = -4.2+1.05t
@@ -2337,15 +2291,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("skew");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \begin{cases}x\amp = 0.1+1.1t\\ y\amp = 2.9-1.5t\\ z\amp = 3.2+1.6t\end{cases}</m> and
@@ -2374,12 +2326,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>Q=(1,1,1)</m>, <m>\vec\ell(t) = \la 2,1,3\ra + t\la 2,1,-2\ra</m>
@@ -2394,14 +2343,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("3sqrt(2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance from the point
@@ -2416,12 +2363,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>Q=(0,3)</m>, <m>\vec\ell(t) = \la 2,0\ra + t\la 1,1\ra</m>
@@ -2436,14 +2380,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance from the point <m>Q=(1,1)</m> to the line <m>\vec\ell(t) = \la 4,5\ra + t\la -4,3\ra</m>.
@@ -2466,12 +2408,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\vec\ell_1(t) = \la 1,2,1\ra + t\la 2,-1,1\ra</m>,
@@ -2490,14 +2429,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance between the line
@@ -2521,12 +2458,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Let <m>Q</m> be a point on the line <m>\vec\ell(t)</m>.
@@ -2545,12 +2479,9 @@
       </exercise>
 
       <exercise xml:id="x10_05_ex_30">
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Let lines <m>\vec\ell_1(t)</m> and
@@ -2574,12 +2505,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Let lines <m>\vec\ell_1(t)</m> and <m>\vec\ell_2(t)</m> be parallel.

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -13,7 +13,7 @@
     </p>
 
     <p>
-      One can represent the terrain as the surface defined by a multivariable function <m>z=f(x,y)</m>;
+      One can represent the terrain as the surface defined by a multivariable function <m>f(x,y)</m>;
       one can represent the path of the off-road vehicle, as seen from above,
       with a vector-valued function <m>\vec r(t) = \langle x(t),
       y(t)\rangle</m>;
@@ -725,7 +725,7 @@
 
     <p>
       In <xref ref="sec_partial_derivatives">Section</xref>
-      we learned how partial derivatives give certain instantaneous rate of change information about a function <m>z=f(x,y)</m>.
+      we learned how partial derivatives give certain instantaneous rate of change information about a function <m>f(x,y)</m>.
       In that section,
       we measured the rate of change of <m>f</m> by holding one variable constant and letting the other vary
       (such as, holding <m>y</m> constant and letting <m>x</m> vary gives <m>f_x</m>).

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -8,12 +8,12 @@
       <video youtube="smAvod2dFsw"/>
     </figure> -->
     <p>
-      Given a function <m>z=f(x,y)</m>,
-      we are often interested in points where <m>z</m> takes on the largest or smallest values.
-      For instance, if <m>z</m> represents a cost function,
+      Given a function <m>f(x,y)</m>,
+      we are often interested in points where <m>z=f(x,y)</m> takes on the largest or smallest values.
+      For instance, if <m>f</m> represents a cost function,
       we would likely want to know what <m>(x,y)</m> values minimize the cost.
-      If <m>z</m> represents the ratio of a volume to surface area,
-      we would likely want to know where <m>z</m> is greatest.
+      If <m>f</m> represents the ratio of a volume to surface area,
+      we would likely want to know where <m>f</m> is greatest.
       This leads to the following definition.
     </p>
 
@@ -2239,7 +2239,7 @@
               </p>
 
               <p>
-                The function <m>z=f(x,y)</m> itself has a critical point at <m>(-1,-1)</m>.
+                The function <m>f(x,y)</m> itself has a critical point at <m>(-1,-1)</m>.
               </p>
 
               <p>

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -381,9 +381,9 @@
     </figure>
 
     <p>
-      Given a function <m>z=f(x,y)</m>,
+      Given a function <m>f(x,y)</m>,
       we can draw a <q>topographical map</q>
-      of <m>f</m> by drawing <em>level curves</em>
+      of the graph <m>z=f(x,y)</m> by drawing <em>level curves</em>
       (or, contour lines).
       A level curve at <m>z=c</m> is a curve in the <m>x</m>-<m>y</m> plane such that for all points <m>(x,y)</m> on the curve,
       <m>f(x,y) = c</m>.
@@ -1692,9 +1692,9 @@
               </p>
 
               <p>
-                The function <m>z=\sqrt{x^2+4y^2}</m> can be rewritten as <m>z^2=x^2+4y^2</m>,
+                The graph <m>z=\sqrt{x^2+4y^2}</m> can be rewritten as <m>z^2=x^2+4y^2</m>,
                 an elliptic cone;
-                the function <m>z=x^2+4y^2</m> is a paraboloid,
+                the graph <m>z=x^2+4y^2</m> is a paraboloid,
                 each matching the description above.
               </p>
             </solution>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -20,6 +20,12 @@
       <q>tangent</q> to the surface.
     </p>
 
+    <p>
+      In <xref ref="subsec-tangent-plane">Section</xref> we introduced the concept of the tangent plane,
+      which could be thought of as consisting of all possible lines tangent to the surface at a given point.
+      In this section, we explore this idea in more detail.
+    </p>
+
     <figure xml:id="fig_space_tangent_intro">
       <caption>Showing various lines tangent to a surface.</caption>
       <!--
@@ -1105,6 +1111,7 @@
       With <m>a=f_x(x_0,y_0)</m>,
       <m>b=f_y(x_0,y_0)</m> and <m>P = \big(x_0,y_0,f(x_0,y_0)\big)</m>,
       the vector <m>\vec n=\la a,b,-1\ra</m> is orthogonal to <m>f</m> at <m>P</m>.
+      (See <xref ref="def-tangent-plane">Definition</xref>.)
       The plane through <m>P</m> with normal vector <m>\vec n</m> is therefore
       <em>tangent</em> to <m>f</m> at <m>P</m>.
     </p>
@@ -1651,9 +1658,9 @@
 
       <introduction>
         <p>
-          In the following exercises, a function <m>z=f(x,y)</m>,
+          In the following exercises, a function <m>f(x,y)</m>,
           a vector <m>\vec v</m> and a point <m>P</m> are given.
-          Give the parametric equations of the following directional tangent lines to <m>f</m> at <m>P</m>:
+          Give the parametric equations of the following directional tangent lines to <m>z=f(x,y)</m> at <m>P</m>:
         </p>
 
         <p>
@@ -1959,8 +1966,8 @@
       <introduction>
         <p>
           In the following exercises,
-          a function <m>z=f(x,y)</m> and a point <m>P</m> are given.
-          Find the equation of the normal line to <m>f</m> at <m>P</m>.
+          a function <m>f(x,y)</m> and a point <m>P</m> are given.
+          Find the equation of the normal line to <m>z=f(x,y)</m> at <m>P</m>.
           Note: these are the same functions as in <xref ref="x12_06_ex_05">Exercises</xref>
           <mdash/> <xref ref="x12_06_ex_08"/>.
         </p>
@@ -2140,8 +2147,8 @@
       <introduction>
         <p>
           In the following exercises,
-          a function <m>z=f(x,y)</m> and a point <m>P</m> are given.
-          Find the two points that are <m>2</m> units from the surface <m>f</m> at <m>P</m>.
+          a function <m>f(x,y)</m> and a point <m>P</m> are given.
+          Find the two points that are <m>2</m> units from the surface <m>z=f(x,y)</m> at <m>P</m>.
           Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
         </p>
       </introduction>
@@ -2221,8 +2228,8 @@
       <introduction>
         <p>
           In the following exercises,
-          a function <m>z=f(x,y)</m> and a point <m>P</m> are given.
-          Find an equation of the tangent plane to <m>f</m> at <m>P</m>.
+          a function <m>f(x,y)</m> and a point <m>P</m> are given.
+          Find an equation of the tangent plane to <m>z=f(x,y)</m> at <m>P</m>.
           Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
         </p>
       </introduction>

--- a/ptx/sec_parametric_surfaces.ptx
+++ b/ptx/sec_parametric_surfaces.ptx
@@ -9,7 +9,10 @@
       We now move our attention to 3-dimensional vector fields,
       considering both curves and surfaces in space.
     </p>
+  </introduction>
 
+  <subsection xml:id="subsec-parametrized-surfaces">
+    <title>Parametrizing surfaces</title>
     <p>
       We are accustomed to describing surfaces as functions of two variables,
       usually written as <m>z=f(x,y)</m>.
@@ -31,7 +34,7 @@
       </p>
 
       <sidebyside>
-        <image xml:id="img_param_intro">
+        <image xml:id="img_param_intro" width="20%">
           <latex-image>
 
           \begin{tikzpicture}[x={(.55ex,0)},y={(0,.55ex)}]
@@ -64,8 +67,9 @@
       <title>Parametrized Surface</title>
       <statement>
         <p>
-          Let <m>\vec r(u,v) = \langle\, f(u,v),g(u,v),h(u,v)\rangle</m> be a vector<ndash/>valued function that is continuous and one to one on the interior of its domain <m>R</m> in the <m>u</m>-<m>v</m> plane.
-          The set of all terminal points of <m>\vec r</m> (i.e., the <term>range</term>
+          Let <m>\vec r(u,v) = \langle\, f(u,v),g(u,v),h(u,v)\rangle</m>
+          be a vector<ndash/>valued function that is continuous and one to one on the interior of its domain <m>R</m> in the <m>u</m>-<m>v</m> plane.
+          The set of all terminal points of <m>\vec r</m> (<ie/>, the <term>range</term>
           of <m>\vec r</m> ) is the <term>surface</term>
           <m>\surfaceS</m>, and <m>\vec r</m> along with its domain <m>R</m> form a
           <term>parametrization</term> of <m>\surfaceS</m>.
@@ -84,20 +88,10 @@
       </statement>
     </definition>
 
-    <aside>
-      <p>
-        <em>Note:</em> A function is <em>one to one</em>
-        on its domain if the function never repeats an output value over the domain.
-        In the case of <m>\vec r(u,v)</m>,
-        <m>\vec r</m> is one to one if <m>\vec r(u_1,v_1) \neq \vec r(u_2,v_2)</m> for all points
-        <m>(u_1,v_1) \neq (u_2,v_2)</m> in the domain of <m>\vec r</m>.
-            <idx><h>one to one</h></idx>
-      </p>
-    </aside>
     <p>
       Given a point <m>(u_0,v_0)</m> in the domain of a vector<ndash/>valued function <m>\vec r</m>,
       the vectors <m>\vec r_u(u_0,v_0)</m> and
-      <m>\vec r_v(u_0,v_0)</m> are tangent to the surface <m>\surfaceS</m>at
+      <m>\vec r_v(u_0,v_0)</m> are tangent to the surface <m>\surfaceS</m> at
       <m>\vec r(u_0,v_0)</m> (a proof of this is developed later in this section).
       The definition of smoothness dictates that <m>\vec r_u\times \vec r_v \neq \vec 0</m>;
       this ensures that neither <m>\vec r_u</m> nor <m>\vec r_v</m> are <m>\vec 0</m>,
@@ -106,10 +100,21 @@
       <m>\vec r_v</m> determine a plane that is tangent to <m>\surfaceS</m>.
     </p>
 
+    <aside>
+      <p>
+        Recall that function is <em>one to one</em>
+        on its domain if the function never repeats an output value over the domain.
+        In the case of <m>\vec r(u,v)</m>,
+        <m>\vec r</m> is one to one if <m>\vec r(u_1,v_1) \neq \vec r(u_2,v_2)</m> for all points
+        <m>(u_1,v_1) \neq (u_2,v_2)</m> in the domain of <m>\vec r</m>.
+            <idx><h>one to one</h></idx>
+      </p>
+    </aside>
+
     <p>
-      A surface <m>\surfaceS</m>is said to be <em>orientable</em>
+      A surface <m>\surfaceS</m> is said to be <em>orientable</em>
           <idx><h>orientable</h></idx>
-      if a field of normal vectors can be defined on <m>\surfaceS</m>that vary continuously along <m>\surfaceS</m>. This definition may be hard to understand;
+      if a field of normal vectors can be defined on <m>\surfaceS</m> that vary continuously along <m>\surfaceS</m>. This definition may be hard to understand;
       it may help to know that orientable surfaces are often called <q>two sided.</q>
       A sphere is an orientable surface,
       and one can easily envision an <q>inside</q>
@@ -154,7 +159,7 @@
       3Dcoo=11.086544036865234 -8.5783109664917 -7.167413711547852,
       3Droo=399.99997970940404,
       3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-      <image xml:id="img_mobius_3D">
+      <image xml:id="img_mobius_3D" width="47%">
         <description></description>
         <asymptote>
 
@@ -278,7 +283,7 @@
     </p>
 
     <example xml:id="ex_parsurf1">
-      <title>parametrizing a surface over a rectangle</title>
+      <title>Parametrizing a surface over a rectangle</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the rectangular region <m>R</m> defined by
@@ -306,7 +311,7 @@
           3Dcoo=-11.887701988220215 -11.637335777282715 52.40430450439453,
           3Droo=399.9999800778292,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf1">
+          <image xml:id="img_parsurf1" width="47%">
             <description></description>
             <asymptote>
 
@@ -386,7 +391,7 @@
     </example>
 
     <example xml:id="ex_parsurf2">
-      <title>parametrizing a surface over a circular disk</title>
+      <title>Parametrizing a surface over a circular disk</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the circular region <m>R</m> enclosed by the circle of radius 2 that is centered at the origin.
@@ -425,7 +430,7 @@
           3Dcoo=-11.887701988220215 -11.637335777282715 52.40430450439453,
           3Droo=399.9999800778292,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="fig_parsurf2_3D">
+          <image xml:id="fig_parsurf2_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -547,39 +552,15 @@
     </p>
 
     <example xml:id="ex_parsurf3">
-      <title>parametrizing a surface over a triangle</title>
+      <title>Parametrizing a surface over a triangle</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the triangular region <m>R</m> enclosed by the coordinate axes and the line <m>y=2-2x/3</m>,
           as shown in <xref ref="fig_parsurf3a">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          We may begin by letting <m>x=u</m>,
-          <m>0\leq u\leq 3</m>, and <m>y = 2-2u/3</m>.
-          This gives only the line on the
-          <q>upper</q> side of the triangle.
-          To get all of the region <m>R</m>,
-          we can once again scale <m>y</m> by a variable factor,
-          <m>v</m>.
-        </p>
-
-        <p>
-          Still letting <m>x = u</m>,
-          <m>0\leq u\leq 3</m>, we let
-          <m>y = v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
-          When <m>v=0</m>,
-          all <m>y</m>-values are 0, and we get the portion of the <m>x</m>-axis between <m>x=0</m> and <m>x=3</m>.
-          When <m>v=1</m>, we get the upper side of the triangle.
-          When <m>v=1/2</m>, we get the line <m>y=1/2(2-2u/3) = 1-u/3</m>,
-          which is the line <q>halfway up</q> the triangle,
-          shown in the figure with a dashed line.
-        </p>
-
         <figure xml:id="fig_parsurf3">
           <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf3">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%" valign="bottom">
             <figure xml:id="fig_parsurf3a">
               <caption/>
               <image xml:id="img_parsurf3a">
@@ -601,9 +582,6 @@
                 \draw (axis cs: .5,.5) node {$R$};
 
                 \end{axis}
-
-                \node [right] at (myplot.right of origin) {\scriptsize $x$};
-                \node [above] at (myplot.above origin) {\scriptsize $y$};
 
                 \end{tikzpicture}
 
@@ -697,8 +675,30 @@
               </image>
             </figure>
           </sidebyside>
-
         </figure>
+      </statement>
+      <solution>
+        <p>
+          We may begin by letting <m>x=u</m>,
+          <m>0\leq u\leq 3</m>, and <m>y = 2-2u/3</m>.
+          This gives only the line on the
+          <q>upper</q> side of the triangle.
+          To get all of the region <m>R</m>,
+          we can once again scale <m>y</m> by a variable factor,
+          <m>v</m>.
+        </p>
+
+        <p>
+          Still letting <m>x = u</m>,
+          <m>0\leq u\leq 3</m>, we let
+          <m>y = v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
+          When <m>v=0</m>,
+          all <m>y</m>-values are 0, and we get the portion of the <m>x</m>-axis between <m>x=0</m> and <m>x=3</m>.
+          When <m>v=1</m>, we get the upper side of the triangle.
+          When <m>v=1/2</m>, we get the line <m>y=1/2(2-2u/3) = 1-u/3</m>,
+          which is the line <q>halfway up</q> the triangle,
+          shown in the figure with a dashed line.
+        </p>
 
         <p>
           Letting <m>z = f(x,y) = x^2+2y^2</m>,
@@ -725,50 +725,15 @@
     </example>
 
     <example xml:id="ex_parsurf4">
-      <title>parametrizing a surface over a triangle</title>
+      <title>Parametrizing a surface over a triangle</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the triangular region <m>R</m> enclosed by the lines <m>y=3-2x/3</m>,
           <m>y=1</m> and <m>x=0</m> as shown in <xref ref="fig_parsurf4a">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          While the region <m>R</m> in this example is very similar to the region <m>R</m> in the previous example,
-          and our method of parametrizing the surface is fundamentally the same,
-          it will feel as though our answer is much different than before.
-        </p>
-
-        <p>
-          We begin with letting <m>x=u</m>, <m>0\leq u\leq 3</m>.
-          We may be tempted to let <m>y = v(3-2u/3)</m>,
-          <m>0\leq v\leq 1</m>, but this is incorrect.
-          When <m>v = 1</m>,
-          we obtain the upper line of the triangle as desired.
-          However, when <m>v=0</m>,
-          the <m>y</m>-value is 0, which does not lie in the region <m>R</m>.
-        </p>
-
-        <p>
-          We will describe the general method of proceeding following this example.
-          For now, consider <m>y = 1+v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
-          Note that when <m>v=1</m>,
-          we have <m>y=3-2u/3</m>, the upper line of the boundary of <m>R</m>.
-          Also, when <m>v=0</m>, we have <m>y=1</m>,
-          which is the lower boundary of <m>R</m>.
-          With <m>z=x^2+2y^2</m>,
-          we determine <m>\vec r(u,v) = \langle u, 1+v(2-2u/3),
-          u^2+2\big(1+v(2-2u/3)\big)^2\rangle</m>,
-          <m>0\leq u\leq 3</m>, <m>0\leq v\leq 1</m>.
-        </p>
-
-        <p>
-          The surface is graphed in <xref ref="fig_parsurf4b_3D">Figure</xref>.
-        </p>
-
         <figure xml:id="fig_parsurf4">
           <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf4">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%" valign="bottom">
             <figure xml:id="fig_parsurf4a">
               <caption/>
               <image xml:id="img_parsurf4a">
@@ -789,10 +754,6 @@
                 \draw (axis cs: 1,1.75) node {$R$};
 
                 \end{axis}
-
-                \node [right] at (myplot.right of origin) {\scriptsize $x$};
-                \node [above] at (myplot.above origin) {\scriptsize $y$};
-
                 \end{tikzpicture}
 
                 </latex-image>
@@ -887,6 +848,40 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          While the region <m>R</m> in this example is very similar to the region <m>R</m> in the previous example,
+          and our method of parametrizing the surface is fundamentally the same,
+          it will feel as though our answer is much different than before.
+        </p>
+
+        <p>
+          We begin with letting <m>x=u</m>, <m>0\leq u\leq 3</m>.
+          We may be tempted to let <m>y = v(3-2u/3)</m>,
+          <m>0\leq v\leq 1</m>, but this is incorrect.
+          When <m>v = 1</m>,
+          we obtain the upper line of the triangle as desired.
+          However, when <m>v=0</m>,
+          the <m>y</m>-value is 0, which does not lie in the region <m>R</m>.
+        </p>
+
+        <p>
+          We will describe the general method of proceeding following this example.
+          For now, consider <m>y = 1+v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
+          Note that when <m>v=1</m>,
+          we have <m>y=3-2u/3</m>, the upper line of the boundary of <m>R</m>.
+          Also, when <m>v=0</m>, we have <m>y=1</m>,
+          which is the lower boundary of <m>R</m>.
+          With <m>z=x^2+2y^2</m>,
+          we determine <m>\vec r(u,v) = \langle u, 1+v(2-2u/3),
+          u^2+2\big(1+v(2-2u/3)\big)^2\rangle</m>,
+          <m>0\leq u\leq 3</m>, <m>0\leq v\leq 1</m>.
+        </p>
+
+        <p>
+          The surface is graphed in <xref ref="fig_parsurf4b_3D">Figure</xref>.
+        </p>
       </solution>
     </example>
 
@@ -939,9 +934,9 @@
     </p>
 
     <insight xml:id="idea_parametrizing_surfaces">
-      <title>parametrizing Surfaces</title>
+      <title>Parametrizing Surfaces</title>
       <p>
-        Let a surface <m>\surfaceS</m>be the graph of a function <m>z=f(x,y)</m>,
+        Let a surface <m>\surfaceS</m> be the graph of a function <m>f(x,y)</m>,
         where the domain of <m>f</m> is a closed,
         bounded region <m>R</m> in the <m>x</m>-<m>y</m> plane.
         Let <m>R</m> be bounded by <m>a\leq x\leq b</m>,
@@ -951,7 +946,7 @@
       </p>
 
       <p>
-        <m>\surfaceS</m>can be parametrized as
+        <m>\surfaceS</m> can be parametrized as
         <me>
           \vec r(u,v) = \la u, h(u,v), f\big(u,h(u,v)\big)\ra, a\leq u\leq b,\ 0\leq v\leq 1
         </me>.
@@ -959,30 +954,13 @@
     </insight>
 
     <example xml:id="ex_parsurf5">
-      <title>parametrizing a cylindrical surface</title>
+      <title>Parametrizing a cylindrical surface</title>
       <statement>
         <p>
           Find a parametrization of the cylinder <m>x^2 + z^2/4=1</m>,
           where <m>-1\leq y\leq 2</m>,
           as shown in <xref ref="fig_parsurf5">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          The equation <m>x^2+z^2/4=1</m> can be envisioned to describe an ellipse in the <m>x</m>-<m>z</m> plane;
-          as the equation lacks a <m>y</m>-term,
-          the equation describes a cylinder
-          (recall <xref ref="def_cylinder">Definition</xref>)
-          that extends without bound parallel to the <m>y</m>-axis.
-          This ellipse has a vertical major axis of length 4, a horizontal minor axis of length 2, and is centered at the origin.
-          We can parametrize this ellipse using sines and cosines;
-          our parametrization can begin with
-          <me>
-            \vec r(u,v) = \la \cos u, \text{ ??? } , 2\sin u\ra, 0\leq u\leq 2\pi
-          </me>,
-          where we still need to determine the <m>y</m> component.
-        </p>
-
         <figure xml:id="fig_parsurf5">
           <caption>The cylinder parametrized in <xref ref="ex_parsurf5">Example</xref>.</caption>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -992,7 +970,7 @@
           3Dcoo=1.6293458938598633 13.199743270874023 -3.546671152114868,
           3Droo=399.9999708739728,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf5_3D">
+          <image xml:id="img_parsurf5_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -1073,6 +1051,22 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          The equation <m>x^2+z^2/4=1</m> can be envisioned to describe an ellipse in the <m>x</m>-<m>z</m> plane;
+          as the equation lacks a <m>y</m>-term,
+          the equation describes a cylinder
+          (recall <xref ref="def_cylinder">Definition</xref>)
+          that extends without bound parallel to the <m>y</m>-axis.
+          This ellipse has a vertical major axis of length 4, a horizontal minor axis of length 2, and is centered at the origin.
+          We can parametrize this ellipse using sines and cosines;
+          our parametrization can begin with
+          <me>
+            \vec r(u,v) = \la \cos u, \text{ ??? } , 2\sin u\ra, 0\leq u\leq 2\pi
+          </me>,
+          where we still need to determine the <m>y</m> component.
+        </p>
 
         <p>
           While the cylinder <m>x^2+z^2/4=1</m> is satisfied by any <m>y</m> value,
@@ -1088,23 +1082,13 @@
     </example>
 
     <example xml:id="ex_parsurf6">
-      <title>parametrizing an elliptic cone</title>
+      <title>Parametrizing an elliptic cone</title>
       <statement>
         <p>
           Find a parametrization of the elliptic cone <m>z^2 = \frac{x^2}{4}+\frac{y^2}{9}</m>,
           where <m>-2\leq z\leq 3</m>,
           as shown in <xref ref="fig_parsurf6a">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          One way to parametrize this cone is to recognize that given a <m>z</m> value,
-          the cross section of the cone at that <m>z</m> value is an ellipse with equation <m>\frac{x^2}{(2z)^2} + \frac{y^2}{(3z)^2}=1</m>.
-          We can let <m>z=v</m>, for
-          <m>-2\leq v\leq 3</m> and then parametrize the above ellipses using sines,
-          cosines and <m>v</m>.
-        </p>
-
         <figure xml:id="fig_parsurf6a">
           <caption>The elliptic cone as described in  <xref ref="ex_parsurf6">Example</xref>.</caption>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1114,7 +1098,7 @@
           3Dcoo=0.0026521924883127213 4.370458126068115 12.347787857055664,
           3Droo=399.9999637774216,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf6a">
+          <image xml:id="img_parsurf6a" width="47%">
             <description></description>
             <asymptote>
 
@@ -1195,6 +1179,15 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          One way to parametrize this cone is to recognize that given a <m>z</m> value,
+          the cross section of the cone at that <m>z</m> value is an ellipse with equation <m>\frac{x^2}{(2z)^2} + \frac{y^2}{(3z)^2}=1</m>.
+          We can let <m>z=v</m>, for
+          <m>-2\leq v\leq 3</m> and then parametrize the above ellipses using sines,
+          cosines and <m>v</m>.
+        </p>
 
         <p>
           We can parametrize the <m>x</m> component of our surface with
@@ -1226,7 +1219,7 @@
           3Dcoo=0.0026521924883127213 4.370458126068115 12.347787857055664,
           3Droo=399.9999637774216,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf6b_3D">
+          <image xml:id="img_parsurf6b_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -1311,49 +1304,15 @@
     </example>
 
     <example xml:id="ex_parsurf7">
-      <title>parametrizing an ellipsoid</title>
+      <title>Parametrizing an ellipsoid</title>
       <statement>
         <p>
           Find a parametrization of the ellipsoid
           <m>\frac{x^2}{25}+y^2+\frac{z^2}{4}=1</m> as shown in <xref ref="fig_parsurf7a_3D">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Recall <xref ref="idea_unit_vectors">Key Idea</xref>
-          from <xref ref="sec_vector_intro">Section</xref>,
-          which states that all unit vectors in space have the form
-          <m>\langle \sin\theta\cos\varphi,\sin\theta\sin\varphi,\cos\theta\rangle</m> for some angles <m>\theta</m> and <m>\varphi</m>.
-          If we choose our angles appropriately,
-          this allows us to draw the unit sphere.
-          To get an ellipsoid,
-          we need only scale each component of the sphere appropriately.
-        </p>
-
-        <p>
-          The <m>x</m>-radius of the given ellipsoid is 5, the <m>y</m>-radius is 1 and the <m>z</m>-radius is 2.
-          Substituting <m>u</m> for <m>\theta</m> and <m>v</m> for <m>\varphi</m>,
-          we have <m>\vec r(u,v) = \langle 5\sin u\cos v, \sin u\sin v,2\cos u\rangle</m>,
-          where we still need to determine the ranges of <m>u</m> and <m>v</m>.
-        </p>
-
-        <p>
-          Note how the <m>x</m> and <m>y</m> components of <m>\vec r</m> have <m>\cos v</m> and <m>\sin v</m> terms,
-          respectively.
-          This hints at the fact that ellipses are drawn parallel to the <m>x</m>-<m>y</m> plane as <m>v</m> varies,
-          which implies we should have <m>v</m> range from <m>0</m> to <m>2\pi</m>.
-        </p>
-
-        <p>
-          One may be tempted to let <m>0\leq u\leq 2\pi</m> as well,
-          but note how the <m>z</m> component is <m>2\cos u</m>.
-          We only need <m>\cos u</m> to take on values between <m>-1</m> and <m>1</m> once,
-          therefore we can restrict <m>u</m> to <m>0\leq u\leq \pi</m>.
-        </p>
-
         <figure xml:id="fig_parsurf7">
           <caption>An ellipsoid in (a), drawn again in (b) with its domain restricted, as described in  <xref ref="ex_parsurf7">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_parsurf7a_3D">
               <caption/>
               <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1520,6 +1479,39 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Recall <xref ref="idea_unit_vectors">Key Idea</xref>
+          from <xref ref="sec_vector_intro">Section</xref>,
+          which states that all unit vectors in space have the form
+          <m>\langle \sin\theta\cos\varphi,\sin\theta\sin\varphi,\cos\theta\rangle</m> for some angles <m>\theta</m> and <m>\varphi</m>.
+          If we choose our angles appropriately,
+          this allows us to draw the unit sphere.
+          To get an ellipsoid,
+          we need only scale each component of the sphere appropriately.
+        </p>
+
+        <p>
+          The <m>x</m>-radius of the given ellipsoid is 5, the <m>y</m>-radius is 1 and the <m>z</m>-radius is 2.
+          Substituting <m>u</m> for <m>\theta</m> and <m>v</m> for <m>\varphi</m>,
+          we have <m>\vec r(u,v) = \langle 5\sin u\cos v, \sin u\sin v,2\cos u\rangle</m>,
+          where we still need to determine the ranges of <m>u</m> and <m>v</m>.
+        </p>
+
+        <p>
+          Note how the <m>x</m> and <m>y</m> components of <m>\vec r</m> have <m>\cos v</m> and <m>\sin v</m> terms,
+          respectively.
+          This hints at the fact that ellipses are drawn parallel to the <m>x</m>-<m>y</m> plane as <m>v</m> varies,
+          which implies we should have <m>v</m> range from <m>0</m> to <m>2\pi</m>.
+        </p>
+
+        <p>
+          One may be tempted to let <m>0\leq u\leq 2\pi</m> as well,
+          but note how the <m>z</m> component is <m>2\cos u</m>.
+          We only need <m>\cos u</m> to take on values between <m>-1</m> and <m>1</m> once,
+          therefore we can restrict <m>u</m> to <m>0\leq u\leq \pi</m>.
+        </p>
 
         <p>
           The final parametrization is thus
@@ -1552,17 +1544,17 @@
       Because technology is often readily available,
       it is often a good idea to check one's work by graphing a parametrization of a surface to check if it indeed represents what it was intended to.
     </p>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Surface Area</title>
     <p>
-      It will become important in the following sections to be able to compute the surface area of a surface <m>\surfaceS</m>given a smooth parametrization <m>\vec r(u,v)</m>,
+      It will become important in the following sections to be able to compute the surface area of a surface <m>\surfaceS</m> given a smooth parametrization <m>\vec r(u,v)</m>,
       <m>a\leq u\leq b</m>, <m>c\leq v\leq d</m>.
       Following the principles given in the integration review at the beginning of this chapter,
       we can say that<idx><h>surface area</h><h>of parametrized surface</h></idx>
       <me>
-        \text{ Surface Area of \surfaceS } =S = \iint_{\surfaceS}\, dS
+        \text{ Surface Area of }\surfaceS\, =S = \iint_{\surfaceS}\, dS
       </me>,
       where <m>dS</m> represents a small amount of surface area.
       That is, to compute total surface area <m>S</m>,
@@ -1611,7 +1603,7 @@
 
     <figure xml:id="fig_parsurfarea">
       <caption>Illustrating the process of finding surface area by approximating with planes.</caption>
-      <sidebyside>
+      <sidebyside widths="33% 33% 33%">
         <figure xml:id="fig_parsurfareaa">
           <caption/>
           <image xml:id="img_parsurfareaa">
@@ -1629,6 +1621,8 @@
               extra y tick labels={$c$,$d$,$v_0$,$v_0+\Delta v$},
               ymin=-.1,ymax=2.5,
               xmin=-.1,xmax=2.5,
+              xlabel={$u$},
+              ylabel={$v$}
             ]
 
             \filldraw [thick,draw=firstcolor,fill=firstcolor!15] (axis cs: .5,.1) -- (axis cs: .5,2) -- (axis cs: 2.25,2)  -- (axis cs: 2.25,.1) -- cycle;
@@ -1648,8 +1642,6 @@
 
             \end{axis}
 
-            \node [right] at (myplot.right of origin) {\scriptsize $u$};
-            \node [above] at (myplot.above origin) {\scriptsize $v$};
 
             \end{tikzpicture}
 
@@ -1972,7 +1964,7 @@
       If we repeat this approximation process for each rectangle in the partition of <m>R</m>,
       we can sum the areas of all the parallelograms to get an approximation of the surface area <m>S</m>:
       <me>
-        \text{ Surface area of \surfaceS }  =S \approx \sum_{j=1}^n\sum_{i=1}^n \snorm{\vec u_{i,j}\times \vec v_{i,j}}
+        \text{ Surface area of } \surfaceS \,  =S \approx \sum_{j=1}^n\sum_{i=1}^n \snorm{\vec u_{i,j}\times \vec v_{i,j}}
       </me>,
       where <m>\vec u_{i,j} = \vec r(u_i+\Delta u,v_j) - \vec r(u_i,v_j)</m> and <m>\vec v_{i,j} = \vec r(u_i,v_j+\Delta v)-\vec r(u_i,v_j)</m>.
     </p>
@@ -2004,7 +1996,7 @@
 
     <p>
       (This limit process also demonstrates that <m>\vec r_u(u,v)</m> and
-      <m>\vec r_v(u,v)</m> are tangent to the surface <m>\surfaceS</m>at <m>\vec r(u,v)</m>.
+      <m>\vec r_v(u,v)</m> are tangent to the surface <m>\surfaceS</m> at <m>\vec r(u,v)</m>.
       We don't need this fact now, but it will be important in the next section.)
     </p>
 
@@ -2019,7 +2011,7 @@
       <title>Surface Area of Parametrically Defined Surfaces</title>
       <statement>
         <p>
-          Let <m>\vec r(u,v)</m> be a smooth parametrization of a surface <m>\surfaceS</m>over a closed,
+          Let <m>\vec r(u,v)</m> be a smooth parametrization of a surface <m>\surfaceS</m> over a closed,
           bounded region <m>R</m> of the <m>u</m>-<m>v</m> plane.
               <idx><h>surface area</h><h>of parametrized surface</h></idx>
           <ul>
@@ -2032,7 +2024,7 @@
 
             <li>
               <p>
-                The surface area <m>S</m> of <m>\surfaceS</m>is
+                The surface area <m>S</m> of <m>\surfaceS</m> is
                 <me>
                   S = \iint_\surfaceS\, dS = \iint_R \snorm{\vec r_u\times \vec r_v}\, dA
                 </me>.
@@ -2291,7 +2283,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a surface <m>\surfaceS</m> in space is described that cannot be defined in terms of a function <m>z=f(x,y)</m>.
+          a surface <m>\surfaceS</m> in space is described that cannot be defined as the graph of a function <m>f(x,y)</m>.
           Give a parametrization of <m>\surfaceS</m>.
         </p>
       </introduction>
@@ -2299,7 +2291,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the rectangle in space with corners at <m>(0,0,0)</m>,
+            <m>\surfaceS</m> is the rectangle in space with corners at <m>(0,0,0)</m>,
             <m>(0,2,0)</m>,
             <m>(0,2,1)</m> and <m>(0,0,1)</m>.
           </p>
@@ -2315,7 +2307,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the triangle in space with corners at <m>(1,0,0)</m>,
+            <m>\surfaceS</m> is the triangle in space with corners at <m>(1,0,0)</m>,
             <m>(1,0,1)</m> and <m>(0,0,1)</m>.
           </p>
         </statement>
@@ -2330,7 +2322,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the ellipsoid <m>\ds\frac{x^2}{9} + \frac{y^2}{4}+\frac{z^2}{16} = 1</m>.
+            <m>\surfaceS</m> is the ellipsoid <m>\ds\frac{x^2}{9} + \frac{y^2}{4}+\frac{z^2}{16} = 1</m>.
           </p>
         </statement>
         <answer>
@@ -2344,7 +2336,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the elliptic cone <m>\ds y^2= x^2+\frac{z^2}{16}</m>,
+            <m>\surfaceS</m> is the elliptic cone <m>\ds y^2= x^2+\frac{z^2}{16}</m>,
             for <m>-1 \leq y \leq 5</m>.
           </p>
         </statement>
@@ -3518,7 +3510,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=2x+3y</m> over the rectangle
+            <m>\surfaceS</m> is the plane <m>z=2x+3y</m> over the rectangle
             <m>-1\leq x\leq 1</m>, <m>2\leq v \leq 3</m>.
           </p>
         </statement>
@@ -3532,7 +3524,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=x+2y</m> over the triangle with vertices at <m>(0,0)</m>,
+            <m>\surfaceS</m> is the plane <m>z=x+2y</m> over the triangle with vertices at <m>(0,0)</m>,
             <m>(1,0)</m> and <m>(0,1)</m>.
           </p>
         </statement>
@@ -3546,7 +3538,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=x+y</m> over the circular disk,
+            <m>\surfaceS</m> is the plane <m>z=x+y</m> over the circular disk,
             centered at the origin, with radius 2.
           </p>
         </statement>
@@ -3560,7 +3552,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=x+y</m> over the annulus bounded by the circles,
+            <m>\surfaceS</m> is the plane <m>z=x+y</m> over the annulus bounded by the circles,
             centered at the origin, with radius 1 and radius 2.
           </p>
         </statement>
@@ -3583,7 +3575,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the paraboloid
+            <m>\surfaceS</m> is the paraboloid
             <m>z=x^2+y^2</m> over the circular disk of radius 3 centered at the origin.
           </p>
         </statement>
@@ -3597,7 +3589,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the paraboloid
+            <m>\surfaceS</m> is the paraboloid
             <m>z=x^2+y^2</m> over the triangle with vertices at <m>(0,0)</m>,
             <m>(0,1)</m> and <m>(1,1)</m>.
           </p>
@@ -3612,7 +3604,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=5x-y</m> over the region enclosed by the parabola <m>y=1-x^2</m> and the <m>x</m>-axis.
+            <m>\surfaceS</m> is the plane <m>z=5x-y</m> over the region enclosed by the parabola <m>y=1-x^2</m> and the <m>x</m>-axis.
           </p>
         </statement>
         <answer>
@@ -3625,7 +3617,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the hyperbolic paraboloid
+            <m>\surfaceS</m> is the hyperbolic paraboloid
             <m>z=x^2-y^2</m> over the circular disk of radius 1 centered at the origin.
           </p>
         </statement>

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -21,12 +21,12 @@
   <subsection xml:id="subsec-first-partial">
     <title>First-order partial derivatives</title>
     <p>
-      Consider the function <m>z=f(x,y) = x^2+2y^2</m>,
+      Consider the function <m>f(x,y) = x^2+2y^2</m>,
       as graphed in <xref ref="fig_partialintroa_3D">Figure</xref>.
       By fixing <m>y=2</m>,
       we focus our attention to all points on the surface where the <m>y</m>-value is 2, shown in both <xref ref="fig_partialintroa_3D">Figure</xref> and <xref ref="fig_partialintrob_3D">Figure</xref>.
-      These points form a curve in space:
-      <m>z = f(x,2) = x^2+8</m> which is a function of just one variable.
+      These points form a curve in the plane <m>y=2</m>:
+      <m>z = f(x,2) = x^2+8</m> which defines <m>z</m> as a function of just one variable.
       We can take the derivative of <m>z</m> with respect to <m>x</m> along this curve and find equations of tangent lines, etc.
     </p>
 
@@ -406,6 +406,11 @@
       </solution>
     </example>
 
+    <!-- <figure xml:id="vid-multi-partial-examples">
+      <caption>Additional partial derivative computation examples</caption>
+      <video youtube="R3PXGwjOmtw"/> -->
+    </figure>
+
     <p>
       We have shown <em>how</em> to compute a partial derivative,
       but it may still not be clear what a partial derivative <em>means</em>.
@@ -696,11 +701,105 @@
         </p>
       </solution>
     </example>
+  </subsection>
 
-    <!-- <figure xml:id="vid-multi-partial-examples">
-      <caption>Additional partial derivative computation examples</caption>
-      <video youtube="R3PXGwjOmtw"/>
-    </figure> -->
+  <subsection xml:id="subsec-tangent-plane">
+    <title>Tangent Planes</title>
+    <p>
+      Another way to interpret partial derivatives is in terms of the <em>tangent plane</em>.
+      Consider a graph <m>z=f(x,y)</m>, such as the one in <xref ref="fig_partialintro">Figure</xref>.
+      Setting <m>x=a</m>, <m>y=b</m> defines a point <m>(a,b,f(a,b))</m> on the graph.
+      Through the point <m>(a,b)</m>, we have the lines <m>x=a+s, y=b</m>, and <m>x=a, y=b+t</m>,
+      parallel to the <m>x</m> and <m>y</m> axes, respectively (where <m>s,t</m> are parameters).
+    </p>
+
+    <p>
+      Using the function <m>f(x,y)</m> we define two vector-valued functions:
+      <md>
+        <mrow>\vec{r}_1(s) \amp = \la a+s, b, f(a+s,b)\ra</mrow>
+        <mrow>\vec{r}_2(t) \amp = \la a, b+t, f(a,b+t)\ra</mrow>
+      </md>.
+      Both vector-valued functions define space curves that lie on the surface <m>z=f(x,y)</m>,
+      and these curves intersect at the point <m>(a,b,f(a,b))</m>.
+    </p>
+
+    <p>
+      Notice that in <m>\vec{r}_1(s)</m>, we vary <m>x</m> while holding <m>y</m> constant.
+      Using <xref ref="def_partial_derivative">Definition</xref>, we see that
+      <me>
+        \vec{v}=\vec{r}_1'(0) = \la 1,0,f_x(a,b)\ra
+      </me>,
+      and similarly,
+      <me>
+        \vec{w}=\vec{r}_2'(0) = \la 0,1,f_y(a,b)\ra
+      </me>.
+      From <xref ref="sec_vvf_calc">Section</xref>,
+      we know that <m>\vec{r}_1'(0)</m> defines a tangent vector to the curve <m>\vec{r}_1(s)</m> when <m>s=0</m>,
+      and similarly, <m>\vec{r}_2'(0)</m> defines a tangent vector to the curve <m>\vec{r}_2(t)</m> when <m>t=0</m>.
+    </p>
+
+    <p>
+      It seems reasonable that any vector that is tangent to these curves,
+      which lie on our surface, should also be considered tangent to that surface.
+      The vectors <m>\vec{v}</m> and <m>\vec{w}</m> are therefore tangent to <m>z=f(x,y)</m> at <m>(a,b,f(a,b))</m>,
+      and they are definitely not parallel.
+      From <xref ref="sec_planes">Section</xref> we know that any two non-parallel vectors at a point define a plane through that point.
+      We also know that taking the cross product of these two vectors gives us a normal vector:
+      the cross product gives us
+      <me>
+        \vec{n}=\vec{r}_1'(0)\times\vec{r}_2'(0)=\la -f_x(a,b), -f_y(a,b), 1\ra
+      </me>.
+    </p>
+
+    <p>
+      The equation of the plane through <m>(a,b,f(a,b))</m> with normal vector <m>\vec{n}=\la -f_x(a,b),-f_y(a,b),1\ra</m> is
+      <me>
+        -f_x(a,b)(x-a)-f_y(a,b)(y-b)+(z-f(a,b))=0
+      </me>.
+      It is customary to solve for <m>z</m> in this equation and make the following definition.
+    </p>
+
+    <definition xml:id="def-tangent-plane">
+      <statement>
+        <p>
+          Let <m>f(x,y)</m> be a function whose first-order partial derivatives exist at <m>(a,b)</m>.
+          The <term>tangent plane</term> to the graph <m>z=f(x,y)</m> at the point <m>(a,b,f(a,b))</m> is the plane defined by the equation
+          <me>
+            z = f(a,b)+f_x(a,b)(x-a)+f_y(a,b)(y-b)
+          </me>.
+          <idx><h>tangent plane</h></idx>
+          <idx><h>tangent plane</h><h>to a graph</h></idx>
+        </p>
+      </statement>
+    </definition>
+
+    <example>
+      <title>Finding a tangent plane equation</title>
+      <statement>
+        <p>
+          Find the equation of tangent plane to the surface <m>z=x^2+3y^2</m> when <m>(x,y)=(1,-1)</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Our function is <m>f(x,y)=x^2+3y^2</m>, and we have <m>f(1,-1)=4</m>,
+          so the point on the surface is <m>(1,-1,4)</m>.
+          The partial derivatives are <m>f_x(x,y)=2x</m> and <m>f_y(x,y)=6y</m>,
+          so <m>f_x(1,-1)=2</m>, <m>f_y(1,-1)=-6</m>, and our plane is given by
+          <me>
+            z = 4+2(x-1)-6(y+1)
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      Notice the similarity between the tangent plane equation in <xref ref="def-tangent-plane"/>
+      and the single variable tangent line equation <m>y = f(c)+f'(c)(x-c)</m>.
+      As with functions of one variable, this suggests a connection between derivatives and linear approximation.
+      We explore this connection in <xref ref="sec_total_differential"/>,
+      where we'll see that <xref ref="def-tangent-plane"/> should be strengthed to require that the partial derivatives of <m>f</m> be <em>continuous</em>.
+    </p>
   </subsection>
 
   <subsection xml:id="subsec-second-partial">
@@ -1494,7 +1593,7 @@
             </pg-code> -->
             <statement>
               <p>
-                Given a function <m>z=f(x,y)</m>,
+                Given a function <m>f(x,y)</m>,
                 explain in your own words how to compute <m>f_x</m>.
               </p>
             </statement>
@@ -2308,7 +2407,7 @@
       <introduction>
         <p>
           In the following exercises,
-          form a function <m>z=f(x,y)</m> such that <m>f_x</m> and <m>f_y</m> match those given.
+          form a function <m>f(x,y)</m> such that <m>f_x</m> and <m>f_y</m> match those given.
         </p>
       </introduction>
 

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -195,7 +195,7 @@
     </p>
 
     <example xml:id="ex_planes1">
-      <title>Finding the equation of a plane.</title>
+      <title>Finding the equation of a plane</title>
       <statement>
         <p>
           Write the equation of the plane that passes through the points <m>P=(1,1,0)</m>,
@@ -351,7 +351,7 @@
     </p>
 
     <example xml:id="ex_planes2">
-      <title>Finding the equation of a plane.</title>
+      <title>Finding the equation of a plane</title>
       <statement>
         <p>
           Verify that lines <m>\ell_1</m> and <m>\ell_2</m>,
@@ -1125,12 +1125,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 In order to find the equation of a plane,
@@ -1146,12 +1144,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 What is the relationship between a plane and one of its normal vectors?
@@ -1175,12 +1171,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 <m>2x-4y+7z=2</m>
@@ -1195,9 +1189,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               $points=List("(-2,9,0),(2,9,3)");
@@ -1234,7 +1226,7 @@
                 return ($score,@errors);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 List any two points in the plane with equation <m>3(x+2)+5(y-9)-4z=0</m>.
@@ -1248,12 +1240,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 <m>x=2</m>
@@ -1268,9 +1258,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               $points=List("(0,-2,6),(1,-2,6)");
@@ -1307,7 +1295,7 @@
                 return ($score,@errors);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 List any two points in the plane with equation <m>4(y+2)-(z-6)=0</m>.
@@ -1331,12 +1319,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Passes through <m>(2,3,4)</m> and has normal vector
@@ -1359,8 +1345,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               sub grouped {
                 my $op = shift;
@@ -1400,7 +1385,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane passes through <m>(1,3,5)</m> and has normal vector <m>\vec n= \la 0,2,4\ra</m>.
@@ -1418,12 +1403,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Passes through the points <m>(1,2,3)</m>,
@@ -1447,9 +1430,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1490,7 +1471,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane passes through the points <m>(5,3,8)</m>,
@@ -1509,12 +1490,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Contains the intersecting lines
@@ -1545,9 +1524,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1588,7 +1565,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the intersecting lines
@@ -1607,12 +1584,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Contains the parallel lines
@@ -1643,9 +1618,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1686,7 +1659,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the parallel lines
@@ -1705,12 +1678,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Contains the point <m>(2,-6,1)</m> and the line
@@ -1740,9 +1711,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1783,7 +1752,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(5,7,3)</m> and the line <m>\vec\ell(t) = \begin{cases}x\amp=t\\y\amp=t\\z\amp=t\end{cases}</m>.
@@ -1801,9 +1770,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1844,7 +1811,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(5,7,3)</m> and is orthogonal to the line <m>\vec\ell(t) = \la 4,5,6\ra+ t\la 1,1,1\ra</m>.
@@ -1862,9 +1829,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1905,7 +1870,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(4,1,1)</m> and is orthogonal to the line <m>\begin{cases}x\amp=4+4t\\y\amp=1+t\\z\amp=1+t\end{cases}</m>.
@@ -1923,9 +1888,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1966,7 +1929,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point
@@ -1985,9 +1948,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -2028,7 +1989,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(1,2,3)</m> and is parallel to the plane <m>x=5</m>.
@@ -2056,12 +2017,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 <m>p1:\ 3 (x - 2) + (y - 1) + 4 z=0</m>, and
@@ -2087,9 +2046,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -2103,7 +2060,7 @@
                 return ($par and $tch);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the line
@@ -2130,12 +2087,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 line: <m>\la 5,1,-1\ra + t\la 2,2,1\ra</m>,
@@ -2154,15 +2109,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add('the entire line'=>{});
               $point=Point("(3,1,1)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the point of intersection between the line
@@ -2180,12 +2133,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 line: <m>\la 1,2,3\ra + t\la 3,5,-1\ra</m>,
@@ -2204,15 +2155,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add('the entire line'=>{});
               $point=Compute('the entire line');
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the point of intersection between the line
@@ -2239,12 +2188,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 The distance from the point <m>(1,2,3)</m> to the plane
@@ -2263,14 +2210,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("8/sqrt(21)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance from the point <m>(2,6,2)</m> to the plane <m>2(x-1)-y+4(z+1)=0</m>.
@@ -2284,12 +2229,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 The distance between the parallel planes
@@ -2312,14 +2255,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance between the parallel planes
@@ -2336,12 +2277,10 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
           </pg-code>
-          </setup>-->
+          -->
           <statement>
             <p>
               Show why if the point <m>Q</m> lies in a plane,
@@ -2361,12 +2300,10 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
           </pg-code>
-          </setup>-->
+          -->
           <statement>
             <p>
               How is <xref ref="x10_05_ex_30">Exercise</xref>

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -395,10 +395,10 @@
   <subsection>
     <title>Spheres</title>
     <p>
-          <idx><h>sphere</h></idx>
       Just as a circle is the set of all points in the <em>plane</em> equidistant from a given point (its center), a sphere is the set of all points in <em>space</em> that are equidistant from a given point.
       <xref ref="def_space_distance">Definition</xref>
       allows us to write an equation of the sphere.
+      <idx><h>sphere</h></idx>
     </p>
 
     <p>
@@ -2433,7 +2433,7 @@
       3Dlights=Headlamp,add3Djscript=asylabels.js]
        -->
       <!-- START figures/figquadric_parb_3D.asy -->
-      <image xml:id="img_quadric1">
+      <image xml:id="img_quadric1" width="47%">
         <description></description>
         <asymptote>
 
@@ -2564,7 +2564,9 @@
       <dl>
         <li>
           <title>Elliptic Paraboloid</title>
-          <m>z=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          <p>
+            <m>z=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -2782,7 +2784,9 @@
       <dl>
         <li>
           <title>Elliptic Cone</title>
-          <m>z^2=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          <p>
+            <m>z^2=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3102,7 +3106,9 @@
       <dl>
         <li>
           <title>Ellipsoid</title>
-          <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}+\frac{z^2}{c^2}=1</m>
+          <p>
+            <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}+\frac{z^2}{c^2}=1</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3336,7 +3342,9 @@
       <dl>
         <li>
           <title>Hyperboloid of One Sheet</title>
-          <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}-\frac{z^2}{c^2}=1</m>
+          <p>
+            <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}-\frac{z^2}{c^2}=1</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3578,7 +3586,9 @@
       <dl>
         <li>
           <title>Hyperboloid of Two Sheets</title>
-          <m>\frac{z^2}{c^2}-\frac{x^2}{a^2}-\frac{y^2}{b^2}=1</m>
+          <p>
+            <m>\frac{z^2}{c^2}-\frac{x^2}{a^2}-\frac{y^2}{b^2}=1</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3836,7 +3846,9 @@
       <dl>
         <li>
           <title>Hyperbolic Paraboloid</title>
-          <m>z=\frac{x^2}{a^2}-\frac{y^2}{b^2}</m>
+          <p>
+            <m>z=\frac{x^2}{a^2}-\frac{y^2}{b^2}</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -5022,12 +5034,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 Axes drawn in space must conform to the <fillin/> <fillin/> rule.
@@ -5042,10 +5051,8 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <!-- <pg-macros><macro-file>contextArbitraryString.pl</macro-file></pg-macros> -->
-            <setup>
-
 
             <pg-code>
               Context("ArbitraryString");
@@ -5066,7 +5073,7 @@
                 return uc($correct) eq uc($student);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 In the plane,
@@ -5081,12 +5088,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 In the plane, the equation <m>y=x^2</m> defines a <fillin/>;
@@ -5102,13 +5106,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $surfaces=PopUp(['?','Elliptic Paraboloid','Elliptic Cone','Ellipsoid','Hyperboloid of One Sheet','Hyperboloid of Two Sheets','Hyperbolic Paraboloid'],6);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Which quadric surface looks like a Pringles<!--<trademark/>-->(TM)<nbsp/>chip?
@@ -5119,12 +5121,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 Consider the hyperbola <m>x^2-y^2=1</m> in the plane.
@@ -5141,12 +5140,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 Consider the hyperbola <m>x^2-y^2=1</m> in the plane.
@@ -5165,8 +5161,7 @@
     </exercisegroup>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
+      <webwork>
           <pg-code>
             Context("Point");
             $A=Point("(1,4,2)");
@@ -5186,7 +5181,7 @@
             $dodonot=(($a)**2+($b)**2==($c)**2)?'do':'do not';
             $yn=PopUp(['?','do','do not'],$dodonot);
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               The points <m>A=(1,4,2)</m>,
@@ -5222,11 +5217,9 @@
     </exercise>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
+      <!-- <webwork>
           <pg-code>
-          </pg-code>
-          </setup> -->
+          </pg-code> -->
           <statement>
             <p>
               The points <m>A=(1,1,3)</m>, <m>B=(3,2,7)</m>,
@@ -5245,14 +5238,13 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
+      <webwork>
           <pg-code>
             Context("Point");
             $center=Point("(4,-1,0)");
             $radius=Real("3");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the center and radius of the sphere defined by
@@ -5273,15 +5265,14 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
+      <webwork>
           <pg-code>
             Context("Point");
             $center=Point("(-2,1,2)");
             Context()->flags->set(reduceConstantFunctions=>0);
             $radius=Formula("sqrt(5)");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the center and radius of the sphere defined by
@@ -5311,12 +5302,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>x^2+y^2+z^2\lt 1</m>
@@ -5331,12 +5319,10 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>0\leq x\leq 3</m>
@@ -5353,12 +5339,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>x\geq 0,\ y\geq0, \ z\geq0</m>
@@ -5376,12 +5359,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>y\geq 3</m>
@@ -5409,12 +5389,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>z=x^3</m>
@@ -5534,12 +5511,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>y=\cos(z)</m>
@@ -5641,12 +5615,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds \frac{x^2}{4}+\frac{y^2}{9}=1</m>
@@ -5759,12 +5730,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds y=\frac1x</m>
@@ -5895,15 +5863,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("x^2+z^2=(1/(1+y^2))^2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving
@@ -5918,15 +5884,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("y^2+z^2=x^4");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving <m>y=x^2</m> in the <m>xy</m>-plane about the <m>x</m>-axis.
@@ -5940,15 +5904,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("x^2+y^2=z");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving <m>z=x^2</m> in the <m>xz</m>-plane about the <m>z</m>-axis.
@@ -5962,15 +5924,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("x^2+y^2=1/z^2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving <m>z=1/x</m> in the <m>xz</m>-plane about the <m>z</m>-axis.
@@ -5994,12 +5954,9 @@
       </introduction>
       <!--TODO: probably should use an ordered list for the two options in each problem here.-->
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6098,12 +6055,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6209,12 +6163,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6313,12 +6264,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6433,12 +6381,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds z-y^2+x^2=0</m>
@@ -6527,12 +6472,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds z^2=x^2+\frac{y^2}4</m>
@@ -6620,12 +6562,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>x=-y^2-z^2</m>
@@ -6713,12 +6652,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds 16x^2-16y^2-16z^2=1</m>
@@ -6813,12 +6749,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds \frac{x^2}9-y^2+\frac{z^2}{25}=1</m>
@@ -6906,12 +6839,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds 4x^2+2y^2+z^2=4</m>

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -27,7 +27,7 @@
       <statement>
         <p>
           Let <m>D</m> be a closed domain in space whose boundary is an orientable,
-          piecewise smooth surface <m>\surfaceS</m>with outer unit normal vector <m>\vec n</m>,
+          piecewise smooth surface <m>\surfaceS</m> with outer unit normal vector <m>\vec n</m>,
           and let <m>\vec F</m> be a vector field whose components are differentiable on <m>D</m>.
           Then<idx><h>Divergence Theorem</h><h>in space</h></idx>
           <me>
@@ -53,7 +53,7 @@
           Let <m>D</m> be the domain in space bounded by the planes <m>z=0</m> and <m>z=2x</m>,
           along with the cylinder <m>x=1-y^2</m>,
           as graphed in <xref ref="fig_divthm_space2">Figure</xref>,
-          let <m>\surfaceS</m>be the boundary of <m>D</m>,
+          let <m>\surfaceS</m> be the boundary of <m>D</m>,
           and let <m>\vec F = \langle x+y,y^2, 2z\rangle</m>.
         </p>
 
@@ -66,7 +66,7 @@
           3Dcoo=-4.848384857177734 2.0102698802948 61.921504974365234,
           3Droo=399.9999594035934,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_divthm_space2_3D">
+          <image xml:id="img_divthm_space2_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -140,7 +140,7 @@
       </statement>
       <solution>
         <p>
-          The surface <m>\surfaceS</m>is piecewise smooth,
+          The surface <m>\surfaceS</m> is piecewise smooth,
           comprising surfaces <m>\surfaceS_1</m>,
           which is part of the plane <m>z=2x</m>,
           surface <m>\surfaceS_2</m>, which is part of the cylinder <m>x=1-y^2</m>,
@@ -187,7 +187,7 @@
           meaning <em>to the outside</em>, of <m>\surfaceS</m>.)
           The flux across <m>\surfaceS_1</m> is:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_1\): }  \amp = \iint_{\surfaceS_1} \vec F\cdot \vec n_1\, dS</mrow>
+            <mrow>\text{ Flux across }\surfaceS_1:\,   \amp = \iint_{\surfaceS_1} \vec F\cdot \vec n_1\, dS</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \vec F\big(\vec r_1(u,v)\big)\cdot \big(\vec r_{1v}\times\vec r_{1u}\big)\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \la v(1-u^2)+u, u^2,4v(1-u^2)\ra \cdot \la 2(u^2-1),0,1-u^2\ra\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \big(2u^4v+2u^3-4u^2v-2u+2v\big)\, du\, dv</mrow>
@@ -202,7 +202,7 @@
           meaning this vector points outside <m>\surfaceS</m>.)
           The flux across <m>\surfaceS_2</m> is:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_2\): }  \amp = \iint_{\surfaceS_2} \vec F\cdot \vec n_2\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_2:\,  \amp = \iint_{\surfaceS_2} \vec F\cdot \vec n_2\, dS</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \vec F\big(\vec r_2(u,v)\big)\cdot \big(\vec r_{2u}\times\vec r_{2v}\big)\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \la 1-u^2+u, u^2, 4v(1-u^2)\ra \cdot \la 2(1-u^2), 4u(1-u^2),0\ra\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \big(4u^5-2u^4-2u^3+4u^2-2u-2\big)\, du\, dv</mrow>
@@ -217,7 +217,7 @@
           meaning this vector points down, outside of <m>\surfaceS</m>.)
           The flux across <m>\surfaceS_3</m> is:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_3\): }  \amp = \iint_{\surfaceS_3} \vec F\cdot \vec n_3\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_3:\,  \amp = \iint_{\surfaceS_3} \vec F\cdot \vec n_3\, dS</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \vec F\big(\vec r_3(u,v)\big)\cdot \big(\vec r_{3u}\times\vec r_{3v}\big)\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \la v(1-u^2)+u,u^2,0\ra \cdot \la 0,0,u^2-1\ra\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 0\, du\, dv</mrow>
@@ -243,7 +243,7 @@
 
         <p>
           With <m>\divv \vec F = 1+2y+2 = 2y+3</m>,
-          we find the total outward flux of <m>\vec F</m> over <m>\surfaceS</m>as:
+          we find the total outward flux of <m>\vec F</m> over <m>\surfaceS</m> as:
           <me>
             \text{ Flux = }  \iiint_D\divv \vec F\, dV = \int_{-1}^1\int_0^{1-y^2}\int_0^{2x}\big(2y+3\big)\, dz\, dx\, dy = 16/5
           </me>,
@@ -257,7 +257,7 @@
       we see that the total outward flux of a vector field across a closed surface can be found two different ways because of the Divergence Theorem.
       One computation took far less work to obtain.
       In that particular case,
-      since <m>\surfaceS</m>was comprised of three separate surfaces,
+      since <m>\surfaceS</m> was comprised of three separate surfaces,
       it was far simpler to compute one triple integral than three surface integrals
       (each of which required partial derivatives and a cross product).
       In practice, if outward flux needs to be measured,
@@ -273,7 +273,7 @@
       <title>Using the Divergence Theorem in space</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be the surface formed by the paraboloid <m>z=1-x^2-y^2</m>,
+          Let <m>\surfaceS</m> be the surface formed by the paraboloid <m>z=1-x^2-y^2</m>,
           <m>z\geq 0</m>,
           and the unit disk centered at the origin in the <m>x</m>-<m>y</m> plane,
           graphed in <xref ref="fig_divthm_space1">Figure</xref>,
@@ -290,7 +290,7 @@
           3Dcoo=-4.848384857177734 2.0102698802948 61.921504974365234,
           3Droo=399.9999594035934,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_divthm_space1_3D">
+          <image xml:id="img_divthm_space1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -348,14 +348,14 @@
 
         <p>
           Verify the Divergence Theorem;
-          find the total outward flux across <m>\surfaceS</m>and evaluate the triple integral of <m>\divv \vec F</m>,
+          find the total outward flux across <m>\surfaceS</m> and evaluate the triple integral of <m>\divv \vec F</m>,
           showing that these two quantities are equal.
         </p>
       </statement>
       <solution>
         <p>
-          We find the flux across <m>\surfaceS</m>first.
-          As <m>\surfaceS</m>is piecewise<ndash/>smooth,
+          We find the flux across <m>\surfaceS</m> first.
+          As <m>\surfaceS</m> is piecewise<ndash/>smooth,
           we decompose it into smooth components <m>\surfaceS_1</m>,
           the disk,
           and <m>\surfaceS_2</m>, the paraboloid,
@@ -442,15 +442,6 @@
           etc., as shown in <xref ref="fig_divthm_space3">Figure</xref>).
           Find the flux across the six faces of the cube and compare this to <m>\iint_D \divv\vec F\, dV</m>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Let <m>\surfaceS_1</m> be the <q>top</q> face of the cube,
-          which can be parametrized by <m>\vec r(u,v) = \langle u,v,a\rangle</m> for
-          <m>-a\leq u\leq a</m>, <m>-a\leq v\leq a</m>.
-          We leave it to the reader to confirm that <m>\vec r_u\times \vec r_v = \langle 0,0,1\rangle</m>,
-          which points outside of the cube.
-        </p>
 
         <figure xml:id="fig_divthm_space3">
           <caption>The cube used in  <xref ref="ex_divthm_space3">Example</xref>.</caption>
@@ -461,7 +452,7 @@
           3Dcoo=9.648120880126953 3.759108543395996 12.013349533081055,
           3Droo=399.9999533297849,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_divthm_space3_3D">
+          <image xml:id="img_divthm_space3_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -540,6 +531,15 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Let <m>\surfaceS_1</m> be the <q>top</q> face of the cube,
+          which can be parametrized by <m>\vec r(u,v) = \langle u,v,a\rangle</m> for
+          <m>-a\leq u\leq a</m>, <m>-a\leq v\leq a</m>.
+          We leave it to the reader to confirm that <m>\vec r_u\times \vec r_v = \langle 0,0,1\rangle</m>,
+          which points outside of the cube.
+        </p>
 
         <p>
           The flux across this face is:
@@ -626,7 +626,7 @@
       <title>Using the Divergence Theorem to compute flux</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be the cube bounded by the planes <m>x=\pm 1</m>,
+          Let <m>\surfaceS</m> be the cube bounded by the planes <m>x=\pm 1</m>,
           <m>y=\pm 1</m>, <m>z=\pm 1</m>,
           and let <m>\vec F = \langle x^2y,2yz,x^2z^3\rangle</m>.
           Compute the outward flux of <m>\vec F</m> over <m>\surfaceS</m>.
@@ -665,7 +665,7 @@
       as we do not sum <m>\curl \vec F</m>,
       but <m>\curl \vec F\cdot\vec n</m>,
       where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m>. That is,
-      we sum the portion of <m>\curl \vec F</m> that is orthogonal to <m>\surfaceS</m>at a point.
+      we sum the portion of <m>\curl \vec F</m> that is orthogonal to <m>\surfaceS</m> at a point.
     </p>
 
     <p>
@@ -680,7 +680,7 @@
       <title>Stokes' Theorem</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be a piecewise smooth,
+          Let <m>\surfaceS</m> be a piecewise smooth,
           orientable surface whose boundary is a piecewise smooth curve <m>C</m>,
           let <m>\vec n</m> be a unit vector normal to <m>\surfaceS</m>, let <m>C</m> be traversed with respect to <m>\vec n</m> according to the right hand rule,
           and let the components of <m>\vec F</m> have continuous first partial derivatives over <m>\surfaceS</m>. Then
@@ -693,7 +693,7 @@
     </theorem>
 
     <p>
-      In general, the best approach to evaluating the surface integral in Stokes' Theorem is to parametrize the surface <m>\surfaceS</m>with a function <m>\vec r(u,v)</m>.
+      In general, the best approach to evaluating the surface integral in Stokes' Theorem is to parametrize the surface <m>\surfaceS</m> with a function <m>\vec r(u,v)</m>.
       We can find a unit normal vector <m>\vec n</m> as
       <me>
         \vec n = \frac{\vec r_u\times\vec r_v}{\snorm{\vec r_u\times\vec r_v}}
@@ -716,14 +716,14 @@
         <p>
           Considering the planar surface <m>f(x,y) = 7-2x-2y</m>,
           let <m>C</m> be the curve in space that lies on this surface above the circle of radius 1 and centered at <m>(1,1)</m> in the <m>x</m>-<m>y</m> plane,
-          let <m>\surfaceS</m>be the planar region enclosed by <m>C</m>,
+          let <m>\surfaceS</m> be the planar region enclosed by <m>C</m>,
           as illustrated in <xref ref="fig_stokes1">Figure</xref>,
           and let <m>\vec F = \langle x+y,2y, y^2\rangle</m>.
           Verify Stoke's Theorem by showing <m>\oint_C \vec F\cdot \, d\vec r = \iint_\surfaceS (\curl\vec F)\cdot \vec n\, dS</m>.
         </p>
 
         <figure xml:id="fig_stokes1">
-          <caption>As given in <xref ref="ex_stokes1">Example</xref>, the surface \surfaceS<nbsp/>is the portion of the plane bounded by the curve.</caption>
+          <caption>As given in <xref ref="ex_stokes1">Example</xref>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve.</caption>
           <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
           3Droll=0,
           3Dortho=0.004444748163223267,
@@ -731,7 +731,7 @@
           3Dcoo=45.07202911376953 32.75735855102539 55.02788543701172,
           3Droo=399.9999566444115,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="fig_stokes1_3D">
+          <image xml:id="fig_stokes1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -837,7 +837,7 @@
         <p>
           We now parametrize <m>\surfaceS</m>. (We reuse the letter <q>r</q>
           for our surface as this is our custom.) Based on the parametrization of <m>C</m> above,
-          we describe <m>\surfaceS</m>with <m>\vec r(u,v) = \la v\cos u+1, v\sin u+1, 3-2v\cos u-2v\sin u\ra</m>,
+          we describe <m>\surfaceS</m> with <m>\vec r(u,v) = \la v\cos u+1, v\sin u+1, 3-2v\cos u-2v\sin u\ra</m>,
           where <m>0\leq u\leq 2\pi</m> and <m>0\leq v\leq 1</m>.
         </p>
 
@@ -875,14 +875,14 @@
         <p>
           Let <m>C</m> be the curve given in <xref ref="ex_stokes1">Example</xref>
           and note that it lies on the surface <m>z = 6-x^2-y^2</m>.
-          Let <m>\surfaceS</m>be the region of this surface bounded by <m>C</m>,
+          Let <m>\surfaceS</m> be the region of this surface bounded by <m>C</m>,
           and let <m>\vec F = \langle x+y,2y,y^2\rangle</m> as in the previous example.
           Compute <m>\iint_\surfaceS (\curl\vec F)\cdot \vec n\, dS</m> to show it equals the result found in the previous example.
         </p>
 
         <figure xml:id="fig_stokes2">
           <caption>As given in <xref ref="ex_stokes2">Example</xref>, the surface \surfaceS<nbsp/>is the portion of the plane bounded by the curve.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_stokes2a_3D">
               <caption/>
               <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1094,7 +1094,7 @@
         </p>
 
         <p>
-          We parametrize <m>\surfaceS</m>with
+          We parametrize <m>\surfaceS</m> with
           <me>
             \vec r(u,v) = \langle v\cos u+1,v\sin u+1, 6-(v\cos u+1)^2-(v\sin u+1)^2\rangle
           </me>,
@@ -1156,7 +1156,7 @@
     <p>
       Each of the named theorems above can be expressed in similar terms.
       Consider the Fundamental Theorem of Line Integrals:
-      given a function <m>z=f(x,y)</m>,
+      given a function <m>f(x,y)</m>,
       the gradient <m>\nabla f</m> is a type of rate of change of <m>f</m>.
       Given a curve <m>C</m> with initial and terminal points <m>A</m> and <m>B</m>,
       respectively,
@@ -1170,7 +1170,7 @@
     <p>
       Green's Theorem is essentially a special case of Stokes' Theorem,
       so we consider just Stokes' Theorem here.
-      Recalling that the curl of a vector field <m>\vec F</m> is a measure of a rate of change of <m>\vec F</m>, Stokes' Theorem states that over a surface <m>\surfaceS</m>bounded by a closed curve <m>C</m>,
+      Recalling that the curl of a vector field <m>\vec F</m> is a measure of a rate of change of <m>\vec F</m>, Stokes' Theorem states that over a surface <m>\surfaceS</m> bounded by a closed curve <m>C</m>,
       <me>
         \iint_\surfaceS \big(\curl \vec F\big)\cdot \vec n\, dS = \oint_C \vec F\cdot d\vec r
       </me>,
@@ -1261,7 +1261,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a closed surface <m>\surfaceS</m>enclosing a domain <m>D</m> and a vector field <m>\vec F</m> are given.
+          a closed surface <m>\surfaceS</m> enclosing a domain <m>D</m> and a vector field <m>\vec F</m> are given.
           Verify the Divergence Theorem on <m>\surfaceS</m>; that is,
           show <m>\iint_\surfaceS \vec F\cdot \vec n\, dS = \iiint_D\divv \vec F\, dV</m>.
         </p>
@@ -1270,7 +1270,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface bounding the domain <m>D</m> enclosed by the plane
+            <m>\surfaceS</m> is the surface bounding the domain <m>D</m> enclosed by the plane
             <m>z=2-x/2-2y/3</m> and the coordinate planes in the first octant;
             <m>\vec F = \langle x^2,y^2,x\rangle</m>.
           </p>
@@ -1415,7 +1415,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface bounding the domain <m>D</m> enclosed by the cylinder
+            <m>\surfaceS</m> is the surface bounding the domain <m>D</m> enclosed by the cylinder
             <m>x^2+y^2=1</m> and the planes <m>z=-3</m> and <m>z=3</m>;
             <m>\vec F = \langle -x,y,z\rangle</m>.
           </p>
@@ -1548,7 +1548,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface bounding the domain <m>D</m> enclosed by
+            <m>\surfaceS</m> is the surface bounding the domain <m>D</m> enclosed by
             <m>z=xy(3-x)(3-y)</m> and the plane <m>z=0</m>;
             <m>\vec F = \langle 3x,4y,5z+1\rangle</m>.
           </p>
@@ -1673,7 +1673,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface composed of <m>\surfaceS_1</m>,
+            <m>\surfaceS</m> is the surface composed of <m>\surfaceS_1</m>,
             the paraboloid <m>z=4-x^2-y^2</m> for <m>z\geq 0</m>,
             and <m>\surfaceS_2</m>, the disk of radius 2 centered at the origin;
             <m>\vec F = \langle x,y,z^2\rangle</m>.
@@ -1800,7 +1800,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m>is given along with a vector field <m>\vec F</m>.
+          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m> is given along with a vector field <m>\vec F</m>.
           Verify Stokes' Theorem on <m>C</m>;
           that is, show <m>\oint_C \vec F\cdot d\vec r = \iint_\surfaceS\big(\curl \vec F\,\big)\cdot\vec n\, dS</m>.
         </p>
@@ -2273,14 +2273,14 @@
         <p>
           In the following exercises,
           a closed surface <m>\surfaceS</m> and a vector field <m>\vec F</m> are given.
-          Find the outward flux of <m>\vec F</m> over <m>\surfaceS</m>either through direct computation or through the Divergence Theorem.
+          Find the outward flux of <m>\vec F</m> over <m>\surfaceS</m> either through direct computation or through the Divergence Theorem.
         </p>
       </introduction>
 
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of <m>z=0</m> and <m>z=(x^2-1)(y^2-1)</m>;
+            <m>\surfaceS</m> is the surface formed by the intersections of <m>z=0</m> and <m>z=(x^2-1)(y^2-1)</m>;
             <m>\vec F = \langle x^2+1,yz,xz^2\rangle</m>.
           </p>
 
@@ -2395,7 +2395,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of the planes <m>z=\frac12(3-x)</m>,
+            <m>\surfaceS</m> is the surface formed by the intersections of the planes <m>z=\frac12(3-x)</m>,
             <m>x=1</m>,
             <m>y=0</m>, <m>y=2</m> and <m>z=0</m>;
             <m>\vec F = \langle x,y^2,z\rangle</m>.
@@ -2507,7 +2507,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of the planes <m>z=2y</m>,
+            <m>\surfaceS</m> is the surface formed by the intersections of the planes <m>z=2y</m>,
             <m>y=4-x^2</m> and <m>z=0</m>;
             <m>\vec F = \langle xz,0,xz\rangle</m>.
           </p>
@@ -2641,7 +2641,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of the cylinder <m>z=1-x^2</m> and the planes <m>y=-2</m>,
+            <m>\surfaceS</m> is the surface formed by the intersections of the cylinder <m>z=1-x^2</m> and the planes <m>y=-2</m>,
             <m>y=2</m> and <m>z=0</m>;
             <m>\vec F = \langle 0,y^3,0\rangle</m>.
           </p>
@@ -2776,7 +2776,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m>is given along with a vector field <m>\vec F</m>.
+          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m> is given along with a vector field <m>\vec F</m>.
           Find the circulation of <m>\vec F</m> around <m>C</m> either through direct computation or through Stokes' Theorem.
         </p>
       </introduction>
@@ -3260,20 +3260,20 @@
       <exercise>
         <statement>
           <p>
-            Let <m>\surfaceS</m>be any closed surface enclosing a domain <m>D</m>.
+            Let <m>\surfaceS</m> be any closed surface enclosing a domain <m>D</m>.
             Consider <m>\vec F_1 = \langle x,0,0\rangle</m> and <m>\vec F_2=\langle y,y^2,z-2yz\rangle</m>.
           </p>
 
           <p>
             These fields are clearly very different.
-            Why is it that the total outward flux of each field across <m>\surfaceS</m>is the same?
+            Why is it that the total outward flux of each field across <m>\surfaceS</m> is the same?
           </p>
         </statement>
         <answer>
           <p>
             Each field has a divergence of 1;
             by the Divergence Theorem,
-            the total outward flux across <m>\surfaceS</m>is <m>\iint_D 1\, dS</m> for each field.
+            the total outward flux across <m>\surfaceS</m> is <m>\iint_D 1\, dS</m> for each field.
           </p>
         </answer>
       </exercise>
@@ -3328,7 +3328,7 @@
         <answer>
           <p>
             Answers will vary.
-            Often the closed surface <m>\surfaceS</m>is composed of several smooth surfaces.
+            Often the closed surface <m>\surfaceS</m> is composed of several smooth surfaces.
             To measure total outward flux,
             this may require evaluating multiple double integrals.
             Each double integral requires the parametrization of a surface and the computation of the cross product of partial derivatives.

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -3,7 +3,7 @@
   <title>Surface Integrals</title>
   <introduction>
     <p>
-      Consider a smooth surface <m>\surfaceS</m>that represents a thin sheet of metal.
+      Consider a smooth surface <m>\surfaceS</m> that represents a thin sheet of metal.
       How could we find the mass of this metallic object?
     </p>
 
@@ -42,7 +42,7 @@
     <p>
       To evaluate the above integral,
       we would seek <m>\vec r(u,v)</m>,
-      a smooth parametrization of <m>\surfaceS</m>over a region <m>R</m> of the <m>u</m>-<m>v</m> plane.
+      a smooth parametrization of <m>\surfaceS</m> over a region <m>R</m> of the <m>u</m>-<m>v</m> plane.
       The density would become a function of <m>u</m> and <m>v</m>,
       and we would integrate <m>\iint_R \delta(u,v)\snorm{\vec r_u\times \vec r_v}\, dA</m>.
     </p>
@@ -50,6 +50,10 @@
     <p>
       The integral in Equation <xref ref="eq_surface_int"/> is a specific example of a more general construction defined below.
     </p>
+  </introduction>
+
+  <subsection xml:id="subsec-surfint-scalar">
+    <title>Surface integrals of scalar fields</title>
 
     <definition xml:id="def_surface_integral">
       <title>Surface Integral</title>
@@ -84,17 +88,6 @@
           with density function <m>\delta(x,y,z) = x^2+5y+z</m>,
           where all distances are measured in cm and the density is given as gm/cm<m>^2</m>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          We begin by parametrizing the planar surface <m>\surfaceS</m>. Using the techniques of the previous section,
-          we can let <m>x=u</m> and <m>y=v(2-2u)</m>,
-          where <m>0\leq u\leq 1</m> and <m>0\leq v\leq 1</m>.
-          Solving for <m>z</m> in the equation of the plane,
-          we have <m>z=3-2x-y</m>, hence <m>z = 3-2u-v(2-2u)</m>,
-          giving the parametrization <m>\vec r(u,v) = \langle u, v(2-2u), 3-2u-v(2-2u)\rangle</m>.
-        </p>
-
         <figure xml:id="fig_surfint1">
           <caption>The surface whose mass is computed in <xref ref="ex_surfint1">Example</xref>.</caption>
           <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -104,7 +97,7 @@
           3Dcoo=-2.5405526161193848 7.828289031982422 42.677555084228516,
           3Droo=399.9999621232421,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_surfint1_3D">
+          <image xml:id="img_surfint1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -191,6 +184,16 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          We begin by parametrizing the planar surface <m>\surfaceS</m>. Using the techniques of the previous section,
+          we can let <m>x=u</m> and <m>y=v(2-2u)</m>,
+          where <m>0\leq u\leq 1</m> and <m>0\leq v\leq 1</m>.
+          Solving for <m>z</m> in the equation of the plane,
+          we have <m>z=3-2x-y</m>, hence <m>z = 3-2u-v(2-2u)</m>,
+          giving the parametrization <m>\vec r(u,v) = \langle u, v(2-2u), 3-2u-v(2-2u)\rangle</m>.
+        </p>
 
         <p>
           We need <m>dS=\snorm{\vec r_u\times \vec r_v}dA</m>,
@@ -235,16 +238,16 @@
         </p>
       </solution>
     </example>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Flux</title>
     <p>
-      Let a surface <m>\surfaceS</m>lie within a vector field <m>\vec F</m>.
+      Let a surface <m>\surfaceS</m> lie within a vector field <m>\vec F</m>.
       One is often interested in measuring the <em>flux</em>
       of <m>\vec F</m> across <m>\surfaceS</m>; that is,
       measuring <q>how much of the vector field passes across <m>\surfaceS</m>.</q> For instance,
-      if <m>\vec F</m> represents the velocity field of moving air and <m>\surfaceS</m>represents the shape of an air filter,
+      if <m>\vec F</m> represents the velocity field of moving air and <m>\surfaceS</m> represents the shape of an air filter,
       the flux will measure how much air is passing through the filter per unit time.
           <idx><h>flux</h></idx>
     </p>
@@ -254,19 +257,19 @@
       <q>amount of <m>\vec F</m> orthogonal to <m>\surfaceS</m>.</q>
       Similar to our measure of flux in the plane,
       this is equal to <m>\vec F\cdot \vec n</m>,
-      where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m>at a point.
+      where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m> at a point.
       We now consider how to find <m>\vec n</m>.
     </p>
 
     <p>
       Given a smooth parametrization
       <m>\vec r(u,v)</m> of <m>\surfaceS</m>, the work in the previous section showing the development of our method of computing surface area also shows that <m>\vec r_u(u,v)</m> and
-      <m>\vec r_v(u,v)</m> are tangent to <m>\surfaceS</m>at <m>\vec r(u,v)</m>.
+      <m>\vec r_v(u,v)</m> are tangent to <m>\surfaceS</m> at <m>\vec r(u,v)</m>.
       Thus <m>\vec r_u\times \vec r_v</m> is orthogonal to <m>\surfaceS</m>, and we let
       <me>
         \vec n = \frac{\vec r_u\times \vec r_v}{\snorm{\vec r_u\times \vec r_v}}
       </me>,
-      which is a unit vector normal to <m>\surfaceS</m>at <m>\vec r(u,v)</m>.
+      which is a unit vector normal to <m>\surfaceS</m> at <m>\vec r(u,v)</m>.
     </p>
 
     <p>
@@ -288,9 +291,9 @@
     </p>
 
     <p>
-      The above only makes sense if <m>\surfaceS</m>is orientable;
+      The above only makes sense if <m>\surfaceS</m> is orientable;
       the normal vectors <m>\vec n</m> must vary continuously across <m>\surfaceS</m>. We assume that <m>\vec n</m> does vary continuously.
-      (If the parametrization <m>\vec r</m> of <m>\surfaceS</m>is smooth,
+      (If the parametrization <m>\vec r</m> of <m>\surfaceS</m> is smooth,
       then our above definition of <m>\vec n</m> will vary continuously.)
     </p>
 
@@ -298,8 +301,8 @@
       <title>Flux over a surface</title>
       <statement>
         <p>
-          Let <m>\vec F</m> be a vector field with continuous components defined on an orientable surface <m>\surfaceS</m>with normal vector <m>\vec n</m>.
-          The <term>flux</term> of <m>\vec F</m> across <m>\surfaceS</m>is
+          Let <m>\vec F</m> be a vector field with continuous components defined on an orientable surface <m>\surfaceS</m> with normal vector <m>\vec n</m>.
+          The <term>flux</term> of <m>\vec F</m> across <m>\surfaceS</m> is
               <idx><h>flux</h></idx>
           <me>
             \text{ Flux }  = \iint_\surfaceS \vec F\cdot \vec n\, dS
@@ -307,7 +310,7 @@
         </p>
 
         <p>
-          If <m>\surfaceS</m>is parametrized by <m>\vec r(u,v)</m>,
+          If <m>\surfaceS</m> is parametrized by <m>\vec r(u,v)</m>,
           which is smooth on its domain <m>R</m>, then
           <me>
             \text{ Flux }  = \iint_R \vec F\big(\vec r(u,v)\big)\cdot (\vec r_u\times \vec r_v)\, dA
@@ -317,25 +320,25 @@
     </definition>
 
     <p>
-      Since <m>\surfaceS</m>is orientable,
+      Since <m>\surfaceS</m> is orientable,
       we adopt the convention of saying one passes from the <q>back</q>
-      side of <m>\surfaceS</m>to the <q>front</q>
+      side of <m>\surfaceS</m> to the <q>front</q>
       side when moving across the surface parallel to the direction of <m>\vec n</m>.
-      Also, when <m>\surfaceS</m>is closed,
+      Also, when <m>\surfaceS</m> is closed,
       it is natural to speak of the regions of space
       <q>inside</q> and <q>outside</q>
-      <m>\surfaceS</m>. We also adopt the convention that when <m>\surfaceS</m>is a closed surface,
+      <m>\surfaceS</m>. We also adopt the convention that when <m>\surfaceS</m> is a closed surface,
       <m>\vec n</m> should point to the outside of <m>\surfaceS</m>. If
       <m>\vec n = \vec r_u\times\vec r_v</m> points inside <m>\surfaceS</m>, use <m>\vec n = \vec r_v\times \vec r_u</m> instead.
     </p>
 
     <p>
       When the computation of flux is positive,
-      it means that the field is moving from the back side of <m>\surfaceS</m>to the front side;
+      it means that the field is moving from the back side of <m>\surfaceS</m> to the front side;
       when flux is negative,
       it means the field is moving opposite the direction of <m>\vec n</m>,
-      and is moving from the front of <m>\surfaceS</m>to the back.
-      When <m>\surfaceS</m>is not closed,
+      and is moving from the front of <m>\surfaceS</m> to the back.
+      When <m>\surfaceS</m> is not closed,
       there is not a <q>right</q> and <q>wrong</q>
       direction in which <m>\vec n</m> should point,
       but one should be mindful of its direction to make full sense of the flux computation.
@@ -350,8 +353,8 @@
       <title>Finding flux across a surface</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be the surface given in <xref ref="ex_surfint1">Example</xref>,
-          where <m>\surfaceS</m>is parametrized by
+          Let <m>\surfaceS</m> be the surface given in <xref ref="ex_surfint1">Example</xref>,
+          where <m>\surfaceS</m> is parametrized by
           <m>\vec r(u,v) = \langle u, v(2-2u),3-2u-v(2-2u)\rangle</m> on <m>0\leq u\leq 1</m>,
           <m>0\leq v\leq 1</m>, and let <m>\vec F = \langle 1, x,-y\rangle</m>,
           as shown in <xref ref="fig_surfflux1">Figure</xref>.
@@ -367,7 +370,7 @@
           3Dcoo=-2.5405526161193848 7.828289031982422 42.677555084228516,
           3Droo=399.9999621232421,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_surfflux1_3D">
+          <image xml:id="img_surfflux1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -490,7 +493,7 @@
         </p>
 
         <p>
-          Thus the flux of <m>\vec F</m> across <m>\surfaceS</m>is:
+          Thus the flux of <m>\vec F</m> across <m>\surfaceS</m> is:
           <md>
             <mrow>\text{ Flux }  \amp = \iint_\surfaceS \vec F\cdot \vec n\, dS</mrow>
             <mrow>\amp = \iint_R \langle 1,u,-v(2-2u)\rangle\cdot\langle 4-4u,2-2u,2-2u\rangle\, dA</mrow>
@@ -512,10 +515,10 @@
           This vector has positive <m>x</m>,
           <m>y</m> and <m>z</m> components.
           Generally speaking, one has <em>some</em>
-          idea of what the surface <m>\surfaceS</m>looks like,
+          idea of what the surface <m>\surfaceS</m> looks like,
           as that surface is for some reason important.
           In our case,
-          we know <m>\surfaceS</m>is a plane with <m>z</m>-intercept of <m>z=3</m>.
+          we know <m>\surfaceS</m> is a plane with <m>z</m>-intercept of <m>z=3</m>.
           Knowing <m>\vec n</m> and the flux measurement of positive <m>5/3</m>,
           we know that the field must be passing from <q>behind</q>
           <m>\surfaceS</m>, i.e., the side the origin is on,
@@ -544,7 +547,7 @@
           3Dcoo=-4.848384857177734 2.0102698802948 61.921504974365234,
           3Droo=399.9999594035934,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_surfflux2_3D">
+          <image xml:id="img_surfflux2_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -675,13 +678,13 @@
           We are now set to compute flux.
           Over field <m>\vec F_1=\langle 0,0,1\rangle</m>:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_1\) }  \amp = \iint_{\surfaceS_1} \vec F_1\cdot \vec n_1\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_1  \amp = \iint_{\surfaceS_1} \vec F_1\cdot \vec n_1\, dS</mrow>
             <mrow>\amp = \iint_R\langle 0,0,1\rangle\cdot\langle 0,0,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (v)\, du\, dv</mrow>
             <mrow>\amp = \pi</mrow>
           </md>.
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_2\) }  \amp = \iint_{\surfaceS_2} \vec F_1\cdot \vec n_2\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_2  \amp = \iint_{\surfaceS_2} \vec F_1\cdot \vec n_2\, dS</mrow>
             <mrow>\amp = \iint_R\langle 0,0,1\rangle\cdot\langle 2v^2\cos u,2v^2\sin u,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (v)\, du\, dv</mrow>
             <mrow>\amp = \pi</mrow>
@@ -707,13 +710,13 @@
         </p>
 
         <p>
-          If we treated the surfaces as creating one piecewise<ndash/>smooth surface <m>\surfaceS</m>, we would find the total flux across <m>\surfaceS</m>by finding the flux across each piece,
+          If we treated the surfaces as creating one piecewise<ndash/>smooth surface <m>\surfaceS</m>, we would find the total flux across <m>\surfaceS</m> by finding the flux across each piece,
           being sure that each normal vector pointed to the outside of the closed surface.
           Above, <m>\vec n_1</m> does not point outside the surface,
           though <m>\vec n_2</m> does.
           We would instead want to use <m>-\vec n_1</m> in our computation.
           We would then find that the flux across <m>\surfaceS_1</m> is <m>-\pi</m>,
-          and hence the total flux across <m>\surfaceS</m>is <m>-\pi + \pi = 0</m>.
+          and hence the total flux across <m>\surfaceS</m> is <m>-\pi + \pi = 0</m>.
           (As <m>0</m> is a special number,
           we should wonder if this answer has special significance.
           It does, which is briefly discussed following this example and will be more fully developed in the next section.)
@@ -722,14 +725,14 @@
         <p>
           We now compute the flux across each surface with <m>\vec F_2=\langle 0,0,z\rangle</m>:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_1\) }  \amp = \iint_{\surfaceS_1} \vec F_2\cdot \vec n_1\, dS .</mrow>
+            <mrow>\text{ Flux across } \surfaceS_1  \amp = \iint_{\surfaceS_1} \vec F_2\cdot \vec n_1\, dS .</mrow>
             <intertext>Over <m>\surfaceS_1</m>, <m>\vec F_2 = \vec F_2\big(\vec r_2(u,v)\big) = \langle 0,0,0\rangle</m>. Therefore,</intertext>
             <mrow>\amp = \iint_R\langle 0,0,0\rangle\cdot\langle 0,0,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (0)\, du\, dv</mrow>
             <mrow>\amp = 0</mrow>
           </md>.
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_2\) }  \amp = \iint_{\surfaceS_2} \vec F_2\cdot \vec n_2\, dS .</mrow>
+            <mrow>\text{ Flux across } \surfaceS_2  \amp = \iint_{\surfaceS_2} \vec F_2\cdot \vec n_2\, dS .</mrow>
             <intertext>Over <m>\surfaceS_2</m>, <m>\vec F_2 = \vec F_2\big(\vec r_2(u,v)\big) = \langle 0,0,1-v^2\rangle</m>. Therefore,</intertext>
             <mrow>\amp = \iint_R\langle 0,0,1-v^2\rangle\cdot\langle 2v^2\cos u,2v^2\sin u,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (v^3-v)\, du\, dv</mrow>
@@ -760,9 +763,10 @@
       The quick answer to why the flux was the same when considering
       <m>\vec F_1</m> is that <m>\divv \vec F_1 = 0</m>.
       In the next section,
-      we'll see the second part of the Divergence Theorem which will more fully explain this occurrence.
-      We will also explore Stokes' Theorem,
-      the spatial analogue to Green's Theorem.
+      we'll see the second part of the <xref ref="thm_divergence2" text="custom">Divergence Theorem</xref>,
+      which will more fully explain this occurrence.
+      We will also explore <xref ref="thm_stokes_thm" text="custom">Stokes' Theorem</xref>,
+      the spatial analogue to <xref ref="thm_greens" text="custom">Green's Theorem</xref>.
     </p>
   </subsection>
 
@@ -821,8 +825,8 @@
       <exercise>
         <statement>
           <p>
-            If <m>\surfaceS</m>is a plane,
-            and <m>\vec F</m> is always parallel to <m>\surfaceS</m>, then the flux of <m>\vec F</m> across <m>\surfaceS</m>will be <fillin/>.
+            If <m>\surfaceS</m> is a plane,
+            and <m>\vec F</m> is always parallel to <m>\surfaceS</m>, then the flux of <m>\vec F</m> across <m>\surfaceS</m> will be <fillin/>.
           </p>
         </statement>
         <answer>
@@ -836,7 +840,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a surface <m>\surfaceS</m>that represents a thin sheet of material with density <m>\delta</m> is given.
+          a surface <m>\surfaceS</m> that represents a thin sheet of material with density <m>\delta</m> is given.
           Find the mass of each thin sheet.
         </p>
       </introduction>
@@ -845,7 +849,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane
+            <m>\surfaceS</m> is the plane
             <m>f(x,y)=x+y</m> on <m>-2\leq x\leq 2</m>,
             <m>-3\leq y\leq 3</m>, with <m>\delta(x,y,z) = z</m>.
           </p>
@@ -860,7 +864,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the unit sphere,
+            <m>\surfaceS</m> is the unit sphere,
             with <m>\delta(x,y,z) = x+y+z+10</m>.
           </p>
         </statement>
@@ -876,9 +880,9 @@
       <introduction>
         <p>
           In the following exercises,
-          a surface <m>\surfaceS</m>and a vector field <m>\vec F</m> are given.
+          a surface <m>\surfaceS</m> and a vector field <m>\vec F</m> are given.
           Compute the flux of <m>\vec F</m> across <m>\surfaceS</m>.
-          (If <m>\surfaceS</m>is not a closed surface,
+          (If <m>\surfaceS</m> is not a closed surface,
           choose <m>\vec n</m> so that it has a positive <m>z</m>-component,
           unless otherwise indicated.)
         </p>
@@ -887,7 +891,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>f(x,y) = 3x+y</m> on
+            <m>\surfaceS</m> is the plane <m>f(x,y) = 3x+y</m> on
             <m>0\leq x\leq 1</m>, <m>1\leq y\leq 4</m>;
             <m>\vec F = \langle x^2,-z,2y\rangle</m>.
           </p>
@@ -902,7 +906,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane
+            <m>\surfaceS</m> is the plane
             <m>f(x,y) = 8-x-y</m> over the triangle with vertices at <m>(0,0)</m>,
             <m>(1,0)</m> and <m>(1,5)</m>;
             <m>\vec F = \langle 3,1,2\rangle</m>.
@@ -918,7 +922,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the paraboloid <m>f(x,y) = x^2+y^2</m> over the unit disk;
+            <m>\surfaceS</m> is the paraboloid <m>f(x,y) = x^2+y^2</m> over the unit disk;
             <m>\vec F = \langle 1,0,0\rangle</m>.
           </p>
         </statement>
@@ -932,7 +936,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the unit sphere;
+            <m>\surfaceS</m> is the unit sphere;
             <m>\vec F = \langle y-z,z-x,x-y\rangle</m>.
           </p>
         </statement>
@@ -946,7 +950,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the square in space with corners at <m>(0,0,0)</m>,
+            <m>\surfaceS</m> is the square in space with corners at <m>(0,0,0)</m>,
             <m>(1,0,0)</m>,
             <m>(1,0,1)</m> and <m>(0,0,1)</m> (choose <m>\vec n</m> such that it has a positive <m>y</m>-component);
             <m>\vec F = \langle 0,-z,y\rangle</m>.
@@ -962,7 +966,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the disk in the <m>y</m>-<m>z</m> plane with radius 1, centered at <m>(0,1,1)</m> (choose <m>\vec n</m> such that it has a positive <m>x</m>-component);
+            <m>\surfaceS</m> is the disk in the <m>y</m>-<m>z</m> plane with radius 1, centered at <m>(0,1,1)</m> (choose <m>\vec n</m> such that it has a positive <m>x</m>-component);
             <m>\vec F = \langle y,z,x\rangle</m>.
           </p>
         </statement>
@@ -976,7 +980,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the closed surface composed of <m>\surfaceS_1</m>,
+            <m>\surfaceS</m> is the closed surface composed of <m>\surfaceS_1</m>,
             whose boundary is the ellipse in the <m>x</m>-<m>y</m> plane described by
             <m>\frac{x^2}{25}+\frac{y^2}9 = 1</m> and <m>\surfaceS_2</m>,
             part of the elliptical paraboloid <m>f(x,y) = 1-\frac{x^2}{25}-\frac{y^2}9</m> (see graph);
@@ -1078,7 +1082,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the closed surface composed of <m>\surfaceS_1</m>,
+            <m>\surfaceS</m> is the closed surface composed of <m>\surfaceS_1</m>,
             part of the unit sphere and <m>\surfaceS_2</m>,
             part of the plane <m>z=1/2</m> (see graph);
             <m>\vec F = \langle x,-y,z\rangle</m>.

--- a/ptx/sec_total_differential.ptx
+++ b/ptx/sec_total_differential.ptx
@@ -439,6 +439,77 @@
     </example>
   </subsection>
 
+  <subsection xml:id="subsec-tangent-plane-approximation">
+    <title>Tangent Plane Approximation</title>
+    <p>
+      Recall from <xref ref="chapter_derivatives">Chapter</xref> that in one variable,
+      the essence of differentiability is the tangent line approximation.
+      This idea is emphasized in <xref ref="sec_differentials">Section</xref>,
+      where we first introduced the differential.
+    </p>
+
+    <p>
+      In <xref ref="subsec-tangent-plane">Section</xref> we saw that the partial derivatives of a function <m>f(x,y)</m>
+      can be used to define the define the tangent <em>plane</em> to a graph <m>z=f(x,y)</m>.
+      We will now see that this plane plays the same role for functions of two variables as the tangent line to a graph <m>y=f(x)</m> for a function of one variable.
+    </p>
+
+    <p>
+      Recall from <xref ref="def-linearization">Definition</xref> that for a function <m>f(x)</m>,
+      when <m>x</m> is near <m>c</m> we have the linear approximation <m>f(x)\approx \ell(x)</m>,
+      where
+      <me>
+        \ell(x) = f(c)+f'(c)(x-c)
+      </me>
+      is the linearization of <m>f</m> at <m>c</m>. If we set <m>dx=\dx = x-c</m>,
+      and evaluate the differential <m>dy = f'(x)\,dx</m> at <m>c</m>,
+      then we have
+      <md>
+        <mrow>\dy \amp = f(x)-f(c)</mrow>
+        <mrow>dy \amp = \ell(x)-f(c)</mrow>
+      </md>.
+    </p>
+
+    <p>
+      Given the graph <m>y=f(x)</m>, we know that <m>y=\ell(x)</m> gives the tangent line to the graph at <m>c</m>.
+      For the graph <m>z=f(x,y)</m> of a function of two variables, we similarly have the tangent plane
+      <me>
+        z=f(a,b)+f_x(a,b)(x-a)+f_y(a,b)(y-b)
+      </me>
+      defined in <xref ref="def-tangent-plane"/>,
+      suggesting that we define the two variable linearization
+      <me>
+        \ell(x,y) = f(a,b)+f_x(a,b)(x-a)+f_y(a,b)(y-b)
+      </me>.
+    </p>
+
+    <p>
+      Consider the total differential <m>dz</m> at <m>(a,b)</m>:
+      <me>
+        dz = f_x(a,b)\,dx + f_y(a,b)\,dy = f_x(a,b)(x-a)+f_y(a,b)(y-b)
+      </me>.
+      If we assume that <m>(x,y)</m> is <q>close</q> to <m>(a,b)</m>,
+      and set <m>dx = x-a</m>, <m>dy = y-b</m>,
+      then we have <m>\ell(x,y)-\ell(a,b) = dz</m>,
+      since <m>\ell(a,b)=f(a,b)</m>.
+      This agrees with the one-variable situation,
+      and with the conception of the differential as the <q>linear change</q> in a function.
+    </p>
+
+    <p>
+      If we recast <xref ref="def_multi_differentiability"/> in the language of tangent planes,
+      we can more easily see the analogy with functions of a single variable.
+      We can now say that <m>f(x,y)</m> is differentiable at <m>(a,b)</m> if it has a valid tangent plane approximation at <m>(a,b)</m>.
+      Note that <m>f(x,y)-\ell(x,y)</m> is equal to the error term <m>E_x\,dx+E_y\,dy</m>.
+    </p>
+
+    <p>
+      By <xref ref="thm_diff_cont_multi"/>, we know that the tangent plane at <m>(a,b,f(a,b))</m>
+      exists, and gives a good approximation to the graph <m>z=f(x,y)</m>,
+      as long as the partial derivatives of <m>f</m> exist and are continuous at <m>(a,b)</m>.
+    </p>
+  </subsection>
+
   <subsection xml:id="subsec-error-analysis-total-diff">
     <title>Error/Sensitivity Analysis</title>
     <p>
@@ -794,7 +865,7 @@
 
       <introduction>
         <p>
-          In the following exercises, a function <m>z=f(x,y)</m> is given.
+          In the following exercises, a function <m>f(x,y)</m> is given.
           Give the indicated approximation using the total differential.
         </p>
       </introduction>

--- a/ptx/sec_transformations.ptx
+++ b/ptx/sec_transformations.ptx
@@ -152,7 +152,7 @@
 		</aside>
 
 		<figure xml:id="fig_polar_trans1">
-			<caption>Transforming a rectangle to a disk using polar coordinates.</caption>
+			<caption>Transforming a rectangle to a disk using polar coordinates</caption>
 			<sidebyside widths="40% 10% 40%" valign="middle">
 				<image xml:id="img_polar_trans1a">
 				  <description></description>
@@ -234,7 +234,7 @@
 		</p>
 
 		<figure xml:id="fig_polar_trans2">
-			<caption>Transforming a rectangle to an annular portion using polar coordinates.</caption>
+			<caption>Transforming a rectangle to an annular portion using polar coordinates</caption>
 			<sidebyside widths="40% 10% 40%" valign="middle">
 				<image xml:id="img_polar_trans2a">
 				  <description></description>

--- a/ptx/sec_vector_fields.ptx
+++ b/ptx/sec_vector_fields.ptx
@@ -76,7 +76,7 @@
 
     <figure xml:id="fig_vectorfieldintro1">
       <caption>Demonstrating methods of graphing vector fields.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_vectorfieldintro1a">
           <caption/>
           <image xml:id="img_vectorfieldintro1a">
@@ -244,7 +244,7 @@
 
     <figure xml:id="fig_vectorfieldintro2">
       <caption>Demonstrating methods of graphing vector fields.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_vectorfieldintro2a">
           <caption/>
           <image xml:id="img_vectorfieldintro2a">
@@ -406,7 +406,7 @@
       3Dcoo=40.4605598449707 -31.11708641052246 21.908815383911133,
       3Droo=141.89772583942957,
       3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-      <image xml:id="img_vectorfieldintro3_3D">
+      <image xml:id="img_vectorfieldintro3_3D" width="47%">
         <description></description>
         <asymptote>
 
@@ -764,7 +764,7 @@
 
               <figure xml:id="fig_vectorfield1a">
                 <caption>The vector fields in parts 1 and 2 in <xref ref="ex_vectorfield1">Example</xref>.</caption>
-                <sidebyside>
+                <sidebyside widths="47% 47%">
                   <figure xml:id="fig_vectorfield1a_a">
                     <caption/>
                     <image xml:id="img_vectorfield1a_a">
@@ -962,7 +962,7 @@
 
               <figure xml:id="fig_vectorfield1b">
                 <caption>The vector fields in parts 3 and 4 in <xref ref="ex_vectorfield1">Example</xref>.</caption>
-                <sidebyside>
+                <sidebyside widths="47% 47%">
                   <figure xml:id="fig_vectorfield1b_a">
                     <caption/>
                     <image xml:id="img_vectorfield1b_a">
@@ -1209,7 +1209,7 @@
 
     <figure xml:id="fig_vectorfield3">
       <caption>A vector field representing a planar gravitational force.</caption>
-          <image xml:id="img_vectorfield3">
+          <image xml:id="img_vectorfield3" width="47%">
             <description></description>
             <asymptote>
 
@@ -1277,7 +1277,7 @@
     </figure>
 
     <p>
-      A function <m>z=f(x,y)</m> naturally induces a vector field,
+      A function <m>f(x,y)</m> naturally induces a vector field,
       <m>\vec F = \nabla f = \langle f_x,f_y\rangle</m>.
       Given what we learned of the gradient in <xref ref="sec_directional_derivative">Section</xref>,
       we know that the vectors of <m>\vec F</m> point in the direction of greatest increase of <m>f</m>.
@@ -1311,8 +1311,8 @@
         </p>
 
         <figure xml:id="fig_vectorfield4">
-          <caption>A graph of a function <m>z=f(x,y)</m> and the vector field <m>\vec F = \nabla f</m> in <xref ref="ex_vectorfield4">Example</xref>.</caption>
-          <sidebyside>
+          <caption>A graph of a function <m>f(x,y)</m> and the vector field <m>\vec F = \nabla f</m> in <xref ref="ex_vectorfield4">Example</xref>.</caption>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_vectorfield4a">
               <caption/>
               <image xml:id="img_vectorfield4a">

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1077,6 +1077,8 @@
     (see marginal note).
   </p>
   <aside xml:id="aside-def-orthogonal">
+    <title>Direction and the zero vector</title>
+
     <p>
       <m>\vec 0</m> is directionless;
       because <m>\vnorm{0}=0</m>,
@@ -1101,7 +1103,7 @@
     <p>
       We prefer the given definition of parallel as it is grounded in the fact that unit vectors provide direction information.
       One may adopt the convention that <m>\vec 0</m> is parallel to all vectors if they desire.
-      (See also <xref ref="aside-cross-orthogonal">aside</xref> in <xref ref="sec_cross_product">Section</xref>.)
+      (See also the <xref ref="aside-cross-orthogonal" text="custom">aside</xref> in <xref ref="sec_cross_product">Section</xref>.)
     </p>
   </aside>
   <p>
@@ -1515,12 +1517,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 Name two different things that cannot be described with just one number,
@@ -1536,12 +1536,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What is the difference between <m>(1,2)</m> and <m>\la 1,2\ra</m>?
@@ -1557,12 +1555,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What is a unit vector?
@@ -1591,12 +1587,10 @@
 
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What does it mean for two vectors to be parallel?
@@ -1613,12 +1607,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What effect does multiplying a vector by <m>-2</m> have?
@@ -1643,9 +1635,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector2D");
@@ -1656,7 +1646,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("i+6j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(2,-1)</m> and <m>Q = (3,5)</m>,
@@ -1684,9 +1674,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector2D");
@@ -1697,7 +1685,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("4i-4j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(3,2)</m> and <m>Q = (7,-2)</m>,
@@ -1725,9 +1713,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector");
@@ -1738,7 +1724,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("6i-j+6k");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(0,3,-1)</m> and <m>Q = (6,2,5)</m>,
@@ -1766,9 +1752,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector");
@@ -1779,7 +1763,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("2i+2j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(2,1,2)</m> and <m>Q = (4,3,2)</m>,
@@ -1809,12 +1793,10 @@
     </exercisegroup>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Let <m>\vec u = \la 1,-2\ra</m> and <m>\vec v= \la 1,1\ra</m>.
@@ -1867,12 +1849,10 @@
     </exercise>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Let <m>\vec u = \la 1,1,-1\ra</m> and <m>\vec v= \la 2,1,2\ra</m>.
@@ -1934,12 +1914,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_11.tex -->
@@ -2005,12 +1983,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_13.tex -->
@@ -2079,12 +2055,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_14.tex -->
@@ -2171,12 +2145,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_15.tex -->
@@ -2273,8 +2245,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("sqrt(5)");
@@ -2282,7 +2253,7 @@
               $normupv=Formula("sqrt(26)");
               $normumv=Formula("sqrt(10)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la 2,1\ra</m> and <m>\vec v = \la 3,-2\ra</m>, find:
@@ -2308,8 +2279,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("sqrt(17)");
@@ -2317,7 +2287,7 @@
               $normupv=Formula("sqrt(14)");
               $normumv=Formula("sqrt(26)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la -3,2,2\ra</m> and <m>\vec v = \la 1,-1,1\ra</m>, find:
@@ -2343,8 +2313,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("sqrt(5)");
@@ -2352,7 +2321,7 @@
               $normupv=Formula("2sqrt(5)");
               $normumv=Formula("4sqrt(5)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la 1,2\ra</m> and <m>\vec v = \la -3,-6\ra</m>, find:
@@ -2378,8 +2347,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("7");
@@ -2387,7 +2355,7 @@
               $normupv=Formula("42");
               $normumv=Formula("28");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la 2,-3,6\ra</m> and <m>\vec v = \la 10,-15,30\ra</m>, find:
@@ -2415,12 +2383,10 @@
     </exercisegroup>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Under what conditions is <m>\norm{\vec u}+\norm{\vec v} = \norm{\vec u+\vec v}</m>?
@@ -2445,15 +2411,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0);
               $u=Compute("&lt;3/sqrt(58), 7/sqrt(58)>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 3,7\ra</m>.
@@ -2467,15 +2431,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0);
               $u=Compute("&lt;0.6, 0.8>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 6,8\ra</m>.
@@ -2489,15 +2451,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;1/3,-2/3,2/3>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 1,-2,2\ra</m>.
@@ -2511,15 +2471,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;1/sqrt(3),-1/sqrt(3),1/sqrt(3)>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 2,-2,2\ra</m>.
@@ -2535,15 +2493,13 @@
     </exercisegroup>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
-
+      <webwork>
           <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;cos(50*pi/180),sin(50*pi/180)>");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the unit vector in the first quadrant of <m>\mathbb{R}^2</m> that makes a
@@ -2558,15 +2514,13 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
-
+      <webwork>
           <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;-1/2,sqrt(3)/2>");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the unit vector in the second quadrant of <m>\mathbb{R}^2</m> that makes a
@@ -2581,12 +2535,10 @@
     </exercise>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Verify, from <xref ref="idea_unit_vectors">Key Idea</xref>,
@@ -2646,12 +2598,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 30^\circ</m>,<m>\varphi=30^\circ</m>
@@ -2666,12 +2616,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 60^\circ</m>,<m>\varphi=60^\circ</m>
@@ -2686,12 +2634,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 20^\circ</m>,<m>\varphi=15^\circ</m>
@@ -2709,12 +2655,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 0^\circ</m>,<m>\varphi=0^\circ</m>
@@ -2766,12 +2710,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=1</m>lb, <m>\ell = 1</m>ft, <m>p = 1</m>lb
@@ -2787,12 +2729,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=1</m>lb, <m>\ell = 1</m>ft, <m>p = 10</m>lb
@@ -2808,12 +2748,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=1</m>lb, <m>\ell = 10</m>ft, <m>p = 1</m>lb
@@ -2828,12 +2766,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=10</m>lb, <m>\ell = 10</m>ft, <m>p = 1</m>lb

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -767,7 +767,6 @@
           note that the dimensions are for the water, not the pool itself.
           Compute the amount of work performed in draining the pool.
         </p>
-
         <figure xml:id="fig_pump3">
           <caption>The cross<ndash/>section of a swimming pool filled with water in <xref ref="ex_pump3">Example</xref>.</caption>
           <!-- START figures/fig_pump4.tex -->
@@ -807,22 +806,22 @@
 
             \foreach \y/\x in {0/0,1.5/$y$,3/3,6/6,8/8}
             {
-              \draw (-2.5,\y) node [left] {\scriptsize $\x$} -- (-1.5,\y);
+	            \draw (-2.5,\y) node [left] {\scriptsize $\x$} -- (-1.5,\y);
             }
 
             \draw [thick] (0,0) -- (10,0) -- (15,3) -- (25,3) -- (25,6) -- (0,6) -- (0,0);
 
             \draw [thick,firstcolor] (0,5) -- (25,5)
-                                      (0,1.5) -- (12.5,1.5);
+												              (0,1.5) -- (12.5,1.5);
 
             \draw [fill=black] (10,0) circle (1.5pt) node [shift={(15pt,-2pt)}] {\scriptsize $(10,0)$}
-                               (15,3) circle (1.5pt) node [shift={(15pt,-6pt)}] {\scriptsize $(15,3)$};
+								               (15,3) circle (1.5pt) node [shift={(15pt,-6pt)}] {\scriptsize $(15,3)$};
 
             \draw[&gt;=stealth,-&gt;] (-2,-2) -- (20,-2) node [right] {\scriptsize $x$};
 
             \foreach \y in {0,10,15}
             {
-              \draw (\y,-2.5) node [below] {\scriptsize $\y$} -- (\y,-1.5);
+	            \draw (\y,-2.5) node [below] {\scriptsize $\y$} -- (\y,-1.5);
             }
 
             \end{tikzpicture}
@@ -831,7 +830,7 @@
           </image>
           <!-- figures/fig_pump4b.tex END -->
         </figure>
-        
+
         <p>
           <xref ref="fig_pump_3a">Figure</xref>
           shows the pool oriented with this <m>y</m>-axis,


### PR DESCRIPTION
This pull request hits more files than originally intended, sorry!
The good news is that this gets us to the end of the book. (Still little bits and pieces to iron out though.)

Main elements:
- Update to vector calculus chapter. A few pieces needed attention, such as location of figures in examples, the `\surfaceS` macro (which was not always in math mode and did not always have a space after it), sectioning (there were some rather long introductions), and some typos.

- Update to chapter on vectors. Somehow I missed this chapter??

- Addition of content on tangent planes in `chapter_multi`. Content appears in sections on partial derivatives, total differential, and tangent/normal vectors. Also a short tie-in added back in the section on differentials.
Review needed here by @APEXCalculus 

Remaining until the two branches are even except for videos: Chapters 2 and 3.