### PR TITLE
Chapters 1, 2, and 3

### DIFF
--- a/apex.xml
+++ b/apex.xml
@@ -54,4 +54,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     </html>
 
+    <!-- WeBWorK problem merging  -->
+    <!-- Replace path accordingly -->
+    <source webwork-problems="/home/sean/github/APEXCalculusPTX/webwork-extraction/webwork-representations.ptx"/>
+
 </publication>

--- a/ptx/bibliography.ptx
+++ b/ptx/bibliography.ptx
@@ -1,6 +1,5 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <references>
   <title>Bibliography</title>
 </references>
-

--- a/ptx/chapter_deriv_apps.ptx
+++ b/ptx/chapter_deriv_apps.ptx
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_deriv_apps">
   <title>Applications of the Derivative</title>

--- a/ptx/chapter_derivatives.ptx
+++ b/ptx/chapter_derivatives.ptx
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_derivatives">
   <title>Derivatives</title>
@@ -19,5 +19,5 @@
   <xi:include  href="sec_deriv_prodquot.ptx" />
   <xi:include  href="sec_deriv_chainrule.ptx" />
   <xi:include  href="sec_deriv_implicit.ptx" />
-  <!-- <xi:include  href="sec_deriv_inverse_function.ptx" /> -->
+  <xi:include  href="sec_deriv_inverse_function.ptx" />
 </chapter>

--- a/ptx/chapter_differential_equations.ptx
+++ b/ptx/chapter_differential_equations.ptx
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_differential_equations">
   <title>Differential Equations</title>
   <introduction>

--- a/ptx/chapter_vector_calc.ptx
+++ b/ptx/chapter_vector_calc.ptx
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <chapter xmlns:xi="http://www.w3.org/2001/XInclude"  xml:id="chapter_vector_calc">
   <title>Vector Analysis</title>
@@ -16,82 +16,81 @@
       and how that relates to the notation we use to describe it.
     </p>
 
-    <p>
-      <em>Integration review</em>
-    </p>
-    
-    <p>
-      Recall from <xref ref="sec_iterated_integrals">Section</xref>
-      that when <m>R</m> is a region in the <m>x</m>-<m>y</m> plane,
-      <m>\iint_R dA</m> gives the area of the region <m>R</m>.
-      The integral symbols are <q>elongated esses</q> meaning <q>sum</q>
-      and <m>dA</m> represents <q>a small amount of area.</q> Taken together,
-      <m>\iint_R dA</m> means <q>sum up, over <m>R</m>,
-      small amounts of area.</q> This sum then gives the total area of <m>R</m>.
-      We use two integral symbols since <m>R</m> is a two<ndash />dimensional region.
-    </p>
+    <paragraphs xml:id="pars-integration-review">
+      <title>Integration review</title>
+      <p>
+        Recall from <xref ref="sec_iterated_integrals">Section</xref>
+        that when <m>R</m> is a region in the <m>x</m>-<m>y</m> plane,
+        <m>\iint_R dA</m> gives the area of the region <m>R</m>.
+        The integral symbols are <q>elongated esses</q> meaning <q>sum</q>
+        and <m>dA</m> represents <q>a small amount of area.</q> Taken together,
+        <m>\iint_R dA</m> means <q>sum up, over <m>R</m>,
+        small amounts of area.</q> This sum then gives the total area of <m>R</m>.
+        We use two integral symbols since <m>R</m> is a two<ndash />dimensional region.
+      </p>
 
-    <p>
-      Now let <m>z=f(x,y)</m> represent a surface.
-      The double integral <m>\iint_R f(x,y)\, dA</m> means
-      <q>sum up, over <m>R</m>,
-      function values (heights) given by <m>f</m> times small amounts of area.</q>
-      Since <q>height <times /> area = volume,</q>
-      we are summing small amounts of volume over <m>R</m>,
-      giving the total signed volume under the surface
-      <m>z=f(x,y)</m> and above the <m>x</m>-<m>y</m> plane.
-    </p>
+      <p>
+        Now let <m>z=f(x,y)</m> represent a surface.
+        The double integral <m>\iint_R f(x,y)\, dA</m> means
+        <q>sum up, over <m>R</m>,
+        function values (heights) given by <m>f</m> times small amounts of area.</q>
+        Since <q>height <times /> area = volume,</q>
+        we are summing small amounts of volume over <m>R</m>,
+        giving the total signed volume under the surface
+        <m>z=f(x,y)</m> and above the <m>x</m>-<m>y</m> plane.
+      </p>
 
-    <p>
-      This notation does not directly inform us <em>how</em>
-      to evaluate the double integrals to find an area or a volume.
-      With additional work,
-      we recognize that a small amount of area <m>dA</m> can be measured as the area of a small rectangle,
-      with one side length a small change in <m>x</m> and the other side length a small change in <m>y</m>.
-      That is, <m>dA = dx\,dy</m> or <m>dA = dy\,dx</m>.
-      We could also compute a small amount of area by thinking in terms of polar coordinates,
-      where <m>dA = r\,dr\,d\theta</m>.
-      These understandings lead us to the iterated integrals we used in <xref ref="chapter_mult_int">Chapter</xref>.
-    </p>
+      <p>
+        This notation does not directly inform us <em>how</em>
+        to evaluate the double integrals to find an area or a volume.
+        With additional work,
+        we recognize that a small amount of area <m>dA</m> can be measured as the area of a small rectangle,
+        with one side length a small change in <m>x</m> and the other side length a small change in <m>y</m>.
+        That is, <m>dA = dx\,dy</m> or <m>dA = dy\,dx</m>.
+        We could also compute a small amount of area by thinking in terms of polar coordinates,
+        where <m>dA = r\,dr\,d\theta</m>.
+        These understandings lead us to the iterated integrals we used in <xref ref="chapter_mult_int">Chapter</xref>.
+      </p>
 
-    <p>
-      Let us back our review up farther.
-      Note that <m>\int_1^3\, dx = x\big|_1^3 = 3-1 = 2</m>.
-      We have simply measured the length of the interval <m>[1,3]</m>.
-      We could rewrite the above integral using syntax similar to the double integral syntax above:
-      <me>
-        \int_1^3\, dx = \int_Idx, \text{ where \(I\) = \([1,3]\) }
-      </me>.
-    </p>
+      <p>
+        Let us back our review up farther.
+        Note that <m>\int_1^3\, dx = x\big|_1^3 = 3-1 = 2</m>.
+        We have simply measured the length of the interval <m>[1,3]</m>.
+        We could rewrite the above integral using syntax similar to the double integral syntax above:
+        <me>
+          \int_1^3\, dx = \int_Idx, \text{ where \(I\) = \([1,3]\) }
+        </me>.
+      </p>
 
-    <p>
-      We interpret <q><m>\int_I dx</m></q> as meaning <q>sum up,
-      over the interval <m>I</m>,
-      small changes in <m>x</m>.</q>
-      A change in <m>x</m> is a length along the <m>x</m>-axis,
-      so we are adding up along <m>I</m> small lengths,
-      giving the total length of <m>I</m>.
-    </p>
+      <p>
+        We interpret <q><m>\int_I dx</m></q> as meaning <q>sum up,
+        over the interval <m>I</m>,
+        small changes in <m>x</m>.</q>
+        A change in <m>x</m> is a length along the <m>x</m>-axis,
+        so we are adding up along <m>I</m> small lengths,
+        giving the total length of <m>I</m>.
+      </p>
 
-    <p>
-      We could also write <m>\int_1^3f(x)\, dx</m> as <m>\int_I f(x)\, dx</m>,
-      interpreted as <q>sum up, over <m>I</m>,
-      heights given by <m>y = f(x)</m> times small changes in <m>x</m>.</q>
-      Since <q>height<times />length = area,</q>
-      we are summing up areas and finding the total signed area between
-      <m>y = f(x)</m> and the <m>x</m>-axis.
-    </p>
+      <p>
+        We could also write <m>\int_1^3f(x)\, dx</m> as <m>\int_I f(x)\, dx</m>,
+        interpreted as <q>sum up, over <m>I</m>,
+        heights given by <m>y = f(x)</m> times small changes in <m>x</m>.</q>
+        Since <q>height<times />length = area,</q>
+        we are summing up areas and finding the total signed area between
+        <m>y = f(x)</m> and the <m>x</m>-axis.
+      </p>
 
-    <p>
-      This method of referring to the process of integration can be very powerful.
-      It is the core of our notion of the Riemann Sum.
-      When faced with a quantity to compute,
-      if one can think of a way to approximate its value through a sum,
-      the one is well on their way to constructing an integral (or,
-      double or triple integral) that computes the desired quantity.
-      We will demonstrate this process throughout this chapter,
-      starting with the next section.
-    </p>
+      <p>
+        This method of referring to the process of integration can be very powerful.
+        It is the core of our notion of the Riemann Sum.
+        When faced with a quantity to compute,
+        if one can think of a way to approximate its value through a sum,
+        the one is well on their way to constructing an integral (or,
+        double or triple integral) that computes the desired quantity.
+        We will demonstrate this process throughout this chapter,
+        starting with the next section.
+      </p>
+    </paragraphs>
   </introduction>
 
   <xi:include  href="sec_line_int_intro.ptx" />

--- a/ptx/chapter_vectors.ptx
+++ b/ptx/chapter_vectors.ptx
@@ -30,4 +30,3 @@
   <xi:include href="sec_lines.ptx" />
   <xi:include href="sec_planes.ptx" />
 </chapter>
-

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -6,6 +6,9 @@
         <package>cancel</package>
     </latex-preamble>
 
+    <brandlogo url="http://www.apexcalculus.com" source="images/aa_website_favicon.png"/>
+    <initialism>APEX</initialism>
+
     <macros>
       \newcommand{\highlight}[1]{{\color{blue}{#1}}}
       \newcommand{\apex}{A\kern -1pt \lower -2pt\mbox{P}\kern -4pt \lower .7ex\mbox{E}\kern -1pt X}

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -109,7 +109,7 @@
     <p>
       Now repeat the first two columns after the original three:
       <me>
-        \begin{matrix \veci\amp \vecj\amp \veck\amp \veci\amp \vecj \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
+        \begin{matrix} \veci\amp \vecj\amp \veck\amp \veci\amp \vecj \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
         \end{matrix}
       </me>
       This gives three full <q>upper left to lower right</q> diagonals,
@@ -342,6 +342,8 @@
     </theorem>
 
     <aside xml:id="aside-cross-orthogonal">
+      <title>Parallel vectors and the cross product</title>
+
       <p>
         We could rewrite <xref ref="def_orthogonal">Definition</xref>
         and <xref ref="thm_cross_product">Theorem</xref> to include <m>\vec 0</m>,
@@ -350,7 +352,7 @@
         this would mean that <m>\vec 0</m> is both parallel <em>and</em>
         orthogonal to all vectors.
         Apparent paradoxes such as this are not uncommon in mathematics and can be very useful.
-        (See also <xref ref="aside-def-orthogonal">aside</xref> in <xref ref="sec_vector_intro">Section</xref>.)
+        (See also the <xref ref="aside-def-orthogonal" text="custom">aside</xref> in <xref ref="sec_vector_intro">Section</xref>.)
       </p>
     </aside>
     <p>
@@ -563,7 +565,7 @@
 
       <figure xml:id="fig_crossp_parallelogram">
         <caption>Using the cross product to find the area of a parallelogram.</caption>
-        <sidebyside widths="47% 47%">
+        <sidebyside widths="47% 47%" margins="0%">
           <figure xml:id="fig_crossp_parallelograma">
             <caption/>
             <!-- START figures/fig_crossp_parallelogram1.tex -->
@@ -653,7 +655,7 @@
 
                 <figure xml:id="fig_crossp4">
                   <caption>Sketching the parallelograms in <xref ref="ex_crossp4">Example</xref>.</caption>
-                  <sidebyside widths="47% 47%">
+                  <sidebyside widths="47% 47%" valign="bottom">
                     <figure xml:id="fig_crossp4a">
                       <caption/>
                     <!-- START figures/fig_crossp4b.tex -->
@@ -807,7 +809,7 @@
           <figure xml:id="fig_crossp5">
             <caption>Finding the area of a triangle in <xref ref="ex_crossp5">Example</xref>.</caption>
             <!-- START figures/fig_crossp5.tex -->
-            <image xml:id="img_crossp5">
+            <image xml:id="img_crossp5" width="47%">
               <description></description>
               <latex-image>
 
@@ -1336,12 +1338,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 The cross product of two vectors is a <fillin/>, not a scalar.
@@ -1356,12 +1355,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 One can visualize the direction of <m>\vec u\times\vec v</m> using the
@@ -1380,12 +1376,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Give a synonym for <q>orthogonal.</q>
@@ -1400,15 +1393,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -1421,12 +1412,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <fillin/> is a measure of the turning force applied to an object.
@@ -1465,14 +1453,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;12, -15, 3>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 3,2,-2\ra</m>,
@@ -1491,14 +1477,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;11, 1, -17>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 5, -4, 3\ra</m>,
@@ -1517,14 +1501,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;-5, -31, 27>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 4, -5, -5\ra</m>,
@@ -1543,14 +1525,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;47, -36, -44>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la -4, 7, -10\ra</m>,
@@ -1569,14 +1549,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;0, -2, 0>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 1, 0, 1\ra</m>,
@@ -1595,14 +1573,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $cp=Vector("&lt;0, 0, 0>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \la 1, 5, -4\ra</m>,
@@ -1636,15 +1612,13 @@
 
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(ijk=>1);
               $cp=Vector("k");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \hat\imath</m>,
@@ -1663,15 +1637,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(ijk=>1);
               $cp=Vector("-j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \hat\imath</m>, <m>\vec v = \hat{k}</m>.
@@ -1689,15 +1661,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(ijk=>1);
               $cp=Vector("i");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>\vec u = \hat\jmath</m>, <m>\vec v = \hat{k}</m>.
@@ -1717,12 +1687,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Pick any vectors <m>\vec u</m>,
@@ -1739,12 +1706,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Pick any vectors <m>\vec u</m>,
@@ -1772,14 +1736,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 2</m>, <m>\vnorm{v} = 5</m>,
@@ -1791,14 +1753,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("21");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 3</m>, <m>\vnorm{v} = 7</m>,
@@ -1810,14 +1770,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 3</m>, <m>\vnorm{v} = 4</m>,
@@ -1829,14 +1787,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $normucv=Formula("5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vnorm{u} = 2</m>, <m>\vnorm{v} = 5</m>,
@@ -1858,14 +1814,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("sqrt(14)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la 1,1,2\ra</m>,
@@ -1880,14 +1834,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("sqrt(230)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la -2,1,5\ra</m>,
@@ -1902,14 +1854,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la 1,2\ra</m>,
@@ -1924,14 +1874,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("6");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the parallelogram defined by <m>\vec u = \la 2,0\ra</m>,
@@ -1956,14 +1904,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("5sqrt(2)/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(0,0,0)</m>,
@@ -1978,14 +1924,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("3sqrt(30)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(5,2,-1)</m>,
@@ -2000,14 +1944,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("1");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(1,1)</m>,
@@ -2022,14 +1964,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("5/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the triangle with vertices <m>(3,1)</m>,
@@ -2055,14 +1995,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("7");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the quadrilateral with vertices <m>(0,0)</m>,
@@ -2083,14 +2021,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $area=Formula("4sqrt(14)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the area of the quadrilateral with vertices <m>(0,0,0)</m>,
@@ -2120,13 +2056,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $volume=Compute("2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the volume of the parallelepiped defined by <m>\vec u = \la 1,1,1\ra</m>,
@@ -2141,13 +2075,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $volume=Compute("15");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the volume of the parallelepiped defined by <m>\vec u = \la -1,2,1\ra</m>,
@@ -2172,16 +2104,14 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $w=Compute("&lt;1/sqrt(6),1/sqrt(6),-2/sqrt(6)>");
               $w=OneOf("$w,-$w");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 1,1,1\ra</m>,
@@ -2196,16 +2126,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $w=Compute("&lt;-2/sqrt(21),1/sqrt(21),4/sqrt(21)>");
               $w=OneOf("$w,-$w");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 1,-2,1\ra</m>,
@@ -2220,16 +2148,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
               $w=Compute("&lt;0,1,0>");
               $w=OneOf("$w,-$w");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 5,0,2\ra</m>,
@@ -2244,9 +2170,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
@@ -2257,7 +2181,7 @@
                       return 1 if (($student . $student == 1) and ($student . $u == 0));
                    });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find a unit vector orthogonal to both <m>\vec u = \la 1,-2,1\ra</m>,
@@ -2281,12 +2205,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A bicycle rider applies 150lb of force, straight down,
@@ -2303,12 +2224,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A bicycle rider applies 150lb of force,
@@ -2326,12 +2244,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               To turn a stubborn bolt, 80lb of force is applied to a 10in wrench.
@@ -2347,12 +2262,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               To turn a stubborn bolt, 80lb of force is applied to a 10in wrench in a confined space,
@@ -2370,12 +2282,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Show, using the definition of the Cross Product,
@@ -2397,12 +2306,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Show, using the definition of the Cross Product,

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -100,6 +100,12 @@
       </statement>
     </theorem>
 
+    <!-- <figure xml:id="vid_deriv_basic_rules">
+      <caption>Video explanation of <xref ref="thm_deriv_common"/> (2 videos)</caption>
+      <video  youtube="Je10KZXLlwo fSaHMq9mNq0"/>
+    </figure> -->
+
+
     <p>
       This theorem starts by stating an intuitive fact:
       constant functions have zero rate of change as they are <em>constant</em>.
@@ -136,6 +142,17 @@
       we can say that the derivative of <m>f(x)=x</m> is <m>\fp(x)=1</m>.
     </p>
 
+    <!-- <p xml:id="vidint-deriv_basic_rules_exp_func">
+      <xref ref="thm_deriv_common"/> states that the natural exponential function has a remarkable propery:
+      it is equal to its own derivative! The following video explains why this is the case.
+    </p>
+
+    <figure xml:id="vid_deriv_basic_rules_exp_func">
+      <caption>Determining the derivative of <m>f(x)=e^x</m></caption>
+      <video youtube="ipKTEdQFBjw"/>
+    </figure> -->
+
+
     <p>
       Let's practice using this theorem.
     </p>
@@ -171,6 +188,7 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_basic_rules_ex" width="90%" youtube="lyAEJSmSr-A"/> -->
         <p>
           <ol>
             <li>
@@ -285,6 +303,24 @@
       </statement>
     </theorem>
 
+    <!-- <figure xml:id="vid_deriv_basic_rules_const_sum_rule">
+      <caption>Video presentation of <xref ref="thm_deriv_prop"/></caption>
+      <video youtube="Hr0sQcVhQ9A"/>
+    </figure> -->
+
+    <!-- <p xml:id="vidint_deriv_basic_rules_proofs">
+      While we will be mainly focused on <em>using</em> these rules,
+      it can also be interesting to see where they come from.
+      Fortunately, it is not too difficult to establish these rules using the definition of the derivative.
+      The video below shows why the sum rule is true.
+    </p> -->
+
+    <!-- <figure xml:id="vid_deriv_basic_rules_proofs">
+      <caption>Proving the sum rule.</caption>
+      <video youtube="nVVpyilxZTw"/>
+    </figure> -->
+
+
     <p>
       <xref ref="thm_deriv_prop">Theorem</xref>
       allows us to find the derivatives of a wide variety of functions.
@@ -293,8 +329,8 @@
       using the limit definition, the derivative of <m>f(x) = 3x^2+5x-7</m>.
       We can now find its derivative without expressly using limits:
       <md>
-        <mrow>\lzoo{x}{3x^2+5x+7} \amp = 3\lzoo{x}{x^2} + 5\lzoo{x}{x} + \lzoo{x}{7}</mrow>
-        <mrow>\amp = 3\cdot 2x+5\cdot 1+ 0</mrow>
+        <mrow>\lzoo{x}{3x^2+5x-7} \amp = 3\lzoo{x}{x^2} + 5\lzoo{x}{x} - \lzoo{x}{7}</mrow>
+        <mrow>\amp = 3\cdot 2x+5\cdot 1- 0</mrow>
         <mrow>\amp = 6x+5</mrow>
       </md>.
     </p>
@@ -313,6 +349,7 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_basic_rules_examples_1" width="90%" youtube="a0hsWtT74jM"/> -->
         <p>
           This problem is intentionally ambiguous;
           we are to <em>approximate</em> using an
@@ -506,6 +543,11 @@
       </p>
     </aside>
 
+    <!-- <figure xml:id="vid_deriv_basic_rules_higher_order_deriv">
+      <caption>Video explanation of <xref ref="def_Higher_Deriv"/></caption>
+      <video youtube="usabSpUh65w"/>
+    </figure> -->
+
     <p>
       In general, when finding the fourth derivative and on,
       we resort to the <m>f\,^{(4)}(x)</m> notation, not <m>\fp'''(x)</m>;
@@ -529,6 +571,7 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_basic_rules_examples_2" width="90%" youtube="nF2-IrvHmqc"/> -->
         <p>
           <ol>
             <li>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -10,7 +10,7 @@
     (including by a constant)
     and division led to the <xref ref="sum-difference-derivative-rule" text="title"/>,
     the <xref ref="constant-multiple-derivative-rule" text="title"/>,
-    the <xref ref="thm_PowerRule" text="title">Power Rule</xref>,
+    the <xref ref="thm_PowerRule" text="title"/>,
     the <xref ref="thm_ProductRule" text="title"/> and the <xref ref="thm_QuotientRule" text="title"/>.
     To complete the list of differentiation rules,
     we look at the last way two
@@ -924,7 +924,7 @@
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            
+
             <statement>
               <p>
                 True or False?
@@ -940,7 +940,7 @@
             <pg-code>
               $tf=PopUp(['?','True','False'],2);
             </pg-code>
-            
+
             <statement>
               <p>
                 True or False?
@@ -956,7 +956,7 @@
             <pg-code>
               $tf=PopUp(['?','True','False'],2);
             </pg-code>
-            
+
             <statement>
               <p>
                 True or False?
@@ -972,7 +972,7 @@
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            
+
             <statement>
               <p>
                 True or False?
@@ -988,7 +988,7 @@
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            
+
             <statement>
               <p>
                 True or False?
@@ -1004,7 +1004,7 @@
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            
+
             <statement>
               <p>
                 True or False?
@@ -1030,7 +1030,7 @@
             <pg-code>
               $fp=Formula("10(4x^3-x)^9(12x^2-1)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = \left(4x^3-x\right)^{10}</m>
@@ -1049,7 +1049,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("15(3t-2)^4");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(t) = (3t-2)^{5}</m>
@@ -1068,7 +1068,7 @@
               Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $fp=Formula("3(sin(theta)+cos(theta))^2(cos(theta)-sin(theta))");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(\theta)=(\sin(\theta)+\cos(\theta))^3</m>
@@ -1091,7 +1091,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("(6t+1)e^(3t^2+t-1)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>h(t) = e^{3t^2+t-1}</m>
@@ -1139,7 +1139,7 @@
             <pg-code>
               $fp=Formula("4(x+1/x)^3(1-1/x^2)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = \left(x+\frac{1}{x}\right)^4</m>
@@ -1157,7 +1157,7 @@
             <pg-code>
               $fp=Formula("-3sin(3x)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = \cos(3x)</m>
@@ -1175,7 +1175,7 @@
             <pg-code>
               $fp=Formula("5sec^2(5x)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(x) = \tan(5x)</m>
@@ -1224,7 +1224,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("8 sin^3(2t) cos(2t)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>h(t) = \sin^4(2t)</m>
@@ -1243,7 +1243,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("-3 cos^2(t^2+3t+1) sin(t^2+3t+1) (2t+3)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>p(t) = \cos^3\mathopen{}\left(t^2+3t+1\right)\mathclose{}</m>
@@ -1261,7 +1261,7 @@
             <pg-code>
               $fp=Formula("-tan(x)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x)=\ln\mathopen{}\left(\cos(x)\right)\mathclose{}</m>
@@ -1279,7 +1279,7 @@
             <pg-code>
                $fp=Formula("2/x");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = \ln\mathopen{}\left(x^2\right)\mathclose{}</m>
@@ -1297,7 +1297,7 @@
             <pg-code>
                $fp=Formula("2/x");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = 2\ln(x)</m>
@@ -1317,7 +1317,7 @@
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("ln(4) 4^r");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(r) = 4^r</m>
@@ -1337,7 +1337,7 @@
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("-ln(5)*5^(cos(t))*sin(t)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(t)=5^{\cos(t)}</m>
@@ -1356,7 +1356,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("0");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(t) = 15^2</m>
@@ -1376,7 +1376,7 @@
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("ln(3/2) (3/2)^w");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>m(w) = \dfrac{3^w}{2^w}</m>
@@ -1396,7 +1396,7 @@
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("((3^t+2)ln(2)2^t-(2^t+3)(ln(3)3^t))/(3^t+2)^2");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>h(t) = \dfrac{2^t+3}{3^t+2}</m>
@@ -1416,7 +1416,7 @@
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("(2^w(ln(3)3^w-ln(2)(3^w+1)))/(2^(2w))");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>m(w) = \dfrac{3^w+1}{2^w}</m>
@@ -1435,7 +1435,7 @@
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("(2^(x^2)(ln(3)3^(x^2)2x+1) - (3^(x^2)+x)ln(2)2^(x^2)2x)/2^(2x^2)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = \dfrac{3^{x^2}+x}{2^{x^2}}</m>
@@ -1453,7 +1453,7 @@
             <pg-code>
               $fp=Formula("5x^2cos(5x) + 2xsin(5x)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = x^2\sin(5x)</m>
@@ -1487,7 +1487,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("5cos(t^2+3t)cos(5t-7)- (2t+3)sin(t^2+3t)sin(5t-7)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(t)=\cos\mathopen{}\left(t^2+3t\right)\mathclose{}\sin(5t-7)</m>
@@ -1519,7 +1519,7 @@
               Context()->variables->are(t=>'Real');
               $fp=Formula("10t cos(1/t)e^(5t^2)+1/t^2sin(1/t)e^(5t^2)");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(t)=\cos\mathopen{}\left(\frac{1}{t}\right)\mathclose{}e^{5t^2}</m>
@@ -1578,7 +1578,7 @@
               $t=Formula("y=0");
               $n=Formula("x=0");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = \left(4x^3-x\right)^{10}</m>
@@ -1606,7 +1606,7 @@
               $t=Formula("y=15(x-1)+1");
               $n=Formula("y=-1/15(x-1)+1");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>f(x) = (3x-2)^5</m>
@@ -1634,7 +1634,7 @@
               $t=Formula("y=-3(x - pi/2)+1");
               $n=Formula("y=1/3(x - pi/2)+1");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>g(x) = (\sin(x)+\cos(x))^3</m>
@@ -1662,7 +1662,7 @@
               $t=Formula("y=-5e(x+1)+e");
               $n=Formula("y=1/(5e)(x+1)+e");
             </pg-code>
-            
+
             <statement>
               <p>
                 <m>h(x) = e^{3x^2+x-1}</m>
@@ -1773,7 +1773,7 @@
             <pg-code>
               $sign=PopUp(['?','positive','negative'],2);
             </pg-code>
-            
+
             <statement>
               <p>
                 The <q>wind chill factor</q> is a measurement of how cold it <q>feels</q>
@@ -1835,7 +1835,7 @@
               $fp=Formula("2xe^xcot(x) + x^2e^xcot(x) - x^2e^xcsc^2(x)");
               $gp=Formula("ln(24)24^x");
             </pg-code>
-            
+
             <statement>
               <p>
                 Find the derivatives of the following functions.

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -20,6 +20,11 @@
     <q>inside</q> another).
   </p>
 
+  <!-- <figure xml:id="vid_deriv_chain_intro">
+    <caption>Video introduction to <xref ref="sec_chainrule"/></caption>
+    <video youtube="k7wX-kxd7Kw"/>
+  </figure> -->
+
   <p>
     One example of a composition of functions is <m>f(x) = \cos(x^2)</m>.
     We currently do not know how to compute this derivative.
@@ -174,6 +179,11 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_deriv_chain_theorem">
+    <caption>Video presentation of <xref ref="thm_chain_rule"/></caption>
+    <video youtube="1_Lp-ONIMuc"/>
+  </figure> -->
+
   <p>
     Here is the Chain Rule in words:
   </p>
@@ -195,7 +205,8 @@
     <title>Using the Chain Rule</title>
     <statement>
       <p>
-        Use the Chain Rule to find the derivatives of the following functions,
+        Use the Chain Rule to find the derivatives of the functions <m>F_1(x)</m>,
+        <m>F_2(x)</m>, and <m>F_3(x)</m>,
         as given in <xref ref="ex_chain1">Example</xref>.
       </p>
     </statement>
@@ -331,6 +342,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_chain_examples_1" width="90%" youtube="yW1BbOeDFcM"/> -->
+
       <p>
         <ol>
           <li>
@@ -506,6 +519,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_chain_examples_2" width="90%" youtube="2QJLR-Y-Ht8"/> -->
+
       <p>
         <ol>
           <li>
@@ -572,6 +587,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_chain_examples_3_func" width="90%" youtube="JeLuSDqqFPA"/> -->
+
       <p>
         Recognize that we have the
         <m>g(x)=\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}</m> function <q>inside</q>
@@ -727,6 +744,11 @@
       </p>
     </statement>
   </theorem>
+
+  <!-- <figure xml:id="vid_deriv_chain_gen_power_exp">
+    <caption>Derivatives of exponential and general power functions</caption>
+    <video youtube="LnmwxZ5w30w"/>
+  </figure> -->
 
   <paragraphs>
     <title>Alternate Chain Rule Notation</title>
@@ -898,12 +920,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -915,12 +936,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -932,12 +952,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -949,12 +968,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -966,12 +984,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -983,12 +1000,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -1010,12 +1026,11 @@
       </introduction>
 
       <exercise xml:id="exer_02_05_06">
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $fp=Formula("10(4x^3-x)^9(12x^2-1)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = \left(4x^3-x\right)^{10}</m>
@@ -1029,13 +1044,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("15(3t-2)^4");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(t) = (3t-2)^{5}</m>
@@ -1049,13 +1063,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $fp=Formula("3(sin(theta)+cos(theta))^2(cos(theta)-sin(theta))");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(\theta)=(\sin(\theta)+\cos(\theta))^3</m>
@@ -1073,13 +1086,12 @@
       </exercise>
 
       <exercise xml:id="exer_02_05_09">
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("(6t+1)e^(3t^2+t-1)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>h(t) = e^{3t^2+t-1}</m>
@@ -1102,7 +1114,7 @@
       </statement>
       <answer>
         <p>
-          <m>\fp(x) = 3\big(\ln x+x^2\big)2(\frac1x+2x)</m>
+          <m>\fp(x) = 3\big(\ln x+x^2\big)^2(\frac1x+2x)</m>
         </p>
       </answer>
     </exercise>
@@ -1123,12 +1135,11 @@
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $fp=Formula("4(x+1/x)^3(1-1/x^2)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = \left(x+\frac{1}{x}\right)^4</m>
@@ -1142,12 +1153,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $fp=Formula("-3sin(3x)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = \cos(3x)</m>
@@ -1161,12 +1171,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $fp=Formula("5sec^2(5x)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(x) = \tan(5x)</m>
@@ -1204,19 +1213,18 @@
       </statement>
       <answer>
         <p>
-          <m>g\,'(t) = \cos\left(t^5+\frac1t\right)\left(5t^4-\frac1{t^3}\right)</m>
+          <m>g\,'(t) = \cos\left(t^5+\frac1t\right)\left(5t^4-\frac1{t^2}\right)</m>
         </p>
       </answer>
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("8 sin^3(2t) cos(2t)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>h(t) = \sin^4(2t)</m>
@@ -1230,13 +1238,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("-3 cos^2(t^2+3t+1) sin(t^2+3t+1) (2t+3)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>p(t) = \cos^3\mathopen{}\left(t^2+3t+1\right)\mathclose{}</m>
@@ -1250,12 +1257,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $fp=Formula("-tan(x)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x)=\ln\mathopen{}\left(\cos(x)\right)\mathclose{}</m>
@@ -1269,12 +1275,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
                $fp=Formula("2/x");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = \ln\mathopen{}\left(x^2\right)\mathclose{}</m>
@@ -1288,12 +1293,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
                $fp=Formula("2/x");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = 2\ln(x)</m>
@@ -1307,14 +1311,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(r=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("ln(4) 4^r");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(r) = 4^r</m>
@@ -1328,14 +1331,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("-ln(5)*5^(cos(t))*sin(t)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(t)=5^{\cos(t)}</m>
@@ -1349,13 +1351,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("0");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(t) = 15^2</m>
@@ -1369,14 +1370,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(w=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("ln(3/2) (3/2)^w");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>m(w) = \dfrac{3^w}{2^w}</m>
@@ -1390,14 +1390,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("((3^t+2)ln(2)2^t-(2^t+3)(ln(3)3^t))/(3^t+2)^2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>h(t) = \dfrac{2^t+3}{3^t+2}</m>
@@ -1411,14 +1410,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(w=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("(2^w(ln(3)3^w-ln(2)(3^w+1)))/(2^(2w))");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>m(w) = \dfrac{3^w+1}{2^w}</m>
@@ -1432,13 +1430,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("(2^(x^2)(ln(3)3^(x^2)2x+1) - (3^(x^2)+x)ln(2)2^(x^2)2x)/2^(2x^2)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = \dfrac{3^{x^2}+x}{2^{x^2}}</m>
@@ -1452,12 +1449,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $fp=Formula("5x^2cos(5x) + 2xsin(5x)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = x^2\sin(5x)</m>
@@ -1486,13 +1482,12 @@
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("5cos(t^2+3t)cos(5t-7)- (2t+3)sin(t^2+3t)sin(5t-7)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(t)=\cos\mathopen{}\left(t^2+3t\right)\mathclose{}\sin(5t-7)</m>
@@ -1519,13 +1514,12 @@
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("10t cos(1/t)e^(5t^2)+1/t^2sin(1/t)e^(5t^2)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(t)=\cos\mathopen{}\left(\frac{1}{t}\right)\mathclose{}e^{5t^2}</m>
@@ -1577,15 +1571,14 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
               $t=Formula("y=0");
               $n=Formula("x=0");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = \left(4x^3-x\right)^{10}</m>
@@ -1605,8 +1598,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1614,7 +1606,7 @@
               $t=Formula("y=15(x-1)+1");
               $n=Formula("y=-1/15(x-1)+1");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>f(x) = (3x-2)^5</m>
@@ -1634,8 +1626,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1643,7 +1634,7 @@
               $t=Formula("y=-3(x - pi/2)+1");
               $n=Formula("y=1/3(x - pi/2)+1");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>g(x) = (\sin(x)+\cos(x))^3</m>
@@ -1663,8 +1654,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1672,7 +1662,7 @@
               $t=Formula("y=-5e(x+1)+e");
               $n=Formula("y=1/(5e)(x+1)+e");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 <m>h(x) = e^{3x^2+x-1}</m>
@@ -1694,7 +1684,7 @@
     </exercisegroup>
 
     <exercise>
-      <webwork seed="1">
+      <webwork>
           <statement>
             <p>
               Compute <m>\lzoo{x}{\ln(kx)}</m> two ways:
@@ -1732,7 +1722,7 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
+      <webwork>
           <statement>
             <p>
               Compute <m>\lzoo{x}{\ln\mathopen{}\left(x^k\right)\mathclose{}}</m> two ways:
@@ -1779,12 +1769,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $sign=PopUp(['?','positive','negative'],2);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 The <q>wind chill factor</q> is a measurement of how cold it <q>feels</q>
@@ -1840,14 +1829,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0);
               $fp=Formula("2xe^xcot(x) + x^2e^xcot(x) - x^2e^xcsc^2(x)");
               $gp=Formula("ln(24)24^x");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the derivatives of the following functions.

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -15,6 +15,12 @@
       Knowing <m>x</m>, we can directly find <m>y</m>.)
     </p>
 
+    <!-- <figure>
+      <caption>Video introduction to <xref ref="sec_imp_deriv"/></caption>
+      <video xml:id="vid_deriv_impl_intro" youtube="JWOOMkaNbQg A134hhXIF-0"/>
+    </figure> -->
+
+
     <p>
       Sometimes the relationship between <m>y</m> and <m>x</m> is not explicit;
       rather, it is <em>implicit</em>.
@@ -62,7 +68,6 @@
       </image>
       <!-- figures/fig_implicit1.tex END -->
     </figure>
-
   </introduction>
 
   <subsection>
@@ -106,6 +111,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_impl_ex_1" width="90%" youtube="0baXlbhup0o"/> -->
+
         <p>
           We start by taking the derivative of both sides
           (thus maintaining the equality.)
@@ -192,6 +199,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_impl_tan_line_prev_ex" width="90%" youtube="qYrcm4ObwOM"/> -->
+
         <p>
           In <xref ref="ex_implicit1">Example</xref> we found that
           <me>
@@ -292,6 +301,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_impl_ex_2" width="90%" youtube="O5OqJ7a_Ovo"/> -->
+
         <p>
           We will take the implicit derivatives term by term.
           The derivative of <m>y^3</m> is <m>3y^2y'</m>.
@@ -384,6 +395,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_impl_ex_3" width="90%" youtube="BMn-BU6VTQU"/> -->
+
         <p>
           Differentiating term by term,
           we find the most difficulty in the first term.
@@ -752,6 +765,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_impl_second_deriv" width="90%" youtube="V6piqsjn2mk"/> -->
+
         <p>
           We found that <m>y' = \lz{y}{x} = -x/y</m> in <xref ref="ex_implicit7">Example</xref>.
           To find <m>y''</m>, we apply implicit differentiation to <m>y'</m>.
@@ -851,6 +866,22 @@
         </p>
       </statement>
       <solution>
+        <!-- <figure>
+          <caption>Two approaches to solving <xref ref="ex_implicit10"/></caption>
+          <sidebyside widths="47% 47%">
+            <figure xml:id="vid_deriv_impl_logarithmic">
+              <caption>Taking the natural log of both sides</caption>
+              <video youtube="aofx_jgKDhU"/>
+            </figure>
+            <figure xml:id="vid_deriv_impl_inv_rel_ln_exp">
+              <caption>Using the inverse relationship <m>e^{\ln(x)}=x</m></caption>
+              <video youtube="w93T6AyU_aE"/>
+            </figure> -->
+
+
+          </sidebyside>
+        </figure>
+
         <p>
           As suggested above,
           we start by taking the natural log of both sides then applying implicit differentiation.
@@ -905,6 +936,18 @@
         </figure>
       </solution>
     </example>
+    <!-- <p xml:id="vidint_deriv_impl_ex5">
+      We would not have been able to compute the derivative of the function in <xref ref="ex_implicit10"/>
+      without logarithmic differentiation.
+      But the method is also useful in cases where the product and quotient rules could be used,
+      but logarithmic differentiation is simpler.
+      The following video provides such an example.
+    </p> -->
+
+    <!-- <figure xml:id="vid_deriv_impl_ex_5">
+      <caption>Using logarithmic differentiation</caption>
+      <video youtube="3Cv2EgjH9ZE"/>
+    </figure> -->
 
     <p>
       Implicit differentiation proves to be useful as it allows us to find the instantaneous rates of change of a variety of functions.
@@ -944,11 +987,10 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               $derivativerules=RadioButtons(["Constant Rule", "Power Rule", "Sum/Difference Rule", "Constant Multiple Rule", "Product Rule", "Quotient Rule", "Chain Rule"],6);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Implicit differentiation is based on what other differentiation rule?
@@ -963,11 +1005,10 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -980,11 +1021,10 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -1006,12 +1046,11 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               Context()->variables->set(x=>{limits=>[0,4]});
               $fp=Formula("1/(2sqrt(x))-1/(2sqrt(x^3))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x)=\sqrt{x}+\dfrac{1}{\sqrt{x}}</m>
@@ -1026,14 +1065,12 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->set(x=>{limits=>[0,4]});
               Context()->flags->set(reduceConstants=>0);
               $fp=Formula("1/3 x^(-2/3)+2/3 x^(-1/3)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x)=\sqrt[3]{x}+x^{2/3}</m>
@@ -1048,14 +1085,12 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->variables->set(t=>{limits=>[-1,1]});
               $fp=Formula("-t/sqrt(1-t^2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(t)=\sqrt{1-t^2}</m>
@@ -1070,14 +1105,12 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->variables->set(t=>{limits=>[0,4]});
               $fp=Formula("sqrt(t)cos(t)+sin(t)/(2sqrt(t))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>g(t)=\sqrt{t}\sin(t)</m>
@@ -1092,13 +1125,11 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->set(x=>{limits=>[0,4]});
               $fp=Formula("1.5sqrt(x)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>h(x)=x^{1.5}</m>
@@ -1113,14 +1144,12 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->set(x=>{limits=>[0,4]});
               Context()->flags->set(reduceConstants=>0);
               $fp=Formula("pi x^(pi-1)+1.9x^(0.9)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x)=x^{\pi}+x^{1.9}+\pi^{1.9}</m>
@@ -1135,13 +1164,11 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->set(x=>{limits=>[0,4]});
               $fp=Formula("1/(2sqrt(x))-7/(2sqrt(x^3))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>g(x)=\dfrac{x+7}{\sqrt{x}}</m>
@@ -1156,14 +1183,12 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->variables->set(t=>{limits=>[0,4]});
               $fp=Formula("1/5t^(-4/5)(sec(t)+e^t)+t^(1/5)(sec(t)tan(t)+e^t)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(t)=\sqrt[5]{t}\left(\sec(t) + e^t\right)</m>
@@ -1188,8 +1213,6 @@
 
       <exercise xml:id="exer_02_06_ex_09">
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-4x^3/(2y+1)");
@@ -1198,7 +1221,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>x^4+y^2+y=7</m>
@@ -1213,8 +1236,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-y^(3/5)/x^(3/5)");
@@ -1223,7 +1244,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>x^{2/5}+y^{2/5}=1</m>
@@ -1238,8 +1259,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("sin(x)sec(y)");
@@ -1248,7 +1267,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\cos(x)+\sin(y)=1</m>
@@ -1263,8 +1282,6 @@
 
       <exercise xml:id="exer_02_06_ex_12">
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("y/x");
@@ -1273,7 +1290,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\dfrac{x}{y}=10</m>
@@ -1288,8 +1305,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("y/x");
@@ -1298,7 +1313,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\dfrac{y}{x}=10</m>
@@ -1313,8 +1328,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               Context()->flags->set(reduceConstantFunctions=>0);
@@ -1324,7 +1337,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>x^2e^x+2^y=5</m>
@@ -1339,8 +1352,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-2sin(y)cos(y)/x");
@@ -1350,7 +1361,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>x^2\tan(y) =50</m>
@@ -1365,8 +1376,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-x/y^2");
@@ -1375,7 +1384,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>(3 x^2+2 y^3)^4=2</m>
@@ -1391,8 +1400,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("1/(2y+2)");
@@ -1401,7 +1408,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>(y^2+2y-x)^2=200</m>
@@ -1417,8 +1424,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("(x^2+2xy^2-y)/(2x^2y-x+y^2)");
@@ -1427,7 +1432,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\dfrac{x^2+y}{x+y^2}=17</m>
@@ -1461,14 +1466,12 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("(-cos(x)(x+cos(y))+sin(x)+y)/(sin(y)(sin(x)+y)+x+cos(y))");
               $dydx->{test_points}=[[-3.1,-3.83041],[-0.41,0.732269],[0.59,0.759097],[2.6,1.82908],[5.3,6.93017]];
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\dfrac{\sin(x)+y}{\cos(y)+x}=1</m>
@@ -1502,8 +1505,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-x/y");
@@ -1513,7 +1514,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ln\mathopen{}\left(x^2+y^2\right)\mathclose{}=e</m>
@@ -1529,8 +1530,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-(2x+y)/(2y+x)");
@@ -1542,7 +1541,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ln\mathopen{}\left(x^2+xy+y^2\right)\mathclose{} = 1</m>
@@ -1630,8 +1629,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1654,7 +1651,7 @@
               $gr->stamps(closed_circle(0.1,0.2811,'black'));
               $gr->lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom'));
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 On the curve <m>x^{2/5}+y^{2/5} = 1</m>,
@@ -1695,8 +1692,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
 
             <pg-code>
@@ -1720,7 +1715,7 @@
               $gr->stamps(closed_circle(0.7746,0.8944,'black'));
               $gr->lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top'));
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 On the curve <m>x^{4}+y^{4} = 1</m>,
@@ -1770,8 +1765,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1794,7 +1787,7 @@
               $gr->stamps(closed_circle(2,-3.224,'black'));
               $gr->lb(new Label(2,-3.224,'(2,-108^(1/4))','black','left','bottom'));
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 On the curve <m>(x^2+y^2-4)^3 = 108y^2</m>,
@@ -1834,8 +1827,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1858,7 +1849,7 @@
               $gr->stamps(closed_circle(-0.75,1.299,'black'));
               $gr->lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','center','bottom'));
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 On the curve <m>(x^2+y^2+x)^2 = x^2+y^2</m>,
@@ -1898,8 +1889,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1924,7 +1913,7 @@
               $gr->stamps(closed_circle(4.598,1.5,'black'));
               $gr->lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom'));
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 On the curve <m>(x-2)^2+(y-3)^2=9</m>,
@@ -2011,9 +2000,7 @@
 
           \end{axis}
 
-          \node [right] at (myplot.right of origin) {\scriptsize $x$};
-          \node [above] at (myplot.above origin) {\scriptsize $y$};
-
+          
           \end{tikzpicture}
 
           </latex-image>
@@ -2058,8 +2045,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("-((2y+1)(12x^2)-4x^3(2*-(4x^3)/(2y+1)))/(2y+1)^2");
@@ -2068,7 +2053,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $ddyddx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>x^4+y^2+y=7</m>
@@ -2084,8 +2069,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("-(x^(3/5)*3/5y^(-2/5)(-y^(3/5)/x^(3/5))-y^(3/5)*3/5x^(-2/5))/x^(6/5)");
@@ -2094,7 +2077,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $ddyddx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>x^{2/5}+y^{2/5}=1</m>
@@ -2110,8 +2093,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("sin^2(x)sec^2(y)tan(y)+cos(x)sec(y)");
@@ -2120,7 +2101,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $ddyddx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\cos(x)+\sin(y)=1</m>
@@ -2136,8 +2117,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("0");
@@ -2146,7 +2125,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $ddyddx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\dfrac{x}{y}=10</m>
@@ -2173,8 +2152,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->variables->set(x=>{limits=>[-0.9,4]});
@@ -2187,7 +2164,7 @@
               parser::Assignment->Allow;
               $t=Formula("y=(1-2ln(2))(x-1)+2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>y=(1+x)^{1/x}</m>
@@ -2219,8 +2196,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->variables->set(x=>{limits=>[0.01,4]});
@@ -2233,7 +2208,7 @@
               parser::Assignment->Allow;
               $t=Formula("y=(2+4ln(2))(x-1)+2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>y=(2x)^{x^2}</m>
@@ -2265,8 +2240,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->variables->set(x=>{limits=>[0.01,4]});
@@ -2279,7 +2252,7 @@
               parser::Assignment->Allow;
               $t=Formula("y=1/4*(x-1)+1/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>y=\dfrac{x^{x}}{x+1}</m>
@@ -2311,8 +2284,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->variables->set(x=>{limits=>[0.01,4]});
@@ -2325,7 +2296,7 @@
               parser::Assignment->Allow;
               $t=Formula("y=(3pi^2)/4*(x-pi/2)+(pi/2)^3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>y=x^{\sin(x)+2}</m>
@@ -2358,8 +2329,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2371,7 +2340,7 @@
               parser::Assignment->Allow;
               $t=Formula("y=1/9(x-1)+2/3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>y=\dfrac{x+1}{x+2}</m>
@@ -2403,8 +2372,6 @@
 
       <exercise>
         <webwork>
-            <setup>
-
 
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2416,7 +2383,7 @@
               parser::Assignment->Allow;
               $t=Formula("y=11/72x+1/6");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>y=\dfrac{(x+1)(x+2)}{(x+3)(x+4)}</m>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -4,6 +4,12 @@
   <title>Instantaneous Rates of Change: The Derivative</title>
   <subsection xml:id="sec-deriv-intro">
     <title>Introduction</title>
+
+    <!-- <figure xml:id="vid_deriv_intro_introduction">
+      <caption>Video introduction to <xref ref="sec_derivative"/></caption>
+      <video youtube="jRW9d25E_ls"/>
+    </figure> -->
+
     <p>
       A common amusement park ride lifts riders to a height then allows them to freefall a certain distance before safely stopping them.
       Suppose such a ride drops riders from a height of <m>150</m> feet.
@@ -179,7 +185,7 @@
     <sbsgroup>
       <sidebyside>
         <figure xml:id="fig_derivfalling">
-        <caption>The function <m>f(t)</m> and its secant line corresponding to <m>t=2</m> and <m>  t=3</m>.</caption>
+        <caption>The function <m>f(t)</m> and its secant line corresponding to <m>t=2</m> and <m>  t=3</m></caption>
           <image xml:id="img_derivfalling">
           <!-- START figures/fig_derivfalling.tex -->
             <description></description>
@@ -203,7 +209,7 @@
         </figure>
 
         <figure xml:id="fig_derivfalling2">
-          <caption>The function <m>f(t)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m>.</caption>
+          <caption>The function <m>f(t)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m></caption>
           <image xml:id="img_derivfalling2">
           <!-- START figures/fig_derivfalling2.tex -->
             <description></description>
@@ -230,7 +236,7 @@
 
       <sidebyside>
         <figure xml:id="fig_derivfalling3">
-          <caption>The function <m>f(t)</m> with the same secant line, zoomed in further.</caption>
+          <caption>The function <m>f(t)</m> with the same secant line, zoomed in further</caption>
           <image xml:id="img_derivfalling3">
           <!-- START figures/fig_derivfalling3.tex -->
             <description></description>
@@ -255,7 +261,7 @@
         </figure>
 
         <figure xml:id="fig_derivfalling4">
-          <caption>The function <m>f(t)</m> with its tangent line at <m>t=2</m>.</caption>
+          <caption>The function <m>f(t)</m> with its tangent line at <m>t=2</m></caption>
           <!-- START figures/fig_derivfalling4.tex -->
           <image xml:id="img_derivfalling4">
             <description></description>
@@ -324,6 +330,11 @@
       </statement>
     </definition>
 
+    <!-- <figure xml:id="vid_deriv_intro_defn">
+      <caption>Video presentation of <xref ref="def_derivative_at_a_point"/></caption>
+      <video youtube="JXFMh21PMx4"/>
+    </figure> -->
+
     <definition xml:id="def_tangent_line">
       <title>Tangent Line</title>
       <statement>
@@ -377,6 +388,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_intro_ex_v1" youtube="EheTlvVDaGg q_XfRMmSEmc"/> -->
+
         <p>
           <ol label="a.">
             <li>
@@ -433,7 +446,7 @@
           </p>
 
           <figure xml:id="fig_tangent1">
-            <caption>A graph of <m>f(x) = 3x^2+5x-7</m> and its tangent lines at <m>x=1</m> and <m>x=3</m>.</caption>
+            <caption>A graph of <m>f(x) = 3x^2+5x-7</m> and its tangent lines at <m>x=1</m> and <m>x=3</m></caption>
             <!-- START figures/fig_tangent1.tex -->
             <image xml:id="img_tangent1">
               <description></description>
@@ -458,6 +471,18 @@
         </sidebyside>
       </solution>
     </example>
+
+    <!-- <p xml:id="vidint-diff-imp-cont">
+      An important consequence of <xref ref="def_derivative_at_a_point"/>
+      is that a function has to be continuous at any point where it is differentiable.
+      Or, in other words, a function cannot be differentiable at a point of discontinuity.
+      This is explained in the following video.
+    </p> -->
+
+    <!-- <figure xml:id="vid_deriv_intro_diff_imp_cont">
+      <caption>Showing that every differentiable function is continuous</caption>
+      <video youtube="q1ZAqRsgVPk"/>
+    </figure> -->
 
     <p>
       Another important line that can be created using information from the derivative is the
@@ -519,7 +544,7 @@
           </p>
 
           <figure xml:id="fig_normal1">
-            <caption>A graph of <m>f(x)=3x^2+5x-7</m>, along with its normal line at <m>x=1</m>.</caption>
+            <caption>A graph of <m>f(x)=3x^2+5x-7</m>, along with its normal line at <m>x=1</m></caption>
             <!-- START figures/fig_normal1.tex -->
             <image xml:id="img_normal1">
               <description></description>
@@ -672,7 +697,7 @@
           </p>
 
           <figure xml:id="fig_tangentsinx">
-            <caption><m>f(x) = \sin(x)</m> graphed with an approximation to its tangent line at <m>x=0</m>.</caption>
+            <caption><m>f(x) = \sin(x)</m> graphed with an approximation to its tangent line at <m>x=0</m></caption>
             <!-- START figures/fig_tangentsinx.tex -->
             <image xml:id="img_tangentsinx">
               <description></description>
@@ -786,6 +811,14 @@
       </statement>
     </definition>
 
+    <!-- <figure xml:id="vid_deriv_intro_deriv_func">
+      <caption>Video presentation of <xref ref="def_the_derivative"/></caption>
+      <video youtube="yPzNYlzA0Js"/>
+    </figure> -->
+
+
+
+
     <p>
       <alert>Important:</alert> The notation <m>\frac{dy}{dx}</m> is one symbol;
       it is <em>not</em> the fraction <q><m>dy/dx</m></q>.
@@ -798,6 +831,12 @@
       and when we learn about integration
       (topics that appear in later sections and chapters).
     </p>
+
+    <!-- <figure xml:id="vid_deriv_intro_notation">
+      <caption>Explaining derivative notation</caption>
+      <video youtube="TJhJiA_w4mQ"/>
+    </figure> -->
+
 
     <p>
       Examples will help us understand this definition.
@@ -841,6 +880,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_intro_ex_1" width="90%" youtube="JKHbXYanjDs"/> -->
+
         <p>
           We apply <xref ref="def_the_derivative">Definition</xref>.
           <md>
@@ -877,6 +918,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_deriv_intro_deriv_sin" width="90%" youtube="vsnDopbWHXQ"/> -->
+
         <p>
           Before applying <xref ref="def_the_derivative">Definition</xref>,
           note that once this is found,
@@ -918,6 +961,18 @@
           We approximated the slope as <m>0.9983</m>;
           we now know the slope is <em>exactly</em> <m>\cos(0) =1</m>.
         </p>
+
+        <!-- <p xml:id="vidint_deriv_intro_deriv_cos">
+          Using similar techniques, we can show that the derivative of <m>\cos(x)</m>
+          is <m>-\sin(x)</m>. See if you can show this yourself; if you get stuck,
+          you can check out the next video.
+        </p> -->
+
+        <!-- <figure xml:id="vid_deriv_intro_deriv_cos">
+          <caption>Finding the derivative of <m>\cos(x)</m></caption>
+          <video youtube="-1lOFzhDJAo"/>
+        </figure> -->
+
       </solution>
     </example>
 
@@ -1076,7 +1131,7 @@
         </p>
 
         <figure xml:id="fig_piecewisesinx1">
-          <caption>A graph of <m>f(x)</m> as defined in <xref ref="ex_diff_piecewise">Example</xref>.</caption>
+          <caption>A graph of <m>f(x)</m> as defined in <xref ref="ex_diff_piecewise">Example</xref></caption>
           <!-- START figures/fig_piecewisesinx1.tex -->
           <image xml:id="img_piecewisesinx1" width="47%">
             <description></description>
@@ -1193,6 +1248,16 @@
         </figure>
       </solution>
     </example>
+
+    <!-- <p xml:id="vidint_deriv_intro_ex_2>
+      For one more example involving piecewise-defined functions,
+      we turn to the following video.
+    </p> -->
+
+    <!-- <figure xml:id="vid_deriv_intro_ex_2">
+      <caption>Determining when a piecewise-defined function is differentiable</caption>
+      <video youtube="Ev9hJVbDO1k"/>
+    </figure> -->
 
     <p>
       Recall we pseudo-defined a continuous function as one in which we could sketch its graph   without lifting our pencil.

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_deriv_inverse_function">
   <title>Derivatives of Inverse Functions</title>
-  <!--<introduction>-->
+
+  <!-- <figure xml:id="vid_deriv_inverse_intro">
+    <caption>Video introduction to <xref ref="sec_deriv_inverse_function"/></caption>
+    <video youtube="rBIBiDXbWf8"/>
+  </figure> -->
+
   <p>
     Recall that a function <m>y=f(x)</m> is said to be <term>one-to-one</term>
     if it passes the horizontal line test;
@@ -42,6 +47,21 @@
     (on the appropriate domains),
     then they are inverses.
   </p>
+
+  <!-- <figure xml:id="vid_deriv_inverse_prop">
+    <caption>Properties of inverse functions</caption>
+    <video youtube="1g9gAQC301Q"/>
+  </figure> -->
+
+  <!-- <p xml:id="vidint_derive_inverse_examples">
+    For a refresher on how to determine the inverse of a given function,
+    watch the following video.
+  </p> -->
+
+  <!-- <figure xml:id="vid_deriv_inverse_examples">
+    <caption>Finding the inverse of a one-to-one function</caption>
+    <video youtube="PsJKKckGcXE"/>
+  </figure> -->
 
   <p>
     When the point <m>(a,b)</m> lies on the graph of <m>f</m>,
@@ -223,6 +243,11 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_deriv_inverse_inv_func_thm">
+    <caption>Video presentation of <xref ref="thm_deriv_inverse_functions"/></caption>
+    <video youtube="dOtVBJd75h8"/>
+  </figure> -->
+
   <p>
     The results of <xref ref="thm_deriv_inverse_functions">Theorem</xref> are not trivial;
     the notation may seem confusing at first.
@@ -234,6 +259,21 @@
     In the next example we apply <xref ref="thm_deriv_inverse_functions">Theorem</xref> to the arcsine function.
   </p>
 
+  <!-- <p xml:id="vidint_deriv_inverse_restrict_domain">
+    A word of caution is required here. The function <m>\sin(x)</m> is clearly not one-to-one.
+    How can we say that <m>\arcsin(x)</m> is the inverse of <m>\sin(x)</m>?
+    To make sense of this, we employ a technique known as <em>restriction of domain</em>:
+    instead of considering the entire domain of the sine function,
+    we consider a portion of it, on which the function is one-to-one,
+    as explained in the following video.
+  </p> -->
+
+  <!-- <figure xml:id="vid_deriv_inverse_restrict_domain">
+    <caption>Restricting the domain of <m>\sin(x)</m></caption>
+    <video youtube="lCNZPbfiono"/>
+  </figure> -->
+
+
   <example xml:id="ex_deriv_arcsin">
     <title>Finding the derivative of an inverse trigonometric function</title>
     <statement>
@@ -243,6 +283,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_inverse_deriv_arcsin" width="90%" youtube="xBZqkvQRSG4"/> -->
+
       <p>
         Adopting our previously defined notation,
         let <m>g(x) = \arcsin(x) </m> and <m>f(x) = \sin(x)</m>.
@@ -398,7 +440,7 @@
   </p>
 
   <table xml:id="tab_domain_trig">
-    <title>Domains and ranges of the trigonometric and inverse trigonometric functions.</title>
+    <title>Domains and ranges of the trigonometric and inverse trigonometric functions</title>
     <tabular>
       <row bottom="medium">
         <cell>Function</cell>
@@ -503,6 +545,12 @@
     <m>\sin^{-1}(x)</m>, <m>\tan^{-1}(x)</m>,
     and <m>\sec^{-1}(x)</m> are used almost exclusively throughout this text.
   </p>
+
+  <!-- <figure xml:id="vid_deriv_inverse_seriv_arctan">
+    <caption>Computing the derivative of <m>\arctan(x)</m></caption>
+    <video youtube="yO-BT5vEZ9A"/>
+  </figure> -->
+
 
   <p>
     In <xref ref="sec_basic_diff_rules">Section</xref>,
@@ -617,12 +665,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -634,7 +681,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 In your own words explain what it means for a function to be <q>one-to-one.</q>
@@ -648,7 +695,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 If <m>(1,10)</m> lies on the graph of <m>y=f(x)</m>,
@@ -669,7 +716,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 If <m>(1,10)</m> lies on the graph of <m>y=f(x)</m> and <m>\fp(1) = 5</m>,
@@ -700,7 +747,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Verify that <m>f(x) = 2x+6</m> and
@@ -720,7 +767,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Verify that <m>f(x) = x^2+6x+11</m>,
@@ -741,7 +788,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Verify that <m>f(x) = \frac{3}{x-5}</m>,
@@ -762,7 +809,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Verify that <m>f(x) = \frac{x+1}{x-1}</m>,
@@ -794,13 +841,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The point <m>(2,20)</m> is on the graph of <m>f(x) = 5x+10</m>.
@@ -815,13 +861,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/4");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The point <m>(3,7)</m> is on the graph of <m>f(x) = x^2-2x+4</m>,
@@ -837,13 +882,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The point <m>\left(\pi/6,\sqrt{3}/2\right)</m> is on the graph of <m>f(x) = \sin(2x)</m>,
@@ -859,13 +903,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/6");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The point <m>(1,8)</m> is on the graph of <m>f(x) = x^3-6x^2+15x-2</m>.
@@ -880,14 +923,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("-2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The point <m>(1,1/2)</m> is on the graph of <m>\ds f(x) = \frac{1}{1+x^2}</m>,
@@ -903,14 +944,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fip=Formula("1/18");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The point <m>(0,6)</m> is on the graph of <m>f(x) = 6e^{3x}</m>.
@@ -934,16 +973,14 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(t=>{limits=>[-0.25,0.25]});
               $fp=Formula("2/sqrt(1-4t^2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>h(t) = \sin^{-1}(2t)</m>
@@ -958,15 +995,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("1/(|t|sqrt(4t^2+1))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(t) = \sec^{-1}(2t)</m>
@@ -981,14 +1016,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $fp=Formula("2/(1+4x^2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>g(x)=\tan^{-1}(2x)</m>
@@ -1003,15 +1036,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("x/sqrt(1-x^2)+sin^(-1)(x)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x) =x\sin^{-1}(x)</m>
@@ -1026,16 +1057,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(t=>{limits=>[-1,1]});
               $fp=Formula("cos^(-1)(t)cos(t)-sin(t)/sqrt(1-t^2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>g(t) = \sin(t) \cos^{-1}(t)</m>
@@ -1050,16 +1079,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(t=>{limits=>[1,5]});
               $fp=Formula("e^t/t+ln(t)e^t");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(t) = \ln(t) e^t</m>
@@ -1074,14 +1101,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("(sin^-1(x)+cos^-1(x))/(sqrt(1-x^2)(cos^-1(x))^2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>h(x) = \frac{\sin^{-1}(x) }{\cos^{-1}(x) }</m>
@@ -1096,15 +1122,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(x=>{limits=>[1,5]});
               $fp=Formula("1/(2sqrt(x)(1+x))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>g(x) = \tan^{-1}\mathopen{}\left(\sqrt{x}\right)\mathclose{}</m>
@@ -1119,15 +1143,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("-1/sqrt(1-x^2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x)=\sec^{-1}(1/x)</m>
@@ -1142,15 +1164,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->set(x=>{limits=>[-1,1]});
               $fp=Formula("1");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x) =\sin(\sin^{-1}(x) )</m>
@@ -1207,7 +1227,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Compute the derivative of <m>f(x)=\sin(\sin^{-1}(x))</m> in two ways:
@@ -1237,7 +1257,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Compute the derivative of <m>f(x)=\tan^{-1}(\tan(x))</m> in two ways:
@@ -1267,7 +1287,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Compute the derivative of <m>f(x) \sin(\cos^{-1}(x))</m> in two ways:
@@ -1307,16 +1327,14 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $t=Formula("y=sqrt(2)(x-sqrt(2)/2)+pi/4");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the equation of the tangent line to
@@ -1332,16 +1350,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $t=Formula("y=-4(x-sqrt(3)/4)+pi/6");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the equation of the tangent line to
@@ -1366,9 +1382,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("(y(y-2x))/(x(x-2y))");
@@ -1377,7 +1391,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find <m>\lz{y}{x}</m>, where <m>x^2y-y^2x = 1</m>.
@@ -1392,16 +1406,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $t=Formula("y=-4/5(x-1)+2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the equation of the line tangent to the graph of
@@ -1417,13 +1429,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $l=Formula("3x^2+1");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>f(x) = x^3+x</m>.

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_prod_quot_rules">
   <title>The Product and Quotient Rules</title>
-  <!--<introduction> Violates DTD to have introduction with no subsections -->
   <p>
     <xref ref="sec_basic_diff_rules">Section</xref> showed that,
     in some ways, derivatives behave nicely.
@@ -15,6 +14,12 @@
     which are defined in this section.
     We begin with the Product Rule.
   </p>
+
+  <!-- <figure xml:id="vid_deriv_prod_quot_prod_intro">
+    <caption>Video introduction to <xref ref="sec_prod_quot_rules"/></caption>
+    <video youtube="1X3PTrkMsJ8"/>
+  </figure> -->
+
 
   <theorem xml:id="thm_ProductRule">
     <title>Product Rule</title>
@@ -52,6 +57,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_prod_ex" width="90%" youtube="37efDywkDyE"/> -->
+      
       <p>
         To make our use of the <xref ref="thm_ProductRule" text="title"/> explicit,
         let's set <m>f(x) = 5x^2</m> and <m>g(x) = \sin(x)</m>.
@@ -111,6 +118,8 @@
 
   <proof>
     <title>Proof of Product Rule</title>
+    <!-- <video xml:id="vid_deriv_prod_quot_proof_prod_rule" youtube="i791Y97O5hI"/> -->
+
     <p>
       We can use the definition of the derivative to prove <xref ref="thm_ProductRule">Theorem</xref>.
     </p>
@@ -170,6 +179,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_ex_1" width="90%" youtube="-plvLFQ21Ig"/> -->
+
       <p>
         We first expand the expression for <m>y</m>;
         a little algebra shows that <m>y = 2x^4+3x^3-6x^2+1</m>.
@@ -207,6 +218,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_ex_3_func" width="90%" youtube="PYK64WB4JUg"/> -->
+
       <p>
         We have a product of three functions while the <xref ref="thm_ProductRule" text="title"/> only specifies how to handle a product of two functions.
         Our method of handling this problem is to simply group the latter two functions together,
@@ -242,6 +255,16 @@
       </p>
     </solution>
   </example>
+
+  <!-- <p xml:id="vidint_deriv_prod_quite_ex_4_func">
+    Now that we have the hang of the product rule pattern,
+    it's not much more difficult to move on to products of four or more functions,
+    as the following video demonstrates.
+  </p> -->
+  <!-- <figure xml:id="vid_deriv_prod_quot_ex_4_func">
+    <caption>Taking the derivative of a product of four functions</caption>
+    <video youtube="QdQ14efmlMg"/>
+  </figure> -->
 
   <p>
     We consider one more example before discussing another derivative rule.
@@ -324,6 +347,11 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_deriv_prod_quot_quot_rule">
+    <caption>Video presentation of <xref ref="thm_QuotientRule"/></caption>
+    <video youtube="IlsA8342GvQ"/>
+  </figure> -->
+
   <p>
     The <xref ref="thm_QuotientRule" text="title"/> is not hard to use,
     although it might be a bit tricky to remember.
@@ -356,6 +384,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_example_2" width="90%" youtube="Hr4bt6yFwPg"/> -->
+
       <p>
         Directly applying the <xref ref="thm_QuotientRule" text="title"/> gives:
         <md>
@@ -379,6 +409,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_tanx" width="90%" youtube="wslbADxDg4c"/> -->
+
       <p>
         At first, one might feel unequipped to answer this question.
         But recall that <m>\tan(x) = \sin(x) /\cos(x)</m>,
@@ -531,6 +563,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_neg_power" width="90%" youtube="jPqqK-ObPm4"/> -->
+
       <p>
         We employ the <xref ref="thm_QuotientRule" text="title"/>.
 
@@ -636,6 +670,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_deriv_prod_quot_ex_simp_first" width="90%" youtube="ESYjxNMNvh8"/> -->
+
       <p>
         <ol>
           <li>
@@ -711,7 +747,7 @@
     such as <q>the derivative of <m>\sin(x)</m> is <m>\cos(x)</m>.</q>
     The <xref ref="sum-difference-derivative-rule" text="title"/>,
     <xref ref="constant-multiple-derivative-rule" text="title"/>,
-    <xref ref="thm_PowerRule" text="title">Power Rule</xref>,
+    <xref ref="thm_PowerRule" text="title"/>,
     <xref ref="thm_ProductRule" text="title"/> and <xref ref="thm_QuotientRule" text="title"/> show us how to find the derivatives of certain combinations of these functions.
     The next section shows how to find the derivatives when we <em>compose</em>
     these functions together.
@@ -728,13 +764,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $t=PopUp(['?','True','False'],1);
               $f=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -746,13 +781,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $t=PopUp(['?','True','False'],1);
               $f=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -764,13 +798,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $t=PopUp(['?','True','False'],1);
               $f=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -783,12 +816,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $rules=PopUp(['?','Constant Rule','Constant Multiple Rule','Sum/Difference Rule','Product Rule','Quotient Rule'],5);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 What derivative rule is used to extend the Power Rule to include negative integer exponents?
@@ -799,13 +831,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $t=PopUp(['?','True','False'],1);
               $f=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 True or False?
@@ -818,7 +849,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 In your own words,
@@ -862,7 +893,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>f(x) = x\left(x^2+3x\right)</m>.
@@ -898,7 +929,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>g(x) = 2x^2\left(5x^3\right)</m>.
@@ -934,7 +965,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>h(s) = (2s-1)(s+4)</m>.
@@ -970,7 +1001,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>f(x)= \left(x^2+5\right)\left(3-x^3\right)</m>.
@@ -1036,7 +1067,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>f(x)= \dfrac{x^2+3}{x}</m>.
@@ -1072,7 +1103,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>g(x)= \dfrac{x^3-2x^2}{2x^2}</m>.
@@ -1108,7 +1139,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>h(s)= \dfrac{3}{4s^3}</m>.
@@ -1144,7 +1175,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Let <m>f(t)= \dfrac{t^2-1}{t+1}</m>.
@@ -1191,8 +1222,7 @@
 
 <!-- TODO: In this and subsequent problems, syntax highlighting says there's an error in the vars. I can't find it -->
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'f';
               $x = 'x';
@@ -1200,7 +1230,7 @@
               $formula = Formula("$x sin($x)");
               $deriv = $formula->D("$x");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1244,15 +1274,15 @@
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>            <pg-code>
+        <webwork>
+            <pg-code>
               $f = 'f';
               $x = 't';
               Context()->variables->are($x => 'Real');
               $formula = Formula("1/$x^2*(csc($x)-4)");
               $deriv = $formula->D("$x");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1266,8 +1296,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $x = 'x';
@@ -1275,7 +1304,7 @@
               $formula = Formula("($x+7)/($x-5)");
               $deriv = Formula("-12/(x-5)^2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1289,8 +1318,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $x = 't';
@@ -1298,7 +1326,7 @@
               $formula = Formula("$x^5/(cos($x)-2 $x^2)");
               $deriv = $formula->D("$x");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1312,8 +1340,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'h';
               $x = 'x';
@@ -1321,7 +1348,7 @@
               $formula = Formula("cot($x) - e^$x");
               $deriv = $formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1350,8 +1377,7 @@
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'h';
               $x = 'x';
@@ -1359,7 +1385,7 @@
               $formula = Formula("cot($x) - e^$x");
               $deriv = $formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1373,8 +1399,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'h';
               $x = 't';
@@ -1382,7 +1407,7 @@
               $formula = Formula("7$x^2+6$x-2");
               $deriv = Formula("14$x+6");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1396,8 +1421,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'f';
               $x = 'x';
@@ -1405,7 +1429,7 @@
               $formula = Formula("($x^4+2$x^3)/($x+2)");
               $deriv = $formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1419,8 +1443,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'f';
               $x = 'x';
@@ -1428,7 +1451,7 @@
               $formula = Formula("(16$x^4+24$x^2+3)*((7$x-1)/(16$x^4+24$x^2+3))");
               $deriv = Formula("7");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1442,8 +1465,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'f';
               $x = 't';
@@ -1451,7 +1473,7 @@
               $formula = Formula("$x^5(sec($x) + e^$x)");
               $deriv = Formula("5$x^4*(sec($x)+e^$x)+t^5*(sec($x)*tan($x)+e^$x)");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1465,8 +1487,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'f';
               $x = 'x';
@@ -1474,7 +1495,7 @@
               $formula = Formula("sin($x)/(cos($x)+3)");
               $deriv = Formula("(1+3*cos($x))/(cos($x)+3)^2");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1514,8 +1535,7 @@
     </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $x = 'x';
@@ -1524,7 +1544,7 @@
               $formula = Formula("e^2*(sin(pi/4) - 1)");
               $deriv = Formula("0");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1538,8 +1558,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $x = 't';
@@ -1547,7 +1566,7 @@
               $formula = Formula("4$x^3e^$x - sin($x)*cos($x)");
               $deriv = Formula("12$x^2e^$x + 4$x^3e^$x - cos^2($x) + sin^2($x)");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1561,8 +1580,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'h';
               $x = 't';
@@ -1570,7 +1588,7 @@
               $formula = Formula("($x^2*sin($x)+3)/($x^2*cos($x)+2)");
               $deriv = $formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1584,8 +1602,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'f';
               $x = 'x';
@@ -1593,7 +1610,7 @@
               $formula = Formula("$x^2*e^$x*tan($x)");
               $deriv = Formula("2$x*e^$x*tan($x) + $x^2*e^$x*tan($x) + $x^2*e^$x*sec^2($x)");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1607,8 +1624,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $x = 'x';
@@ -1616,7 +1632,7 @@
               $formula = Formula("2$x*sin($x)*sec($x)");
               $deriv = Formula("2*tan($x)+2*$x*sec^2($x)");#$formula->D("$x")->reduce;
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m><var name="$f"/>(<var name="$x"/>) = <var name="$formula"/></m>
@@ -1641,8 +1657,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $formula = Formula("e^x(x^2+2)");
@@ -1654,7 +1669,7 @@
               Context("Point");
               $point=Point("(0,2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
@@ -1673,8 +1688,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $formula = Formula("x sin(x)");
@@ -1687,7 +1701,7 @@
               Context()->flags->set(reduceConstants=>0);
               $point='\left(\frac{3\pi}{2},-\frac{3\pi}{2}\right)';
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
@@ -1706,8 +1720,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $formula = Formula("x^2/(x-1)");
@@ -1719,7 +1732,7 @@
               Context("Point");
               $point=Point("(2,4)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
@@ -1738,8 +1751,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $f = 'g';
               $formula = Formula("(cos(x)-8x)/(x+1)");
@@ -1751,7 +1763,7 @@
               Context("Point");
               $point=Point("(0,1)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m><var name="$f"/>(x) = <var name="$formula"/></m>.
@@ -1780,12 +1792,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $points = List("3/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>f(x) = 6x^2-18x-24</m>.
@@ -1803,12 +1814,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $points = List("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>f(x) = x\sin(x)</m> on <m>[-1,1]</m>.
@@ -1826,12 +1836,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $points = Compute("NONE");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>f(x) = \frac{x}{x+1}</m>.
@@ -1849,12 +1858,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $points = List("-2,0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Let <m>f(x) = \frac{x^2}{x+1}</m>.
@@ -1881,12 +1889,11 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $answer=Formula("2cos(x)-x*sin(x)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x) = x\sin(x)</m>
@@ -1900,12 +1907,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $answer=Formula("-4cos(x)+x*sin(x)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x) = x\sin(x)</m>
@@ -1919,12 +1925,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $answer=Formula("cot^2(x)*csc(x)+csc^3(x)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x) = \csc(x)</m>
@@ -1938,12 +1943,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $answer=Formula("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>f(x) = (x^3-5x+2)(x^2+x-7)</m>

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -135,7 +135,7 @@
   <p>
     We now generalize this concept.
     Given <m>f(x)</m> and an <m>x</m>-value <m>c</m>,
-    the tangent line is <m>\ell(x) = \fp(c)(x-c)+f(c)</m>.
+    the tangent line is <m>y=\ell(x)</m>, where <m>\ell(x) = \fp(c)(x-c)+f(c)</m>.
     Clearly, <m>f(c) = \ell(c)</m>.
     Let <m>\dx</m> be a small number,
     representing a small change in the <m>x</m>-value.
@@ -144,7 +144,21 @@
       f(c+\dx) \approx \ell(c+\dx)
     </me>,
     since the tangent line to a function approximates well the values of that function near <m>x=c</m>.
+    This tangent line approximation is used frequently enough in applications that we give it a name.
   </p>
+
+  <definition xml:id="def-linearization">
+    <statement>
+      <p>
+        The function <m>\ell(x)</m> is often referred to as the <term>linearization</term>,
+        or <term>linear approximation</term> of <m>f</m> at <m>c</m>.
+        It is the linear function that best approximates the value of <m>f(x)</m> when <m>x</m> is close to <m>c</m>.
+        <idx><h>linearization</h></idx>
+        <idx><h>approximation</h><h>tangent line</h></idx>
+        <idx><h>approximation</h><h>linear</h></idx>
+      </p>
+    </statement>
+  </definition>
 
   <p>
     As the <m>x</m>-value changes from <m>c</m> to <m>c+\dx</m>,
@@ -218,6 +232,23 @@
   <p>
     It is helpful to organize our new concepts and notations in one place.
   </p>
+
+  <aside>
+    <title>Differentials and linearization</title>
+    <p>
+      The relationship between the differential and the linearization given in
+      <xref ref="def-linearization"/> is as follows:
+      <me>
+        \ell(x) = f(c)+dy
+      </me>,
+      if we take <m>dy</m> to be evaluated at <m>x=c</m>.
+    </p>
+
+    <p>
+      It is often useful to think of <m>dy</m> is the <em>linear change</em> in <m>f</m>,
+      while <m>\dy</m> represents the true change in <m>f</m>.
+    </p>
+  </aside>
 
   <insight xml:id="idea_differential">
     <title>Differential Notation</title>

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1436,7 +1436,7 @@
 
       <introduction>
         <p>
-          In the following exercises, a function <m>z=f(x,y)</m> is given.
+          In the following exercises, a function <m>f(x,y)</m> is given.
           Find <m>\nabla f</m>.
         </p>
       </introduction>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -171,7 +171,7 @@
 
     <figure xml:id="fig_dotpangle">
       <caption>Illustrating the angle formed by two vectors with the same initial point.</caption>
-      <sidebyside widths="37% 47%" valign="bottom">
+      <sidebyside widths="47% 47%" valign="bottom">
         <figure xml:id="fig_dotpanglea">
           <caption/>
         <!-- START figures/fig_dotpangle.tex -->
@@ -875,7 +875,7 @@
       <statement>
         <p>
           <ol>
-            <li>
+            <li xml:id="ex_dotp4_part1">
               <p>
                 Let <m>\vec u= \la -2,1\ra</m> and <m>\vec v=\la 3,1\ra</m>.
                 Find <m>\proj uv</m>,
@@ -883,7 +883,7 @@
               </p>
             </li>
 
-            <li>
+            <li xml:id="ex_dotp4_part2">
               <p>
                 Let <m>\vec w = \la 2,1,3\ra</m> and <m>\vec x = \la 1,1,1\ra</m>.
                 Find <m>\proj wx</m>,
@@ -912,249 +912,34 @@
                 That is because the angle between <m>\vec u</m> and <m>\vec v</m> is obtuse (i.e., greater than <m>90^\circ</m>).
               </p>
 
-              <figure xml:id="fig_dotp4">
-                <caption>Graphing the vectors used in <xref ref="ex_dotp4">Example</xref>.</caption>
-                <sidebyside widths="33% 33% 33%">
-                  <figure xml:id="fig_dotp4a">
-                    <caption/>
-                      <image xml:id="img_dotp4a">
-                        <description></description>
-                        <latex-image>
+              <figure xml:id="fig_dotp4a">
+                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part1">Part</xref> of <xref ref="ex_dotp4">Example</xref></caption>
+                <image xml:id="img_dotp4a" width="47%">
+                  <description></description>
+                  <latex-image>
 
-                        \begin{tikzpicture}[&gt;=stealth]
+                  \begin{tikzpicture}[&gt;=stealth]
 
-                        \begin{axis}[
-                        axis on top,
-                        xtick={-3,-2,-1,1,2,3},
-                        ytick={1,2,-1,-2},
-                        ymin=-2.8,ymax=2.8,
-                        xmin=-2.9,xmax=3.9,
-                        ]
+                  \begin{axis}[
+                  axis on top,
+                  xtick={-3,-2,-1,1,2,3},
+                  ytick={1,2,-1,-2},
+                  ymin=-2.8,ymax=2.8,
+                  xmin=-2.9,xmax=3.9,
+                  ]
 
-                        \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: -2,1) node [above] {\scriptsize$\vec u$};
-                        \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: 3,1) node [above] {\scriptsize$\vec v$};
-                        \draw [thick,-&gt;,gray] (axis cs:0,0) -- (axis cs: -1.5,-.5) node [below,black] {\scriptsize$\text{proj}_{\, \vec v}\, \vec u$};
+                  \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: -2,1) node [above] {\scriptsize$\vec u$};
+                  \draw [thick,-&gt;] (axis cs:0,0) -- (axis cs: 3,1) node [above] {\scriptsize$\vec v$};
+                  \draw [thick,-&gt;,gray] (axis cs:0,0) -- (axis cs: -1.5,-.5) node [below,black] {\scriptsize$\text{proj}_{\, \vec v}\, \vec u$};
 
-                        \draw [dotted,thick] (axis cs: -2,1) -- (axis cs:-1.5,-.5);
+                  \draw [dotted,thick] (axis cs: -2,1) -- (axis cs:-1.5,-.5);
 
-                        \end{axis}
+                  \end{axis}
 
-                        \end{tikzpicture}
+                  \end{tikzpicture}
 
-                        </latex-image>
-                      </image>
-                  </figure>
-
-                  <figure xml:id="figdotp4b_3D">
-                    <caption/>
-                    <!--
-                      \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
-                    3Droll=0,
-                    3Dortho=0.0046,
-                    3Dc2c=.9 .12 .42,
-                    3Dcoo=0 50 30,
-                    3Droo=250,
-                    3Dlights=Headlamp,add3Djscript=asylabels.js]
-                      -->
-                      <image xml:id="img_dotp4b_3D">
-                        <description></description>
-                        <asymptote>
-
-                          import graph3;
-
-                          //ASY file for figdotp4b.asy in Chapter 10
-
-                          size(200,200,IgnoreAspect);
-                          //currentprojection=perspective(7,2,1);
-
-                          // The text calls for two viewpoints of this picture to show orthogonality
-                          // The two projections below give those two views
-                          //  view "b", saved as figdotp4b_3D
-                          currentprojection=orthographic(8,2,5);
-
-                          //  view "c", saved as figdotp4c_3D
-                          //currentprojection=orthographic(2,8,6);
-                          defaultrender.merge=true;
-
-                          // setup and draw the axes
-                          real[] myxchoice={2};
-                          real[] myychoice={2};
-                          real[] myzchoice={2};
-                          defaultpen(0.5mm);
-                          pair xbounds=(-0.5,2.5);
-                          pair ybounds=(-1,2.5);
-                          pair zbounds=(-0.5,3);
-
-                          xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-                          yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-                          zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-                          label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-                          label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-                          label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-                          // Draw the lines for vec{x}=&lt;1,1,1&gt;
-                          //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
-                          draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
-                          label("$\vec{x}$",(1,1,1),N);
-                          //dotfactor=3;  dot((2,1,1),blue);
-
-                          // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
-                          //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
-                          //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
-                          draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
-                          label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
-
-                          // Draw the lines for \vec{w}=&lt;2,1,3&gt;
-                          //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
-                          draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
-                          label("$\vec{w}$",(2,1,3),N);
-
-                          // ////////////////////////////////////
-                          //    SAMPLE CODE
-
-                          // defaultpen(fontsize(10pt));
-
-                          //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
-                          //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
-
-                          //triple f(pair t) {
-                          //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
-                          //}
-                          //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
-
-                          //draw(s,paleblue);
-                          //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
-                          //draw(mypath,2bp+blue);
-
-                          //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
-                          //path3 mypath=graph(g,-1,1,operator ..);
-
-                          //pen p=rgb(0,0,1);
-                          //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
-
-                        </asymptote>
-                      </image>
-                  <!-- figures/figdotp4b_3D.asy END -->
-                    </figure>
-
-                    <figure xml:id="figdotp4c_3D">
-                      <caption/>
-                  <!--
-                      \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
-                    3Droll=0,
-                    3Dortho=0.0046,
-                    3Dc2c=.29 .77 .56,
-                    3Dcoo=50 0 40,
-                    3Droo=250,
-                    3Dlights=Headlamp,add3Djscript=asylabels.js]
-                      -->
-                    <!-- START figures/figdotp4c_3D.asy -->
-                      <image xml:id="img_dotp4c_3D">
-                        <description></description>
-                        <asymptote>
-
-                          import graph3;
-
-                          //ASY file for figdotp4b.asy in Chapter 10
-
-                          size(200,200,IgnoreAspect);
-                          //currentprojection=perspective(7,2,1);
-
-                          // The text calls for two viewpoints of this picture to show orthogonality
-                          // The two projections below give those two views
-                          //  view "b", saved as figdotp4b_3D
-                          //currentprojection=orthographic(8,2,5);
-
-                          //  view "c", saved as figdotp4c_3D
-                          currentprojection=orthographic(2,8,6);
-                          defaultrender.merge=true;
-
-                          // setup and draw the axes
-                          real[] myxchoice={2};
-                          real[] myychoice={2};
-                          real[] myzchoice={2};
-                          defaultpen(0.5mm);
-                          pair xbounds=(-0.5,2.5);
-                          pair ybounds=(-1,2.5);
-                          pair zbounds=(-0.5,3);
-
-                          xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-                          yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-                          zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-                          label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-                          label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-                          label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-                          // Draw the lines for vec{x}=&lt;1,1,1&gt;
-                          //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
-                          draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
-                          label("$\vec{x}$",(1,1,1),N);
-                          //dotfactor=3;  dot((2,1,1),blue);
-
-                          // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
-                          //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
-                          //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
-                          draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
-                          label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
-
-                          // Draw the lines for \vec{w}=&lt;2,1,3&gt;
-                          //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
-                          draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
-                          //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
-                          //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
-                          draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
-                          draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
-                          label("$\vec{w}$",(2,1,3),N);
-
-                          // ////////////////////////////////////
-                          //    SAMPLE CODE
-
-                          // defaultpen(fontsize(10pt));
-
-                          //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
-                          //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
-
-                          //triple f(pair t) {
-                          //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
-                          //}
-                          //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
-
-                          //draw(s,paleblue);
-                          //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
-                          //draw(mypath,2bp+blue);
-
-                          //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
-                          //path3 mypath=graph(g,-1,1,operator ..);
-
-                          //pen p=rgb(0,0,1);
-                          //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
-
-                        </asymptote>
-                      </image>
-                    <!-- figures/figdotp4c_3D.asy END -->
-                    </figure>
-                </sidebyside>
-
+                  </latex-image>
+                </image>
               </figure>
             </li>
 
@@ -1172,6 +957,220 @@
                 the sketch in <xref ref="figdotp4b_3D">Figure</xref> makes it difficult to recognize that the drawn projection has the geometric properties it should.
                 The graph shown in <xref ref="figdotp4c_3D">Figure</xref> illustrates these properties better.
               </p>
+
+              <figure xml:id="fig_dotp4bc">
+                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part2">Part</xref> of <xref ref="ex_dotp4">Example</xref></caption>
+                <sidebyside widths="47% 47%">
+                  <figure xml:id="figdotp4b_3D">
+                    <caption/>
+                    <!--
+                      \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
+                    3Droll=0,
+                    3Dortho=0.0046,
+                    3Dc2c=.9 .12 .42,
+                    3Dcoo=0 50 30,
+                    3Droo=250,
+                    3Dlights=Headlamp,add3Djscript=asylabels.js]
+                      -->
+                    <image xml:id="img_dotp4b_3D">
+                      <description></description>
+                      <asymptote>
+
+                        import graph3;
+
+                        //ASY file for figdotp4b.asy in Chapter 10
+
+                        size(200,200,IgnoreAspect);
+                        //currentprojection=perspective(7,2,1);
+
+                        // The text calls for two viewpoints of this picture to show orthogonality
+                        // The two projections below give those two views
+                        //  view "b", saved as figdotp4b_3D
+                        currentprojection=orthographic(8,2,5);
+
+                        //  view "c", saved as figdotp4c_3D
+                        //currentprojection=orthographic(2,8,6);
+                        defaultrender.merge=true;
+
+                        // setup and draw the axes
+                        real[] myxchoice={2};
+                        real[] myychoice={2};
+                        real[] myzchoice={2};
+                        defaultpen(0.5mm);
+                        pair xbounds=(-0.5,2.5);
+                        pair ybounds=(-1,2.5);
+                        pair zbounds=(-0.5,3);
+
+                        xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+                        yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+                        zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+                        label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+                        label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+                        label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+                        // Draw the lines for vec{x}=&lt;1,1,1&gt;
+                        //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
+                        draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
+                        label("$\vec{x}$",(1,1,1),N);
+                        //dotfactor=3;  dot((2,1,1),blue);
+
+                        // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
+                        //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
+                        //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
+                        draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
+                        label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
+
+                        // Draw the lines for \vec{w}=&lt;2,1,3&gt;
+                        //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
+                        draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
+                        label("$\vec{w}$",(2,1,3),N);
+
+                        // ////////////////////////////////////
+                        //    SAMPLE CODE
+
+                        // defaultpen(fontsize(10pt));
+
+                        //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
+                        //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
+
+                        //triple f(pair t) {
+                        //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
+                        //}
+                        //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
+
+                        //draw(s,paleblue);
+                        //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
+                        //draw(mypath,2bp+blue);
+
+                        //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
+                        //path3 mypath=graph(g,-1,1,operator ..);
+
+                        //pen p=rgb(0,0,1);
+                        //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
+
+                      </asymptote>
+                    </image>
+                <!-- figures/figdotp4b_3D.asy END -->
+                  </figure>
+
+                  <figure xml:id="figdotp4c_3D">
+                    <caption/>
+                <!--
+                    \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
+                  3Droll=0,
+                  3Dortho=0.0046,
+                  3Dc2c=.29 .77 .56,
+                  3Dcoo=50 0 40,
+                  3Droo=250,
+                  3Dlights=Headlamp,add3Djscript=asylabels.js]
+                    -->
+                  <!-- START figures/figdotp4c_3D.asy -->
+                    <image xml:id="img_dotp4c_3D">
+                      <description></description>
+                      <asymptote>
+
+                        import graph3;
+
+                        //ASY file for figdotp4b.asy in Chapter 10
+
+                        size(200,200,IgnoreAspect);
+                        //currentprojection=perspective(7,2,1);
+
+                        // The text calls for two viewpoints of this picture to show orthogonality
+                        // The two projections below give those two views
+                        //  view "b", saved as figdotp4b_3D
+                        //currentprojection=orthographic(8,2,5);
+
+                        //  view "c", saved as figdotp4c_3D
+                        currentprojection=orthographic(2,8,6);
+                        defaultrender.merge=true;
+
+                        // setup and draw the axes
+                        real[] myxchoice={2};
+                        real[] myychoice={2};
+                        real[] myzchoice={2};
+                        defaultpen(0.5mm);
+                        pair xbounds=(-0.5,2.5);
+                        pair ybounds=(-1,2.5);
+                        pair zbounds=(-0.5,3);
+
+                        xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+                        yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+                        zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+                        label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+                        label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+                        label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+                        // Draw the lines for vec{x}=&lt;1,1,1&gt;
+                        //draw((0,0,1)--(0,1,1)--(1,1,1)--(1,0,1)--(0,0,1), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(1,1,0)--(1,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((1,0,0)--(1,0,1), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,1), dashed+linewidth(.5));//up2
+                        draw((1,1,0)--(1,1,1), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(1,1,1), Arrow3(size=3mm));
+                        label("$\vec{x}$",(1,1,1),N);
+                        //dotfactor=3;  dot((2,1,1),blue);
+
+                        // Draw the lines for projection of w onto x as &lt;2,2,2&gt;
+                        //draw((0,0,2)--(0,2,2)--(2,2,2)--(2,0,2)--(0,0,2), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,2,0)--(2,2,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,2), dashed+linewidth(.5));//up1
+                        //draw((0,2,0)--(0,2,2), dashed+linewidth(.5));//up2
+                        draw((2,2,0)--(2,2,2), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,2,2), gray,Arrow3(size=3mm));
+                        label("$\textrm{proj}_{\vec{x}} \vec{w}$",(2,2,2),N);
+
+                        // Draw the lines for \vec{w}=&lt;2,1,3&gt;
+                        //draw((0,0,3)--(0,1,3)--(2,1,3)--(2,0,3)--(0,0,3), dashed+linewidth(.5));//top
+                        draw((0,0,0)--(0,1,0)--(2,1,0)--(2,0,0)--(0,0,0), dashed+linewidth(.5));//bottom
+                        //draw((2,0,0)--(2,0,3), dashed+linewidth(.5));//up1
+                        //draw((0,1,0)--(0,1,3), dashed+linewidth(.5));//up2
+                        draw((2,1,0)--(2,1,3), dashed+linewidth(.5));//up3
+                        draw((0,0,0)--(2,1,3), Arrow3(size=3mm));
+                        label("$\vec{w}$",(2,1,3),N);
+
+                        // ////////////////////////////////////
+                        //    SAMPLE CODE
+
+                        // defaultpen(fontsize(10pt));
+
+                        //real f(pair z) {return -z.x^4+2*z.x^2-z.y^4+2*z.y^2;}
+                        //surface s=surface(f,(-1.5,-1.5),(1.5,1.5),Spline);
+
+                        //triple f(pair t) {
+                        //  return (cos(t.x)*1.5*cos(t.y),sin(t.x)*cos(t.y),sin(t.y));
+                        //}
+                        //surface s=surface(f,(0,0),(pi,2*pi),8,8,Spline);
+
+                        //draw(s,paleblue);
+                        //draw(s,lightblue,meshpen=black+thick(),nolight,render(merge=true));
+                        //draw(mypath,2bp+blue);
+
+                        //triple g(real t) {return (t,t,-2*t^4+4*t^2);}
+                        //path3 mypath=graph(g,-1,1,operator ..);
+
+                        //pen p=rgb(0,0,1);
+                        //draw(s,paleblue+opacity(.5),meshpen=p,render(merge=true));
+
+                      </asymptote>
+                    </image>
+                  <!-- figures/figdotp4c_3D.asy END -->
+                  </figure>
+                </sidebyside>
+              </figure>
             </li>
           </ol>
         </p>
@@ -1629,12 +1628,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 The dot product of two vectors is a <fillin/>, not a vector.
@@ -1649,12 +1645,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 How are the concepts of the dot product and vector magnitude related?
@@ -1670,12 +1663,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 How can one quickly tell if the angle between two vectors is acute or obtuse?
@@ -1692,12 +1682,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Give a synonym for <q>orthogonal.</q>
@@ -1721,14 +1708,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("-22");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 2,-4\ra</m>, <m>\vec v = \la 3,7\ra</m>
@@ -1742,14 +1727,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("33");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 5,3\ra</m>, <m>\vec v = \la 6,1\ra</m>
@@ -1763,14 +1746,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 1,-1,2\ra</m>,
@@ -1785,14 +1766,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 3,5,-1\ra</m>,
@@ -1807,12 +1786,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\vec u = \la 1,1\ra</m>, <m>\vec v = \la 1,2,3\ra</m>
@@ -1827,14 +1803,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("LimitedNumeric");
               $dot=Real("0");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\vec u = \la 1,2,3\ra</m>,
@@ -1851,12 +1825,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Create your own vectors <m>\vec u</m>,
@@ -1873,12 +1844,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               Create your own vectors <m>\vec u</m> and <m>\vec v</m> in
@@ -1903,14 +1871,12 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("arccos(3/sqrt(10))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la 1,1\ra</m> and
@@ -1921,14 +1887,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("arccos(-1/sqrt(170))");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la -2,1\ra</m> and
@@ -1939,14 +1903,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("pi/4");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la 8,1,-4\ra</m> and
@@ -1957,14 +1919,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $theta=Formula("pi/2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 The angle between <m>\vec u = \la 1,7,2\ra</m> and
@@ -1985,9 +1945,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;4,7>");
@@ -2004,7 +1962,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la 4,7\ra</m>.
@@ -2024,9 +1982,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;-3,5>");
@@ -2043,7 +1999,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la -3,5\ra</m>.
@@ -2063,9 +2019,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;1,1,1>");
@@ -2082,7 +2036,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la 1,1,1\ra</m>.
@@ -2102,9 +2056,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               $v=Vector("&lt;1,-2,3>");
@@ -2121,7 +2073,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find two nonzero vectors orthogonal to <m>\vec v = \la 1,-2,3\ra</m>.
@@ -2153,9 +2105,7 @@
       </introduction>
 
       <exercise xml:id="ex_10_03_ex_21">
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2167,7 +2117,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 1,2\ra</m> and <m>\vec v = \la -1,3\ra</m>,
@@ -2182,9 +2132,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2196,7 +2144,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 5,5\ra</m> and <m>\vec v = \la 1,3\ra</m>,
@@ -2211,9 +2159,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2225,7 +2171,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la -3,2\ra</m> and <m>\vec v = \la 1,1\ra</m>,
@@ -2240,9 +2186,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2254,7 +2198,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la -3,2\ra</m> and <m>\vec v = \la 2,3\ra</m>,
@@ -2269,9 +2213,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2283,7 +2225,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den,$nums[2]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 1,5,1\ra</m> and <m>\vec v = \la 1,2,3\ra</m>,
@@ -2298,9 +2240,7 @@
       </exercise>
 
       <exercise xml:id="ex_10_03_ex_24">
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2312,7 +2252,7 @@
               @nums=map{$_*$num}(@vc);
               $projuv=Compute("&lt;$nums[0]/$den,$nums[1]/$den,$nums[2]/$den>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>\vec u = \la 3,-1,2\ra</m> and <m>\vec v = \la 2,2,1\ra</m>,
@@ -2342,9 +2282,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2397,7 +2335,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 1,2\ra</m> as the sum of two vectors,
@@ -2414,9 +2352,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2469,7 +2405,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 5,5\ra</m> as the sum of two vectors,
@@ -2486,9 +2422,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2541,7 +2475,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la -3,2\ra</m> as the sum of two vectors,
@@ -2558,9 +2492,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2613,7 +2545,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la -3,2\ra</m> as the sum of two vectors,
@@ -2630,9 +2562,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2685,7 +2615,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 1,5,1\ra</m> as the sum of two vectors,
@@ -2702,9 +2632,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2757,7 +2685,7 @@
                    }
                 );
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Write <m>\vec u = \la 3,-1,2\ra</m> as the sum of two vectors,
@@ -2776,12 +2704,9 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A 10lb box sits on a ramp that rises 4ft over a distance of 20ft.
@@ -2797,12 +2722,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               A 10lb box sits on a 15ft ramp that makes a
@@ -2819,12 +2741,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box horizontally 10ft with a force of 20lb applied at an angle of <m>45^\circ</m> to the horizontal?
@@ -2839,12 +2758,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box horizontally 10ft with a force of 20lb applied at an angle of <m>10^\circ</m> to the horizontal?
@@ -2859,12 +2775,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box up the length of a ramp that rises 2ft over a distance of 10ft,
@@ -2880,12 +2793,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box up the length of a ramp that rises 2ft over a distance of 10ft,
@@ -2901,12 +2811,9 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
-          </pg-code>
-          </setup>-->
+          </pg-code> -->
           <statement>
             <p>
               How much work is performed in moving a box up the length of a 10ft ramp that makes a <m>5^\circ</m> angle with the horizontal,

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -177,7 +177,7 @@
   <p>
     So to evaluate <m>\iint_Rf(x,y)\, dA</m>,
     replace <m>dA</m> with <m>r\, dr\, d\theta</m>.
-    Convert the function <m>z=f(x,y)</m> to a function with polar coordinates with the substitutions
+    Convert the function <m>f(x,y)</m> to a function with polar coordinates with the substitutions
     <m>x=r\cos(\theta)</m>, <m>y=r\sin(\theta)</m>.
     Finally, find bounds <m>g_1(\theta)\leq r\leq g_2(\theta)</m> and
     <m>\alpha\leq\theta\leq\beta</m> that describe <m>R</m>.

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -1762,7 +1762,7 @@
     Given a region <m>R</m> in the plane,
     we computed <m>\iint_R 1\, dA</m>;
     again, our understanding at the time was that we were finding the area of <m>R</m>.
-    However, we can now view the function <m>z=1</m> as a surface,
+    However, we can now view the graph <m>z=1</m> as a surface,
     a flat surface with constant <m>z</m>-value of 1.
     The double integral <m>\iint_R 1\, dA</m> finds the volume,
     under <m>z=1</m>, over <m>R</m>,

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -2,6 +2,11 @@
 <section xml:id="sec_concavity">
   <title>Concavity and the Second Derivative</title>
   <introduction>
+    <!-- <figure xml:id="vid_graphs_concav_intro">
+      <caption>Video introduction to <xref ref="sec_concavity"/></caption>
+      <video youtube="0uCjI5J4ew4"/>
+    </figure> -->
+
     <p>
       Our study of <q>nice</q> functions continues.
       The previous section showed how the first derivative of a function,
@@ -339,6 +344,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_graphs_concav_ex_1" width="90%" youtube="n8TRVD_8sY0"/> -->
+
         <p>
           We start by finding <m>\fp(x)=3x^2-3</m> and <m>\fpp(x)=6x</m>.
           To find the inflection points,
@@ -429,6 +436,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_graphs_concav_ex_2" width="90%" youtube="eC6QLbsuRVs"/> -->
+
         <p>
           We need to find <m>\fp</m>and <m>\fpp</m>.
           Using the <xref ref="thm_QuotientRule">Quotient Rule</xref> and simplifying, we find
@@ -628,6 +637,8 @@
         </figure>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_graphs_concav_ex_3" width="90%" youtube="yjcSXaGkL5Y"/> -->
+
         <p>
           We want to maximize the rate of decrease,
           which is to say, we want to find where <m>S'</m> has a minimum.
@@ -800,6 +811,12 @@
         <xref ref="thm_first_der" text="title"/> does not.
       </p>
     </aside>
+
+    <!-- <figure xml:id="vid_graphs_concav_second_deriv_test">
+      <caption>Video presentation of <xref ref="thm_second_der"/></caption>
+      <video youtube="4hWldEUoG2U"/>
+    </figure> -->
+
     <p>
       The Second Derivative Test relates to the <xref ref="thm_first_der" text="title"/> in the following way.
       If <m>\fpp(c)\gt 0</m>,
@@ -819,6 +836,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video xml:id="vid_graphs_concav_ex_4" width="90%" youtube="_DhmPXRZfi8"/> -->
+
         <p>
           We find <m>\fp(x)=-100/x^2+1</m> and <m>\fpp(x) = 200/x^3</m>.
           We set <m>\fp(x)=0</m> and solve for <m>x</m> to find the critical values

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -62,8 +62,13 @@
       <em>at</em> <m>\pi/2</m>,
       and the maximum of <m>\sin(x)</m>
       <em>is</em> <m>1</m>.</q>
-      </p>
-    </aside>
+    </p>
+  </aside>
+
+  <!-- <figure xml:id="vid_graphs_extreme_val_abs_extrema">
+    <caption>Video presentation of <xref ref="def_extreme_values"/></caption>
+    <video youtube="srE7xUmQtCQ"/>
+  </figure> -->
 
  <p>
     Consider <xref ref="fig_extreme">Figure</xref>.
@@ -166,6 +171,11 @@
       </p>
     </statement>
   </theorem>
+
+  <!-- <figure xml:id="vid_graphs_extreme_val_EVT">
+    <caption>Video presentation of <xref ref="thm_extreme_val"/></caption>
+    <video youtube="GIcjxu8dTnY"/>
+  </figure> -->
 
   <p>
     This theorem states that <m>f</m> has extreme values,
@@ -291,6 +301,11 @@
       allows a relative maximum to occur at an interval's endpoint.
     </p>
   </aside>
+
+  <!-- <figure xml:id="vid_graphs_extreme_val_rel_extrema">
+    <caption>Video presentation of <xref ref="def_rel_ext"/></caption>
+    <video youtube="nBZTnxn0vqQ"/>
+  </figure> -->
   <p>
     We briefly practice using these definitions.
   </p>
@@ -421,6 +436,14 @@
     </statement>
   </definition>
 
+  <!-- <aside>
+    <p>
+      In this text we use <q>critical number</q> and <q>critical value</q>
+      interchangeably. Other textbooks reserve the term <em>critical value</em>
+      for the function value <m>f(c)</m>, when <m>c</m> is a critical number.
+    </p>
+  </aside> -->
+
   <theorem xml:id="thm_criticalpts">
     <title>Relative Extrema and Critical Points</title>
     <statement>
@@ -431,6 +454,11 @@
       </p>
     </statement>
   </theorem>
+
+  <!-- <figure xml:id="vid_graphs_extreme_val_crit_pnts">
+    <caption>Video presentation of <xref ref="def_criticalnum"/> and <xref ref="thm_criticalpts"/></caption>
+    <video youtube="WsBGpi006X0"/>
+  </figure> -->
 
   <p>
     Be careful to understand that this theorem states
@@ -541,6 +569,7 @@
       </figure>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_extreme_val_ex_1" width="90%" youtube="LyhHlreZvhc"/> -->
       <p>
         We follow the steps outlined in <xref ref="idea_extrema">Key Idea</xref>.
         We first evaluate <m>f</m> at the endpoints:
@@ -617,6 +646,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_extreme_val_ex_2" width="90%" youtube="zn--ShSSMqk"/> -->
+
       <p>
         Here <m>f</m> is piecewise-defined,
         but we can still apply <xref ref="idea_extrema">Key Idea</xref>
@@ -723,6 +754,7 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_extreme_val_ex_3" width="90%" youtube="sT_3kVSsbz4"/> -->
       <p>
         We again use <xref ref="idea_extrema">Key Idea</xref>.
         Evaluating <m>f</m> at the endpoints of the interval gives:
@@ -931,7 +963,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Describe what an <q>extreme value</q>
@@ -964,7 +996,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Describe the difference between absolute and relative maxima in your own words.
@@ -996,14 +1028,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 True or False?
@@ -1041,8 +1071,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $gr=init_graph(-0.5,-2.5,6.5,3.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1082,7 +1111,7 @@
               $F=PopUp(['?','an absolute maximum','an absolute minimum','a relative maximum','a relative minimum','none of the above'],4);
               $G=PopUp(['?','an absolute maximum','an absolute minimum','a relative maximum','a relative minimum','none of the above'],5);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Identify each of the marked points as being an absolute maximum or minimum,
@@ -1125,8 +1154,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $gr=init_graph(-0.5,-2.5,5.5,2.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1157,7 +1185,7 @@
               $D=PopUp(['?','an absolute maximum','an absolute minimum','a relative maximum','a relative minimum','none of the above'],5);
               $E=PopUp(['?','an absolute maximum','an absolute minimum','a relative maximum','a relative minimum','none of the above'],5);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Identify each of the marked points as being an absolute maximum or minimum,
@@ -1202,9 +1230,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-5.5,-0.5,5.5,2.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1215,7 +1241,7 @@
               $gr->stamps(closed_circle(0,2,'blue'));
               $gr->lb(new Label(0+0.1,2+0.05,'(0,2)','black','left','bottom'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = \frac{2}{x^2+1}</m>,
@@ -1236,9 +1262,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-4,-1,4,6.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1251,7 +1275,7 @@
               $gr->stamps(closed_circle(2,5.656854,'blue'));
               $gr->lb(new Label(2+0.1,5.656+0.05,'(2,4sqrt(2))','black','left','bottom'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = x^2\sqrt{6-x^2}</m>,
@@ -1276,9 +1300,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-0.5,-1.4,6.5,1.4,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1291,7 +1313,7 @@
               $gr->stamps(closed_circle(4.712389,-1,'blue'));
               $gr->lb(new Label(4.712389+0.1,-1-0.05,'(3pi/2,-1)','black','left','top'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = \sin(x)</m>, evaluate <m>\fp(x)</m> at the points indicated.
@@ -1315,9 +1337,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-2.5,-2,4.5,11,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1330,7 +1350,7 @@
               $gr->stamps(closed_circle(16/5,512*sqrt(5)/125,'blue'));
               $gr->lb(new Label(16/5-0.1,512*sqrt(5)/125+0.05,'(16/5,512sqrt(5)/125)','black','right','bottom'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = x^2\sqrt{4-x}</m>,
@@ -1355,9 +1375,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-1.1,-0.6,1.1,1.1,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1370,7 +1388,7 @@
               $gr->stamps(closed_circle(0,0,'blue'));
               $gr->lb(new Label(0+0.1,0-0.05,'(0,0)','black','left','top'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = \begin{cases}x^2\amp x\leq0\\x^5\amp x\gt0\end{cases}</m>,
@@ -1391,9 +1409,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-1.1,-0.6,1.1,1.1,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1406,7 +1422,7 @@
               $gr->stamps(closed_circle(0,0,'blue'));
               $gr->lb(new Label(0+0.1,0-0.05,'(0,0)','black','left','top'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = \begin{cases}x^2\amp x\leq0\\x\amp x\gt0\end{cases}</m>,
@@ -1427,9 +1443,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $gr=init_graph(-1,-0.5,11,6.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1444,7 +1458,7 @@
               $gr->stamps(closed_circle(6,1+2**(1/3)/3,'blue'));
               $gr->lb(new Label(6,1+2**(1/3)/3+0.05,'(6,1+cbrt(2)/3)','black','center','bottom'));
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 If <m>f(x) = \frac{\sqrt[3]{(x-2)^{2}}}{x}+1</m>,
@@ -1479,16 +1493,14 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $maxy=Compute("10");
               $maxx=Compute("2");
               $miny=Compute("3.75");
               $minx=Compute("-0.5");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = x^2+x+4</m> on <m>[-1,2]</m>.
@@ -1503,16 +1515,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $maxy=Compute("3");
               $maxx=Compute("0");
               $miny=Compute("-134.5");
               $minx=Compute("5");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = x^3-\frac{9}{2}x^2-30x+3</m> on <m>[0,6]</m>.
@@ -1527,9 +1537,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("3");
@@ -1537,7 +1545,7 @@
               $miny=Compute("3sqrt(2)/2");
               $minx=Compute("pi/4");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of
@@ -1553,9 +1561,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("16sqrt(3)/9");
@@ -1563,7 +1569,7 @@
               $miny=Compute("0");
               $minx=Compute("-2,0,2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = x^2\sqrt{4-x^2}</m> on <m>[-2,2]</m>.
@@ -1578,9 +1584,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("28/5");
@@ -1588,7 +1592,7 @@
               $miny=Compute("2*sqrt(3)");
               $minx=Compute("sqrt(3)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = x+\frac3x</m> on <m>[1,5]</m>.
@@ -1603,9 +1607,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("5/6");
@@ -1613,7 +1615,7 @@
               $miny=Compute("0");
               $minx=Compute("0");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = \frac{x^2}{x^2+5}</m> on <m>[-3,5]</m>.
@@ -1628,9 +1630,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("(sqrt(2)e^(pi/4))/2");
@@ -1638,7 +1638,7 @@
               $miny=Compute("-e^(pi)");
               $minx=Compute("pi");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = e^x\cos(x)</m> on <m>[0,\pi]</m>.
@@ -1653,9 +1653,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("(sqrt(2)e^(3pi/4))/2");
@@ -1663,7 +1661,7 @@
               $miny=Compute("0");
               $minx=Compute("0,pi");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = e^x\sin(x)</m> on <m>[0,\pi]</m>.
@@ -1678,9 +1676,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("1/e");
@@ -1688,7 +1684,7 @@
               $miny=Compute("0");
               $minx=Compute("1");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = \frac{\ln(x) }{x}</m> on <m>[1,4]</m>.
@@ -1703,9 +1699,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $maxy=Compute("4/27");
@@ -1713,7 +1707,7 @@
               $miny=Compute("2^(2/3)-2");
               $minx=Compute("2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the extreme values of <m>f(x) = x^{2/3}-x</m> on <m>[0,2]</m>.
@@ -1737,9 +1731,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("(y*(y-2x))/(x*(x-2y))");
@@ -1748,7 +1740,7 @@
               @xy=map{[$x[$_],$y[$_]]}(0..4);
               $dydx->{test_points}=~~@xy;
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find <m>\lz{y}{x}</m>, where <m>x^2y-y^2x = 1</m>.
@@ -1762,15 +1754,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0);
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               $line=Formula("y=-4/5(x-1)+2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Find the equation of the line tangent to the graph of
@@ -1785,12 +1776,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $L=Formula("3x^2+1");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = x^3+x</m>.

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -78,6 +78,11 @@
     Informally, a function is increasing if as <m>x</m> gets larger (i.e., looking left to right) <m>f(x)</m> gets larger.
   </p>
 
+  <!-- <figure xml:id="vid_graphs_incr_decr_defn">
+    <caption>Vidoe presentation of <xref ref="def_incr_decr"/></caption>
+    <video youtube="NtV0R-JxrmM"/>
+  </figure> -->
+
   <p>
     Our interest lies in finding intervals in the domain of <m>f</m> on which <m>f</m> is either increasing or decreasing.
     Such information should seem useful.
@@ -104,7 +109,6 @@
     Therefore:
   </p>
 
-  <!--TODO: where to put the xml id and caption on this? -->
   <figure xml:id="fig_incr00">
     <caption>Examining the secant line of an increasing function.</caption>
     <sidebyside widths="47% 47%" margins="0%">
@@ -117,8 +121,6 @@
         </md>.
       </p>
 
-      <!--    <figure xml:id="fig_incr00"> -->
-      <!--    <caption>Examining the secant line of an increasing function.</caption>   -->
       <!-- START figures/fig_incr00.tex -->
       <image xml:id="img_incr00">
         <description></description>
@@ -141,7 +143,6 @@
         </latex-image>
       </image>
       <!-- figures/fig_incr00.tex END -->
-      <!--  </figure>  -->
     </sidebyside>
   </figure>
 
@@ -204,11 +205,17 @@
       </p>
 
       <p>
-        The conclusions of <xref ref="thm_incr"/> and <xref ref="thm_decr"/> also hold if if
+        The conclusions of <xref ref="thm_incr"/> and <xref ref="thm_decr"/> also hold if
         <m>\fp(c) = 0</m> for a finite number of nonadjacent values of <m>c</m> in <m>I</m>.
       </p>
     </statement>
   </theorem>
+
+  <!-- <figure xml:id="vid_graphs_incr_decr_role_deriv_sign">
+    <caption>Video presentation of <xref ref="thm_incr_decr"/></caption>
+    <video youtube="SjF3vslBqOA"/>
+  </figure> -->
+
 
   <p>
     Let <m>f</m> be differentiable on an interval <m>I</m> and let <m>a</m> and <m>b</m> be in <m>I</m> where
@@ -288,6 +295,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_incr_decr_ex_1" width="90%" youtube="DW6qcgE1TZ0"/> -->
+
       <p>
         Since an interval was not specified for us to consider, using <xref ref="idea_incr_decr">Key Idea</xref>,
         the domain of <m>f</m> is <m>\mathbb{R}</m> or <m>(-\infty,\infty)</m>.
@@ -536,6 +545,12 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_graphs_incr_decr_first_deriv_test">
+    <caption>Video presentation of <xref ref="thm_first_der"/></caption>
+    <video youtube="_HjE4urOM4Y"/>
+  </figure> -->
+
+
   <aside>
     <title>Importance of Continuity</title>
     <p>
@@ -584,6 +599,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_incr_decr_ex_2" width="90%" youtube="94iCiIX07R0"/> -->
+
       <p>
         We start by noting the domain of <m>f</m>:
         <m>(-\infty,1)\cup(1,\infty)</m>.
@@ -780,6 +797,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_incr_decr_ex_3" width="90%" youtube="T4RxcQnNotc"/> -->
+
       <p>
         The domain of <m>f</m> is <m>\mathbb{R}</m>
         (you can take the odd root of both positive and negative nubmers).

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -27,6 +27,11 @@
     under some very reasonable assumptions, is <q>yes.</q>
   </p>
 
+  <!-- <figure xml:id="vid_graphs_MVT_intro">
+    <caption>Video introduction to <xref ref="sec_mvt"/></caption>
+    <video youtube="GvdxKh6RpT0"/>
+  </figure> -->
+
   <p>
     Let's now see why this situation is in a calculus text by translating it into mathematical symbols.
   </p>
@@ -191,6 +196,11 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_graphs_MVT_rolles_thm">
+    <caption>Video presentation of <xref ref="thm_rolles"/></caption>
+    <video youtube="E05H1f8TByI"/>
+  </figure> -->
+
   <p>
     Consider <xref ref="fig_mvt3">Figure</xref>
     where the graph of a function <m>f</m> is given, where <m>f(a) = f(b)</m>.
@@ -224,6 +234,18 @@
     </image>
       <!-- figures/fig_mvt3.tex END -->
   </figure>
+
+  <!-- <p xml:id="vidint_graphs_MVT_ex1">
+    Rolle's Theorem is presented here as a stepping stone toward the Mean Value Theorem,
+    but it's a useful result in its own right.
+    It often turns up as a tool in mathematical problem solving.
+    The following video illustrates one such use of Rolle's Theorem.
+  </p> -->
+
+  <!-- <figure xml:id="vid_graphs_MVT_ex_1">
+    <caption>Using Rolle's Theorem to show a polynomial has at most one real root</caption>
+    <video youtube="le-5zsb6O7o"/>
+  </figure> -->
 
   <p>
     Rolle's Theorem is really just a special case of the Mean Value Theorem.
@@ -275,8 +297,9 @@
 
   <proof>
     <title>Proof of the Mean Value Theorem</title>
+    <!-- <video xml:id="vid_graphs_MVT_proof_MVT" width="90%" youtube="1b9af8q5JMg"/> -->
 
-   <p>
+    <p>
       Define the function
       <me>
         g(x) = f(x) - \frac{f(b)-f(a)}{b-a}x
@@ -338,6 +361,7 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_MVT_ex_3" width="90%" youtube="ON7WYLJY2tE"/> -->
       <p>
         The average rate of change of <m>f</m> on <m>[-3,3]</m> is:
         <md>
@@ -411,7 +435,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Explain in your own words what the Mean Value Theorem states.
@@ -430,7 +454,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <statement>
               <p>
                 Explain in your own words what Rolle's Theorem states.
@@ -461,14 +485,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->strings->add('does not apply'=>{});
               $c=Compute("(-1,1)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = 6</m>.
@@ -486,14 +509,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->strings->add('does not apply'=>{});
               $c=Compute("does not apply");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = 6x</m>.
@@ -511,15 +533,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("-1/2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = x^2+x-6</m>.
@@ -537,15 +558,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("-1/2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = x^2+x-2</m>.
@@ -563,15 +583,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("does not apply");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = x^2+x</m>.
@@ -590,14 +609,13 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("pi/2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = \sin(x)</m>.
@@ -617,14 +635,13 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("does not apply");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = \cos(x)</m>.
@@ -646,14 +663,13 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("does not apply");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>f(x) = \frac{1}{x^2-2x+1}</m>.
@@ -700,14 +716,13 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("0");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = x^2+3x-1</m>.
@@ -728,15 +743,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("5/2");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = 5x^2-6x+8</m>.
@@ -757,15 +771,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("3/sqrt(2)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = \sqrt{9-x^2}</m>.
@@ -786,15 +799,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("19/4");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = \sqrt{25-x}</m>.
@@ -815,15 +827,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("does not apply");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) =\frac{x^2-9}{x^2-1}</m>.
@@ -844,15 +855,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("4/ln(5)");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = \ln(x)</m>.
@@ -875,15 +885,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("-asec(2/sqrt(pi)), asec(2/sqrt(pi))");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = \tan(x)</m>.
@@ -907,15 +916,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Formula("-2/3");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = x^3-2x^2+x+1</m>.
@@ -938,15 +946,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("5+7sqrt(7)/6, 5-7sqrt(7)/6");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = 2x^3-5x^2+6x+1</m>.
@@ -969,15 +976,14 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->strings->add('does not apply'=>{});
               $c=Compute("sqrt(pi^2-4)/pi, -sqrt(pi^2-4)/pi");
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Let <m>\ds f(x) = \sin^{-1}(x)</m>.
@@ -1009,11 +1015,10 @@
       </introduction>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
+<!--         <webwork>
             <pg-code>
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             Find the extreme values of <m>f(x) =x^2-3x+9</m> on <m>[-2,5]</m>
@@ -1032,11 +1037,10 @@
       </exercise>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
+<!--         <webwork>
             <pg-code>
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             Describe the critical points of <m>f(x) = \cos(x)</m>.
@@ -1053,11 +1057,10 @@
       </exercise>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
+<!--         <webwork>
             <pg-code>
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             Describe the critical points of <m>f(x) = \tan(x)</m>.

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -111,6 +111,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_sketch_poly" width="90%" youtube="41XMvSHgl-Y"/> -->
+
       <p>
         We follow the steps outlined in <xref ref="idea_sketch">Key Idea</xref>.
 
@@ -199,8 +201,8 @@
 
 <!--TODO: Sean is not so sure about the table that has
 replaced Greg's sign diagram image here... Also, can we consider having separate sign diagrams for f, f', f'' or is Sean the only one who does it that way?-->
-      <!-- <table xml:id="tab_sketchline1">
-        <title/>
+      <figure xml:id="fig_sketchline1">
+        <caption>Number line for <m>f</m> in <xref ref="ex_sketch1"/></caption>
 
         <tabular halign="center">
           <row bottom="major">
@@ -240,8 +242,9 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           </row>
         </tabular>
 
-      </table> -->
-      <figure xml:id="fig_sketchline1">
+      </figure>
+      <!-- TODO: find a way to make this table work. It clearly doesn't at the moment.-->
+      <!-- <figure xml:id="fig_sketchline1">
         <caption>Number line for <m>f</m> in Example \ref{ex_sketch1}.</caption>
 
         <image width="100%">
@@ -263,7 +266,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             \end{tikzpicture}
           </latex-image>
         </image>
-      </figure>
+      </figure> -->
 
       <figure xml:id="fig_sketch1">
       <caption>Sketching <m>f</m> in <xref ref="ex_sketch1">Example</xref>.</caption>
@@ -336,6 +339,8 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </p>
     </statement>
     <solution>
+      <!-- <video xml:id="vid_graphs_sketch_rational" width="90%" youtube="t3VI2oTmOiA"/> -->
+
       <p>
         We again follow the steps outlined in <xref ref="idea_sketch">Key Idea</xref>.
       </p>
@@ -432,10 +437,10 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           </li>
         </ol>
       </p>
-<!--TODO: Another vote fro Sean for going back to the TikZ number line -->
-      <!-- <table xml:id="tab_sketchline2">
-        <title>Number line for <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</title>
 
+      <!--TODO: Another vote from Sean for going back to the TikZ number line, but there are issues with dimensions -->
+      <figure xml:id="fig_sketchline2">
+        <caption>Number line for <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</caption>
 
         <tabular halign="center">
           <row bottom="major">
@@ -469,8 +474,8 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           </row>
         </tabular>
 
-      </table> -->
-      <figure xml:id="fig_sketchline2">
+      </figure>
+      <!-- <figure xml:id="fig_sketchline2">
         <caption/>
         <image width="100%">
           <latex-image>
@@ -492,7 +497,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
             \end{tikzpicture}
           </latex-image>
         </image>
-      </figure>
+      </figure> -->
       <figure xml:id="fig_sketch2">
         <caption>Sketching <m>f</m> in <xref ref="ex_sketch2">Example</xref>.</caption>
     <sidebyside widths="32% 32% 32%">
@@ -662,9 +667,10 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           </li>
         </ol>
       </p>
-<!--TODO: take a look at this table too -->
-      <!-- <table xml:id="tab_sketchline3">
-        <title>Number line for <m>f</m> in Example <xref ref="ex_sketch3">Example</xref>.</title>
+
+      <!--TODO: take a look at this table too -->
+      <figure xml:id="fig_sketchline3">
+        <caption>Number line for <m>f</m> in Example <xref ref="ex_sketch3">Example</xref>.</caption>
 
         <tabular halign="center">
           <row bottom="major">
@@ -710,8 +716,8 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
           </row>
         </tabular>
 
-      </table> -->
-          <figure xml:id="fig_sketchline3">
+      </figure>
+          <!-- <figure xml:id="fig_sketchline3">
           <caption/>
           <image width="100%">
             <latex-image>
@@ -737,7 +743,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
               \end{tikzpicture}
             </latex-image>
           </image>
-        </figure>
+        </figure> -->
 
         <figure xml:id="fig_sketch3">
         <caption>Sketching <m>f</m> in <xref ref="ex_sketch3">Example</xref>.</caption>
@@ -907,11 +913,10 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 Why is sketching curves by hand beneficial even though technology is ubiquitous?
@@ -930,11 +935,10 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 What does <q>ubiquitous</q> mean?
@@ -953,12 +957,11 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 T/F: When sketching graphs of functions,
@@ -974,12 +977,11 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 T/F: When sketching graphs of functions,
@@ -995,12 +997,11 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
-            </setup>
+            
             <statement>
               <p>
                 T/F: When sketching graphs of functions,
@@ -1329,13 +1330,11 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </introduction>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
-
+<!--         <webwork>
 
             <pg-code>
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             <m>\ds f(x) = \frac{a}{x^2+b^2}</m>
@@ -1371,15 +1370,13 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
-
+<!--         <webwork>
 
             <pg-code>
               $crit=Formula("(a+b)/2");
               $inf=Compute("does not apply");
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             <m>\ds f(x) = \sin(ax+b)</m>
@@ -1417,16 +1414,14 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
-
+<!--         <webwork>
 
             <pg-code>
               Context()->strings->add('does not apply'=>{});
               $crit=Formula("(a+b)/2");
               $inf=Compute("does not apply");
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             <m>\ds f(x) = (x-a)(x-b)</m>
@@ -1462,12 +1457,10 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise>
-<!--         <webwork seed="1">
-          <setup>
-
+<!--         <webwork>
             <pg-code>
             </pg-code>
-          </setup> -->
+           -->
         <statement>
           <p>
             Given <m>x^2+y^2=1</m>, use implicit differentiation to find

--- a/ptx/sec_greensthm.ptx
+++ b/ptx/sec_greensthm.ptx
@@ -15,7 +15,7 @@
 
     <figure xml:id="fig_flowfluxintro">
       <caption>Illustrating the principles of flow and flux.</caption>
-          <image xml:id="img_flowfluxintro">
+          <image xml:id="img_flowfluxintro" width="47%">
             <description></description>
             <asymptote>
 
@@ -161,7 +161,7 @@
 
     <figure xml:id="fig_fluxcounterclockwise">
       <caption>Determining <q>counterclockwise</q> is not always simple without a good definition.</caption>
-           <image xml:id="img_fluxcounterclockwise">
+           <image xml:id="img_fluxcounterclockwise" width="47%">
             <description></description>
             <asymptote>
 
@@ -313,11 +313,9 @@
           Find the flux across both curves for the vector fields
           <m>\vec F_1 = \la y, -x+1\ra</m> and <m>\vec F_2 = \la -x, 2y-x\ra</m>.
         </p>
-      </statement>
-      <solution>
         <figure xml:id="fig_flux1">
           <caption>Illustrating the curves and vector fields in <xref ref="ex_flux1">Example</xref>. In (a) the vector field is <m>\vec F_1</m>, and in (b) the vector field is <m>\vec F_2</m>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_flux1a">
               <caption/>
               <image xml:id="img_flux1a">
@@ -469,7 +467,8 @@
           </sidebyside>
 
         </figure>
-
+      </statement>
+      <solution>
         <p>
           We begin by finding parametrizations of <m>C_1</m> and <m>C_2</m>.
           As done in <xref ref="ex_livf3">Example</xref>,
@@ -618,7 +617,7 @@
 
         <figure xml:id="fig_green1">
           <caption>The vector field and planar region used in <xref ref="ex_green1">Example</xref>.</caption>
-          <image xml:id="img_green1">
+          <image xml:id="img_green1" width="47%">
             <description></description>
             <asymptote>
 
@@ -771,7 +770,7 @@
 
         <figure xml:id="fig_green2">
           <caption>The vector field and planar region used in <xref ref="ex_green2">Example</xref>.</caption>
-          <image xml:id="img_green2">
+          <image xml:id="img_green2" width="47%">
             <description></description>
             <asymptote>
 
@@ -863,7 +862,7 @@
           we can conclude that the circulation is 0 in two ways.
           One method is to employ Green's Theorem as done above.
           The second way is to recognize that <m>\vec F</m> is a conservative field,
-          hence there is a function <m>z=f(x,y)</m> wherein <m>\vec F = \nabla f</m>.
+          hence there is a function <m>f(x,y)</m> wherein <m>\vec F = \nabla f</m>.
           Let <m>A</m> be any point on the curve <m>C</m>;
           since <m>C</m> is closed,
           we can say that <m>C</m> <q>begins</q>
@@ -905,7 +904,7 @@
 
         <figure xml:id="fig_green3">
           <caption>The region <m>R</m>, whose area is found in <xref ref="ex_green3">Example</xref>.</caption>
-          <image xml:id="img_green3">
+          <image xml:id="img_green3" width="47%">
             <description></description>
             <latex-image>
 
@@ -989,7 +988,7 @@
 
         <figure xml:id="fig_div1">
           <caption>The region <m>R</m> used in <xref ref="ex_div1">Example</xref>.</caption>
-          <image xml:id="img_div1">
+          <image xml:id="img_div1" width="47%">
             <description></description>
             <asymptote>
 
@@ -1091,7 +1090,7 @@
     </example>
 
     <example xml:id="ex_div2">
-      <title>Flux when $\divv \vec F = 0$</title>
+      <title>Flux when <m>\divv \vec F = 0</m></title>
       <statement>
         <p>
           Let <m>\vec F</m> be any field where <m>\divv \vec F = 0</m>,
@@ -1121,7 +1120,7 @@
 
         <figure xml:id="fig_div2">
           <caption>As used in <xref ref="ex_div2">Example</xref>, the vector field has a divergence of 0 and the two paths only intersect at their initial and terminal points.</caption>
-          <image xml:id="img_div2">
+          <image xml:id="img_div2" width="47%">
             <description></description>
             <asymptote>
 

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -117,6 +117,11 @@
     </statement>
   </theorem>
 
+  <!-- <figure>
+    <caption>Video presentation of <xref ref="thm_limit_algebra"/> (three videos)</caption>
+    <video youtube="idVyYI9XH-A 5P2Zac-_Xhg lNbLZ2BR1gQ"/>
+  </figure> -->
+
   <aside>
     <p>
       Many people like to remember the <xref ref="sum-difference-limit-rule" text="custom">Sum Property</xref>
@@ -157,6 +162,7 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="8x42kGfu9ts" xml:id="vid_limit_analytic_using_prop"/> -->
       <p>
         <ol label="a.">
           <li>
@@ -250,6 +256,12 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_limit_analytic_imp_thms">
+    <caption>Video presentation of <xref ref="thm_poly_rat"/> and <xref ref="thm_limit_allbut1"/></caption>
+    <video youtube="NGoUHZESPso"/>
+  </figure> -->
+
+
   <example xml:id="ex_limit_rat">
     <title>Finding a limit of a rational function</title>
     <statement>
@@ -312,51 +324,23 @@
             <idx><h>logarithmic function</h><h>continuity of</h></idx>
 
         <ol cols="2">
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\sin(x) = \sin(c)</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\cos(x) = \cos(c)</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\tan(x)= \tan(c)</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\csc(x) = \csc(c)</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\sec(x) = \sec(c)</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\cot(x) = \cot(c)</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}a^x = a^c</m>, if <m>a \gt 0</m>
-            </p>
-          </li>
-          <li>
-            <p>
-              <m>\lim\limits_{x\to c}\ln(x) = \ln(c)</m>
-            </p>
-          </li>
-          <li xml:id="li_root_limit">
-            <p>
-              <m>\lim\limits_{x\to c}\sqrt[n]{x} = \sqrt[n]{c}</m>
-            </p>
-          </li>
+          <li xml:id="item_sin_continuous"><m>\lim\limits_{x\to c}\sin(x) = \sin(c)</m></li>
+
+          <li><m>\lim_{x\to c}\cos(x) = \cos(c)</m></li>
+
+          <li><m>\lim_{x\to c}\tan(x)= \tan(c)</m></li>
+
+          <li><m>\lim_{x\to c}\csc(x) = \csc(c)</m></li>
+
+          <li><m>\lim_{x\to c}\sec(x) = \sec(c)</m></li>
+
+          <li><m>\lim_{x\to c}\cot(x) = \cot(c)</m></li>
+
+          <li><m>\lim_{x\to c}a^x = a^c</m>, if <m>a \gt 0</m></li>
+
+          <li><m>\lim_{x\to c}\ln(x) = \ln(c)</m></li>
+
+          <li xml:id="li_root_limit"><m>\lim_{x\to c}\sqrt[n]{x} = \sqrt[n]{c}</m></li>
         </ol>
         (<xref ref="li_root_limit"/> follows from the
         <xref ref="identity-limit-rule" text="title"/> and
@@ -537,12 +521,27 @@
     </statement>
   </theorem>
 
+  <!-- <figure xml:id="vid_limit_analytic_squeeze_thm">
+    <caption>Explaining the Squeeze Theorem</caption>
+    <video youtube="8Tv-GRQdAVA"/>
+  </figure> -->
+
   <p>
     It can take some work to figure out appropriate functions by which to
     <q>squeeze</q> a given function.
     However, that is generally the only place where work is necessary;
     the theorem makes the <q>evaluating the limit part</q> very simple.
   </p>
+
+  <!-- <p xml:id="vidint_limit_analytic_lim_sin_props">
+    The Squeeze Theorem can be used to show that limits of <m>\sin(x)</m>
+    can be done by direct substitution, as the following videos illustrate.
+  </p> -->
+
+  <!-- <figure xml:id="vid_limit_analytic_lim_sin_0">
+    <caption>Using the Squeeze Theorem to take limits of <m>\sin(x)</m></caption>
+    <video youtube="S0VmjueQn5k L2ohy96L-F4"/>
+  </figure> -->
 
   <p>
     We use the <xref ref="thm_sqz" text="title"/>
@@ -561,6 +560,7 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="pgjv3ojtXh4" xml:id="vid_limit_analytic_sinxoverx"/> -->
       <p>
         We begin by considering the unit circle.
         Each point on the unit circle has coordinates
@@ -697,6 +697,16 @@
     </solution>
   </example>
 
+  <!-- <p xml:id="vidint_limit_analytic_trig_lim">
+    With the limit <m>\lim\limits_{\theta\to 0} \frac{\sin(\theta)}{\theta}=1</m> finally established,
+    we can move on to other limits involving trigonometric functions, as the following video demonstrates.
+  </p> -->
+
+  <!-- <figure xml:id="vid_limit_analytic_trig_lim">
+    <caption>Finding limits involving trigonometric functions</caption>
+    <video youtube="Wd464IIls5Y"/>
+  </figure> -->
+
   <p>
     Two notes about the <xref ref="ex_limit_sinx_prove">Example</xref> are worth mentioning.
     First, one might be discouraged by this application,
@@ -774,12 +784,12 @@
 
   <p>
     The special limits stated in <xref ref="thm_special_limits">Theorem </xref>
-    are called <em>indeterminate forms</em>,
+    are called <em>indeterminate forms</em>;
 
     <idx><h>limit</h><h>indeterminate form</h></idx>
 
     in this case they are of the form <m>0/0</m>,
-    except the third limit which is of a different form.
+    except the third limit, which is of a different form.
     You'll learn techniques to find these limits exactly using calculus in
     <xref ref="sec_lhopitals_rule">Section</xref>.
   </p>
@@ -910,6 +920,7 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="MSckoYqdKH4" xml:id="vid_limit_analytic_alg_ex_1"/> -->
       <p>
         We attempt to apply <xref ref="thm_poly_rat">Theorem</xref>
         by substituting <m>3</m> for <m>x</m>.
@@ -947,6 +958,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="vOW92eipOu4" xml:id="vid_limit_analytic_alg_ex_2"/> -->
+
       <p>
         We begin by trying to apply the <xref ref="quotient-limit-rule" text="title"/> limit rule,
         but the denominator evaluates to zero.

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -59,6 +59,11 @@
     </statement>
   </definition>
 
+  <!-- <figure xml:id="vid_limit_con_defn">
+    <caption>Video presentation of <xref ref="def_continuous"/></caption>
+    <video youtube="bKi6ReLchfw"/>
+  </figure> -->
+
   <p>
     A useful way to establish whether or not a function <m>f</m>
     is continuous at <m>c</m> is to verify the following three things:
@@ -304,6 +309,12 @@
       \ldots, [-2,-1), [-1,0), [0,1), [1,2), \ldots
     </me>.
   </p>
+
+  <!-- <figure xml:id="vid_limit_con_basic_ex">
+    <caption>Two continuity examples</caption>
+    <video youtube="8z07z3yeChY"/>
+  </figure> -->
+
   <p>
     This can tempt us to conclude that <m>f</m> is continuous everywhere;
     after all, if <m>f</m> is continuous on <m>[0,1)</m> and <m>[1,2)</m>,
@@ -355,6 +366,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="by3ioPN6KRM" xml:id="vid_limit_con_invertals_con"/> -->
+
       <p>
         We examine each in turn.
         <ol>
@@ -487,6 +500,11 @@
 
   <!--TODO: Is there a better way to phrase this last part? -->
 
+  <!-- <figure xml:id="vid_limit_con_prop">
+    <caption>Video presentation of <xref ref="thm_continuity_algebra"/></caption>
+    <video youtube="GTiNiZT5ukg"/>
+  </figure> -->
+
   <theorem xml:id="thm_continuous_functions">
     <title>Continuous Functions</title>
     <statement>
@@ -547,6 +565,16 @@
     </statement>
   </theorem>
 
+  <!-- <p xml:id="vidint_limit_con_using_prop">
+    As the following video example illustrates,
+    the above theorems allow us to quickly construct new continuous functions from old ones.
+  </p> -->
+
+  <!-- <figure xml:id="vid_limit_con_using_prop">
+    <caption>Continuity of compositions</caption>
+    <video youtube="ewUiuE9bQlo"/>
+  </figure> -->
+
   <p>
     We apply these theorems in the following Example.
   </p>
@@ -581,6 +609,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="6Lm-0eBi-5E" xml:id="vid_limit_con_internals_again"/> -->
+
       <p>
         We examine each in turn,
         applying <xref ref="thm_continuity_algebra">Theorems</xref>
@@ -660,6 +690,11 @@
 
   <paragraphs>
     <title>Classification of discontinuities</title>
+    <!-- <figure xml:id="vid_limit_con_types_discon">
+      <caption>Discussing classification of discontinuities</caption>
+      <video youtube="TevrD3qci0Q"/>
+    </figure> -->
+
 
     <p>
       We now know what it means for a function to be continuous,
@@ -764,7 +799,7 @@
         </figure>
 
         <figure xml:id="fig_jump_disc">
-          <caption>The graph of a function with a jump discontinuity at <m>x=2</m>.</caption>
+          <caption>The graph of a function with a jump discontinuity at <m>x=2</m></caption>
           <image>
             <description></description>
             <latex-image>
@@ -787,7 +822,7 @@
         </figure>
 
         <figure xml:id="fig_inf_disc">
-          <caption>The graph of a function with an infinite discontinuity at <m>x=2</m>.</caption>
+          <caption>The graph of a function with an infinite discontinuity at <m>x=2</m></caption>
           <image>
             <description></description>
             <latex-image>
@@ -887,6 +922,12 @@
       </statement>
     </theorem>
 
+    <!-- <figure xml:id="vid_limit_con_IVT_stmnt">
+      <caption>Video presentation of <xref ref="thm_IVT"/></caption>
+      <video youtube="Fx7Qu9tZlN4"/>
+    </figure> -->
+
+
     <p>
       One important application of the <xref ref="thm_IVT" text="title"/> is root finding.
       Given a function <m>f</m>,
@@ -948,6 +989,7 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="mwq447zC9R0 dx5reJRcQD0" xml:id="vid_limit_con_IVT_bisec"/> -->
         <p>
           Consider the graph of <m>f(x) = x-\cos(x)</m>,
           shown in <xref ref="fig_xminuscosx">Figure</xref>.

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -15,6 +15,11 @@
       The hyphen between <m>\epsilon</m> and <m>\delta</m> is not a minus sign.
     </p>
   </aside>
+  <!-- <figure xml:id="vid_limit_defn_informal">
+    <caption>An informal definition of the limit</caption>
+    <video youtube="OGvDIXuWn0g"/>
+  </figure> -->
+
   <p>
     Before we give the actual definition,
     let's consider a few informal ways of describing a limit.
@@ -151,6 +156,11 @@
       </p>
     </statement>
   </definition>
+  <!-- <figure xml:id="vid_limit_defn_precise">
+    <caption>Video presentation of <xref ref="def_limit"/></caption>
+    <video youtube="npoSY-AFvOY"/>
+  </figure> -->
+
 
   <p>
     Mathematicians often enjoy writing ideas without using any words.
@@ -184,6 +194,7 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="pdu3nRE8x1I zA_u1Hsd0Jg" xml:id="vid_limit_defn_sqrt_epsilon"/> -->
       <p>
         Before we use the formal definition,
         let's try some numerical tolerances.
@@ -269,8 +280,8 @@
                   \addplot[guideline] coordinates {(6.25,0) (6.25,2.5)};
                   \addplot[guideline,|-&gt;] coordinates {(0.2,2) (0.2,2.5)} node [below right]{$\varepsilon=0.5$} ;
                   \addplot[guideline,|-&gt;] coordinates {(0.2,2) (0.2,1.5)} node [above right]{$\varepsilon=0.5$} ;
-                  \addplot[guideline,|->] coordinates {(4,0.2) (2.25,0.2) } node [above right]{\parbox{3em}{width\\ 1.75}} ;
-                  \addplot[guideline,|->] coordinates {(4,0.2) (6.25,0.2)} node [above left]{\parbox{3em}{\raggedleft width\\ 2.25}} ;
+                  \addplot[guideline,|-&gt;] coordinates {(4,0.2) (2.25,0.2) } node [above right]{\parbox{3em}{width\\ 1.75}} ;
+                  \addplot[guideline,|-&gt;] coordinates {(4,0.2) (6.25,0.2)} node [above left]{\parbox{3em}{\raggedleft width\\ 2.25}} ;
                   \addplot[soliddot] coordinates {(2.25,1.5)};
                   \addplot[soliddot] coordinates {(6.25,2.5)};
                   \addplot[mark=none] coordinates {(2.25,1.5)} node [below right]{\parbox{9em}{\ldots choose $\delta$ smaller\\ than each of these:}};
@@ -395,6 +406,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="QGqoq-xEXyk" xml:id="vid_limit_defn_quadratic"/> -->
+
       <p>
         Let's do this example symbolically from the start.
         Let <m>\varepsilon  \gt  0</m> be given;
@@ -507,8 +520,8 @@
                 \addplot[guideline,dashed] coordinates {(1.73,0) (1.73,3)};
                 \addplot[guideline,dotted] coordinates {(2.2,0) (2.2,4.84)};
                 \addplot[guideline,dotted] coordinates {(1.8,0) (1.8,3.24)};
-                \addplot[guideline,|->] coordinates {(0.2,4) (0.2,5)} node [below right]{$\varepsilon$};
-                \addplot[guideline,|->] coordinates {(0.2,4) (0.2,3)} node [above right]{$\varepsilon$};
+                \addplot[guideline,|-&gt;] coordinates {(0.2,4) (0.2,5)} node [below right]{$\varepsilon$};
+                \addplot[guideline,|-&gt;] coordinates {(0.2,4) (0.2,3)} node [above right]{$\varepsilon$};
                 \addplot[guideline,&lt;-|] coordinates {(2.2,2.2) (2,2.2)};
                 \addplot[guideline,&lt;-|] coordinates {(1.8,2.2) (2,2.2)};
                 \node[pin={[pin distance=2em, pin edge={inner sep=0pt}]60:{$\delta=\varepsilon/5$}}] at (axis cs:2.1,2.2) {};
@@ -596,6 +609,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="--_Rq2GX9IY" xml:id="vid_limit_defn_polynomial"/> -->
+
       <p>
         We start our scratch-work by considering <m>\abs{f(x) - (-1)} \lt  \varepsilon</m>:
         <mdn>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -98,6 +98,11 @@
       </statement>
     </definition>
 
+    <!-- <figure xml:id="vid_limit_inf_defn">
+      <caption>Video presentation of <xref ref="def_limit_of_infinity"/></caption>
+      <video youtube="UVhqWmKqHtw"/>
+    </figure> -->
+
     <p>
       The first definition is similar to the
       <m>\varepsilon</m>-<m>\delta</m> definition in <xref ref="def_limit">Definition</xref>
@@ -209,6 +214,8 @@
         </figure>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="S3dUAUQiKFQ" xml:id="vid_limit_inf_ex_using_defn"/> -->
+
         <p>
           In <xref ref="ex_no_limit2">Example</xref>
           of <xref ref="sec_limit_intro">Section</xref>,
@@ -249,6 +256,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="JP1k74FZE1I" xml:id="vid_limit_inf_ex_1overx"/> -->
+
         <p>
           It is easy to see that the function grows without bound near <m>0</m>,
           but it does so in different ways on different sides of <m>0</m>.
@@ -316,6 +325,11 @@
       </statement>
     </definition>
 
+    <!-- <figure xml:id="vid_limit_inf_vert_asymptotes">
+      <caption>Video presentation of <xref ref="def_vertical_asymptote"/></caption>
+      <video youtube="qIrLL7jbEZw"/>
+    </figure> -->
+
     <example xml:id="ex_vertasy1">
       <title>Finding vertical asymptotes</title>
       <statement>
@@ -324,6 +338,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%"  youtube="h-1BCF_lsHI" xml:id="vid_limit_inf_vert_asymptotes_ex"/> -->
+
         <p>
           Vertical asymptotes occur where the function grows without bound;
           this can occur at values of <m>c</m> where the denominator is <m>0</m>.
@@ -547,6 +563,11 @@
       </statement>
     </definition>
 
+    <!-- <figure xml:id="vid_limit_at_inf_defn">
+      <caption>Video presentation of <xref ref="def_limit_at_infinity"/></caption>
+      <video youtube="7PwKJHgic7U"/>
+    </figure> -->
+
     <p>
       We can also define limits such as
       <m>\lim_{x\to\infty}f(x)=\infty</m> by combining this definition with
@@ -640,6 +661,15 @@
         </p>
       </solution>
     </example>
+
+    <!-- <p xml:id="vidint_limit_at_inf_ex_using_defn">
+      The following video shows how to prove the result from <xref ref="ex_hzasy1"/> using the limit definition.
+    </p> -->
+
+    <!-- <figure xml:id="vid_limit_at_inf_ex_using_defn">
+      <caption>Using an <m>\varepsilon</m><ndash/><m>\delta</m> proof with <xref ref="def_limit_at_infinity"/> in <xref ref="ex_hzasy1"/></caption>
+      <video youtube="kYmfeq-qKiI"/>
+    </figure> -->
 
     <p>
       Horizontal asymptotes can take on a variety of forms.
@@ -748,6 +778,12 @@
         <mrow>\lim_{x\to\infty}\frac1{x^n}\amp=0\amp\lim_{x\to-\infty}\frac1{x^n}\amp=0</mrow>
       </md>.
     </p>
+
+    <!-- <figure xml:id="vid_limit_at_inf_basic_ex">
+      <caption>Basic examples involving limits at infinity</caption>
+      <video youtube="v5SrtUsdMeU"/>
+    </figure> -->
+
 
     <p>
       Now suppose we need to compute the following limit:
@@ -862,6 +898,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="cmZ39j1YI-o" xml:id="vid_limit_at_inf_rat_func_ex"/> -->
+
         <p>
           Before using <xref ref="thm_lim_rational_fn_at_infty">Theorem</xref>,
           let's use the technique of evaluating limits at infinity of rational functions that led to that theorem.
@@ -1058,6 +1096,14 @@
         </p>
       </solution>
     </example>
+
+    <!-- <p xml:id="vidint_limit_at_inf_ex_rad">
+      The following video provides another example similar to <xref ref="ex_hzasy4"/>.
+    </p> -->
+    <!-- <figure xml:id="vid_limit_at_inf_ex_rad">
+      <caption>Limits at infinity with a radical function</caption>
+      <video youtube="vD1-zrRZQTI"/>
+    </figure> -->
   </subsection>
 
   <exercises>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -6,6 +6,11 @@
       We begin our study of <em>limits</em>
       by considering examples that demonstrate key concepts that will be explained as we progress.
     </p>
+    <!-- <figure xml:id="vid_limit_intro_limit_concept">
+      <caption>The concept of a limit</caption>
+      <video youtube="rG3XVvFIZPY"/>
+    </figure> -->
+
 
     <p>
       Consider the function <m>y = \frac{\sin(x) }{x}</m>.
@@ -152,6 +157,11 @@
       since we are working with the pseudo-definition of a limit,
       not the actual definition.)
     </p>
+    <!-- <figure xml:id="vid_limit_intro_sinxoverx">
+      <caption>Investigating <m>\sin(x)/x</m></caption>
+      <video youtube="__qzaSg4y1I"/>
+    </figure> -->
+
 
     <p>
       Once we have the true definition of a limit,
@@ -298,6 +308,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="eHx3LmrQZXM" xml:id="vid_limit_intro_rational_func"/> -->
+
         <p>
           To graphically approximate the limit, graph
           <me>
@@ -445,6 +457,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="7RAiKoLCpgU" xml:id="vid_limit_intro_piecewise_func"/> -->
+
         <p>
           Again we graph <m>f(x)</m> and create a table of its values near
           <m>x=0</m> to approximate the limit.
@@ -535,6 +549,11 @@
 
   <subsection xml:id="subsec_nolimit3">
     <title>Identifying When Limits Do Not Exist</title>
+    <!-- <figure xml:id="vid_limit_intro_limit_dne">
+      <caption>Video introduction for <xref ref="subsec_nolimit3"/></caption>
+      <video youtube="DSIaDa_ABxo"/>
+    </figure> -->
+
     <p>
       A function may not have a limit for all values of <m>x</m>.
       That is, we cannot say <m>\lim_{x\to c}f(x)=L</m>
@@ -752,6 +771,11 @@
       </solution>
     </example>
 
+    <!-- <figure>
+      <caption>Video presentation for <xref first="ex_no_limit1" last="ex_no_limit2">Examples</xref></caption>
+      <video xml:id="vid_limit_intro_jumps_asymptotes" youtube="NnV1A1KTbg0"/>
+    </figure> -->
+
     <example xml:id="ex_no_limit3">
       <title>The Function Oscillates</title>
       <statement>
@@ -760,6 +784,8 @@
         </p>
       </statement>
       <solution>
+        <!-- <video width="90%" youtube="gGvvFX5QyjE" xml:id="vid_limit_intro_limit_oscillation"/> -->
+
         <p>
           Two graphs of <m>f(x) = \sin(1/x)</m> are given in <xref ref="fig_nolimit3">Figure</xref>.
           <xref ref="fig_nolimit3a">Figure</xref>
@@ -959,7 +985,7 @@
     </example>
   </subsection>
 
-  <subsection>
+  <subsection xml:id="sec_diff_quot_intro">
     <title>Limits of Difference Quotients</title>
     <p>
       We have approximated limits of functions as <m>x</m> approached a particular number.
@@ -968,6 +994,11 @@
           <idx><h>limit</h><h>difference quotient</h></idx>
 
     </p>
+    <!-- <figure xml:id="vid_limit_intro_limit_diff_quot">
+      <caption>Video introduction to <xref ref="sec_diff_quot_intro"/></caption>
+      <video youtube="2NJmd0Jrt4U"/>
+    </figure> -->
+
 
     <p>
       Let <m>f(x)</m> represent the position function, in feet,
@@ -1191,6 +1222,10 @@
         </row>
       </tabular>
     </figure>
+    <!-- <figure xml:id="vid_limit_intro_limit_diff_quot_ex">
+      <caption>Video examples for difference quotients: once with direct computation, and then by simplifying first</caption>
+      <video  youtube="lNI90Y321b0 uUyZHfTYlBQ"/>
+    </figure> -->
 
     <p>
       Proper understanding of limits is key to understanding calculus.

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -108,6 +108,11 @@
     </statement>
   </definition>
 
+  <!-- <figure xml:id="vid_limit_one_sided_defn">
+    <caption>Video presentation of <xref ref="def_onesidedlimit"/></caption>
+    <video youtube="VU8lUocFAfE"/>
+  </figure> -->
+
   <p>
     Practically speaking, when evaluating a left-hand limit,
     we consider only values of <m>x</m>
@@ -195,6 +200,8 @@
       </figure>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="NdBPwaP4Xkk" xml:id="vid_limit_one_sided_ex_1"/> -->
+
       <p>
         For these problems,
         the visual aid of the graph is likely more effective in
@@ -369,6 +376,8 @@
       </p>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="vE_7FG2h_LU" xml:id="vid_limit_one_sided_ex_2"/> -->
+
       <p>
         In this example, we evaluate each expression using just the definition of <m>f</m>,
         without using a graph as we did in the previous example.
@@ -559,6 +568,8 @@
       </figure>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="HVFazve-Qxc" xml:id="vid_limit_one_sided_ex_4"/> -->
+
       <p>
         It is clear by looking at the graph that both the left- and right-hand limits of <m>f</m>,
         as <m>x</m> approaches <m>1</m>, are <m>0</m>.
@@ -615,6 +626,8 @@
       </figure>
     </statement>
     <solution>
+      <!-- <video width="90%" youtube="Nn6JoJRK7nk" xml:id="vid_limit_one_sided_ex_3"/> -->
+
       <p>
         It is clear from the definition of the function and its graph that all of the following are equal:
         <me>

--- a/ptx/sec_line_int_intro.ptx
+++ b/ptx/sec_line_int_intro.ptx
@@ -7,7 +7,10 @@
       <q>area under a curve.</q> In this section,
       we learn to do this (again), but in a different context.
     </p>
+  </introduction>
 
+  <subsection xml:id="subsec-line-int-scalar">
+    <title>Line Integrals of Functions</title>
     <p>
       Consider the surface and curve shown in <xref ref="fig_line_integral_intro1a_3D">Figure</xref>.
       The surface is given by <m>f(x,y)=1-\cos(x)\sin(y)</m>.
@@ -32,7 +35,7 @@
 
     <figure xml:id="fig_line_integral_intro1">
       <caption>Finding area under a curve in space.</caption>
-      <sidebyside>
+      <sidebyside widths="33% 33% 33%">
         <figure xml:id="fig_line_integral_intro1a_3D">
           <caption/>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -366,11 +369,11 @@
       we can say that <m>f</m> is a function of <m>s</m>.
       Given a value <m>s</m>, we can compute <m>f(s)</m> and find a height.
       Thus
-      <md>
-        <mrow>\text{ area under \(f\) and above \(C\) } \amp \approx \sum (\text{ heights } \times\text{ widths } );</mrow>
-        <mrow>\text{ area under \(f\) and above \(C\) }               \amp =\lim_{||\Delta s||\to0}\sum f(c_i)\Delta s_i</mrow>
-        <mrow>\amp =\int_Cf(s)\, ds</mrow>
-      </md>.
+      <mdn>
+        <mrow number="no">\text{ area under \(f\) and above \(C\) } \amp \approx \sum (\text{ heights } \times\text{ widths } );</mrow>
+        <mrow number="no">\text{ area under \(f\) and above \(C\) }               \amp =\lim_{\norm{\Delta s}\to0}\sum f(c_i)\Delta s_i</mrow>
+        <mrow xml:id="eq_line0">\amp =\int_Cf(s)\, ds</mrow>
+      </mdn>.
     </p>
 
     <p>
@@ -405,12 +408,12 @@
           and let <m>f</m> be a continuous function of <m>s</m>.
           A <term>line integral</term> is an integral of the form
           <me>
-            \int_C f(s)\, ds = \lim_{||\Delta s||\to 0}\sum_{i=1}^n f(c_i)\Delta s_i
+            \int_C f(s)\, ds = \lim_{\norm{\Delta s}\to 0}\sum_{i=1}^n f(c_i)\Delta s_i
           </me>,
           where <m>s_1\lt s_2\lt \ldots\lt s_n</m> is any partition of the <m>s</m>-interval over which <m>C</m> is defined,
           <m>c_i</m> is any value in the <m>i</m>th subinterval,
           <m>\Delta s_i</m> is the width of the <m>i</m>th subinterval,
-          and <m>||\Delta s||</m> is the length of the longest subinterval in the partition.
+          and <m>\norm{\Delta s}</m> is the length of the longest subinterval in the partition.
               <idx><h>line integral</h><h>over scalar field</h></idx>
         </p>
       </statement>
@@ -550,7 +553,7 @@
     </p>
 
     <example xml:id="ex_linescalarfield2">
-      <title>Evaluating a line integral: area under a surface over a curve.</title>
+      <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
           Find the area under the surface
@@ -558,28 +561,9 @@
           which is the segment of the line <m>y=2x+1</m> on <m>-1\leq x\leq 1</m>,
           as shown in <xref ref="fig_linescalarfield2">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Our first step is to represent <m>C</m> with a vector<ndash/>valued function.
-          Since <m>C</m> is a simple line,
-          and we have a explicit relationship between <m>y</m> and <m>x</m> (namely,
-          that <m>y</m> is <m>2x+1</m>),
-          we can let <m>x = t</m>, <m>y = 2t+1</m>,
-          and write <m>\vrt = \langle t, 2t+1\rangle</m> for <m>-1\leq t\leq 1</m>.
-        </p>
-
-        <p>
-          We find the values of <m>f</m> over <m>C</m> as <m>f(x,y) = f(t,2t+1) = \cos(t)+\sin(2t+1) + 2</m>.
-          We also need <m>\norm{\vec r\,'(t)}</m>;
-          with <m>\vrp(t) = \langle 1,2\rangle</m>,
-          we have <m>\norm{\vrp(t)} = \sqrt{5}</m>.
-          Thus <m>ds = \sqrt{5}\, dt</m>.
-        </p>
-
         <figure xml:id="fig_linescalarfield2">
           <caption>Finding area under a curve in <xref ref="ex_linescalarfield2">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_linescalarfield2a_3D">
               <caption/>
               <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -759,6 +743,24 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Our first step is to represent <m>C</m> with a vector<ndash/>valued function.
+          Since <m>C</m> is a simple line,
+          and we have a explicit relationship between <m>y</m> and <m>x</m> (namely,
+          that <m>y</m> is <m>2x+1</m>),
+          we can let <m>x = t</m>, <m>y = 2t+1</m>,
+          and write <m>\vrt = \langle t, 2t+1\rangle</m> for <m>-1\leq t\leq 1</m>.
+        </p>
+
+        <p>
+          We find the values of <m>f</m> over <m>C</m> as <m>f(x,y) = f(t,2t+1) = \cos(t)+\sin(2t+1) + 2</m>.
+          We also need <m>\norm{\vec r\,'(t)}</m>;
+          with <m>\vrp(t) = \langle 1,2\rangle</m>,
+          we have <m>\norm{\vrp(t)} = \sqrt{5}</m>.
+          Thus <m>ds = \sqrt{5}\, dt</m>.
+        </p>
 
         <p>
           The area we seek is
@@ -777,24 +779,15 @@
     </p>
 
     <example xml:id="ex_linescalarfield3">
-      <title>Evaluating a line integral: area under a surface over a curve.</title>
+      <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
           Find the area over the unit circle in the <m>x</m>-<m>y</m> plane and under the surface <m>f(x,y) = x^2-y^2+3</m>,
           shown in <xref ref="fig_linescalarfield3">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          The curve <m>C</m> is the unit circle,
-          which we will describe with the parametrization
-          <m>\vrt = \langle \cos t, \sin t\rangle</m> for <m>0\leq t\leq 2\pi</m>.
-          We find <m>\norm{\vrp(t)} = 1</m>, so <m>ds = 1 dt</m>.
-        </p>
-
         <figure xml:id="fig_linescalarfield3">
           <caption>Finding area under a curve in <xref ref="ex_linescalarfield3">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_linescalarfield3a_3D">
               <caption/>
               <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -973,6 +966,14 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          The curve <m>C</m> is the unit circle,
+          which we will describe with the parametrization
+          <m>\vrt = \langle \cos t, \sin t\rangle</m> for <m>0\leq t\leq 2\pi</m>.
+          We find <m>\norm{\vrp(t)} = 1</m>, so <m>ds = 1 dt</m>.
+        </p>
 
         <p>
           We find the values of <m>f</m> over <m>C</m> as <m>f(x,y) = f(\cos t, \sin t) = \cos^2t-\sin^2t+3</m>.
@@ -997,7 +998,7 @@
     </p>
 
     <example xml:id="ex_linescalarfield5">
-      <title>Evaluating a line integral: area under a surface over a curve.</title>
+      <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
           Find the area under <m>f(x,y) = 1-\cos(x)\sin(y)</m> and over the parabola <m>y = x^2</m>,
@@ -1030,37 +1031,13 @@
     </p>
 
     <example xml:id="ex_linescalarfield4">
-      <title>Evaluating a line integral: area under a curve in space.</title>
+      <title>Evaluating a line integral: area under a curve in space</title>
       <statement>
         <p>
           Find the area above the <m>x</m>-<m>y</m> plane and below the helix parametrized by <m>\vrt = \langle \cos t,2\sin t,t/\pi\rangle</m>,
           for <m>0\leq t\leq 2\pi</m>,
           as shown in <xref ref="fig_linescalarfield4">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Note how this is problem is different than the previous examples:
-          here, the height is not given by a surface, but by the curve itself.
-        </p>
-
-        <p>
-          We use the given vector-valued function \vec r(t)<nbsp/>to determine the curve <m>C</m> in the <m>x</m>-<m>y</m> plane by simply using the first two components of \vec r(t):
-          <m>\vec c(t) = \langle \cos t,2\sin t\rangle</m>.
-          Thus <m>ds = \norm{\vec c\,'(t)}\,dt = \sqrt{\sin^2t + 4\cos^2t}\,dt</m>.
-        </p>
-
-        <p>
-          The height is not found by evaluating a surface over <m>C</m>,
-          but rather it is given directly by the third component of \vec r(t):
-          <m>t/\pi</m>.
-          Thus
-          <me>
-            \oint_C f(s)\, ds = \int_0^{2\pi} \frac{t}{\pi}\sqrt{\sin^2t + 4\cos^2t}\,dt \approx 9.69
-          </me>,
-          where the approximation was obtained using numerical methods.
-        </p>
-
         <figure xml:id="fig_linescalarfield4">
           <caption>Finding area under a curve in <xref ref="ex_linescalarfield4">Example</xref>.</caption>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1070,7 +1047,7 @@
           3Dcoo=1.7807315587997437 0.9528753757476807 54.982017517089844,
           3Droo=141.8977232410902,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_linescalarfield4_3D">
+          <image xml:id="img_linescalarfield4_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -1147,6 +1124,29 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Note how this is problem is different than the previous examples:
+          here, the height is not given by a surface, but by the curve itself.
+        </p>
+
+        <p>
+          We use the given vector-valued function \vec r(t)<nbsp/>to determine the curve <m>C</m> in the <m>x</m>-<m>y</m> plane by simply using the first two components of \vec r(t):
+          <m>\vec c(t) = \langle \cos t,2\sin t\rangle</m>.
+          Thus <m>ds = \norm{\vec c\,'(t)}\,dt = \sqrt{\sin^2t + 4\cos^2t}\,dt</m>.
+        </p>
+
+        <p>
+          The height is not found by evaluating a surface over <m>C</m>,
+          but rather it is given directly by the third component of \vec r(t):
+          <m>t/\pi</m>.
+          Thus
+          <me>
+            \oint_C f(s)\, ds = \int_0^{2\pi} \frac{t}{\pi}\sqrt{\sin^2t + 4\cos^2t}\,dt \approx 9.69
+          </me>,
+          where the approximation was obtained using numerical methods.
+        </p>
       </solution>
     </example>
 
@@ -1160,7 +1160,7 @@
       The figures show how the curve <m>C</m> defines another curve on the surface <m>z=f(x,y)</m>,
       and we are finding the area under that curve.
     </p>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Properties of Line Integrals</title>
@@ -1182,7 +1182,7 @@
 
     <figure xml:id="fig_line_int_prop">
       <caption>Illustrating properties of line integrals.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_line_int_propa">
           <caption/>
           <image xml:id="img_line_int_propa">
@@ -1384,7 +1384,7 @@
     </definition>
 
     <example xml:id="ex_linescalarfield6">
-      <title>Evaluating a line integral: calculating mass.</title>
+      <title>Evaluating a line integral: calculating mass</title>
       <statement>
         <p>
           A thin wire follows the path
@@ -1406,7 +1406,7 @@
           3Dcoo=85.21116638183594 55.206966400146484 50.90880584716797,
           3Droo=141.89772711774134,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_linescalarfield6">
+          <image xml:id="img_linescalarfield6" width="47%">
             <description></description>
             <asymptote>
 

--- a/ptx/sec_line_int_vf.ptx
+++ b/ptx/sec_line_int_vf.ptx
@@ -56,12 +56,16 @@
       <m>ds = \norm{\vrp(t)}\, dt</m>,
       and recall that <m>\vec T = \vrp(t)/\norm{\vrp(t)}</m>.
       Thus
-      <men xml:id="eq_line_integral">
-        W = \int_C \vec F\cdot\vec T\, ds = \int_C \vec F\cdot \frac{\vrp(t)}{\norm{\vrp(t)}}\norm{\vrp(t)}\, dt = \int_C\vec F\cdot \vrp(t)\, dt = \int_C \vec F\cdot d\vec r
-      </men>,
+      <mdn >
+        <mrow number="no">W \amp = \int_C \vec F\cdot\vec T\, ds = \int_C \vec F\cdot \frac{\vrp(t)}{\norm{\vrp(t)}}\norm{\vrp(t)}\, dt</mrow>
+        <mrow xml:id="eq_line_integral"> = \int_C\vec F\cdot \vrp(t)\, dt = \int_C \vec F\cdot d\vec r</mrow>
+      </mdn>,
       where the final integral uses the differential <m>d\vec r</m> for <m>\vrp(t)\,dt</m>.
     </p>
+  </introduction>
 
+  <subsection xml:id="subsec-line-int-vector-eval">
+    <title>Evaluating Line Integrals over Vector Fields</title>
     <p>
       These integrals are known as <em>line integrals over vector fields</em>.
       By contrast,
@@ -159,42 +163,9 @@
           Force is measured in newtons and distance is measured in meters.
           Find the work performed by each particle.
         </p>
-      </statement>
-      <solution>
-        <p>
-          To compute work, we need to parametrize each path.
-          We use <m>\vec r_1(t) = \langle t,t\rangle</m> to parametrize <m>y=x</m>,
-          and let <m>\vec r_2(t) =\langle t,t^4\rangle</m> parametrize <m>y=x^4</m>;
-          for each, <m>0\leq t\leq 1</m>.
-        </p>
-
-        <p>
-          Along the straight<ndash/>line path,
-          <m>\vec F\big(\vec r_1(t)\big) = \langle x, x+y\rangle = \langle t, t+t\rangle = \langle t,2t\rangle</m>.
-          We find <m>\vrp_1(t) =\langle 1,2\rangle</m>.
-          The integral that computes work is:
-          <md>
-            <mrow>\int_{C_1} \vec F\cdot d\vec r \amp = \int_0^1 \langle t,2t\rangle\cdot\la 1,1\ra\, dt</mrow>
-            <mrow>\amp = \int_0^1 3t\, dt</mrow>
-            <mrow>\amp = \frac32t^2\Big|_0^1 = 1.5 \text{ joules } </mrow>
-          </md>.
-        </p>
-
-        <p>
-          Along the curve <m>y = x^4</m>,
-          <m>\vec F\big(\vec r_2(t)\big) = \la x, x+y\ra = \la t, t+t^4\ra</m>.
-          We find <m>\vrp_2(t) = \la 1, 4t^3\ra</m>.
-          The work performed along this path is
-          <md>
-            <mrow>\int_{C_2} \vec F\cdot d\vec r \amp = \int_0^1 \la t,t+t^4\ra\cdot\la 1,4t^3\ra\, dt</mrow>
-            <mrow>\amp = \int_0^1 \big(t + 4t^4+ 4t^7\big)\, dt</mrow>
-            <mrow>\amp = \big(\frac12t^2 + \frac45t^5 + \frac12t^8\big)\Big|_0^1 =  1.8 \text{ joules } </mrow>
-          </md>.
-        </p>
-
         <figure xml:id="fig_livf1">
-          <caption>Paths through a vector field in <xref ref="ex_livf1">Example</xref>.</caption>
-          <image xml:id="img_livf1">
+          <caption>Paths through a vector field in <xref ref="ex_livf1">Example</xref></caption>
+          <image xml:id="img_livf1" width="47%">
             <description></description>
             <asymptote>
 
@@ -278,6 +249,38 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          To compute work, we need to parametrize each path.
+          We use <m>\vec r_1(t) = \langle t,t\rangle</m> to parametrize <m>y=x</m>,
+          and let <m>\vec r_2(t) =\langle t,t^4\rangle</m> parametrize <m>y=x^4</m>;
+          for each, <m>0\leq t\leq 1</m>.
+        </p>
+
+        <p>
+          Along the straight<ndash/>line path,
+          <m>\vec F\big(\vec r_1(t)\big) = \langle x, x+y\rangle = \langle t, t+t\rangle = \langle t,2t\rangle</m>.
+          We find <m>\vrp_1(t) =\langle 1,2\rangle</m>.
+          The integral that computes work is:
+          <md>
+            <mrow>\int_{C_1} \vec F\cdot d\vec r \amp = \int_0^1 \langle t,2t\rangle\cdot\la 1,1\ra\, dt</mrow>
+            <mrow>\amp = \int_0^1 3t\, dt</mrow>
+            <mrow>\amp = \frac32t^2\Big|_0^1 = 1.5 \text{ joules } </mrow>
+          </md>.
+        </p>
+
+        <p>
+          Along the curve <m>y = x^4</m>,
+          <m>\vec F\big(\vec r_2(t)\big) = \la x, x+y\ra = \la t, t+t^4\ra</m>.
+          We find <m>\vrp_2(t) = \la 1, 4t^3\ra</m>.
+          The work performed along this path is
+          <md>
+            <mrow>\int_{C_2} \vec F\cdot d\vec r \amp = \int_0^1 \la t,t+t^4\ra\cdot\la 1,4t^3\ra\, dt</mrow>
+            <mrow>\amp = \int_0^1 \big(t + 4t^4+ 4t^7\big)\, dt</mrow>
+            <mrow>\amp = \big(\frac12t^2 + \frac45t^5 + \frac12t^8\big)\Big|_0^1 =  1.8 \text{ joules } </mrow>
+          </md>.
+        </p>
 
         <p>
           Note how differing amounts of work are performed along the different paths.
@@ -300,19 +303,9 @@
           Force is measured in pounds and distances are measured in feet.
           Find the work performed by moving each particle along its path.
         </p>
-      </statement>
-      <solution>
-        <p>
-          We start by parametrizing <m>C_1</m>:
-          the parametrization <m>\vec r_1(t) = \la t, 2t^2-1\ra</m> is straightforward,
-          giving <m>\vrp_1 = \la 1,4t\ra</m>.
-          On <m>C_1</m>,
-          <m>\vec F\big(\vec r_1(t)\big) = \la y,x\ra = \la 2t^2-1,t\ra</m>.
-        </p>
-
         <figure xml:id="fig_livf2">
           <caption>Paths through a vector field in <xref ref="ex_livf2">Example</xref>.</caption>
-          <image xml:id="img_livf2">
+          <image xml:id="img_livf2" width="47%">
             <description></description>
             <asymptote>
 
@@ -382,6 +375,15 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          We start by parametrizing <m>C_1</m>:
+          the parametrization <m>\vec r_1(t) = \la t, 2t^2-1\ra</m> is straightforward,
+          giving <m>\vrp_1 = \la 1,4t\ra</m>.
+          On <m>C_1</m>,
+          <m>\vec F\big(\vec r_1(t)\big) = \la y,x\ra = \la 2t^2-1,t\ra</m>.
+        </p>
 
         <p>
           Computing the work along <m>C_1</m>, we have:
@@ -419,7 +421,7 @@
         </p>
       </solution>
     </example>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Properties of Line Integrals Over Vector Fields</title>
@@ -500,7 +502,7 @@
 
         <figure xml:id="fig_livf3">
           <caption>The vector field and curve in <xref ref="ex_livf3">Example</xref>.</caption>
-          <image xml:id="img_livf3">
+          <image xml:id="img_livf3" width="47%">
             <description></description>
             <asymptote>
 
@@ -647,7 +649,7 @@
           3Dcoo=12.9679536819458 12.412303924560547 19.615886688232422,
           3Droo=399.99998637870164,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_livf4_3D">
+          <image xml:id="img_livf4_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -828,7 +830,7 @@
 
     <figure xml:id="fig_simply_connected_plane">
       <caption><m>R_1</m> is simply connected; <m>R_2</m> is connected, but not simply connected; <m>R_3</m> is not connected.</caption>
-      <image xml:id="img_simply_connected_plane">
+      <image xml:id="img_simply_connected_plane" width="47%">
         <description></description>
         <latex-image>
 
@@ -870,7 +872,7 @@
 
     <figure xml:id="fig_simply_connected_space">
       <caption>The domains in (a) are simply connected, while the domains in (b) are not.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_simply_connected_spacea_3D">
           <caption/>
           <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -1005,7 +1005,7 @@
 
           size(200,200,IgnoreAspect);
           //currentprojection=perspective(7,2,1);
-          currentprojection=orthographic((-.14,-9.67,3.98),(0.003,0.01,0.026),(0,0,0),1.5,(-0.09,-0.2));
+          currentprojection=orthographic((-.14,-9.67,3.98),(0.003,0.01,0.026),(0,0,0),1,(-0.09,-0.2));
           defaultrender.merge=true;
 
 
@@ -1245,12 +1245,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 To find an equation of a line,
@@ -1266,12 +1263,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Two distinct lines in the plane can intersect or be <fillin/>.
@@ -1286,12 +1280,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Two distinct lines in space can intersect,
@@ -1307,12 +1298,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Use your own words to describe what it means for two lines in space to be skew.
@@ -1337,12 +1325,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(2,-4,1)</m>,
@@ -1366,8 +1351,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -1473,7 +1457,7 @@
               });
 
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through <m>P=(6,1,7)</m>,
@@ -1500,12 +1484,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(2,1,5)</m> and <m>Q = (7,-2,4)</m>.
@@ -1529,8 +1510,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -1645,7 +1625,7 @@
               });
 
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through
@@ -1672,12 +1652,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(0,1,2)</m> and orthogonal to both
@@ -1706,8 +1683,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -1767,7 +1743,7 @@
                return (3*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through
@@ -1795,8 +1771,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");Context()->variables->are(t=>"Real");
               $v=Compute("(7,2,-1)+t&lt;1,-1,2>");
@@ -1884,7 +1859,7 @@
                return(3*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through the intersection of
@@ -1912,8 +1887,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");Context()->variables->are(t=>"Real");
               $v=Compute("(2,2,3)+t&lt;5,-1,-3>");
@@ -2001,7 +1975,7 @@
                return(3*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through the intersection of
@@ -2029,12 +2003,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Passes through <m>P=(1,1)</m>,
@@ -2058,8 +2029,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context("Vector");Context()->variables->are(t=>"Real");
               $v=Compute("(-2,5)+t&lt;0,1>");
@@ -2110,7 +2080,7 @@
                return(2*($par and $tch),@err);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>\ell</m> is a line that passes through <m>P=(-2,5)</m>,
@@ -2149,15 +2119,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("parallel");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \la 1,2,1\ra + t\la 2,-1,1\ra</m> and
@@ -2177,15 +2145,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("(12,3,7)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \la 2,1,1\ra + t\la 5,1,3\ra</m> and
@@ -2205,12 +2171,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\vec\ell_1(t) = \la 3,4,1\ra + t\la 2,-3,4\ra</m>,
@@ -2230,15 +2193,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("same");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \la 1,1,1\ra + t\la 3,1,3\ra</m> and
@@ -2258,15 +2219,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("skew");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \begin{cases}x\amp = 1+2t\\ y\amp = 3-2t\\ z\amp = t\end{cases}</m> and
@@ -2286,15 +2245,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("parallel");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \begin{cases}x\amp = 1.1+0.6t\\ y\amp = 3.77+0.9t\\ z\amp = -2.3+1.5t\end{cases}</m> and
@@ -2314,12 +2271,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ell_1 = \left\{\begin{aligned}x\amp = 0.2+0.6t\\ y\amp = 1.33-0.45t\\ z\amp = -4.2+1.05t
@@ -2337,15 +2291,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add(same=>{},parallel=>{},skew=>{});
               $answer=Compute("skew");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Determine if <m>\vec\ell_1(t) = \begin{cases}x\amp = 0.1+1.1t\\ y\amp = 2.9-1.5t\\ z\amp = 3.2+1.6t\end{cases}</m> and
@@ -2374,12 +2326,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>Q=(1,1,1)</m>, <m>\vec\ell(t) = \la 2,1,3\ra + t\la 2,1,-2\ra</m>
@@ -2394,14 +2343,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("3sqrt(2)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance from the point
@@ -2416,12 +2363,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>Q=(0,3)</m>, <m>\vec\ell(t) = \la 2,0\ra + t\la 1,1\ra</m>
@@ -2436,14 +2380,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("5");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance from the point <m>Q=(1,1)</m> to the line <m>\vec\ell(t) = \la 4,5\ra + t\la -4,3\ra</m>.
@@ -2466,12 +2408,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\vec\ell_1(t) = \la 1,2,1\ra + t\la 2,-1,1\ra</m>,
@@ -2490,14 +2429,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance between the line
@@ -2521,12 +2458,9 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Let <m>Q</m> be a point on the line <m>\vec\ell(t)</m>.
@@ -2545,12 +2479,9 @@
       </exercise>
 
       <exercise xml:id="x10_05_ex_30">
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Let lines <m>\vec\ell_1(t)</m> and
@@ -2574,12 +2505,9 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
-            </pg-code>
-            </setup>-->
+            </pg-code> -->
             <statement>
               <p>
                 Let lines <m>\vec\ell_1(t)</m> and <m>\vec\ell_2(t)</m> be parallel.

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -13,7 +13,7 @@
     </p>
 
     <p>
-      One can represent the terrain as the surface defined by a multivariable function <m>z=f(x,y)</m>;
+      One can represent the terrain as the surface defined by a multivariable function <m>f(x,y)</m>;
       one can represent the path of the off-road vehicle, as seen from above,
       with a vector-valued function <m>\vec r(t) = \langle x(t),
       y(t)\rangle</m>;
@@ -725,7 +725,7 @@
 
     <p>
       In <xref ref="sec_partial_derivatives">Section</xref>
-      we learned how partial derivatives give certain instantaneous rate of change information about a function <m>z=f(x,y)</m>.
+      we learned how partial derivatives give certain instantaneous rate of change information about a function <m>f(x,y)</m>.
       In that section,
       we measured the rate of change of <m>f</m> by holding one variable constant and letting the other vary
       (such as, holding <m>y</m> constant and letting <m>x</m> vary gives <m>f_x</m>).

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -8,12 +8,12 @@
       <video youtube="smAvod2dFsw"/>
     </figure> -->
     <p>
-      Given a function <m>z=f(x,y)</m>,
-      we are often interested in points where <m>z</m> takes on the largest or smallest values.
-      For instance, if <m>z</m> represents a cost function,
+      Given a function <m>f(x,y)</m>,
+      we are often interested in points where <m>z=f(x,y)</m> takes on the largest or smallest values.
+      For instance, if <m>f</m> represents a cost function,
       we would likely want to know what <m>(x,y)</m> values minimize the cost.
-      If <m>z</m> represents the ratio of a volume to surface area,
-      we would likely want to know where <m>z</m> is greatest.
+      If <m>f</m> represents the ratio of a volume to surface area,
+      we would likely want to know where <m>f</m> is greatest.
       This leads to the following definition.
     </p>
 
@@ -2239,7 +2239,7 @@
               </p>
 
               <p>
-                The function <m>z=f(x,y)</m> itself has a critical point at <m>(-1,-1)</m>.
+                The function <m>f(x,y)</m> itself has a critical point at <m>(-1,-1)</m>.
               </p>
 
               <p>

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -381,9 +381,9 @@
     </figure>
 
     <p>
-      Given a function <m>z=f(x,y)</m>,
+      Given a function <m>f(x,y)</m>,
       we can draw a <q>topographical map</q>
-      of <m>f</m> by drawing <em>level curves</em>
+      of the graph <m>z=f(x,y)</m> by drawing <em>level curves</em>
       (or, contour lines).
       A level curve at <m>z=c</m> is a curve in the <m>x</m>-<m>y</m> plane such that for all points <m>(x,y)</m> on the curve,
       <m>f(x,y) = c</m>.
@@ -1692,9 +1692,9 @@
               </p>
 
               <p>
-                The function <m>z=\sqrt{x^2+4y^2}</m> can be rewritten as <m>z^2=x^2+4y^2</m>,
+                The graph <m>z=\sqrt{x^2+4y^2}</m> can be rewritten as <m>z^2=x^2+4y^2</m>,
                 an elliptic cone;
-                the function <m>z=x^2+4y^2</m> is a paraboloid,
+                the graph <m>z=x^2+4y^2</m> is a paraboloid,
                 each matching the description above.
               </p>
             </solution>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -20,6 +20,12 @@
       <q>tangent</q> to the surface.
     </p>
 
+    <p>
+      In <xref ref="subsec-tangent-plane">Section</xref> we introduced the concept of the tangent plane,
+      which could be thought of as consisting of all possible lines tangent to the surface at a given point.
+      In this section, we explore this idea in more detail.
+    </p>
+
     <figure xml:id="fig_space_tangent_intro">
       <caption>Showing various lines tangent to a surface.</caption>
       <!--
@@ -1105,6 +1111,7 @@
       With <m>a=f_x(x_0,y_0)</m>,
       <m>b=f_y(x_0,y_0)</m> and <m>P = \big(x_0,y_0,f(x_0,y_0)\big)</m>,
       the vector <m>\vec n=\la a,b,-1\ra</m> is orthogonal to <m>f</m> at <m>P</m>.
+      (See <xref ref="def-tangent-plane">Definition</xref>.)
       The plane through <m>P</m> with normal vector <m>\vec n</m> is therefore
       <em>tangent</em> to <m>f</m> at <m>P</m>.
     </p>
@@ -1651,9 +1658,9 @@
 
       <introduction>
         <p>
-          In the following exercises, a function <m>z=f(x,y)</m>,
+          In the following exercises, a function <m>f(x,y)</m>,
           a vector <m>\vec v</m> and a point <m>P</m> are given.
-          Give the parametric equations of the following directional tangent lines to <m>f</m> at <m>P</m>:
+          Give the parametric equations of the following directional tangent lines to <m>z=f(x,y)</m> at <m>P</m>:
         </p>
 
         <p>
@@ -1959,8 +1966,8 @@
       <introduction>
         <p>
           In the following exercises,
-          a function <m>z=f(x,y)</m> and a point <m>P</m> are given.
-          Find the equation of the normal line to <m>f</m> at <m>P</m>.
+          a function <m>f(x,y)</m> and a point <m>P</m> are given.
+          Find the equation of the normal line to <m>z=f(x,y)</m> at <m>P</m>.
           Note: these are the same functions as in <xref ref="x12_06_ex_05">Exercises</xref>
           <mdash/> <xref ref="x12_06_ex_08"/>.
         </p>
@@ -2140,8 +2147,8 @@
       <introduction>
         <p>
           In the following exercises,
-          a function <m>z=f(x,y)</m> and a point <m>P</m> are given.
-          Find the two points that are <m>2</m> units from the surface <m>f</m> at <m>P</m>.
+          a function <m>f(x,y)</m> and a point <m>P</m> are given.
+          Find the two points that are <m>2</m> units from the surface <m>z=f(x,y)</m> at <m>P</m>.
           Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
         </p>
       </introduction>
@@ -2221,8 +2228,8 @@
       <introduction>
         <p>
           In the following exercises,
-          a function <m>z=f(x,y)</m> and a point <m>P</m> are given.
-          Find an equation of the tangent plane to <m>f</m> at <m>P</m>.
+          a function <m>f(x,y)</m> and a point <m>P</m> are given.
+          Find an equation of the tangent plane to <m>z=f(x,y)</m> at <m>P</m>.
           Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
         </p>
       </introduction>

--- a/ptx/sec_parametric_surfaces.ptx
+++ b/ptx/sec_parametric_surfaces.ptx
@@ -9,7 +9,10 @@
       We now move our attention to 3-dimensional vector fields,
       considering both curves and surfaces in space.
     </p>
+  </introduction>
 
+  <subsection xml:id="subsec-parametrized-surfaces">
+    <title>Parametrizing surfaces</title>
     <p>
       We are accustomed to describing surfaces as functions of two variables,
       usually written as <m>z=f(x,y)</m>.
@@ -31,7 +34,7 @@
       </p>
 
       <sidebyside>
-        <image xml:id="img_param_intro">
+        <image xml:id="img_param_intro" width="20%">
           <latex-image>
 
           \begin{tikzpicture}[x={(.55ex,0)},y={(0,.55ex)}]
@@ -64,8 +67,9 @@
       <title>Parametrized Surface</title>
       <statement>
         <p>
-          Let <m>\vec r(u,v) = \langle\, f(u,v),g(u,v),h(u,v)\rangle</m> be a vector<ndash/>valued function that is continuous and one to one on the interior of its domain <m>R</m> in the <m>u</m>-<m>v</m> plane.
-          The set of all terminal points of <m>\vec r</m> (i.e., the <term>range</term>
+          Let <m>\vec r(u,v) = \langle\, f(u,v),g(u,v),h(u,v)\rangle</m>
+          be a vector<ndash/>valued function that is continuous and one to one on the interior of its domain <m>R</m> in the <m>u</m>-<m>v</m> plane.
+          The set of all terminal points of <m>\vec r</m> (<ie/>, the <term>range</term>
           of <m>\vec r</m> ) is the <term>surface</term>
           <m>\surfaceS</m>, and <m>\vec r</m> along with its domain <m>R</m> form a
           <term>parametrization</term> of <m>\surfaceS</m>.
@@ -84,20 +88,10 @@
       </statement>
     </definition>
 
-    <aside>
-      <p>
-        <em>Note:</em> A function is <em>one to one</em>
-        on its domain if the function never repeats an output value over the domain.
-        In the case of <m>\vec r(u,v)</m>,
-        <m>\vec r</m> is one to one if <m>\vec r(u_1,v_1) \neq \vec r(u_2,v_2)</m> for all points
-        <m>(u_1,v_1) \neq (u_2,v_2)</m> in the domain of <m>\vec r</m>.
-            <idx><h>one to one</h></idx>
-      </p>
-    </aside>
     <p>
       Given a point <m>(u_0,v_0)</m> in the domain of a vector<ndash/>valued function <m>\vec r</m>,
       the vectors <m>\vec r_u(u_0,v_0)</m> and
-      <m>\vec r_v(u_0,v_0)</m> are tangent to the surface <m>\surfaceS</m>at
+      <m>\vec r_v(u_0,v_0)</m> are tangent to the surface <m>\surfaceS</m> at
       <m>\vec r(u_0,v_0)</m> (a proof of this is developed later in this section).
       The definition of smoothness dictates that <m>\vec r_u\times \vec r_v \neq \vec 0</m>;
       this ensures that neither <m>\vec r_u</m> nor <m>\vec r_v</m> are <m>\vec 0</m>,
@@ -106,10 +100,21 @@
       <m>\vec r_v</m> determine a plane that is tangent to <m>\surfaceS</m>.
     </p>
 
+    <aside>
+      <p>
+        Recall that function is <em>one to one</em>
+        on its domain if the function never repeats an output value over the domain.
+        In the case of <m>\vec r(u,v)</m>,
+        <m>\vec r</m> is one to one if <m>\vec r(u_1,v_1) \neq \vec r(u_2,v_2)</m> for all points
+        <m>(u_1,v_1) \neq (u_2,v_2)</m> in the domain of <m>\vec r</m>.
+            <idx><h>one to one</h></idx>
+      </p>
+    </aside>
+
     <p>
-      A surface <m>\surfaceS</m>is said to be <em>orientable</em>
+      A surface <m>\surfaceS</m> is said to be <em>orientable</em>
           <idx><h>orientable</h></idx>
-      if a field of normal vectors can be defined on <m>\surfaceS</m>that vary continuously along <m>\surfaceS</m>. This definition may be hard to understand;
+      if a field of normal vectors can be defined on <m>\surfaceS</m> that vary continuously along <m>\surfaceS</m>. This definition may be hard to understand;
       it may help to know that orientable surfaces are often called <q>two sided.</q>
       A sphere is an orientable surface,
       and one can easily envision an <q>inside</q>
@@ -154,7 +159,7 @@
       3Dcoo=11.086544036865234 -8.5783109664917 -7.167413711547852,
       3Droo=399.99997970940404,
       3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-      <image xml:id="img_mobius_3D">
+      <image xml:id="img_mobius_3D" width="47%">
         <description></description>
         <asymptote>
 
@@ -278,7 +283,7 @@
     </p>
 
     <example xml:id="ex_parsurf1">
-      <title>parametrizing a surface over a rectangle</title>
+      <title>Parametrizing a surface over a rectangle</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the rectangular region <m>R</m> defined by
@@ -306,7 +311,7 @@
           3Dcoo=-11.887701988220215 -11.637335777282715 52.40430450439453,
           3Droo=399.9999800778292,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf1">
+          <image xml:id="img_parsurf1" width="47%">
             <description></description>
             <asymptote>
 
@@ -386,7 +391,7 @@
     </example>
 
     <example xml:id="ex_parsurf2">
-      <title>parametrizing a surface over a circular disk</title>
+      <title>Parametrizing a surface over a circular disk</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the circular region <m>R</m> enclosed by the circle of radius 2 that is centered at the origin.
@@ -425,7 +430,7 @@
           3Dcoo=-11.887701988220215 -11.637335777282715 52.40430450439453,
           3Droo=399.9999800778292,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="fig_parsurf2_3D">
+          <image xml:id="fig_parsurf2_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -547,39 +552,15 @@
     </p>
 
     <example xml:id="ex_parsurf3">
-      <title>parametrizing a surface over a triangle</title>
+      <title>Parametrizing a surface over a triangle</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the triangular region <m>R</m> enclosed by the coordinate axes and the line <m>y=2-2x/3</m>,
           as shown in <xref ref="fig_parsurf3a">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          We may begin by letting <m>x=u</m>,
-          <m>0\leq u\leq 3</m>, and <m>y = 2-2u/3</m>.
-          This gives only the line on the
-          <q>upper</q> side of the triangle.
-          To get all of the region <m>R</m>,
-          we can once again scale <m>y</m> by a variable factor,
-          <m>v</m>.
-        </p>
-
-        <p>
-          Still letting <m>x = u</m>,
-          <m>0\leq u\leq 3</m>, we let
-          <m>y = v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
-          When <m>v=0</m>,
-          all <m>y</m>-values are 0, and we get the portion of the <m>x</m>-axis between <m>x=0</m> and <m>x=3</m>.
-          When <m>v=1</m>, we get the upper side of the triangle.
-          When <m>v=1/2</m>, we get the line <m>y=1/2(2-2u/3) = 1-u/3</m>,
-          which is the line <q>halfway up</q> the triangle,
-          shown in the figure with a dashed line.
-        </p>
-
         <figure xml:id="fig_parsurf3">
           <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf3">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%" valign="bottom">
             <figure xml:id="fig_parsurf3a">
               <caption/>
               <image xml:id="img_parsurf3a">
@@ -601,9 +582,6 @@
                 \draw (axis cs: .5,.5) node {$R$};
 
                 \end{axis}
-
-                \node [right] at (myplot.right of origin) {\scriptsize $x$};
-                \node [above] at (myplot.above origin) {\scriptsize $y$};
 
                 \end{tikzpicture}
 
@@ -697,8 +675,30 @@
               </image>
             </figure>
           </sidebyside>
-
         </figure>
+      </statement>
+      <solution>
+        <p>
+          We may begin by letting <m>x=u</m>,
+          <m>0\leq u\leq 3</m>, and <m>y = 2-2u/3</m>.
+          This gives only the line on the
+          <q>upper</q> side of the triangle.
+          To get all of the region <m>R</m>,
+          we can once again scale <m>y</m> by a variable factor,
+          <m>v</m>.
+        </p>
+
+        <p>
+          Still letting <m>x = u</m>,
+          <m>0\leq u\leq 3</m>, we let
+          <m>y = v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
+          When <m>v=0</m>,
+          all <m>y</m>-values are 0, and we get the portion of the <m>x</m>-axis between <m>x=0</m> and <m>x=3</m>.
+          When <m>v=1</m>, we get the upper side of the triangle.
+          When <m>v=1/2</m>, we get the line <m>y=1/2(2-2u/3) = 1-u/3</m>,
+          which is the line <q>halfway up</q> the triangle,
+          shown in the figure with a dashed line.
+        </p>
 
         <p>
           Letting <m>z = f(x,y) = x^2+2y^2</m>,
@@ -725,50 +725,15 @@
     </example>
 
     <example xml:id="ex_parsurf4">
-      <title>parametrizing a surface over a triangle</title>
+      <title>Parametrizing a surface over a triangle</title>
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the triangular region <m>R</m> enclosed by the lines <m>y=3-2x/3</m>,
           <m>y=1</m> and <m>x=0</m> as shown in <xref ref="fig_parsurf4a">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          While the region <m>R</m> in this example is very similar to the region <m>R</m> in the previous example,
-          and our method of parametrizing the surface is fundamentally the same,
-          it will feel as though our answer is much different than before.
-        </p>
-
-        <p>
-          We begin with letting <m>x=u</m>, <m>0\leq u\leq 3</m>.
-          We may be tempted to let <m>y = v(3-2u/3)</m>,
-          <m>0\leq v\leq 1</m>, but this is incorrect.
-          When <m>v = 1</m>,
-          we obtain the upper line of the triangle as desired.
-          However, when <m>v=0</m>,
-          the <m>y</m>-value is 0, which does not lie in the region <m>R</m>.
-        </p>
-
-        <p>
-          We will describe the general method of proceeding following this example.
-          For now, consider <m>y = 1+v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
-          Note that when <m>v=1</m>,
-          we have <m>y=3-2u/3</m>, the upper line of the boundary of <m>R</m>.
-          Also, when <m>v=0</m>, we have <m>y=1</m>,
-          which is the lower boundary of <m>R</m>.
-          With <m>z=x^2+2y^2</m>,
-          we determine <m>\vec r(u,v) = \langle u, 1+v(2-2u/3),
-          u^2+2\big(1+v(2-2u/3)\big)^2\rangle</m>,
-          <m>0\leq u\leq 3</m>, <m>0\leq v\leq 1</m>.
-        </p>
-
-        <p>
-          The surface is graphed in <xref ref="fig_parsurf4b_3D">Figure</xref>.
-        </p>
-
         <figure xml:id="fig_parsurf4">
           <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf4">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%" valign="bottom">
             <figure xml:id="fig_parsurf4a">
               <caption/>
               <image xml:id="img_parsurf4a">
@@ -789,10 +754,6 @@
                 \draw (axis cs: 1,1.75) node {$R$};
 
                 \end{axis}
-
-                \node [right] at (myplot.right of origin) {\scriptsize $x$};
-                \node [above] at (myplot.above origin) {\scriptsize $y$};
-
                 \end{tikzpicture}
 
                 </latex-image>
@@ -887,6 +848,40 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          While the region <m>R</m> in this example is very similar to the region <m>R</m> in the previous example,
+          and our method of parametrizing the surface is fundamentally the same,
+          it will feel as though our answer is much different than before.
+        </p>
+
+        <p>
+          We begin with letting <m>x=u</m>, <m>0\leq u\leq 3</m>.
+          We may be tempted to let <m>y = v(3-2u/3)</m>,
+          <m>0\leq v\leq 1</m>, but this is incorrect.
+          When <m>v = 1</m>,
+          we obtain the upper line of the triangle as desired.
+          However, when <m>v=0</m>,
+          the <m>y</m>-value is 0, which does not lie in the region <m>R</m>.
+        </p>
+
+        <p>
+          We will describe the general method of proceeding following this example.
+          For now, consider <m>y = 1+v(2-2u/3)</m>, <m>0\leq v\leq 1</m>.
+          Note that when <m>v=1</m>,
+          we have <m>y=3-2u/3</m>, the upper line of the boundary of <m>R</m>.
+          Also, when <m>v=0</m>, we have <m>y=1</m>,
+          which is the lower boundary of <m>R</m>.
+          With <m>z=x^2+2y^2</m>,
+          we determine <m>\vec r(u,v) = \langle u, 1+v(2-2u/3),
+          u^2+2\big(1+v(2-2u/3)\big)^2\rangle</m>,
+          <m>0\leq u\leq 3</m>, <m>0\leq v\leq 1</m>.
+        </p>
+
+        <p>
+          The surface is graphed in <xref ref="fig_parsurf4b_3D">Figure</xref>.
+        </p>
       </solution>
     </example>
 
@@ -939,9 +934,9 @@
     </p>
 
     <insight xml:id="idea_parametrizing_surfaces">
-      <title>parametrizing Surfaces</title>
+      <title>Parametrizing Surfaces</title>
       <p>
-        Let a surface <m>\surfaceS</m>be the graph of a function <m>z=f(x,y)</m>,
+        Let a surface <m>\surfaceS</m> be the graph of a function <m>f(x,y)</m>,
         where the domain of <m>f</m> is a closed,
         bounded region <m>R</m> in the <m>x</m>-<m>y</m> plane.
         Let <m>R</m> be bounded by <m>a\leq x\leq b</m>,
@@ -951,7 +946,7 @@
       </p>
 
       <p>
-        <m>\surfaceS</m>can be parametrized as
+        <m>\surfaceS</m> can be parametrized as
         <me>
           \vec r(u,v) = \la u, h(u,v), f\big(u,h(u,v)\big)\ra, a\leq u\leq b,\ 0\leq v\leq 1
         </me>.
@@ -959,30 +954,13 @@
     </insight>
 
     <example xml:id="ex_parsurf5">
-      <title>parametrizing a cylindrical surface</title>
+      <title>Parametrizing a cylindrical surface</title>
       <statement>
         <p>
           Find a parametrization of the cylinder <m>x^2 + z^2/4=1</m>,
           where <m>-1\leq y\leq 2</m>,
           as shown in <xref ref="fig_parsurf5">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          The equation <m>x^2+z^2/4=1</m> can be envisioned to describe an ellipse in the <m>x</m>-<m>z</m> plane;
-          as the equation lacks a <m>y</m>-term,
-          the equation describes a cylinder
-          (recall <xref ref="def_cylinder">Definition</xref>)
-          that extends without bound parallel to the <m>y</m>-axis.
-          This ellipse has a vertical major axis of length 4, a horizontal minor axis of length 2, and is centered at the origin.
-          We can parametrize this ellipse using sines and cosines;
-          our parametrization can begin with
-          <me>
-            \vec r(u,v) = \la \cos u, \text{ ??? } , 2\sin u\ra, 0\leq u\leq 2\pi
-          </me>,
-          where we still need to determine the <m>y</m> component.
-        </p>
-
         <figure xml:id="fig_parsurf5">
           <caption>The cylinder parametrized in <xref ref="ex_parsurf5">Example</xref>.</caption>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -992,7 +970,7 @@
           3Dcoo=1.6293458938598633 13.199743270874023 -3.546671152114868,
           3Droo=399.9999708739728,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf5_3D">
+          <image xml:id="img_parsurf5_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -1073,6 +1051,22 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          The equation <m>x^2+z^2/4=1</m> can be envisioned to describe an ellipse in the <m>x</m>-<m>z</m> plane;
+          as the equation lacks a <m>y</m>-term,
+          the equation describes a cylinder
+          (recall <xref ref="def_cylinder">Definition</xref>)
+          that extends without bound parallel to the <m>y</m>-axis.
+          This ellipse has a vertical major axis of length 4, a horizontal minor axis of length 2, and is centered at the origin.
+          We can parametrize this ellipse using sines and cosines;
+          our parametrization can begin with
+          <me>
+            \vec r(u,v) = \la \cos u, \text{ ??? } , 2\sin u\ra, 0\leq u\leq 2\pi
+          </me>,
+          where we still need to determine the <m>y</m> component.
+        </p>
 
         <p>
           While the cylinder <m>x^2+z^2/4=1</m> is satisfied by any <m>y</m> value,
@@ -1088,23 +1082,13 @@
     </example>
 
     <example xml:id="ex_parsurf6">
-      <title>parametrizing an elliptic cone</title>
+      <title>Parametrizing an elliptic cone</title>
       <statement>
         <p>
           Find a parametrization of the elliptic cone <m>z^2 = \frac{x^2}{4}+\frac{y^2}{9}</m>,
           where <m>-2\leq z\leq 3</m>,
           as shown in <xref ref="fig_parsurf6a">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          One way to parametrize this cone is to recognize that given a <m>z</m> value,
-          the cross section of the cone at that <m>z</m> value is an ellipse with equation <m>\frac{x^2}{(2z)^2} + \frac{y^2}{(3z)^2}=1</m>.
-          We can let <m>z=v</m>, for
-          <m>-2\leq v\leq 3</m> and then parametrize the above ellipses using sines,
-          cosines and <m>v</m>.
-        </p>
-
         <figure xml:id="fig_parsurf6a">
           <caption>The elliptic cone as described in  <xref ref="ex_parsurf6">Example</xref>.</caption>
           <!-- \apexincludemedia{width=150pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1114,7 +1098,7 @@
           3Dcoo=0.0026521924883127213 4.370458126068115 12.347787857055664,
           3Droo=399.9999637774216,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf6a">
+          <image xml:id="img_parsurf6a" width="47%">
             <description></description>
             <asymptote>
 
@@ -1195,6 +1179,15 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          One way to parametrize this cone is to recognize that given a <m>z</m> value,
+          the cross section of the cone at that <m>z</m> value is an ellipse with equation <m>\frac{x^2}{(2z)^2} + \frac{y^2}{(3z)^2}=1</m>.
+          We can let <m>z=v</m>, for
+          <m>-2\leq v\leq 3</m> and then parametrize the above ellipses using sines,
+          cosines and <m>v</m>.
+        </p>
 
         <p>
           We can parametrize the <m>x</m> component of our surface with
@@ -1226,7 +1219,7 @@
           3Dcoo=0.0026521924883127213 4.370458126068115 12.347787857055664,
           3Droo=399.9999637774216,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_parsurf6b_3D">
+          <image xml:id="img_parsurf6b_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -1311,49 +1304,15 @@
     </example>
 
     <example xml:id="ex_parsurf7">
-      <title>parametrizing an ellipsoid</title>
+      <title>Parametrizing an ellipsoid</title>
       <statement>
         <p>
           Find a parametrization of the ellipsoid
           <m>\frac{x^2}{25}+y^2+\frac{z^2}{4}=1</m> as shown in <xref ref="fig_parsurf7a_3D">Figure</xref>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Recall <xref ref="idea_unit_vectors">Key Idea</xref>
-          from <xref ref="sec_vector_intro">Section</xref>,
-          which states that all unit vectors in space have the form
-          <m>\langle \sin\theta\cos\varphi,\sin\theta\sin\varphi,\cos\theta\rangle</m> for some angles <m>\theta</m> and <m>\varphi</m>.
-          If we choose our angles appropriately,
-          this allows us to draw the unit sphere.
-          To get an ellipsoid,
-          we need only scale each component of the sphere appropriately.
-        </p>
-
-        <p>
-          The <m>x</m>-radius of the given ellipsoid is 5, the <m>y</m>-radius is 1 and the <m>z</m>-radius is 2.
-          Substituting <m>u</m> for <m>\theta</m> and <m>v</m> for <m>\varphi</m>,
-          we have <m>\vec r(u,v) = \langle 5\sin u\cos v, \sin u\sin v,2\cos u\rangle</m>,
-          where we still need to determine the ranges of <m>u</m> and <m>v</m>.
-        </p>
-
-        <p>
-          Note how the <m>x</m> and <m>y</m> components of <m>\vec r</m> have <m>\cos v</m> and <m>\sin v</m> terms,
-          respectively.
-          This hints at the fact that ellipses are drawn parallel to the <m>x</m>-<m>y</m> plane as <m>v</m> varies,
-          which implies we should have <m>v</m> range from <m>0</m> to <m>2\pi</m>.
-        </p>
-
-        <p>
-          One may be tempted to let <m>0\leq u\leq 2\pi</m> as well,
-          but note how the <m>z</m> component is <m>2\cos u</m>.
-          We only need <m>\cos u</m> to take on values between <m>-1</m> and <m>1</m> once,
-          therefore we can restrict <m>u</m> to <m>0\leq u\leq \pi</m>.
-        </p>
-
         <figure xml:id="fig_parsurf7">
           <caption>An ellipsoid in (a), drawn again in (b) with its domain restricted, as described in  <xref ref="ex_parsurf7">Example</xref>.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_parsurf7a_3D">
               <caption/>
               <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1520,6 +1479,39 @@
           </sidebyside>
 
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Recall <xref ref="idea_unit_vectors">Key Idea</xref>
+          from <xref ref="sec_vector_intro">Section</xref>,
+          which states that all unit vectors in space have the form
+          <m>\langle \sin\theta\cos\varphi,\sin\theta\sin\varphi,\cos\theta\rangle</m> for some angles <m>\theta</m> and <m>\varphi</m>.
+          If we choose our angles appropriately,
+          this allows us to draw the unit sphere.
+          To get an ellipsoid,
+          we need only scale each component of the sphere appropriately.
+        </p>
+
+        <p>
+          The <m>x</m>-radius of the given ellipsoid is 5, the <m>y</m>-radius is 1 and the <m>z</m>-radius is 2.
+          Substituting <m>u</m> for <m>\theta</m> and <m>v</m> for <m>\varphi</m>,
+          we have <m>\vec r(u,v) = \langle 5\sin u\cos v, \sin u\sin v,2\cos u\rangle</m>,
+          where we still need to determine the ranges of <m>u</m> and <m>v</m>.
+        </p>
+
+        <p>
+          Note how the <m>x</m> and <m>y</m> components of <m>\vec r</m> have <m>\cos v</m> and <m>\sin v</m> terms,
+          respectively.
+          This hints at the fact that ellipses are drawn parallel to the <m>x</m>-<m>y</m> plane as <m>v</m> varies,
+          which implies we should have <m>v</m> range from <m>0</m> to <m>2\pi</m>.
+        </p>
+
+        <p>
+          One may be tempted to let <m>0\leq u\leq 2\pi</m> as well,
+          but note how the <m>z</m> component is <m>2\cos u</m>.
+          We only need <m>\cos u</m> to take on values between <m>-1</m> and <m>1</m> once,
+          therefore we can restrict <m>u</m> to <m>0\leq u\leq \pi</m>.
+        </p>
 
         <p>
           The final parametrization is thus
@@ -1552,17 +1544,17 @@
       Because technology is often readily available,
       it is often a good idea to check one's work by graphing a parametrization of a surface to check if it indeed represents what it was intended to.
     </p>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Surface Area</title>
     <p>
-      It will become important in the following sections to be able to compute the surface area of a surface <m>\surfaceS</m>given a smooth parametrization <m>\vec r(u,v)</m>,
+      It will become important in the following sections to be able to compute the surface area of a surface <m>\surfaceS</m> given a smooth parametrization <m>\vec r(u,v)</m>,
       <m>a\leq u\leq b</m>, <m>c\leq v\leq d</m>.
       Following the principles given in the integration review at the beginning of this chapter,
       we can say that<idx><h>surface area</h><h>of parametrized surface</h></idx>
       <me>
-        \text{ Surface Area of \surfaceS } =S = \iint_{\surfaceS}\, dS
+        \text{ Surface Area of }\surfaceS\, =S = \iint_{\surfaceS}\, dS
       </me>,
       where <m>dS</m> represents a small amount of surface area.
       That is, to compute total surface area <m>S</m>,
@@ -1611,7 +1603,7 @@
 
     <figure xml:id="fig_parsurfarea">
       <caption>Illustrating the process of finding surface area by approximating with planes.</caption>
-      <sidebyside>
+      <sidebyside widths="33% 33% 33%">
         <figure xml:id="fig_parsurfareaa">
           <caption/>
           <image xml:id="img_parsurfareaa">
@@ -1629,6 +1621,8 @@
               extra y tick labels={$c$,$d$,$v_0$,$v_0+\Delta v$},
               ymin=-.1,ymax=2.5,
               xmin=-.1,xmax=2.5,
+              xlabel={$u$},
+              ylabel={$v$}
             ]
 
             \filldraw [thick,draw=firstcolor,fill=firstcolor!15] (axis cs: .5,.1) -- (axis cs: .5,2) -- (axis cs: 2.25,2)  -- (axis cs: 2.25,.1) -- cycle;
@@ -1648,8 +1642,6 @@
 
             \end{axis}
 
-            \node [right] at (myplot.right of origin) {\scriptsize $u$};
-            \node [above] at (myplot.above origin) {\scriptsize $v$};
 
             \end{tikzpicture}
 
@@ -1972,7 +1964,7 @@
       If we repeat this approximation process for each rectangle in the partition of <m>R</m>,
       we can sum the areas of all the parallelograms to get an approximation of the surface area <m>S</m>:
       <me>
-        \text{ Surface area of \surfaceS }  =S \approx \sum_{j=1}^n\sum_{i=1}^n \snorm{\vec u_{i,j}\times \vec v_{i,j}}
+        \text{ Surface area of } \surfaceS \,  =S \approx \sum_{j=1}^n\sum_{i=1}^n \snorm{\vec u_{i,j}\times \vec v_{i,j}}
       </me>,
       where <m>\vec u_{i,j} = \vec r(u_i+\Delta u,v_j) - \vec r(u_i,v_j)</m> and <m>\vec v_{i,j} = \vec r(u_i,v_j+\Delta v)-\vec r(u_i,v_j)</m>.
     </p>
@@ -2004,7 +1996,7 @@
 
     <p>
       (This limit process also demonstrates that <m>\vec r_u(u,v)</m> and
-      <m>\vec r_v(u,v)</m> are tangent to the surface <m>\surfaceS</m>at <m>\vec r(u,v)</m>.
+      <m>\vec r_v(u,v)</m> are tangent to the surface <m>\surfaceS</m> at <m>\vec r(u,v)</m>.
       We don't need this fact now, but it will be important in the next section.)
     </p>
 
@@ -2019,7 +2011,7 @@
       <title>Surface Area of Parametrically Defined Surfaces</title>
       <statement>
         <p>
-          Let <m>\vec r(u,v)</m> be a smooth parametrization of a surface <m>\surfaceS</m>over a closed,
+          Let <m>\vec r(u,v)</m> be a smooth parametrization of a surface <m>\surfaceS</m> over a closed,
           bounded region <m>R</m> of the <m>u</m>-<m>v</m> plane.
               <idx><h>surface area</h><h>of parametrized surface</h></idx>
           <ul>
@@ -2032,7 +2024,7 @@
 
             <li>
               <p>
-                The surface area <m>S</m> of <m>\surfaceS</m>is
+                The surface area <m>S</m> of <m>\surfaceS</m> is
                 <me>
                   S = \iint_\surfaceS\, dS = \iint_R \snorm{\vec r_u\times \vec r_v}\, dA
                 </me>.
@@ -2291,7 +2283,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a surface <m>\surfaceS</m> in space is described that cannot be defined in terms of a function <m>z=f(x,y)</m>.
+          a surface <m>\surfaceS</m> in space is described that cannot be defined as the graph of a function <m>f(x,y)</m>.
           Give a parametrization of <m>\surfaceS</m>.
         </p>
       </introduction>
@@ -2299,7 +2291,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the rectangle in space with corners at <m>(0,0,0)</m>,
+            <m>\surfaceS</m> is the rectangle in space with corners at <m>(0,0,0)</m>,
             <m>(0,2,0)</m>,
             <m>(0,2,1)</m> and <m>(0,0,1)</m>.
           </p>
@@ -2315,7 +2307,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the triangle in space with corners at <m>(1,0,0)</m>,
+            <m>\surfaceS</m> is the triangle in space with corners at <m>(1,0,0)</m>,
             <m>(1,0,1)</m> and <m>(0,0,1)</m>.
           </p>
         </statement>
@@ -2330,7 +2322,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the ellipsoid <m>\ds\frac{x^2}{9} + \frac{y^2}{4}+\frac{z^2}{16} = 1</m>.
+            <m>\surfaceS</m> is the ellipsoid <m>\ds\frac{x^2}{9} + \frac{y^2}{4}+\frac{z^2}{16} = 1</m>.
           </p>
         </statement>
         <answer>
@@ -2344,7 +2336,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the elliptic cone <m>\ds y^2= x^2+\frac{z^2}{16}</m>,
+            <m>\surfaceS</m> is the elliptic cone <m>\ds y^2= x^2+\frac{z^2}{16}</m>,
             for <m>-1 \leq y \leq 5</m>.
           </p>
         </statement>
@@ -3518,7 +3510,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=2x+3y</m> over the rectangle
+            <m>\surfaceS</m> is the plane <m>z=2x+3y</m> over the rectangle
             <m>-1\leq x\leq 1</m>, <m>2\leq v \leq 3</m>.
           </p>
         </statement>
@@ -3532,7 +3524,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=x+2y</m> over the triangle with vertices at <m>(0,0)</m>,
+            <m>\surfaceS</m> is the plane <m>z=x+2y</m> over the triangle with vertices at <m>(0,0)</m>,
             <m>(1,0)</m> and <m>(0,1)</m>.
           </p>
         </statement>
@@ -3546,7 +3538,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=x+y</m> over the circular disk,
+            <m>\surfaceS</m> is the plane <m>z=x+y</m> over the circular disk,
             centered at the origin, with radius 2.
           </p>
         </statement>
@@ -3560,7 +3552,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=x+y</m> over the annulus bounded by the circles,
+            <m>\surfaceS</m> is the plane <m>z=x+y</m> over the annulus bounded by the circles,
             centered at the origin, with radius 1 and radius 2.
           </p>
         </statement>
@@ -3583,7 +3575,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the paraboloid
+            <m>\surfaceS</m> is the paraboloid
             <m>z=x^2+y^2</m> over the circular disk of radius 3 centered at the origin.
           </p>
         </statement>
@@ -3597,7 +3589,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the paraboloid
+            <m>\surfaceS</m> is the paraboloid
             <m>z=x^2+y^2</m> over the triangle with vertices at <m>(0,0)</m>,
             <m>(0,1)</m> and <m>(1,1)</m>.
           </p>
@@ -3612,7 +3604,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>z=5x-y</m> over the region enclosed by the parabola <m>y=1-x^2</m> and the <m>x</m>-axis.
+            <m>\surfaceS</m> is the plane <m>z=5x-y</m> over the region enclosed by the parabola <m>y=1-x^2</m> and the <m>x</m>-axis.
           </p>
         </statement>
         <answer>
@@ -3625,7 +3617,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the hyperbolic paraboloid
+            <m>\surfaceS</m> is the hyperbolic paraboloid
             <m>z=x^2-y^2</m> over the circular disk of radius 1 centered at the origin.
           </p>
         </statement>

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -21,12 +21,12 @@
   <subsection xml:id="subsec-first-partial">
     <title>First-order partial derivatives</title>
     <p>
-      Consider the function <m>z=f(x,y) = x^2+2y^2</m>,
+      Consider the function <m>f(x,y) = x^2+2y^2</m>,
       as graphed in <xref ref="fig_partialintroa_3D">Figure</xref>.
       By fixing <m>y=2</m>,
       we focus our attention to all points on the surface where the <m>y</m>-value is 2, shown in both <xref ref="fig_partialintroa_3D">Figure</xref> and <xref ref="fig_partialintrob_3D">Figure</xref>.
-      These points form a curve in space:
-      <m>z = f(x,2) = x^2+8</m> which is a function of just one variable.
+      These points form a curve in the plane <m>y=2</m>:
+      <m>z = f(x,2) = x^2+8</m> which defines <m>z</m> as a function of just one variable.
       We can take the derivative of <m>z</m> with respect to <m>x</m> along this curve and find equations of tangent lines, etc.
     </p>
 
@@ -406,6 +406,11 @@
       </solution>
     </example>
 
+    <!-- <figure xml:id="vid-multi-partial-examples">
+      <caption>Additional partial derivative computation examples</caption>
+      <video youtube="R3PXGwjOmtw"/> -->
+    </figure>
+
     <p>
       We have shown <em>how</em> to compute a partial derivative,
       but it may still not be clear what a partial derivative <em>means</em>.
@@ -696,11 +701,105 @@
         </p>
       </solution>
     </example>
+  </subsection>
 
-    <!-- <figure xml:id="vid-multi-partial-examples">
-      <caption>Additional partial derivative computation examples</caption>
-      <video youtube="R3PXGwjOmtw"/>
-    </figure> -->
+  <subsection xml:id="subsec-tangent-plane">
+    <title>Tangent Planes</title>
+    <p>
+      Another way to interpret partial derivatives is in terms of the <em>tangent plane</em>.
+      Consider a graph <m>z=f(x,y)</m>, such as the one in <xref ref="fig_partialintro">Figure</xref>.
+      Setting <m>x=a</m>, <m>y=b</m> defines a point <m>(a,b,f(a,b))</m> on the graph.
+      Through the point <m>(a,b)</m>, we have the lines <m>x=a+s, y=b</m>, and <m>x=a, y=b+t</m>,
+      parallel to the <m>x</m> and <m>y</m> axes, respectively (where <m>s,t</m> are parameters).
+    </p>
+
+    <p>
+      Using the function <m>f(x,y)</m> we define two vector-valued functions:
+      <md>
+        <mrow>\vec{r}_1(s) \amp = \la a+s, b, f(a+s,b)\ra</mrow>
+        <mrow>\vec{r}_2(t) \amp = \la a, b+t, f(a,b+t)\ra</mrow>
+      </md>.
+      Both vector-valued functions define space curves that lie on the surface <m>z=f(x,y)</m>,
+      and these curves intersect at the point <m>(a,b,f(a,b))</m>.
+    </p>
+
+    <p>
+      Notice that in <m>\vec{r}_1(s)</m>, we vary <m>x</m> while holding <m>y</m> constant.
+      Using <xref ref="def_partial_derivative">Definition</xref>, we see that
+      <me>
+        \vec{v}=\vec{r}_1'(0) = \la 1,0,f_x(a,b)\ra
+      </me>,
+      and similarly,
+      <me>
+        \vec{w}=\vec{r}_2'(0) = \la 0,1,f_y(a,b)\ra
+      </me>.
+      From <xref ref="sec_vvf_calc">Section</xref>,
+      we know that <m>\vec{r}_1'(0)</m> defines a tangent vector to the curve <m>\vec{r}_1(s)</m> when <m>s=0</m>,
+      and similarly, <m>\vec{r}_2'(0)</m> defines a tangent vector to the curve <m>\vec{r}_2(t)</m> when <m>t=0</m>.
+    </p>
+
+    <p>
+      It seems reasonable that any vector that is tangent to these curves,
+      which lie on our surface, should also be considered tangent to that surface.
+      The vectors <m>\vec{v}</m> and <m>\vec{w}</m> are therefore tangent to <m>z=f(x,y)</m> at <m>(a,b,f(a,b))</m>,
+      and they are definitely not parallel.
+      From <xref ref="sec_planes">Section</xref> we know that any two non-parallel vectors at a point define a plane through that point.
+      We also know that taking the cross product of these two vectors gives us a normal vector:
+      the cross product gives us
+      <me>
+        \vec{n}=\vec{r}_1'(0)\times\vec{r}_2'(0)=\la -f_x(a,b), -f_y(a,b), 1\ra
+      </me>.
+    </p>
+
+    <p>
+      The equation of the plane through <m>(a,b,f(a,b))</m> with normal vector <m>\vec{n}=\la -f_x(a,b),-f_y(a,b),1\ra</m> is
+      <me>
+        -f_x(a,b)(x-a)-f_y(a,b)(y-b)+(z-f(a,b))=0
+      </me>.
+      It is customary to solve for <m>z</m> in this equation and make the following definition.
+    </p>
+
+    <definition xml:id="def-tangent-plane">
+      <statement>
+        <p>
+          Let <m>f(x,y)</m> be a function whose first-order partial derivatives exist at <m>(a,b)</m>.
+          The <term>tangent plane</term> to the graph <m>z=f(x,y)</m> at the point <m>(a,b,f(a,b))</m> is the plane defined by the equation
+          <me>
+            z = f(a,b)+f_x(a,b)(x-a)+f_y(a,b)(y-b)
+          </me>.
+          <idx><h>tangent plane</h></idx>
+          <idx><h>tangent plane</h><h>to a graph</h></idx>
+        </p>
+      </statement>
+    </definition>
+
+    <example>
+      <title>Finding a tangent plane equation</title>
+      <statement>
+        <p>
+          Find the equation of tangent plane to the surface <m>z=x^2+3y^2</m> when <m>(x,y)=(1,-1)</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Our function is <m>f(x,y)=x^2+3y^2</m>, and we have <m>f(1,-1)=4</m>,
+          so the point on the surface is <m>(1,-1,4)</m>.
+          The partial derivatives are <m>f_x(x,y)=2x</m> and <m>f_y(x,y)=6y</m>,
+          so <m>f_x(1,-1)=2</m>, <m>f_y(1,-1)=-6</m>, and our plane is given by
+          <me>
+            z = 4+2(x-1)-6(y+1)
+          </me>.
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      Notice the similarity between the tangent plane equation in <xref ref="def-tangent-plane"/>
+      and the single variable tangent line equation <m>y = f(c)+f'(c)(x-c)</m>.
+      As with functions of one variable, this suggests a connection between derivatives and linear approximation.
+      We explore this connection in <xref ref="sec_total_differential"/>,
+      where we'll see that <xref ref="def-tangent-plane"/> should be strengthed to require that the partial derivatives of <m>f</m> be <em>continuous</em>.
+    </p>
   </subsection>
 
   <subsection xml:id="subsec-second-partial">
@@ -1494,7 +1593,7 @@
             </pg-code> -->
             <statement>
               <p>
-                Given a function <m>z=f(x,y)</m>,
+                Given a function <m>f(x,y)</m>,
                 explain in your own words how to compute <m>f_x</m>.
               </p>
             </statement>
@@ -2308,7 +2407,7 @@
       <introduction>
         <p>
           In the following exercises,
-          form a function <m>z=f(x,y)</m> such that <m>f_x</m> and <m>f_y</m> match those given.
+          form a function <m>f(x,y)</m> such that <m>f_x</m> and <m>f_y</m> match those given.
         </p>
       </introduction>
 

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -195,7 +195,7 @@
     </p>
 
     <example xml:id="ex_planes1">
-      <title>Finding the equation of a plane.</title>
+      <title>Finding the equation of a plane</title>
       <statement>
         <p>
           Write the equation of the plane that passes through the points <m>P=(1,1,0)</m>,
@@ -351,7 +351,7 @@
     </p>
 
     <example xml:id="ex_planes2">
-      <title>Finding the equation of a plane.</title>
+      <title>Finding the equation of a plane</title>
       <statement>
         <p>
           Verify that lines <m>\ell_1</m> and <m>\ell_2</m>,
@@ -1125,12 +1125,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 In order to find the equation of a plane,
@@ -1146,12 +1144,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 What is the relationship between a plane and one of its normal vectors?
@@ -1175,12 +1171,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 <m>2x-4y+7z=2</m>
@@ -1195,9 +1189,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               $points=List("(-2,9,0),(2,9,3)");
@@ -1234,7 +1226,7 @@
                 return ($score,@errors);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 List any two points in the plane with equation <m>3(x+2)+5(y-9)-4z=0</m>.
@@ -1248,12 +1240,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 <m>x=2</m>
@@ -1268,9 +1258,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               $points=List("(0,-2,6),(1,-2,6)");
@@ -1307,7 +1295,7 @@
                 return ($score,@errors);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 List any two points in the plane with equation <m>4(y+2)-(z-6)=0</m>.
@@ -1331,12 +1319,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Passes through <m>(2,3,4)</m> and has normal vector
@@ -1359,8 +1345,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               sub grouped {
                 my $op = shift;
@@ -1400,7 +1385,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane passes through <m>(1,3,5)</m> and has normal vector <m>\vec n= \la 0,2,4\ra</m>.
@@ -1418,12 +1403,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Passes through the points <m>(1,2,3)</m>,
@@ -1447,9 +1430,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1490,7 +1471,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane passes through the points <m>(5,3,8)</m>,
@@ -1509,12 +1490,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Contains the intersecting lines
@@ -1545,9 +1524,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1588,7 +1565,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the intersecting lines
@@ -1607,12 +1584,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Contains the parallel lines
@@ -1643,9 +1618,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1686,7 +1659,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the parallel lines
@@ -1705,12 +1678,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 Contains the point <m>(2,-6,1)</m> and the line
@@ -1740,9 +1711,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1783,7 +1752,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(5,7,3)</m> and the line <m>\vec\ell(t) = \begin{cases}x\amp=t\\y\amp=t\\z\amp=t\end{cases}</m>.
@@ -1801,9 +1770,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1844,7 +1811,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(5,7,3)</m> and is orthogonal to the line <m>\vec\ell(t) = \la 4,5,6\ra+ t\la 1,1,1\ra</m>.
@@ -1862,9 +1829,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1905,7 +1870,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(4,1,1)</m> and is orthogonal to the line <m>\begin{cases}x\amp=4+4t\\y\amp=1+t\\z\amp=1+t\end{cases}</m>.
@@ -1923,9 +1888,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -1966,7 +1929,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point
@@ -1985,9 +1948,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               sub grouped {
@@ -2028,7 +1989,7 @@
                 return $correct == $student;
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 A plane contains the point <m>(1,2,3)</m> and is parallel to the plane <m>x=5</m>.
@@ -2056,12 +2017,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 <m>p1:\ 3 (x - 2) + (y - 1) + 4 z=0</m>, and
@@ -2087,9 +2046,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->variables->are(t=>"Real");
@@ -2103,7 +2060,7 @@
                 return ($par and $tch);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the line
@@ -2130,12 +2087,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 line: <m>\la 5,1,-1\ra + t\la 2,2,1\ra</m>,
@@ -2154,15 +2109,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add('the entire line'=>{});
               $point=Point("(3,1,1)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the point of intersection between the line
@@ -2180,12 +2133,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 line: <m>\la 1,2,3\ra + t\la 3,5,-1\ra</m>,
@@ -2204,15 +2155,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Point");
               Context()->strings->add('the entire line'=>{});
               $point=Compute('the entire line');
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the point of intersection between the line
@@ -2239,12 +2188,10 @@
       </introduction>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 The distance from the point <m>(1,2,3)</m> to the plane
@@ -2263,14 +2210,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("8/sqrt(21)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance from the point <m>(2,6,2)</m> to the plane <m>2(x-1)-y+4(z+1)=0</m>.
@@ -2284,12 +2229,10 @@
       </exercise>
 
       <exercise>
-        <!--<webwork seed="1">
-            <setup>
-
+        <!--<webwork>
             <pg-code>
             </pg-code>
-            </setup>-->
+            -->
             <statement>
               <p>
                 The distance between the parallel planes
@@ -2312,14 +2255,12 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $distance=Formula("3");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the distance between the parallel planes
@@ -2336,12 +2277,10 @@
     </exercisegroup>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
           </pg-code>
-          </setup>-->
+          -->
           <statement>
             <p>
               Show why if the point <m>Q</m> lies in a plane,
@@ -2361,12 +2300,10 @@
     </exercise>
 
     <exercise>
-      <!--<webwork seed="1">
-          <setup>
-
+      <!--<webwork>
           <pg-code>
           </pg-code>
-          </setup>-->
+          -->
           <statement>
             <p>
               How is <xref ref="x10_05_ex_30">Exercise</xref>

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -395,10 +395,10 @@
   <subsection>
     <title>Spheres</title>
     <p>
-          <idx><h>sphere</h></idx>
       Just as a circle is the set of all points in the <em>plane</em> equidistant from a given point (its center), a sphere is the set of all points in <em>space</em> that are equidistant from a given point.
       <xref ref="def_space_distance">Definition</xref>
       allows us to write an equation of the sphere.
+      <idx><h>sphere</h></idx>
     </p>
 
     <p>
@@ -2433,7 +2433,7 @@
       3Dlights=Headlamp,add3Djscript=asylabels.js]
        -->
       <!-- START figures/figquadric_parb_3D.asy -->
-      <image xml:id="img_quadric1">
+      <image xml:id="img_quadric1" width="47%">
         <description></description>
         <asymptote>
 
@@ -2564,7 +2564,9 @@
       <dl>
         <li>
           <title>Elliptic Paraboloid</title>
-          <m>z=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          <p>
+            <m>z=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -2782,7 +2784,9 @@
       <dl>
         <li>
           <title>Elliptic Cone</title>
-          <m>z^2=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          <p>
+            <m>z^2=\frac{x^2}{a^2}+\frac{y^2}{b^2}</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3102,7 +3106,9 @@
       <dl>
         <li>
           <title>Ellipsoid</title>
-          <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}+\frac{z^2}{c^2}=1</m>
+          <p>
+            <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}+\frac{z^2}{c^2}=1</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3336,7 +3342,9 @@
       <dl>
         <li>
           <title>Hyperboloid of One Sheet</title>
-          <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}-\frac{z^2}{c^2}=1</m>
+          <p>
+            <m>\frac{x^2}{a^2}+\frac{y^2}{b^2}-\frac{z^2}{c^2}=1</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3578,7 +3586,9 @@
       <dl>
         <li>
           <title>Hyperboloid of Two Sheets</title>
-          <m>\frac{z^2}{c^2}-\frac{x^2}{a^2}-\frac{y^2}{b^2}=1</m>
+          <p>
+            <m>\frac{z^2}{c^2}-\frac{x^2}{a^2}-\frac{y^2}{b^2}=1</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -3836,7 +3846,9 @@
       <dl>
         <li>
           <title>Hyperbolic Paraboloid</title>
-          <m>z=\frac{x^2}{a^2}-\frac{y^2}{b^2}</m>
+          <p>
+            <m>z=\frac{x^2}{a^2}-\frac{y^2}{b^2}</m>
+          </p>
         </li>
       </dl>
     </p>
@@ -5022,12 +5034,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 Axes drawn in space must conform to the <fillin/> <fillin/> rule.
@@ -5042,10 +5051,8 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
+        <webwork>
             <!-- <pg-macros><macro-file>contextArbitraryString.pl</macro-file></pg-macros> -->
-            <setup>
-
 
             <pg-code>
               Context("ArbitraryString");
@@ -5066,7 +5073,7 @@
                 return uc($correct) eq uc($student);
               });
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 In the plane,
@@ -5081,12 +5088,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 In the plane, the equation <m>y=x^2</m> defines a <fillin/>;
@@ -5102,13 +5106,11 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               $surfaces=PopUp(['?','Elliptic Paraboloid','Elliptic Cone','Ellipsoid','Hyperboloid of One Sheet','Hyperboloid of Two Sheets','Hyperbolic Paraboloid'],6);
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Which quadric surface looks like a Pringles<!--<trademark/>-->(TM)<nbsp/>chip?
@@ -5119,12 +5121,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 Consider the hyperbola <m>x^2-y^2=1</m> in the plane.
@@ -5141,12 +5140,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 Consider the hyperbola <m>x^2-y^2=1</m> in the plane.
@@ -5165,8 +5161,7 @@
     </exercisegroup>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
+      <webwork>
           <pg-code>
             Context("Point");
             $A=Point("(1,4,2)");
@@ -5186,7 +5181,7 @@
             $dodonot=(($a)**2+($b)**2==($c)**2)?'do':'do not';
             $yn=PopUp(['?','do','do not'],$dodonot);
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               The points <m>A=(1,4,2)</m>,
@@ -5222,11 +5217,9 @@
     </exercise>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
+      <!-- <webwork>
           <pg-code>
-          </pg-code>
-          </setup> -->
+          </pg-code> -->
           <statement>
             <p>
               The points <m>A=(1,1,3)</m>, <m>B=(3,2,7)</m>,
@@ -5245,14 +5238,13 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
+      <webwork>
           <pg-code>
             Context("Point");
             $center=Point("(4,-1,0)");
             $radius=Real("3");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the center and radius of the sphere defined by
@@ -5273,15 +5265,14 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
+      <webwork>
           <pg-code>
             Context("Point");
             $center=Point("(-2,1,2)");
             Context()->flags->set(reduceConstantFunctions=>0);
             $radius=Formula("sqrt(5)");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the center and radius of the sphere defined by
@@ -5311,12 +5302,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>x^2+y^2+z^2\lt 1</m>
@@ -5331,12 +5319,10 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 <m>0\leq x\leq 3</m>
@@ -5353,12 +5339,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>x\geq 0,\ y\geq0, \ z\geq0</m>
@@ -5376,12 +5359,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>y\geq 3</m>
@@ -5409,12 +5389,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>z=x^3</m>
@@ -5534,12 +5511,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>y=\cos(z)</m>
@@ -5641,12 +5615,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds \frac{x^2}{4}+\frac{y^2}{9}=1</m>
@@ -5759,12 +5730,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds y=\frac1x</m>
@@ -5895,15 +5863,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("x^2+z^2=(1/(1+y^2))^2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving
@@ -5918,15 +5884,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("y^2+z^2=x^4");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving <m>y=x^2</m> in the <m>xy</m>-plane about the <m>x</m>-axis.
@@ -5940,15 +5904,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("x^2+y^2=z");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving <m>z=x^2</m> in the <m>xz</m>-plane about the <m>z</m>-axis.
@@ -5962,15 +5924,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("ImplicitEquation");
               Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
               $eq=ImplicitEquation("x^2+y^2=1/z^2");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Give the equation of the surface formed by revolving <m>z=1/x</m> in the <m>xz</m>-plane about the <m>z</m>-axis.
@@ -5994,12 +5954,9 @@
       </introduction>
       <!--TODO: probably should use an ordered list for the two options in each problem here.-->
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6098,12 +6055,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6209,12 +6163,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6313,12 +6264,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <sidebyside width="47%">
               <!--
@@ -6433,12 +6381,9 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds z-y^2+x^2=0</m>
@@ -6527,12 +6472,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds z^2=x^2+\frac{y^2}4</m>
@@ -6620,12 +6562,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>x=-y^2-z^2</m>
@@ -6713,12 +6652,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds 16x^2-16y^2-16z^2=1</m>
@@ -6813,12 +6749,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds \frac{x^2}9-y^2+\frac{z^2}{25}=1</m>
@@ -6906,12 +6839,9 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
-            </pg-code>
-            </setup> -->
+            </pg-code> -->
             <statement>
               <p>
                 <m>\ds 4x^2+2y^2+z^2=4</m>

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -27,7 +27,7 @@
       <statement>
         <p>
           Let <m>D</m> be a closed domain in space whose boundary is an orientable,
-          piecewise smooth surface <m>\surfaceS</m>with outer unit normal vector <m>\vec n</m>,
+          piecewise smooth surface <m>\surfaceS</m> with outer unit normal vector <m>\vec n</m>,
           and let <m>\vec F</m> be a vector field whose components are differentiable on <m>D</m>.
           Then<idx><h>Divergence Theorem</h><h>in space</h></idx>
           <me>
@@ -53,7 +53,7 @@
           Let <m>D</m> be the domain in space bounded by the planes <m>z=0</m> and <m>z=2x</m>,
           along with the cylinder <m>x=1-y^2</m>,
           as graphed in <xref ref="fig_divthm_space2">Figure</xref>,
-          let <m>\surfaceS</m>be the boundary of <m>D</m>,
+          let <m>\surfaceS</m> be the boundary of <m>D</m>,
           and let <m>\vec F = \langle x+y,y^2, 2z\rangle</m>.
         </p>
 
@@ -66,7 +66,7 @@
           3Dcoo=-4.848384857177734 2.0102698802948 61.921504974365234,
           3Droo=399.9999594035934,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_divthm_space2_3D">
+          <image xml:id="img_divthm_space2_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -140,7 +140,7 @@
       </statement>
       <solution>
         <p>
-          The surface <m>\surfaceS</m>is piecewise smooth,
+          The surface <m>\surfaceS</m> is piecewise smooth,
           comprising surfaces <m>\surfaceS_1</m>,
           which is part of the plane <m>z=2x</m>,
           surface <m>\surfaceS_2</m>, which is part of the cylinder <m>x=1-y^2</m>,
@@ -187,7 +187,7 @@
           meaning <em>to the outside</em>, of <m>\surfaceS</m>.)
           The flux across <m>\surfaceS_1</m> is:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_1\): }  \amp = \iint_{\surfaceS_1} \vec F\cdot \vec n_1\, dS</mrow>
+            <mrow>\text{ Flux across }\surfaceS_1:\,   \amp = \iint_{\surfaceS_1} \vec F\cdot \vec n_1\, dS</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \vec F\big(\vec r_1(u,v)\big)\cdot \big(\vec r_{1v}\times\vec r_{1u}\big)\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \la v(1-u^2)+u, u^2,4v(1-u^2)\ra \cdot \la 2(u^2-1),0,1-u^2\ra\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \big(2u^4v+2u^3-4u^2v-2u+2v\big)\, du\, dv</mrow>
@@ -202,7 +202,7 @@
           meaning this vector points outside <m>\surfaceS</m>.)
           The flux across <m>\surfaceS_2</m> is:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_2\): }  \amp = \iint_{\surfaceS_2} \vec F\cdot \vec n_2\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_2:\,  \amp = \iint_{\surfaceS_2} \vec F\cdot \vec n_2\, dS</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \vec F\big(\vec r_2(u,v)\big)\cdot \big(\vec r_{2u}\times\vec r_{2v}\big)\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \la 1-u^2+u, u^2, 4v(1-u^2)\ra \cdot \la 2(1-u^2), 4u(1-u^2),0\ra\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \big(4u^5-2u^4-2u^3+4u^2-2u-2\big)\, du\, dv</mrow>
@@ -217,7 +217,7 @@
           meaning this vector points down, outside of <m>\surfaceS</m>.)
           The flux across <m>\surfaceS_3</m> is:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_3\): }  \amp = \iint_{\surfaceS_3} \vec F\cdot \vec n_3\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_3:\,  \amp = \iint_{\surfaceS_3} \vec F\cdot \vec n_3\, dS</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \vec F\big(\vec r_3(u,v)\big)\cdot \big(\vec r_{3u}\times\vec r_{3v}\big)\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 \la v(1-u^2)+u,u^2,0\ra \cdot \la 0,0,u^2-1\ra\, du\, dv</mrow>
             <mrow>\amp = \int_0^1\int_{-1}^1 0\, du\, dv</mrow>
@@ -243,7 +243,7 @@
 
         <p>
           With <m>\divv \vec F = 1+2y+2 = 2y+3</m>,
-          we find the total outward flux of <m>\vec F</m> over <m>\surfaceS</m>as:
+          we find the total outward flux of <m>\vec F</m> over <m>\surfaceS</m> as:
           <me>
             \text{ Flux = }  \iiint_D\divv \vec F\, dV = \int_{-1}^1\int_0^{1-y^2}\int_0^{2x}\big(2y+3\big)\, dz\, dx\, dy = 16/5
           </me>,
@@ -257,7 +257,7 @@
       we see that the total outward flux of a vector field across a closed surface can be found two different ways because of the Divergence Theorem.
       One computation took far less work to obtain.
       In that particular case,
-      since <m>\surfaceS</m>was comprised of three separate surfaces,
+      since <m>\surfaceS</m> was comprised of three separate surfaces,
       it was far simpler to compute one triple integral than three surface integrals
       (each of which required partial derivatives and a cross product).
       In practice, if outward flux needs to be measured,
@@ -273,7 +273,7 @@
       <title>Using the Divergence Theorem in space</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be the surface formed by the paraboloid <m>z=1-x^2-y^2</m>,
+          Let <m>\surfaceS</m> be the surface formed by the paraboloid <m>z=1-x^2-y^2</m>,
           <m>z\geq 0</m>,
           and the unit disk centered at the origin in the <m>x</m>-<m>y</m> plane,
           graphed in <xref ref="fig_divthm_space1">Figure</xref>,
@@ -290,7 +290,7 @@
           3Dcoo=-4.848384857177734 2.0102698802948 61.921504974365234,
           3Droo=399.9999594035934,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_divthm_space1_3D">
+          <image xml:id="img_divthm_space1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -348,14 +348,14 @@
 
         <p>
           Verify the Divergence Theorem;
-          find the total outward flux across <m>\surfaceS</m>and evaluate the triple integral of <m>\divv \vec F</m>,
+          find the total outward flux across <m>\surfaceS</m> and evaluate the triple integral of <m>\divv \vec F</m>,
           showing that these two quantities are equal.
         </p>
       </statement>
       <solution>
         <p>
-          We find the flux across <m>\surfaceS</m>first.
-          As <m>\surfaceS</m>is piecewise<ndash/>smooth,
+          We find the flux across <m>\surfaceS</m> first.
+          As <m>\surfaceS</m> is piecewise<ndash/>smooth,
           we decompose it into smooth components <m>\surfaceS_1</m>,
           the disk,
           and <m>\surfaceS_2</m>, the paraboloid,
@@ -442,15 +442,6 @@
           etc., as shown in <xref ref="fig_divthm_space3">Figure</xref>).
           Find the flux across the six faces of the cube and compare this to <m>\iint_D \divv\vec F\, dV</m>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          Let <m>\surfaceS_1</m> be the <q>top</q> face of the cube,
-          which can be parametrized by <m>\vec r(u,v) = \langle u,v,a\rangle</m> for
-          <m>-a\leq u\leq a</m>, <m>-a\leq v\leq a</m>.
-          We leave it to the reader to confirm that <m>\vec r_u\times \vec r_v = \langle 0,0,1\rangle</m>,
-          which points outside of the cube.
-        </p>
 
         <figure xml:id="fig_divthm_space3">
           <caption>The cube used in  <xref ref="ex_divthm_space3">Example</xref>.</caption>
@@ -461,7 +452,7 @@
           3Dcoo=9.648120880126953 3.759108543395996 12.013349533081055,
           3Droo=399.9999533297849,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_divthm_space3_3D">
+          <image xml:id="img_divthm_space3_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -540,6 +531,15 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          Let <m>\surfaceS_1</m> be the <q>top</q> face of the cube,
+          which can be parametrized by <m>\vec r(u,v) = \langle u,v,a\rangle</m> for
+          <m>-a\leq u\leq a</m>, <m>-a\leq v\leq a</m>.
+          We leave it to the reader to confirm that <m>\vec r_u\times \vec r_v = \langle 0,0,1\rangle</m>,
+          which points outside of the cube.
+        </p>
 
         <p>
           The flux across this face is:
@@ -626,7 +626,7 @@
       <title>Using the Divergence Theorem to compute flux</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be the cube bounded by the planes <m>x=\pm 1</m>,
+          Let <m>\surfaceS</m> be the cube bounded by the planes <m>x=\pm 1</m>,
           <m>y=\pm 1</m>, <m>z=\pm 1</m>,
           and let <m>\vec F = \langle x^2y,2yz,x^2z^3\rangle</m>.
           Compute the outward flux of <m>\vec F</m> over <m>\surfaceS</m>.
@@ -665,7 +665,7 @@
       as we do not sum <m>\curl \vec F</m>,
       but <m>\curl \vec F\cdot\vec n</m>,
       where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m>. That is,
-      we sum the portion of <m>\curl \vec F</m> that is orthogonal to <m>\surfaceS</m>at a point.
+      we sum the portion of <m>\curl \vec F</m> that is orthogonal to <m>\surfaceS</m> at a point.
     </p>
 
     <p>
@@ -680,7 +680,7 @@
       <title>Stokes' Theorem</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be a piecewise smooth,
+          Let <m>\surfaceS</m> be a piecewise smooth,
           orientable surface whose boundary is a piecewise smooth curve <m>C</m>,
           let <m>\vec n</m> be a unit vector normal to <m>\surfaceS</m>, let <m>C</m> be traversed with respect to <m>\vec n</m> according to the right hand rule,
           and let the components of <m>\vec F</m> have continuous first partial derivatives over <m>\surfaceS</m>. Then
@@ -693,7 +693,7 @@
     </theorem>
 
     <p>
-      In general, the best approach to evaluating the surface integral in Stokes' Theorem is to parametrize the surface <m>\surfaceS</m>with a function <m>\vec r(u,v)</m>.
+      In general, the best approach to evaluating the surface integral in Stokes' Theorem is to parametrize the surface <m>\surfaceS</m> with a function <m>\vec r(u,v)</m>.
       We can find a unit normal vector <m>\vec n</m> as
       <me>
         \vec n = \frac{\vec r_u\times\vec r_v}{\snorm{\vec r_u\times\vec r_v}}
@@ -716,14 +716,14 @@
         <p>
           Considering the planar surface <m>f(x,y) = 7-2x-2y</m>,
           let <m>C</m> be the curve in space that lies on this surface above the circle of radius 1 and centered at <m>(1,1)</m> in the <m>x</m>-<m>y</m> plane,
-          let <m>\surfaceS</m>be the planar region enclosed by <m>C</m>,
+          let <m>\surfaceS</m> be the planar region enclosed by <m>C</m>,
           as illustrated in <xref ref="fig_stokes1">Figure</xref>,
           and let <m>\vec F = \langle x+y,2y, y^2\rangle</m>.
           Verify Stoke's Theorem by showing <m>\oint_C \vec F\cdot \, d\vec r = \iint_\surfaceS (\curl\vec F)\cdot \vec n\, dS</m>.
         </p>
 
         <figure xml:id="fig_stokes1">
-          <caption>As given in <xref ref="ex_stokes1">Example</xref>, the surface \surfaceS<nbsp/>is the portion of the plane bounded by the curve.</caption>
+          <caption>As given in <xref ref="ex_stokes1">Example</xref>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve.</caption>
           <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
           3Droll=0,
           3Dortho=0.004444748163223267,
@@ -731,7 +731,7 @@
           3Dcoo=45.07202911376953 32.75735855102539 55.02788543701172,
           3Droo=399.9999566444115,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="fig_stokes1_3D">
+          <image xml:id="fig_stokes1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -837,7 +837,7 @@
         <p>
           We now parametrize <m>\surfaceS</m>. (We reuse the letter <q>r</q>
           for our surface as this is our custom.) Based on the parametrization of <m>C</m> above,
-          we describe <m>\surfaceS</m>with <m>\vec r(u,v) = \la v\cos u+1, v\sin u+1, 3-2v\cos u-2v\sin u\ra</m>,
+          we describe <m>\surfaceS</m> with <m>\vec r(u,v) = \la v\cos u+1, v\sin u+1, 3-2v\cos u-2v\sin u\ra</m>,
           where <m>0\leq u\leq 2\pi</m> and <m>0\leq v\leq 1</m>.
         </p>
 
@@ -875,14 +875,14 @@
         <p>
           Let <m>C</m> be the curve given in <xref ref="ex_stokes1">Example</xref>
           and note that it lies on the surface <m>z = 6-x^2-y^2</m>.
-          Let <m>\surfaceS</m>be the region of this surface bounded by <m>C</m>,
+          Let <m>\surfaceS</m> be the region of this surface bounded by <m>C</m>,
           and let <m>\vec F = \langle x+y,2y,y^2\rangle</m> as in the previous example.
           Compute <m>\iint_\surfaceS (\curl\vec F)\cdot \vec n\, dS</m> to show it equals the result found in the previous example.
         </p>
 
         <figure xml:id="fig_stokes2">
           <caption>As given in <xref ref="ex_stokes2">Example</xref>, the surface \surfaceS<nbsp/>is the portion of the plane bounded by the curve.</caption>
-          <sidebyside>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_stokes2a_3D">
               <caption/>
               <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -1094,7 +1094,7 @@
         </p>
 
         <p>
-          We parametrize <m>\surfaceS</m>with
+          We parametrize <m>\surfaceS</m> with
           <me>
             \vec r(u,v) = \langle v\cos u+1,v\sin u+1, 6-(v\cos u+1)^2-(v\sin u+1)^2\rangle
           </me>,
@@ -1156,7 +1156,7 @@
     <p>
       Each of the named theorems above can be expressed in similar terms.
       Consider the Fundamental Theorem of Line Integrals:
-      given a function <m>z=f(x,y)</m>,
+      given a function <m>f(x,y)</m>,
       the gradient <m>\nabla f</m> is a type of rate of change of <m>f</m>.
       Given a curve <m>C</m> with initial and terminal points <m>A</m> and <m>B</m>,
       respectively,
@@ -1170,7 +1170,7 @@
     <p>
       Green's Theorem is essentially a special case of Stokes' Theorem,
       so we consider just Stokes' Theorem here.
-      Recalling that the curl of a vector field <m>\vec F</m> is a measure of a rate of change of <m>\vec F</m>, Stokes' Theorem states that over a surface <m>\surfaceS</m>bounded by a closed curve <m>C</m>,
+      Recalling that the curl of a vector field <m>\vec F</m> is a measure of a rate of change of <m>\vec F</m>, Stokes' Theorem states that over a surface <m>\surfaceS</m> bounded by a closed curve <m>C</m>,
       <me>
         \iint_\surfaceS \big(\curl \vec F\big)\cdot \vec n\, dS = \oint_C \vec F\cdot d\vec r
       </me>,
@@ -1261,7 +1261,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a closed surface <m>\surfaceS</m>enclosing a domain <m>D</m> and a vector field <m>\vec F</m> are given.
+          a closed surface <m>\surfaceS</m> enclosing a domain <m>D</m> and a vector field <m>\vec F</m> are given.
           Verify the Divergence Theorem on <m>\surfaceS</m>; that is,
           show <m>\iint_\surfaceS \vec F\cdot \vec n\, dS = \iiint_D\divv \vec F\, dV</m>.
         </p>
@@ -1270,7 +1270,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface bounding the domain <m>D</m> enclosed by the plane
+            <m>\surfaceS</m> is the surface bounding the domain <m>D</m> enclosed by the plane
             <m>z=2-x/2-2y/3</m> and the coordinate planes in the first octant;
             <m>\vec F = \langle x^2,y^2,x\rangle</m>.
           </p>
@@ -1415,7 +1415,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface bounding the domain <m>D</m> enclosed by the cylinder
+            <m>\surfaceS</m> is the surface bounding the domain <m>D</m> enclosed by the cylinder
             <m>x^2+y^2=1</m> and the planes <m>z=-3</m> and <m>z=3</m>;
             <m>\vec F = \langle -x,y,z\rangle</m>.
           </p>
@@ -1548,7 +1548,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface bounding the domain <m>D</m> enclosed by
+            <m>\surfaceS</m> is the surface bounding the domain <m>D</m> enclosed by
             <m>z=xy(3-x)(3-y)</m> and the plane <m>z=0</m>;
             <m>\vec F = \langle 3x,4y,5z+1\rangle</m>.
           </p>
@@ -1673,7 +1673,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface composed of <m>\surfaceS_1</m>,
+            <m>\surfaceS</m> is the surface composed of <m>\surfaceS_1</m>,
             the paraboloid <m>z=4-x^2-y^2</m> for <m>z\geq 0</m>,
             and <m>\surfaceS_2</m>, the disk of radius 2 centered at the origin;
             <m>\vec F = \langle x,y,z^2\rangle</m>.
@@ -1800,7 +1800,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m>is given along with a vector field <m>\vec F</m>.
+          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m> is given along with a vector field <m>\vec F</m>.
           Verify Stokes' Theorem on <m>C</m>;
           that is, show <m>\oint_C \vec F\cdot d\vec r = \iint_\surfaceS\big(\curl \vec F\,\big)\cdot\vec n\, dS</m>.
         </p>
@@ -2273,14 +2273,14 @@
         <p>
           In the following exercises,
           a closed surface <m>\surfaceS</m> and a vector field <m>\vec F</m> are given.
-          Find the outward flux of <m>\vec F</m> over <m>\surfaceS</m>either through direct computation or through the Divergence Theorem.
+          Find the outward flux of <m>\vec F</m> over <m>\surfaceS</m> either through direct computation or through the Divergence Theorem.
         </p>
       </introduction>
 
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of <m>z=0</m> and <m>z=(x^2-1)(y^2-1)</m>;
+            <m>\surfaceS</m> is the surface formed by the intersections of <m>z=0</m> and <m>z=(x^2-1)(y^2-1)</m>;
             <m>\vec F = \langle x^2+1,yz,xz^2\rangle</m>.
           </p>
 
@@ -2395,7 +2395,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of the planes <m>z=\frac12(3-x)</m>,
+            <m>\surfaceS</m> is the surface formed by the intersections of the planes <m>z=\frac12(3-x)</m>,
             <m>x=1</m>,
             <m>y=0</m>, <m>y=2</m> and <m>z=0</m>;
             <m>\vec F = \langle x,y^2,z\rangle</m>.
@@ -2507,7 +2507,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of the planes <m>z=2y</m>,
+            <m>\surfaceS</m> is the surface formed by the intersections of the planes <m>z=2y</m>,
             <m>y=4-x^2</m> and <m>z=0</m>;
             <m>\vec F = \langle xz,0,xz\rangle</m>.
           </p>
@@ -2641,7 +2641,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the surface formed by the intersections of the cylinder <m>z=1-x^2</m> and the planes <m>y=-2</m>,
+            <m>\surfaceS</m> is the surface formed by the intersections of the cylinder <m>z=1-x^2</m> and the planes <m>y=-2</m>,
             <m>y=2</m> and <m>z=0</m>;
             <m>\vec F = \langle 0,y^3,0\rangle</m>.
           </p>
@@ -2776,7 +2776,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m>is given along with a vector field <m>\vec F</m>.
+          a closed curve <m>C</m> that is the boundary of a surface <m>\surfaceS</m> is given along with a vector field <m>\vec F</m>.
           Find the circulation of <m>\vec F</m> around <m>C</m> either through direct computation or through Stokes' Theorem.
         </p>
       </introduction>
@@ -3260,20 +3260,20 @@
       <exercise>
         <statement>
           <p>
-            Let <m>\surfaceS</m>be any closed surface enclosing a domain <m>D</m>.
+            Let <m>\surfaceS</m> be any closed surface enclosing a domain <m>D</m>.
             Consider <m>\vec F_1 = \langle x,0,0\rangle</m> and <m>\vec F_2=\langle y,y^2,z-2yz\rangle</m>.
           </p>
 
           <p>
             These fields are clearly very different.
-            Why is it that the total outward flux of each field across <m>\surfaceS</m>is the same?
+            Why is it that the total outward flux of each field across <m>\surfaceS</m> is the same?
           </p>
         </statement>
         <answer>
           <p>
             Each field has a divergence of 1;
             by the Divergence Theorem,
-            the total outward flux across <m>\surfaceS</m>is <m>\iint_D 1\, dS</m> for each field.
+            the total outward flux across <m>\surfaceS</m> is <m>\iint_D 1\, dS</m> for each field.
           </p>
         </answer>
       </exercise>
@@ -3328,7 +3328,7 @@
         <answer>
           <p>
             Answers will vary.
-            Often the closed surface <m>\surfaceS</m>is composed of several smooth surfaces.
+            Often the closed surface <m>\surfaceS</m> is composed of several smooth surfaces.
             To measure total outward flux,
             this may require evaluating multiple double integrals.
             Each double integral requires the parametrization of a surface and the computation of the cross product of partial derivatives.

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -3,7 +3,7 @@
   <title>Surface Integrals</title>
   <introduction>
     <p>
-      Consider a smooth surface <m>\surfaceS</m>that represents a thin sheet of metal.
+      Consider a smooth surface <m>\surfaceS</m> that represents a thin sheet of metal.
       How could we find the mass of this metallic object?
     </p>
 
@@ -42,7 +42,7 @@
     <p>
       To evaluate the above integral,
       we would seek <m>\vec r(u,v)</m>,
-      a smooth parametrization of <m>\surfaceS</m>over a region <m>R</m> of the <m>u</m>-<m>v</m> plane.
+      a smooth parametrization of <m>\surfaceS</m> over a region <m>R</m> of the <m>u</m>-<m>v</m> plane.
       The density would become a function of <m>u</m> and <m>v</m>,
       and we would integrate <m>\iint_R \delta(u,v)\snorm{\vec r_u\times \vec r_v}\, dA</m>.
     </p>
@@ -50,6 +50,10 @@
     <p>
       The integral in Equation <xref ref="eq_surface_int"/> is a specific example of a more general construction defined below.
     </p>
+  </introduction>
+
+  <subsection xml:id="subsec-surfint-scalar">
+    <title>Surface integrals of scalar fields</title>
 
     <definition xml:id="def_surface_integral">
       <title>Surface Integral</title>
@@ -84,17 +88,6 @@
           with density function <m>\delta(x,y,z) = x^2+5y+z</m>,
           where all distances are measured in cm and the density is given as gm/cm<m>^2</m>.
         </p>
-      </statement>
-      <solution>
-        <p>
-          We begin by parametrizing the planar surface <m>\surfaceS</m>. Using the techniques of the previous section,
-          we can let <m>x=u</m> and <m>y=v(2-2u)</m>,
-          where <m>0\leq u\leq 1</m> and <m>0\leq v\leq 1</m>.
-          Solving for <m>z</m> in the equation of the plane,
-          we have <m>z=3-2x-y</m>, hence <m>z = 3-2u-v(2-2u)</m>,
-          giving the parametrization <m>\vec r(u,v) = \langle u, v(2-2u), 3-2u-v(2-2u)\rangle</m>.
-        </p>
-
         <figure xml:id="fig_surfint1">
           <caption>The surface whose mass is computed in <xref ref="ex_surfint1">Example</xref>.</caption>
           <!-- \apexincludemedia{width=145pt,3Dmenu,activate=onclick,deactivate=onclick,
@@ -104,7 +97,7 @@
           3Dcoo=-2.5405526161193848 7.828289031982422 42.677555084228516,
           3Droo=399.9999621232421,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_surfint1_3D">
+          <image xml:id="img_surfint1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -191,6 +184,16 @@
             </asymptote>
           </image>
         </figure>
+      </statement>
+      <solution>
+        <p>
+          We begin by parametrizing the planar surface <m>\surfaceS</m>. Using the techniques of the previous section,
+          we can let <m>x=u</m> and <m>y=v(2-2u)</m>,
+          where <m>0\leq u\leq 1</m> and <m>0\leq v\leq 1</m>.
+          Solving for <m>z</m> in the equation of the plane,
+          we have <m>z=3-2x-y</m>, hence <m>z = 3-2u-v(2-2u)</m>,
+          giving the parametrization <m>\vec r(u,v) = \langle u, v(2-2u), 3-2u-v(2-2u)\rangle</m>.
+        </p>
 
         <p>
           We need <m>dS=\snorm{\vec r_u\times \vec r_v}dA</m>,
@@ -235,16 +238,16 @@
         </p>
       </solution>
     </example>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Flux</title>
     <p>
-      Let a surface <m>\surfaceS</m>lie within a vector field <m>\vec F</m>.
+      Let a surface <m>\surfaceS</m> lie within a vector field <m>\vec F</m>.
       One is often interested in measuring the <em>flux</em>
       of <m>\vec F</m> across <m>\surfaceS</m>; that is,
       measuring <q>how much of the vector field passes across <m>\surfaceS</m>.</q> For instance,
-      if <m>\vec F</m> represents the velocity field of moving air and <m>\surfaceS</m>represents the shape of an air filter,
+      if <m>\vec F</m> represents the velocity field of moving air and <m>\surfaceS</m> represents the shape of an air filter,
       the flux will measure how much air is passing through the filter per unit time.
           <idx><h>flux</h></idx>
     </p>
@@ -254,19 +257,19 @@
       <q>amount of <m>\vec F</m> orthogonal to <m>\surfaceS</m>.</q>
       Similar to our measure of flux in the plane,
       this is equal to <m>\vec F\cdot \vec n</m>,
-      where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m>at a point.
+      where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m> at a point.
       We now consider how to find <m>\vec n</m>.
     </p>
 
     <p>
       Given a smooth parametrization
       <m>\vec r(u,v)</m> of <m>\surfaceS</m>, the work in the previous section showing the development of our method of computing surface area also shows that <m>\vec r_u(u,v)</m> and
-      <m>\vec r_v(u,v)</m> are tangent to <m>\surfaceS</m>at <m>\vec r(u,v)</m>.
+      <m>\vec r_v(u,v)</m> are tangent to <m>\surfaceS</m> at <m>\vec r(u,v)</m>.
       Thus <m>\vec r_u\times \vec r_v</m> is orthogonal to <m>\surfaceS</m>, and we let
       <me>
         \vec n = \frac{\vec r_u\times \vec r_v}{\snorm{\vec r_u\times \vec r_v}}
       </me>,
-      which is a unit vector normal to <m>\surfaceS</m>at <m>\vec r(u,v)</m>.
+      which is a unit vector normal to <m>\surfaceS</m> at <m>\vec r(u,v)</m>.
     </p>
 
     <p>
@@ -288,9 +291,9 @@
     </p>
 
     <p>
-      The above only makes sense if <m>\surfaceS</m>is orientable;
+      The above only makes sense if <m>\surfaceS</m> is orientable;
       the normal vectors <m>\vec n</m> must vary continuously across <m>\surfaceS</m>. We assume that <m>\vec n</m> does vary continuously.
-      (If the parametrization <m>\vec r</m> of <m>\surfaceS</m>is smooth,
+      (If the parametrization <m>\vec r</m> of <m>\surfaceS</m> is smooth,
       then our above definition of <m>\vec n</m> will vary continuously.)
     </p>
 
@@ -298,8 +301,8 @@
       <title>Flux over a surface</title>
       <statement>
         <p>
-          Let <m>\vec F</m> be a vector field with continuous components defined on an orientable surface <m>\surfaceS</m>with normal vector <m>\vec n</m>.
-          The <term>flux</term> of <m>\vec F</m> across <m>\surfaceS</m>is
+          Let <m>\vec F</m> be a vector field with continuous components defined on an orientable surface <m>\surfaceS</m> with normal vector <m>\vec n</m>.
+          The <term>flux</term> of <m>\vec F</m> across <m>\surfaceS</m> is
               <idx><h>flux</h></idx>
           <me>
             \text{ Flux }  = \iint_\surfaceS \vec F\cdot \vec n\, dS
@@ -307,7 +310,7 @@
         </p>
 
         <p>
-          If <m>\surfaceS</m>is parametrized by <m>\vec r(u,v)</m>,
+          If <m>\surfaceS</m> is parametrized by <m>\vec r(u,v)</m>,
           which is smooth on its domain <m>R</m>, then
           <me>
             \text{ Flux }  = \iint_R \vec F\big(\vec r(u,v)\big)\cdot (\vec r_u\times \vec r_v)\, dA
@@ -317,25 +320,25 @@
     </definition>
 
     <p>
-      Since <m>\surfaceS</m>is orientable,
+      Since <m>\surfaceS</m> is orientable,
       we adopt the convention of saying one passes from the <q>back</q>
-      side of <m>\surfaceS</m>to the <q>front</q>
+      side of <m>\surfaceS</m> to the <q>front</q>
       side when moving across the surface parallel to the direction of <m>\vec n</m>.
-      Also, when <m>\surfaceS</m>is closed,
+      Also, when <m>\surfaceS</m> is closed,
       it is natural to speak of the regions of space
       <q>inside</q> and <q>outside</q>
-      <m>\surfaceS</m>. We also adopt the convention that when <m>\surfaceS</m>is a closed surface,
+      <m>\surfaceS</m>. We also adopt the convention that when <m>\surfaceS</m> is a closed surface,
       <m>\vec n</m> should point to the outside of <m>\surfaceS</m>. If
       <m>\vec n = \vec r_u\times\vec r_v</m> points inside <m>\surfaceS</m>, use <m>\vec n = \vec r_v\times \vec r_u</m> instead.
     </p>
 
     <p>
       When the computation of flux is positive,
-      it means that the field is moving from the back side of <m>\surfaceS</m>to the front side;
+      it means that the field is moving from the back side of <m>\surfaceS</m> to the front side;
       when flux is negative,
       it means the field is moving opposite the direction of <m>\vec n</m>,
-      and is moving from the front of <m>\surfaceS</m>to the back.
-      When <m>\surfaceS</m>is not closed,
+      and is moving from the front of <m>\surfaceS</m> to the back.
+      When <m>\surfaceS</m> is not closed,
       there is not a <q>right</q> and <q>wrong</q>
       direction in which <m>\vec n</m> should point,
       but one should be mindful of its direction to make full sense of the flux computation.
@@ -350,8 +353,8 @@
       <title>Finding flux across a surface</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m>be the surface given in <xref ref="ex_surfint1">Example</xref>,
-          where <m>\surfaceS</m>is parametrized by
+          Let <m>\surfaceS</m> be the surface given in <xref ref="ex_surfint1">Example</xref>,
+          where <m>\surfaceS</m> is parametrized by
           <m>\vec r(u,v) = \langle u, v(2-2u),3-2u-v(2-2u)\rangle</m> on <m>0\leq u\leq 1</m>,
           <m>0\leq v\leq 1</m>, and let <m>\vec F = \langle 1, x,-y\rangle</m>,
           as shown in <xref ref="fig_surfflux1">Figure</xref>.
@@ -367,7 +370,7 @@
           3Dcoo=-2.5405526161193848 7.828289031982422 42.677555084228516,
           3Droo=399.9999621232421,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_surfflux1_3D">
+          <image xml:id="img_surfflux1_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -490,7 +493,7 @@
         </p>
 
         <p>
-          Thus the flux of <m>\vec F</m> across <m>\surfaceS</m>is:
+          Thus the flux of <m>\vec F</m> across <m>\surfaceS</m> is:
           <md>
             <mrow>\text{ Flux }  \amp = \iint_\surfaceS \vec F\cdot \vec n\, dS</mrow>
             <mrow>\amp = \iint_R \langle 1,u,-v(2-2u)\rangle\cdot\langle 4-4u,2-2u,2-2u\rangle\, dA</mrow>
@@ -512,10 +515,10 @@
           This vector has positive <m>x</m>,
           <m>y</m> and <m>z</m> components.
           Generally speaking, one has <em>some</em>
-          idea of what the surface <m>\surfaceS</m>looks like,
+          idea of what the surface <m>\surfaceS</m> looks like,
           as that surface is for some reason important.
           In our case,
-          we know <m>\surfaceS</m>is a plane with <m>z</m>-intercept of <m>z=3</m>.
+          we know <m>\surfaceS</m> is a plane with <m>z</m>-intercept of <m>z=3</m>.
           Knowing <m>\vec n</m> and the flux measurement of positive <m>5/3</m>,
           we know that the field must be passing from <q>behind</q>
           <m>\surfaceS</m>, i.e., the side the origin is on,
@@ -544,7 +547,7 @@
           3Dcoo=-4.848384857177734 2.0102698802948 61.921504974365234,
           3Droo=399.9999594035934,
           3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-          <image xml:id="img_surfflux2_3D">
+          <image xml:id="img_surfflux2_3D" width="47%">
             <description></description>
             <asymptote>
 
@@ -675,13 +678,13 @@
           We are now set to compute flux.
           Over field <m>\vec F_1=\langle 0,0,1\rangle</m>:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_1\) }  \amp = \iint_{\surfaceS_1} \vec F_1\cdot \vec n_1\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_1  \amp = \iint_{\surfaceS_1} \vec F_1\cdot \vec n_1\, dS</mrow>
             <mrow>\amp = \iint_R\langle 0,0,1\rangle\cdot\langle 0,0,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (v)\, du\, dv</mrow>
             <mrow>\amp = \pi</mrow>
           </md>.
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_2\) }  \amp = \iint_{\surfaceS_2} \vec F_1\cdot \vec n_2\, dS</mrow>
+            <mrow>\text{ Flux across } \surfaceS_2  \amp = \iint_{\surfaceS_2} \vec F_1\cdot \vec n_2\, dS</mrow>
             <mrow>\amp = \iint_R\langle 0,0,1\rangle\cdot\langle 2v^2\cos u,2v^2\sin u,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (v)\, du\, dv</mrow>
             <mrow>\amp = \pi</mrow>
@@ -707,13 +710,13 @@
         </p>
 
         <p>
-          If we treated the surfaces as creating one piecewise<ndash/>smooth surface <m>\surfaceS</m>, we would find the total flux across <m>\surfaceS</m>by finding the flux across each piece,
+          If we treated the surfaces as creating one piecewise<ndash/>smooth surface <m>\surfaceS</m>, we would find the total flux across <m>\surfaceS</m> by finding the flux across each piece,
           being sure that each normal vector pointed to the outside of the closed surface.
           Above, <m>\vec n_1</m> does not point outside the surface,
           though <m>\vec n_2</m> does.
           We would instead want to use <m>-\vec n_1</m> in our computation.
           We would then find that the flux across <m>\surfaceS_1</m> is <m>-\pi</m>,
-          and hence the total flux across <m>\surfaceS</m>is <m>-\pi + \pi = 0</m>.
+          and hence the total flux across <m>\surfaceS</m> is <m>-\pi + \pi = 0</m>.
           (As <m>0</m> is a special number,
           we should wonder if this answer has special significance.
           It does, which is briefly discussed following this example and will be more fully developed in the next section.)
@@ -722,14 +725,14 @@
         <p>
           We now compute the flux across each surface with <m>\vec F_2=\langle 0,0,z\rangle</m>:
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_1\) }  \amp = \iint_{\surfaceS_1} \vec F_2\cdot \vec n_1\, dS .</mrow>
+            <mrow>\text{ Flux across } \surfaceS_1  \amp = \iint_{\surfaceS_1} \vec F_2\cdot \vec n_1\, dS .</mrow>
             <intertext>Over <m>\surfaceS_1</m>, <m>\vec F_2 = \vec F_2\big(\vec r_2(u,v)\big) = \langle 0,0,0\rangle</m>. Therefore,</intertext>
             <mrow>\amp = \iint_R\langle 0,0,0\rangle\cdot\langle 0,0,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (0)\, du\, dv</mrow>
             <mrow>\amp = 0</mrow>
           </md>.
           <md>
-            <mrow>\text{ Flux across \(\surfaceS_2\) }  \amp = \iint_{\surfaceS_2} \vec F_2\cdot \vec n_2\, dS .</mrow>
+            <mrow>\text{ Flux across } \surfaceS_2  \amp = \iint_{\surfaceS_2} \vec F_2\cdot \vec n_2\, dS .</mrow>
             <intertext>Over <m>\surfaceS_2</m>, <m>\vec F_2 = \vec F_2\big(\vec r_2(u,v)\big) = \langle 0,0,1-v^2\rangle</m>. Therefore,</intertext>
             <mrow>\amp = \iint_R\langle 0,0,1-v^2\rangle\cdot\langle 2v^2\cos u,2v^2\sin u,v\rangle\, dA</mrow>
             <mrow>\amp = \int_0^1\int_0^{2\pi} (v^3-v)\, du\, dv</mrow>
@@ -760,9 +763,10 @@
       The quick answer to why the flux was the same when considering
       <m>\vec F_1</m> is that <m>\divv \vec F_1 = 0</m>.
       In the next section,
-      we'll see the second part of the Divergence Theorem which will more fully explain this occurrence.
-      We will also explore Stokes' Theorem,
-      the spatial analogue to Green's Theorem.
+      we'll see the second part of the <xref ref="thm_divergence2" text="custom">Divergence Theorem</xref>,
+      which will more fully explain this occurrence.
+      We will also explore <xref ref="thm_stokes_thm" text="custom">Stokes' Theorem</xref>,
+      the spatial analogue to <xref ref="thm_greens" text="custom">Green's Theorem</xref>.
     </p>
   </subsection>
 
@@ -821,8 +825,8 @@
       <exercise>
         <statement>
           <p>
-            If <m>\surfaceS</m>is a plane,
-            and <m>\vec F</m> is always parallel to <m>\surfaceS</m>, then the flux of <m>\vec F</m> across <m>\surfaceS</m>will be <fillin/>.
+            If <m>\surfaceS</m> is a plane,
+            and <m>\vec F</m> is always parallel to <m>\surfaceS</m>, then the flux of <m>\vec F</m> across <m>\surfaceS</m> will be <fillin/>.
           </p>
         </statement>
         <answer>
@@ -836,7 +840,7 @@
       <introduction>
         <p>
           In the following exercises,
-          a surface <m>\surfaceS</m>that represents a thin sheet of material with density <m>\delta</m> is given.
+          a surface <m>\surfaceS</m> that represents a thin sheet of material with density <m>\delta</m> is given.
           Find the mass of each thin sheet.
         </p>
       </introduction>
@@ -845,7 +849,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane
+            <m>\surfaceS</m> is the plane
             <m>f(x,y)=x+y</m> on <m>-2\leq x\leq 2</m>,
             <m>-3\leq y\leq 3</m>, with <m>\delta(x,y,z) = z</m>.
           </p>
@@ -860,7 +864,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the unit sphere,
+            <m>\surfaceS</m> is the unit sphere,
             with <m>\delta(x,y,z) = x+y+z+10</m>.
           </p>
         </statement>
@@ -876,9 +880,9 @@
       <introduction>
         <p>
           In the following exercises,
-          a surface <m>\surfaceS</m>and a vector field <m>\vec F</m> are given.
+          a surface <m>\surfaceS</m> and a vector field <m>\vec F</m> are given.
           Compute the flux of <m>\vec F</m> across <m>\surfaceS</m>.
-          (If <m>\surfaceS</m>is not a closed surface,
+          (If <m>\surfaceS</m> is not a closed surface,
           choose <m>\vec n</m> so that it has a positive <m>z</m>-component,
           unless otherwise indicated.)
         </p>
@@ -887,7 +891,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane <m>f(x,y) = 3x+y</m> on
+            <m>\surfaceS</m> is the plane <m>f(x,y) = 3x+y</m> on
             <m>0\leq x\leq 1</m>, <m>1\leq y\leq 4</m>;
             <m>\vec F = \langle x^2,-z,2y\rangle</m>.
           </p>
@@ -902,7 +906,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the plane
+            <m>\surfaceS</m> is the plane
             <m>f(x,y) = 8-x-y</m> over the triangle with vertices at <m>(0,0)</m>,
             <m>(1,0)</m> and <m>(1,5)</m>;
             <m>\vec F = \langle 3,1,2\rangle</m>.
@@ -918,7 +922,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the paraboloid <m>f(x,y) = x^2+y^2</m> over the unit disk;
+            <m>\surfaceS</m> is the paraboloid <m>f(x,y) = x^2+y^2</m> over the unit disk;
             <m>\vec F = \langle 1,0,0\rangle</m>.
           </p>
         </statement>
@@ -932,7 +936,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the unit sphere;
+            <m>\surfaceS</m> is the unit sphere;
             <m>\vec F = \langle y-z,z-x,x-y\rangle</m>.
           </p>
         </statement>
@@ -946,7 +950,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the square in space with corners at <m>(0,0,0)</m>,
+            <m>\surfaceS</m> is the square in space with corners at <m>(0,0,0)</m>,
             <m>(1,0,0)</m>,
             <m>(1,0,1)</m> and <m>(0,0,1)</m> (choose <m>\vec n</m> such that it has a positive <m>y</m>-component);
             <m>\vec F = \langle 0,-z,y\rangle</m>.
@@ -962,7 +966,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the disk in the <m>y</m>-<m>z</m> plane with radius 1, centered at <m>(0,1,1)</m> (choose <m>\vec n</m> such that it has a positive <m>x</m>-component);
+            <m>\surfaceS</m> is the disk in the <m>y</m>-<m>z</m> plane with radius 1, centered at <m>(0,1,1)</m> (choose <m>\vec n</m> such that it has a positive <m>x</m>-component);
             <m>\vec F = \langle y,z,x\rangle</m>.
           </p>
         </statement>
@@ -976,7 +980,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the closed surface composed of <m>\surfaceS_1</m>,
+            <m>\surfaceS</m> is the closed surface composed of <m>\surfaceS_1</m>,
             whose boundary is the ellipse in the <m>x</m>-<m>y</m> plane described by
             <m>\frac{x^2}{25}+\frac{y^2}9 = 1</m> and <m>\surfaceS_2</m>,
             part of the elliptical paraboloid <m>f(x,y) = 1-\frac{x^2}{25}-\frac{y^2}9</m> (see graph);
@@ -1078,7 +1082,7 @@
       <exercise>
         <statement>
           <p>
-            <m>\surfaceS</m>is the closed surface composed of <m>\surfaceS_1</m>,
+            <m>\surfaceS</m> is the closed surface composed of <m>\surfaceS_1</m>,
             part of the unit sphere and <m>\surfaceS_2</m>,
             part of the plane <m>z=1/2</m> (see graph);
             <m>\vec F = \langle x,-y,z\rangle</m>.

--- a/ptx/sec_total_differential.ptx
+++ b/ptx/sec_total_differential.ptx
@@ -439,6 +439,77 @@
     </example>
   </subsection>
 
+  <subsection xml:id="subsec-tangent-plane-approximation">
+    <title>Tangent Plane Approximation</title>
+    <p>
+      Recall from <xref ref="chapter_derivatives">Chapter</xref> that in one variable,
+      the essence of differentiability is the tangent line approximation.
+      This idea is emphasized in <xref ref="sec_differentials">Section</xref>,
+      where we first introduced the differential.
+    </p>
+
+    <p>
+      In <xref ref="subsec-tangent-plane">Section</xref> we saw that the partial derivatives of a function <m>f(x,y)</m>
+      can be used to define the define the tangent <em>plane</em> to a graph <m>z=f(x,y)</m>.
+      We will now see that this plane plays the same role for functions of two variables as the tangent line to a graph <m>y=f(x)</m> for a function of one variable.
+    </p>
+
+    <p>
+      Recall from <xref ref="def-linearization">Definition</xref> that for a function <m>f(x)</m>,
+      when <m>x</m> is near <m>c</m> we have the linear approximation <m>f(x)\approx \ell(x)</m>,
+      where
+      <me>
+        \ell(x) = f(c)+f'(c)(x-c)
+      </me>
+      is the linearization of <m>f</m> at <m>c</m>. If we set <m>dx=\dx = x-c</m>,
+      and evaluate the differential <m>dy = f'(x)\,dx</m> at <m>c</m>,
+      then we have
+      <md>
+        <mrow>\dy \amp = f(x)-f(c)</mrow>
+        <mrow>dy \amp = \ell(x)-f(c)</mrow>
+      </md>.
+    </p>
+
+    <p>
+      Given the graph <m>y=f(x)</m>, we know that <m>y=\ell(x)</m> gives the tangent line to the graph at <m>c</m>.
+      For the graph <m>z=f(x,y)</m> of a function of two variables, we similarly have the tangent plane
+      <me>
+        z=f(a,b)+f_x(a,b)(x-a)+f_y(a,b)(y-b)
+      </me>
+      defined in <xref ref="def-tangent-plane"/>,
+      suggesting that we define the two variable linearization
+      <me>
+        \ell(x,y) = f(a,b)+f_x(a,b)(x-a)+f_y(a,b)(y-b)
+      </me>.
+    </p>
+
+    <p>
+      Consider the total differential <m>dz</m> at <m>(a,b)</m>:
+      <me>
+        dz = f_x(a,b)\,dx + f_y(a,b)\,dy = f_x(a,b)(x-a)+f_y(a,b)(y-b)
+      </me>.
+      If we assume that <m>(x,y)</m> is <q>close</q> to <m>(a,b)</m>,
+      and set <m>dx = x-a</m>, <m>dy = y-b</m>,
+      then we have <m>\ell(x,y)-\ell(a,b) = dz</m>,
+      since <m>\ell(a,b)=f(a,b)</m>.
+      This agrees with the one-variable situation,
+      and with the conception of the differential as the <q>linear change</q> in a function.
+    </p>
+
+    <p>
+      If we recast <xref ref="def_multi_differentiability"/> in the language of tangent planes,
+      we can more easily see the analogy with functions of a single variable.
+      We can now say that <m>f(x,y)</m> is differentiable at <m>(a,b)</m> if it has a valid tangent plane approximation at <m>(a,b)</m>.
+      Note that <m>f(x,y)-\ell(x,y)</m> is equal to the error term <m>E_x\,dx+E_y\,dy</m>.
+    </p>
+
+    <p>
+      By <xref ref="thm_diff_cont_multi"/>, we know that the tangent plane at <m>(a,b,f(a,b))</m>
+      exists, and gives a good approximation to the graph <m>z=f(x,y)</m>,
+      as long as the partial derivatives of <m>f</m> exist and are continuous at <m>(a,b)</m>.
+    </p>
+  </subsection>
+
   <subsection xml:id="subsec-error-analysis-total-diff">
     <title>Error/Sensitivity Analysis</title>
     <p>
@@ -794,7 +865,7 @@
 
       <introduction>
         <p>
-          In the following exercises, a function <m>z=f(x,y)</m> is given.
+          In the following exercises, a function <m>f(x,y)</m> is given.
           Give the indicated approximation using the total differential.
         </p>
       </introduction>

--- a/ptx/sec_transformations.ptx
+++ b/ptx/sec_transformations.ptx
@@ -152,7 +152,7 @@
 		</aside>
 
 		<figure xml:id="fig_polar_trans1">
-			<caption>Transforming a rectangle to a disk using polar coordinates.</caption>
+			<caption>Transforming a rectangle to a disk using polar coordinates</caption>
 			<sidebyside widths="40% 10% 40%" valign="middle">
 				<image xml:id="img_polar_trans1a">
 				  <description></description>
@@ -234,7 +234,7 @@
 		</p>
 
 		<figure xml:id="fig_polar_trans2">
-			<caption>Transforming a rectangle to an annular portion using polar coordinates.</caption>
+			<caption>Transforming a rectangle to an annular portion using polar coordinates</caption>
 			<sidebyside widths="40% 10% 40%" valign="middle">
 				<image xml:id="img_polar_trans2a">
 				  <description></description>

--- a/ptx/sec_vector_fields.ptx
+++ b/ptx/sec_vector_fields.ptx
@@ -76,7 +76,7 @@
 
     <figure xml:id="fig_vectorfieldintro1">
       <caption>Demonstrating methods of graphing vector fields.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_vectorfieldintro1a">
           <caption/>
           <image xml:id="img_vectorfieldintro1a">
@@ -244,7 +244,7 @@
 
     <figure xml:id="fig_vectorfieldintro2">
       <caption>Demonstrating methods of graphing vector fields.</caption>
-      <sidebyside>
+      <sidebyside widths="47% 47%">
         <figure xml:id="fig_vectorfieldintro2a">
           <caption/>
           <image xml:id="img_vectorfieldintro2a">
@@ -406,7 +406,7 @@
       3Dcoo=40.4605598449707 -31.11708641052246 21.908815383911133,
       3Droo=141.89772583942957,
       3Dlights=Headlamp,add3Djscript=asylabels.js} -->
-      <image xml:id="img_vectorfieldintro3_3D">
+      <image xml:id="img_vectorfieldintro3_3D" width="47%">
         <description></description>
         <asymptote>
 
@@ -764,7 +764,7 @@
 
               <figure xml:id="fig_vectorfield1a">
                 <caption>The vector fields in parts 1 and 2 in <xref ref="ex_vectorfield1">Example</xref>.</caption>
-                <sidebyside>
+                <sidebyside widths="47% 47%">
                   <figure xml:id="fig_vectorfield1a_a">
                     <caption/>
                     <image xml:id="img_vectorfield1a_a">
@@ -962,7 +962,7 @@
 
               <figure xml:id="fig_vectorfield1b">
                 <caption>The vector fields in parts 3 and 4 in <xref ref="ex_vectorfield1">Example</xref>.</caption>
-                <sidebyside>
+                <sidebyside widths="47% 47%">
                   <figure xml:id="fig_vectorfield1b_a">
                     <caption/>
                     <image xml:id="img_vectorfield1b_a">
@@ -1209,7 +1209,7 @@
 
     <figure xml:id="fig_vectorfield3">
       <caption>A vector field representing a planar gravitational force.</caption>
-          <image xml:id="img_vectorfield3">
+          <image xml:id="img_vectorfield3" width="47%">
             <description></description>
             <asymptote>
 
@@ -1277,7 +1277,7 @@
     </figure>
 
     <p>
-      A function <m>z=f(x,y)</m> naturally induces a vector field,
+      A function <m>f(x,y)</m> naturally induces a vector field,
       <m>\vec F = \nabla f = \langle f_x,f_y\rangle</m>.
       Given what we learned of the gradient in <xref ref="sec_directional_derivative">Section</xref>,
       we know that the vectors of <m>\vec F</m> point in the direction of greatest increase of <m>f</m>.
@@ -1311,8 +1311,8 @@
         </p>
 
         <figure xml:id="fig_vectorfield4">
-          <caption>A graph of a function <m>z=f(x,y)</m> and the vector field <m>\vec F = \nabla f</m> in <xref ref="ex_vectorfield4">Example</xref>.</caption>
-          <sidebyside>
+          <caption>A graph of a function <m>f(x,y)</m> and the vector field <m>\vec F = \nabla f</m> in <xref ref="ex_vectorfield4">Example</xref>.</caption>
+          <sidebyside widths="47% 47%">
             <figure xml:id="fig_vectorfield4a">
               <caption/>
               <image xml:id="img_vectorfield4a">

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1077,6 +1077,8 @@
     (see marginal note).
   </p>
   <aside xml:id="aside-def-orthogonal">
+    <title>Direction and the zero vector</title>
+
     <p>
       <m>\vec 0</m> is directionless;
       because <m>\vnorm{0}=0</m>,
@@ -1101,7 +1103,7 @@
     <p>
       We prefer the given definition of parallel as it is grounded in the fact that unit vectors provide direction information.
       One may adopt the convention that <m>\vec 0</m> is parallel to all vectors if they desire.
-      (See also <xref ref="aside-cross-orthogonal">aside</xref> in <xref ref="sec_cross_product">Section</xref>.)
+      (See also the <xref ref="aside-cross-orthogonal" text="custom">aside</xref> in <xref ref="sec_cross_product">Section</xref>.)
     </p>
   </aside>
   <p>
@@ -1515,12 +1517,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 Name two different things that cannot be described with just one number,
@@ -1536,12 +1536,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What is the difference between <m>(1,2)</m> and <m>\la 1,2\ra</m>?
@@ -1557,12 +1555,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What is a unit vector?
@@ -1591,12 +1587,10 @@
 
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What does it mean for two vectors to be parallel?
@@ -1613,12 +1607,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 What effect does multiplying a vector by <m>-2</m> have?
@@ -1643,9 +1635,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector2D");
@@ -1656,7 +1646,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("i+6j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(2,-1)</m> and <m>Q = (3,5)</m>,
@@ -1684,9 +1674,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector2D");
@@ -1697,7 +1685,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("4i-4j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(3,2)</m> and <m>Q = (7,-2)</m>,
@@ -1725,9 +1713,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector");
@@ -1738,7 +1724,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("6i-j+6k");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(0,3,-1)</m> and <m>Q = (6,2,5)</m>,
@@ -1766,9 +1752,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
 
             <pg-code>
               Context("Vector");
@@ -1779,7 +1763,7 @@
               Context()->parens->undefine('&lt;','(','{');
               $stan=Vector("2i+2j");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 If <m>P=(2,1,2)</m> and <m>Q = (4,3,2)</m>,
@@ -1809,12 +1793,10 @@
     </exercisegroup>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Let <m>\vec u = \la 1,-2\ra</m> and <m>\vec v= \la 1,1\ra</m>.
@@ -1867,12 +1849,10 @@
     </exercise>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Let <m>\vec u = \la 1,1,-1\ra</m> and <m>\vec v= \la 2,1,2\ra</m>.
@@ -1934,12 +1914,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_11.tex -->
@@ -2005,12 +1983,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_13.tex -->
@@ -2079,12 +2055,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_14.tex -->
@@ -2171,12 +2145,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <sidebyside width="47%">
             <!-- START figures/fig_10_02_ex_15.tex -->
@@ -2273,8 +2245,7 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("sqrt(5)");
@@ -2282,7 +2253,7 @@
               $normupv=Formula("sqrt(26)");
               $normumv=Formula("sqrt(10)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la 2,1\ra</m> and <m>\vec v = \la 3,-2\ra</m>, find:
@@ -2308,8 +2279,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("sqrt(17)");
@@ -2317,7 +2287,7 @@
               $normupv=Formula("sqrt(14)");
               $normumv=Formula("sqrt(26)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la -3,2,2\ra</m> and <m>\vec v = \la 1,-1,1\ra</m>, find:
@@ -2343,8 +2313,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("sqrt(5)");
@@ -2352,7 +2321,7 @@
               $normupv=Formula("2sqrt(5)");
               $normumv=Formula("4sqrt(5)");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la 1,2\ra</m> and <m>\vec v = \la -3,-6\ra</m>, find:
@@ -2378,8 +2347,7 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
+        <webwork>
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $normu=Formula("7");
@@ -2387,7 +2355,7 @@
               $normupv=Formula("42");
               $normumv=Formula("28");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Given <m>\vec u=\la 2,-3,6\ra</m> and <m>\vec v = \la 10,-15,30\ra</m>, find:
@@ -2415,12 +2383,10 @@
     </exercisegroup>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Under what conditions is <m>\norm{\vec u}+\norm{\vec v} = \norm{\vec u+\vec v}</m>?
@@ -2445,15 +2411,13 @@
       </introduction>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0);
               $u=Compute("&lt;3/sqrt(58), 7/sqrt(58)>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 3,7\ra</m>.
@@ -2467,15 +2431,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0);
               $u=Compute("&lt;0.6, 0.8>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 6,8\ra</m>.
@@ -2489,15 +2451,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;1/3,-2/3,2/3>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 1,-2,2\ra</m>.
@@ -2511,15 +2471,13 @@
       </exercise>
 
       <exercise>
-        <webwork seed="1">
-            <setup>
-
+        <webwork>
             <pg-code>
               Context("Vector");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;1/sqrt(3),-1/sqrt(3),1/sqrt(3)>");
             </pg-code>
-            </setup>
+
             <statement>
               <p>
                 Find the unit vector <m>\vec u</m> in the direction of <m>\vec v = \la 2,-2,2\ra</m>.
@@ -2535,15 +2493,13 @@
     </exercisegroup>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
-
+      <webwork>
           <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;cos(50*pi/180),sin(50*pi/180)>");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the unit vector in the first quadrant of <m>\mathbb{R}^2</m> that makes a
@@ -2558,15 +2514,13 @@
     </exercise>
 
     <exercise>
-      <webwork seed="1">
-          <setup>
-
+      <webwork>
           <pg-code>
               Context("Vector2D");
               Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
               $u=Compute("&lt;-1/2,sqrt(3)/2>");
           </pg-code>
-          </setup>
+
           <statement>
             <p>
               Find the unit vector in the second quadrant of <m>\mathbb{R}^2</m> that makes a
@@ -2581,12 +2535,10 @@
     </exercise>
 
     <exercise>
-      <!-- <webwork seed="1">
-          <setup>
-
+      <!-- <webwork>
           <pg-code>
           </pg-code>
-          </setup> -->
+           -->
           <statement>
             <p>
               Verify, from <xref ref="idea_unit_vectors">Key Idea</xref>,
@@ -2646,12 +2598,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 30^\circ</m>,<m>\varphi=30^\circ</m>
@@ -2666,12 +2616,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 60^\circ</m>,<m>\varphi=60^\circ</m>
@@ -2686,12 +2634,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 20^\circ</m>,<m>\varphi=15^\circ</m>
@@ -2709,12 +2655,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\theta = 0^\circ</m>,<m>\varphi=0^\circ</m>
@@ -2766,12 +2710,10 @@
       </introduction>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=1</m>lb, <m>\ell = 1</m>ft, <m>p = 1</m>lb
@@ -2787,12 +2729,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=1</m>lb, <m>\ell = 1</m>ft, <m>p = 10</m>lb
@@ -2808,12 +2748,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=1</m>lb, <m>\ell = 10</m>ft, <m>p = 1</m>lb
@@ -2828,12 +2766,10 @@
       </exercise>
 
       <exercise>
-        <!-- <webwork seed="1">
-            <setup>
-
+        <!-- <webwork>
             <pg-code>
             </pg-code>
-            </setup> -->
+             -->
             <statement>
               <p>
                 <m>\vec F_w=10</m>lb, <m>\ell = 10</m>ft, <m>p = 1</m>lb

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -767,7 +767,6 @@
           note that the dimensions are for the water, not the pool itself.
           Compute the amount of work performed in draining the pool.
         </p>
-
         <figure xml:id="fig_pump3">
           <caption>The cross<ndash/>section of a swimming pool filled with water in <xref ref="ex_pump3">Example</xref>.</caption>
           <!-- START figures/fig_pump4.tex -->
@@ -807,22 +806,22 @@
 
             \foreach \y/\x in {0/0,1.5/$y$,3/3,6/6,8/8}
             {
-              \draw (-2.5,\y) node [left] {\scriptsize $\x$} -- (-1.5,\y);
+	            \draw (-2.5,\y) node [left] {\scriptsize $\x$} -- (-1.5,\y);
             }
 
             \draw [thick] (0,0) -- (10,0) -- (15,3) -- (25,3) -- (25,6) -- (0,6) -- (0,0);
 
             \draw [thick,firstcolor] (0,5) -- (25,5)
-                                      (0,1.5) -- (12.5,1.5);
+												              (0,1.5) -- (12.5,1.5);
 
             \draw [fill=black] (10,0) circle (1.5pt) node [shift={(15pt,-2pt)}] {\scriptsize $(10,0)$}
-                               (15,3) circle (1.5pt) node [shift={(15pt,-6pt)}] {\scriptsize $(15,3)$};
+								               (15,3) circle (1.5pt) node [shift={(15pt,-6pt)}] {\scriptsize $(15,3)$};
 
             \draw[&gt;=stealth,-&gt;] (-2,-2) -- (20,-2) node [right] {\scriptsize $x$};
 
             \foreach \y in {0,10,15}
             {
-              \draw (\y,-2.5) node [below] {\scriptsize $\y$} -- (\y,-1.5);
+	            \draw (\y,-2.5) node [below] {\scriptsize $\y$} -- (\y,-1.5);
             }
 
             \end{tikzpicture}
@@ -831,7 +830,7 @@
           </image>
           <!-- figures/fig_pump4b.tex END -->
         </figure>
-        
+
         <p>
           <xref ref="fig_pump_3a">Figure</xref>
           shows the pool oriented with this <m>y</m>-axis,


### PR DESCRIPTION
I already did a reconciliation on Chapter 1, but didn't add in the videos (commented out, of course). To be consistent with other chapters, I did that now.

For Chapters 2 and 3: there were a few typos that were caught on the videos branch but not in master. Those are addressed.
For sections that @Alex-Jordan has not done recent WeBWorK work on, I removed the deprecated <setup> tag from WeBWorK problems.
(For the sections that Alex has worked on, changes went in the other direction -- I updated the webwork on the videos branch.)

The two branches should now be even except for videos, once the last two pull requests go through.
(But note that the previous PR has those changes on tangent planes that need review from @APEXCalculus .)

Once all this goes through, I might delete the videos branch here and have it live on my fork with a new name.
I plan to have a main branch that is kept even with this one, and two branches where I adjust the table of contents to match our two calculus streams.