### PR TITLE
fix PG infinite loop bug

### DIFF
--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -685,8 +685,8 @@
           <pg-code>
             Context()->strings->add('the power rule'=>{});
             Context()->strings->add(
-              'power rule' => {alias => 'power rule'},
-              'power' => {alias => 'power rule'}
+              'power rule' => {alias => 'the power rule'},
+              'power' => {alias => 'the power rule'}
             );
             $ans=Compute("the power rule");
           </pg-code>


### PR DESCRIPTION
This problem was entering an infinite loop if a student entered "power rule" or "power" as the answer.