### PR TITLE
webwork coding errors

### DIFF
--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1792,14 +1792,14 @@
               $m = Formula("-$b")->reduce*$trig{$trigd{$c}}{$a} if ($c eq 'cos');
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
-              $t=Formula("y=$m(x-$a)+$k");
+              $t=Formula("y=$m(x-pi/$a)+$k");
               $t=Formula("y=$k") if ($m == 0);
               if (($c eq 'sin') and ($a==2))
                 {$n= Formula("x=pi/$a");}
               else {
-                $rm = Formula("$b")*$trigrecip{$trigd{$c}}{$a};
-                $rm = Formula("-$b")->reduce*$trigrecip{$trigd{$c}}{$a} if ($c eq 'cos');
-                $n= Formula("y=-$rm(x-$a)+$k");
+                $rm = Formula("1/$b")*$trigrecip{$trigd{$c}}{$a};
+                $rm = Formula("1/-$b")->reduce*$trigrecip{$trigd{$c}}{$a} if ($c eq 'cos');
+                $n= Formula("y=-$rm(x-pi/$a)+$k");
                 $t=Formula("y=$k") if ($m == 0);
               };
             </pg-code>
@@ -1871,14 +1871,14 @@
               $m = Formula("-$b")->reduce*$trig{$trigd{$c}}{$a} if ($c eq 'cos');
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
-              $t=Formula("y=$m(x-$a)+$k");
+              $t=Formula("y=$m(x-pi/$a)+$k");
               $t=Formula("y=$k") if ($m == 0);
               if (($c eq 'sin') and ($a==2))
                 {$n= Formula("x=pi/$a");}
               else {
-                $rm = Formula("$b")*$trigrecip{$trigd{$c}}{$a};
-                $rm = Formula("-$b")->reduce*$trigrecip{$trigd{$c}}{$a} if ($c eq 'cos');
-                $n= Formula("y=-$rm(x-$a)+$k");
+                $rm = Formula("1/$b")*$trigrecip{$trigd{$c}}{$a};
+                $rm = Formula("1/-$b")->reduce*$trigrecip{$trigd{$c}}{$a} if ($c eq 'cos');
+                $n= Formula("y=-$rm(x-pi/$a)+$k");
                 $t=Formula("y=$k") if ($m == 0);
               };
             </pg-code>

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1556,8 +1556,8 @@
               $b = Fraction(-3*($r+$s)/2);
               $c = 3*$r*$s;
               $f = Formula("x^3+$b x^2+$c x+$d")->reduce;
-              $max = Fraction(max($f->eval(x=>$low),$f->eval(x=>$high),$f->eval(x=>$r),$f->eval(x=>$s)));
-              $min = Fraction(min($f->eval(x=>$low),$f->eval(x=>$high),$f->eval(x=>$r),$f->eval(x=>$s)));
+              $max = Fraction(max($f->eval(x=>$low),$f->eval(x=>$high),$f->eval(x=>$s)));
+              $min = Fraction(min($f->eval(x=>$low),$f->eval(x=>$high),$f->eval(x=>$s)));
             </pg-code>
             <statement>
               <p>


### PR DESCRIPTION
These two problems had two things wrong with them. One is that instead of something like (x - pi/2) in the formula, it was just (x - 2). The other is that the normal slope was not taking the reciprocal of both of its product components.