### PR TITLE
Add 'instructions' to later WW exercises, and some other small edits

### DIFF
--- a/ptx/appendix_back_reference.ptx
+++ b/ptx/appendix_back_reference.ptx
@@ -190,7 +190,7 @@
 
     <list xml:id="reference-int-elementary">
       <title>Integrals of Elementary (non-Trig) Functions</title>
-      <ol>
+      <ol cols="2">
         <li>
           <m>\int x^n\,dx=\frac{1}{n+1}x^{n+1}+C, n\neq -1</m>
         </li>
@@ -215,7 +215,7 @@
 
     <list xml:id="reference-int-trig">
       <title>Integrals Involving Trigonometric Functions</title>
-      <ol>
+      <ol cols="2">
         <li>
           <m>\int \cos x\,dx=\sin x+C</m>
         </li>
@@ -373,7 +373,7 @@
       <title>Definitions of the Trigonometric Functions</title>
       <assemblage>
         <title>Unit Circle Definition</title>
-        <sidebyside widths="40% 40%">
+        <sidebyside widths="40% 30%">
           <image xml:id="img_unit_circ_def">
             <description></description>
               <latex-image>
@@ -421,7 +421,7 @@
 
       <assemblage>
         <title>Right Triangle Definition</title>
-        <sidebyside widths="40% 40%">
+        <sidebyside widths="30% 30%">
           <image xml:id="img_right_triangle_def">
             <description></description>
             <latex-image>

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -126,7 +126,7 @@
 
       <!-- Todo: Fix this weird image -->
 
-      <image width="100%">
+      <image xml:id="img_anti1" width="100%">
         <description></description>
         <latex-image>
 

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -1176,20 +1176,20 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \la 7\cos(t) ,7\sin(t) \ra</m>,
-                  find the arc length paramter <m>s</m>.
+                  <m>\vrt = \la 7\cos(t) ,7\sin(t) \ra</m>.
+                </p>
+                <instruction>
+                  Find the arc length paramter <m>s</m>.
+                </instruction>
+                <p>
+                  <var name="$s" width="20"/>
                 </p>
 
-                <p>
-                  <m>s=</m><var name="$s" width="20"/>
-                </p>
-
-                <p>
+                <instruction>
                   Rewrite <m>\vrt</m> in terms of <m>s</m>.
-                </p>
-
+                </instruction>
                 <p>
-                  <m>\vec{r}(s)=</m><var name="$rs" width="20"/>
+                  <var name="$rs" width="20"/>
                 </p>
               </statement>
           </webwork>
@@ -1224,20 +1224,21 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \vrt = \la 5\cos(t) ,13\sin(t) , 12\cos(t) \ra</m>,
-                  find the arc length paramter <m>s</m>.
+                  <m>\vrt = \vrt = \la 5\cos(t) ,13\sin(t) , 12\cos(t) \ra</m>.
+                </p>
+                <instruction>
+                  Find the arc length paramter <m>s</m>.
+                </instruction>
+                <p>
+                  <var name="$s" width="30"/>
                 </p>
 
-                <p>
-                  <m>s=</m><var name="$s" width="30"/>
-                </p>
-
-                <p>
+                <instruction>
                   Rewrite <m>\vrt</m> in terms of <m>s</m>.
-                </p>
+                </instruction>
 
                 <p>
-                  <m>\vec{r}(s)=</m><var name="$rs" width="30"/>
+                  <var name="$rs" width="30"/>
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -805,22 +805,23 @@
     <p>
       Consider the function <m>y=x^x</m>;
       it is graphed in <xref ref="fig_logdiffa">Figure</xref>.
-      It is well-defined for <m>x \gt 0</m> and we might be interested in finding equations of lines tangent and normal to its graph.<fn>
-      In calculus the expression <m>0^0</m> is also considered well-defined and equal to <m>1</m>.
-      This is easily confused with a limit of the <em>form</em>
-      <m>0^0</m>, which is indeterminate.
-      We skirt the issue here.
-      </fn> How do we take its derivative?
+      It is well-defined for <m>x \gt 0</m> and we might be interested in finding equations of lines tangent and normal to its graph.
+      How do we take its derivative?
 
-  <!-- TODO: decide on above footnote addded in apex-mbx -->
-
-
-          <idx><h>logarithmic differentiation</h></idx>
-          <idx><h>derivative</h>
-               <h>logarithmic</h>
-          </idx>
-
+                <idx><h>logarithmic differentiation</h></idx>
+                <idx><h>derivative</h>
+                     <h>logarithmic</h>
+                </idx>
     </p>
+    <aside>
+      <p>
+        In calculus the expression <m>0^0</m> is also considered well-defined and equal to <m>1</m>.
+        This is easily confused with a limit of the <em>form</em>
+        <m>0^0</m>, which is indeterminate.
+        We skirt the issue here.
+      </p>
+    </aside>
+
 
     <figure xml:id="fig_logdiffa">
       <caption>A plot of <m>y=x^x</m></caption>

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -138,9 +138,15 @@
       add <m>0</m> to the numerator
       (so that nothing is changed)
       in the form of <m>{}-f(x)g(x+h)+f(x)g(x+h)</m>,
-      then do some regrouping as shown.<fn>
-      Adding <m>0</m> in some clever form is a common mathematical proof technique.
-      </fn><md>
+      then do some regrouping as shown.
+    </p>
+    <aside>
+      <p>
+        Adding <m>0</m> in some clever form is a common mathematical proof technique.
+      </p>
+    </aside>
+    <p>
+      <md>
         <mrow>\amp\lzoo{x}{f(x)g(x)} = \lim_{h\to0} \frac{f(x+h)g(x+h)-f(x)g(x)}{h}</mrow>
         <mrow>\amp \text{ (now add 0 to the numerator) }</mrow>
         <mrow>\amp = \lim_{h\to0} \frac{f(x+h)g(x+h)-f(x)g(x+h)+f(x)g(x+h)-f(x)g(x)}{h}</mrow>

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -1949,7 +1949,7 @@
         <exercise>
           <statement>
             <!-- START figures/fig_02_04_ex_42.tex -->
-            <image xml:id="img_02_04_ex_42" width="47%">
+            <image xml:id="img_02_04_ex_42">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -1967,7 +1967,7 @@
             <!-- figures/fig_02_04_ex_42.tex END -->
           </statement>
           <answer>
-            <image>
+            <image xml:id="img_02_04_ex_42_sol">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -1988,7 +1988,7 @@
         <exercise>
           <statement>
             <!-- START figures/fig_02_04_ex_43.tex -->
-            <image xml:id="img_02_04_ex_43" width="47%">
+            <image xml:id="img_02_04_ex_43">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -2006,7 +2006,7 @@
             <!-- figures/fig_02_04_ex_43.tex END -->
           </statement>
           <answer>
-            <image>
+            <image xml:id="img_02_04_ex_43_sol">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -2047,7 +2047,7 @@
             <!-- figures/fig_02_04_ex_44.tex END -->
           </statement>
           <answer>
-            <image>
+            <image xml:id="img_02_04_ex_44_sol">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -2090,7 +2090,7 @@
             <!-- figures/fig_02_04_ex_45.tex END -->
           </statement>
           <answer>
-            <image>
+            <image xml:id="img_02_04_ex_45_sol">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -833,12 +833,12 @@
 
         <figure xml:id="fig_direct3">
           <caption>A graph of the surface described in <xref ref="ex_direct3">Example</xref> along with the path in the <m>xy</m>-plane with the level curves</caption>
-          <sidebyside>
+          <sidebyside widths="47%" valign="bottom" margins="0%">
             <figure xml:id="fig_direct3a_3D">
               <caption/>
 
               <!-- START figures/figdirect3_3D.asy -->
-              <image xml:id="img_direct3a_3D" width="47%">
+              <image xml:id="img_direct3a_3D">
                 <description></description>
                 <asymptote>
 
@@ -900,7 +900,7 @@
             <figure xml:id="fig_direct3b">
               <caption/>
             <!-- START figures/fig_direct3b.tex -->
-              <image xml:id="img_direct3b" width="47%">
+              <image xml:id="img_direct3b">
                 <description></description>
                 <latex-image>
 
@@ -1351,7 +1351,7 @@
                 </p>
 
                 <p>
-                  <ol>
+                  <ol label="a">
                     <li>
                       <p>
                         In the direction of <m>\vec v = \la 3,4\ra</m>
@@ -1443,7 +1443,7 @@
                 </p>
 
                 <p>
-                  <ol>
+                  <ol label="a">
                     <li>
                       <p>
                         In the direction of <m>\vec v = \la 1,-1\ra</m>.
@@ -1534,7 +1534,7 @@
                 </p>
 
                 <p>
-                  <ol>
+                  <ol label="a">
                     <li>
                       <p>
                         In the direction of <m>\vec v = \la -2,5\ra</m>
@@ -1722,48 +1722,29 @@
                   <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>:
                 </p>
 
+                <instruction>
+                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$maxdir" evaluator="$maxdirev" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                      </p>
-
-                      <p>
-                        <var name="$maxval" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$mindir" evaluator="$mindirev" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$nochange" evaluator="$nochangeev" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$maxdir" evaluator="$maxdirev" width="30"/>
+                </p>
+                <instruction>
+                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                </instruction>
+                <p>
+                  <var name="$maxval" width="30"/>
+                </p>
+                <instruction>
+                  Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$mindir" evaluator="$mindirev" width="30"/>
+                </p>
+                <instruction>
+                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$nochange" evaluator="$nochangeev" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1833,48 +1814,29 @@
                   Given <m>f(x,y) = -4x+3y</m>, <m>P = (5,4)</m>:
                 </p>
 
+                <instruction>
+                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$maxdir" evaluator="$maxdirev" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                      </p>
-
-                      <p>
-                        <var name="$maxval" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$mindir" evaluator="$mindirev" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$nochange" evaluator="$nochangeev" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$maxdir" evaluator="$maxdirev" width="30"/>
+                </p>
+                <instruction>
+                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                </instruction>
+                <p>
+                  <var name="$maxval" width="30"/>
+                </p>
+                <instruction>
+                  Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$mindir" evaluator="$mindirev" width="30"/>
+                </p>
+                <instruction>
+                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$nochange" evaluator="$nochangeev" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1943,49 +1905,29 @@
                 <p>
                   Given <m>f(x,y) = x^2y^3-2x</m>, <m>P = (1,1)</m>:
                 </p>
-
+                <instruction>
+                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$maxdir" evaluator="$maxdirev" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                      </p>
-
-                      <p>
-                        <var name="$maxval" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$mindir" evaluator="$mindirev" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$nochange" evaluator="$nochangeev" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$maxdir" evaluator="$maxdirev" width="30"/>
+                </p>
+                <instruction>
+                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                </instruction>
+                <p>
+                  <var name="$maxval" width="30"/>
+                </p>
+                <instruction>
+                  Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$mindir" evaluator="$mindirev" width="30"/>
+                </p>
+                <instruction>
+                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$nochange" evaluator="$nochangeev" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -2063,28 +2005,17 @@
                   <m>\vec v = \la 2,2,1\ra</m>, <m>P = (0,0,0)</m>:
                 </p>
 
+                <instruction>
+                  Find <m>\nabla F(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find <m>\nabla F(x,y,z)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$gradient" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find <m>D_{\vec u}\,F</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$directional" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$gradient" width="50"/>
+                </p>
+                <instruction>
+                  Find <m>D_{\vec u}\,F</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$directional" width="20"/>
                 </p>
               </statement>
           </webwork>
@@ -2135,28 +2066,17 @@
                   <m>\vec v = \la 1,1,-2\ra</m>, <m>P = (1,1,1)</m>:
                 </p>
 
+                <instruction>
+                  Find <m>\nabla F(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find <m>\nabla F(x,y,z)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$gradient" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find <m>D_{\vec u}\,F</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$directional" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$gradient" width="50"/>
+                </p>
+                <instruction>
+                  Find <m>D_{\vec u}\,F</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$directional" width="20"/>
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -833,7 +833,7 @@
 
         <figure xml:id="fig_direct3">
           <caption>A graph of the surface described in <xref ref="ex_direct3">Example</xref> along with the path in the <m>xy</m>-plane with the level curves</caption>
-          <sidebyside widths="47%" valign="bottom" margins="0%">
+          <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_direct3a_3D">
               <caption/>
 

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -18,7 +18,7 @@
       which do measure this rate of change.
     </p>
 
-    <figure xml:id="vid-mutli-directional-derivative-def">
+    <figure xml:id="vid-multi-directional-derivative-def">
       <caption>Introducing directional derivatives</caption>
       <video youtube="ZQPnmL5CM6s"/>
     </figure>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -171,7 +171,7 @@
 
     <figure xml:id="fig_dotpangle">
       <caption>Illustrating the angle formed by two vectors with the same initial point</caption>
-      <sidebyside widths="47% 47%" valign="bottom" margins="0%">
+      <sidebyside widths="33% 47%" valign="bottom" margins="0%">
         <figure xml:id="fig_dotpanglea">
           <caption/>
         <!-- START figures/fig_dotpangle.tex -->

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -915,8 +915,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            a function <m>f(x,y)</m> is given and a region <m>R</m> of the <m>xy</m>-plane is described.
+            A function <m>f(x,y)</m> is given and a region <m>R</m> of the <m>xy</m>-plane is described.
             Set up and evaluate <m>\iint_Rf(x,y)\, dA</m> using polar coordinates.
           </p>
         </introduction>
@@ -929,8 +928,7 @@
 
               <statement>
                 <p>
-                  Use polar coordinates to evaluate <m>\iint_Rf(x,y)\,dA</m>,
-                  where <m>f(x,y) = 3x-y+4</m> and <m>R</m> is the region enclosed by the circle <m>x^2+y^2=1</m>.
+                  <m>f(x,y) = 3x-y+4</m> and <m>R</m> is the region enclosed by the circle <m>x^2+y^2=1</m>.
                 </p>
 
                 <p>
@@ -966,8 +964,7 @@
 
               <statement>
                 <p>
-                  Use polar coordinates to evaluate <m>\iint_Rf(x,y)\,dA</m>,
-                  where <m>f(x,y) = 8-y</m> and <m>R</m> is the region enclosed by the circles with polar equations
+                  <m>f(x,y) = 8-y</m> and <m>R</m> is the region enclosed by the circles with polar equations
                   <m>r=\cos(\theta)</m> and <m>r=3\cos(\theta)</m>.
                 </p>
 
@@ -1024,8 +1021,7 @@
 
               <statement>
                 <p>
-                  Use polar coordinates to evaluate <m>\iint_Rf(x,y)\,dA</m>,
-                  where <m>f(x,y) = 1-x^2-y^2</m> and <m>R</m> is the region enclosed by the circle <m>x^2+y^2=1</m>.
+                  <m>f(x,y) = 1-x^2-y^2</m> and <m>R</m> is the region enclosed by the circle <m>x^2+y^2=1</m>.
                 </p>
 
                 <p>
@@ -1074,12 +1070,11 @@
         </exercise>
 
       </exercisegroup>
-      <exercisegroup cols="2">
+      <exercisegroup>
 
         <introduction>
           <p>
-            In the following exercises,
-            an iterated integral in rectangular coordinates is given.
+            An iterated integral in rectangular coordinates is given.
             Rewrite the integral using polar coordinates and evaluate the new double integral.
           </p>
         </introduction>
@@ -1109,7 +1104,7 @@
 
               <statement>
                 <p>
-                  Evalueate the integral <m>\ds \int_{-4}^{4}\int_{-\sqrt{16-y^2}}^{0} \big(2y-x\big)\, dx\, dy</m> by first rewriting it using polar coordinates.
+                  <m>\ds \int_{-4}^{4}\int_{-\sqrt{16-y^2}}^{0} \big(2y-x\big)\, dx\, dy</m>
                 </p>
 
                 <p>

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -352,7 +352,7 @@
     </statement>
   </definition>
 
-  <figure xml:id="vid-mutlint-double-def">
+  <figure xml:id="vid-multint-double-def">
     <caption>Defining the double integral</caption>
     <video youtube="l7hGaXcsq9g"/>
   </figure>
@@ -1604,7 +1604,10 @@
             <statement>
               <p>
                 Explain why the following statement is false:
-                <q>Fubini's Theorem states that <m>\ds \int_a^b\int_{g_1(x)}^{g_2(x)} f(x,y)\, dy\, dx = \int_a^b\int_{g_1(y)}^{g_2(y)} f(x,y)\, dx\, dy</m>.</q>
+                Fubini's Theorem states that
+                <me>
+                  \int_a^b\int_{g_1(x)}^{g_2(x)} f(x,y)\, dy\, dx = \int_a^b\int_{g_1(y)}^{g_2(y)} f(x,y)\, dx\, dy
+                </me>.
               </p>
             </statement>
             <solution>
@@ -1667,7 +1670,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
+            For the given integral,
 
             <ol label="a">
               <li>
@@ -1732,21 +1735,12 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Calculate <m>\ds \int_{-\pi/2}^{\pi/2}\int_{0}^\pi\left(\sin(x) \cos(y) \right)\,dx\,dy</m>
-                      </p>
+                  <m>\ds \int_{-\pi/2}^{\pi/2}\int_{0}^\pi\left(\sin(x) \cos(y) \right)\,dx\,dy</m>
+                </p>
 
                       <!-- <p>
                         <var name="$value" width="10"/>
                       </p> -->
-                    </li>
-
-                    <li>
-                      <p>
-                        Rewrite the integral using the other order of integration.
-                      </p>
 
                       <!-- <tabular>
                         <row>
@@ -1763,10 +1757,6 @@
                           <cell><var name="$multians" width="1"/></cell>
                         </row>
                       </tabular> -->
-
-                    </li>
-                  </ol>
-                </p>
               </statement>
           <!-- </webwork> -->
         </exercise>
@@ -1817,21 +1807,13 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Calculate <m>\ds \int_{1}^{3}\int_{y}^{3}\left(x^2y-xy^2\right)\,dx\,dy</m>
-                      </p>
+                  <m>\ds \int_{1}^{3}\int_{y}^{3}\left(x^2y-xy^2\right)\,dx\,dy</m>
+                </p>
 
                       <!-- <p>
                         <var name="$value" width="10"/>
                       </p> -->
-                    </li>
 
-                    <li>
-                      <p>
-                        Rewrite the integral using the other order of integration.
-                      </p>
   <!--
                       <tabular>
                         <row>
@@ -1848,10 +1830,6 @@
                           <cell><var name="$multians" width="1"/></cell>
                         </row>
                       </tabular> -->
-
-                    </li>
-                  </ol>
-                </p>
               </statement>
           <!-- </webwork> -->
         </exercise>
@@ -1902,21 +1880,12 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Calculate <m>\ds \int_{0}^{9}\int_{y/3}^{\sqrt{y}}\left(xy^2\right)\,dx\,dy</m>
-                      </p>
+                  <m>\ds \int_{0}^{9}\int_{y/3}^{\sqrt{y}}\left(xy^2\right)\,dx\,dy</m>
+                </p>
 
                       <!-- <p>
                         <var name="$value" width="10"/>
                       </p> -->
-                    </li>
-
-                    <li>
-                      <p>
-                        Rewrite the integral using the other order of integration.
-                      </p>
 
                       <!-- <tabular>
                         <row>
@@ -1934,9 +1903,6 @@
                         </row>
                       </tabular> -->
 
-                    </li>
-                  </ol>
-                </p>
               </statement>
           <!-- </webwork> -->
         </exercise>

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -200,7 +200,7 @@
         <sidebyside>
           <figure>
             <caption><m>\fp\gt 0</m>, <m>f</m> increasing; <m>\fpp\lt0</m>, <m>f</m> is concave down</caption>
-            <image>
+            <image xml:id="img_concavity3a">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -212,7 +212,7 @@
 
           <figure>
             <caption><m>\fp\lt0</m>, <m>f</m> decreasing; <m>\fpp\lt0</m>, <m>f</m> is concave down</caption>
-            <image>
+            <image xml:id="img_concavity3b">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -226,7 +226,7 @@
         <sidebyside>
           <figure>
             <caption><m>\fp\lt0</m>, <m>f</m> decreasing; <m>\fpp\gt 0</m>, <m>f</m> is concave up</caption>
-            <image>
+            <image xml:id="img_concavity3c">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -238,7 +238,7 @@
 
           <figure>
             <caption><m>\fp\gt 0</m>, <m>f</m> increasing; <m>\fpp\gt 0</m>, <m>f</m> is concave up</caption>
-            <image>
+            <image xml:id="img_concavity3d">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -33,7 +33,7 @@
 
     <figure xml:id="fig_hfcircle">
       <caption>Using trigonometric functions to define points on a circle and hyperbolic functions to define points on a hyperbola. The area of the shaded regions are included in them.</caption>
-      <sidebyside widths="47% 47%" margins="0%">
+      <sidebyside widths="47% 40%" margins="0%">
 
         <figure xml:id="fig_hf_circlearea">
           <caption/>
@@ -863,22 +863,22 @@
         <ol>
           <li>
             <p>
-              <m>\ds\cosh^{-1}(x) =\ln\big(x+\sqrt{x^2-1}\big);\\ x\geq1</m>
+              <m>\ds\cosh^{-1}(x) =\ln\big(x+\sqrt{x^2-1}\big);\, x\geq1</m>
 
               <idx><h>hyperbolic function</h><h>inverse!logarithmic def.</h></idx>
 
             </p>
           </li>
 
-          <li><m>\tanh^{-1}(x) = \frac12\ln\left(\frac{1+x}{1-x}\right);\\ \abs{x}\lt 1</m></li>
+          <li><m>\tanh^{-1}(x) = \frac12\ln\left(\frac{1+x}{1-x}\right);\, \abs{x}\lt 1</m></li>
 
-          <li><m>\sech^{-1}(x) = \ln\left(\frac{1+\sqrt{1-x^2}}x\right);\\ 0\lt x\leq1</m></li>
+          <li><m>\sech^{-1}(x) = \ln\left(\frac{1+\sqrt{1-x^2}}x\right);\, 0\lt x\leq1</m></li>
 
           <li><m>\sinh^{-1}(x) = \ln\big(x+\sqrt{x^2+1}\big)</m></li>
 
-          <li><m>\coth^{-1}(x) = \frac12\ln\left(\frac{x+1}{x-1}\right);\\ \abs{x} \gt 1</m></li>
+          <li><m>\coth^{-1}(x) = \frac12\ln\left(\frac{x+1}{x-1}\right);\, \abs{x} \gt 1</m></li>
 
-          <li><m>\csch^{-1}(x) = \ln\left(\frac1x+\frac{\sqrt{1+x^2}}{\abs{x}}\right);\\ x\neq0</m></li>
+          <li><m>\csch^{-1}(x) = \ln\left(\frac1x+\frac{\sqrt{1+x^2}}{\abs{x}}\right);\, x\neq0</m></li>
         </ol>
       </p>
     </insight>

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -896,7 +896,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <ol label="a">
+                  <ol>
                     <li>
                       <p>
                         <m>\ds \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx=</m><var name="$a" width="20"/>
@@ -983,7 +983,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <ol label="a">
+                  <ol>
                     <li>
                       <p>
                         <m>\ds \int_y^{y^2} (x-y)\,dx=</m><var name="$a" width="20"/>
@@ -1071,7 +1071,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <ol label="a">
+                  <ol>
                     <li>
                       <p>
                         <m>\ds \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy=</m><var name="$a" width="20"/>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -777,7 +777,7 @@
       <sidebyside widths="31% 31% 31%" margins="0%">
         <figure xml:id="fig_removable_disc">
           <caption>The graph of a function with a removable discontinuity at <m>x=2</m></caption>
-          <image>
+          <image xml:id="img_discontinuity_rem">
             <description></description>
             <latex-image>
               \begin{tikzpicture}
@@ -800,7 +800,7 @@
 
         <figure xml:id="fig_jump_disc">
           <caption>The graph of a function with a jump discontinuity at <m>x=2</m></caption>
-          <image>
+          <image xml:id="img_discontinuity_jump">
             <description></description>
             <latex-image>
               \begin{tikzpicture}
@@ -823,7 +823,7 @@
 
         <figure xml:id="fig_inf_disc">
           <caption>The graph of a function with an infinite discontinuity at <m>x=2</m></caption>
-          <image>
+          <image xml:id="img_discontinuity_inf">
             <description></description>
             <latex-image>
               \begin{tikzpicture}

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -1303,10 +1303,10 @@
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
-                <insttuction>
+                <instruction>
                   Give the parametric equations for <m>\ell</m>
                   (separated using commas).
-                </insttuction>
+                </instruction>
                 <p>
                   <var name="$p" evaluator="$pev" width="50"/>.
                 </p>

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -1296,20 +1296,27 @@
                   parallel to <m>\vec d=\la -3,2,5\ra</m>.
                 </p>
 
+                <instruction>
+                  Give a vector equation for <m>\ell</m>.
+                </instruction>
                 <p>
-                  A vector equation for <m>\ell</m> is
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
+                <insttuction>
+                  Give the parametric equations for <m>\ell</m>
+                  (separated using commas).
+                </insttuction>
                 <p>
-                  Parametric equations for <m>\ell</m>
-                  (separated using commas)
-                  are <var name="$p" evaluator="$pev" width="50"/>.
+                  <var name="$p" evaluator="$pev" width="50"/>.
                 </p>
 
-                <p>
-                  Symmetric equations for <m>\ell</m> are <var name="$s" evaluator="$sev" width="50"/>.
+                <instruction>
+                  Give the symmetric equations for <m>\ell</m>.
                   (Enter <c>DNE</c> if they are not defined.)
+                </instruction>
+                <p>
+                  <var name="$s" evaluator="$sev" width="50"/>.
                 </p>
               </statement>
           </webwork>
@@ -1464,20 +1471,27 @@
                   <m>P=(1,-2,3)</m> and <m>Q = (5,5,5)</m>.
                 </p>
 
+                <instruction>
+                  Give a vector equation for <m>\ell</m>.
+                </instruction>
                 <p>
-                  A vector equation for <m>\ell</m> is
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
+                <instruction>
+                  Give the parametric equations for <m>\ell</m>
+                  (separated using commas).
+                </instruction>
                 <p>
-                  Parametric equations for <m>\ell</m>
-                  (separated using commas)
-                  are <var name="$p" evaluator="$pev" width="50"/>.
+                  <var name="$p" evaluator="$pev" width="50"/>.
                 </p>
 
-                <p>
-                  Symmetric equations for <m>\ell</m> are <var name="$s" evaluator="$sev" width="50"/>.
+                <instruction>
+                  Give the ymmetric equations for <m>\ell</m>.
                   (Enter <c>DNE</c> if they are not defined.)
+                </instruction>
+                <p>
+                  <var name="$s" evaluator="$sev" width="50"/>.
                 </p>
               </statement>
           </webwork>
@@ -1583,20 +1597,27 @@
                   <m>\vec d_1=\la 1,0,1\ra</m> and <m>\vec d_2=\la 2,0,3\ra</m>.
                 </p>
 
+                <instruction>
+                  Give a vector equation for <m>\ell</m>.
+                </instruction>
                 <p>
-                  A vector equation for <m>\ell</m> is
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
+                <instruction>
+                  Give parametric equations for <m>\ell</m>
+                  (separated using commas).
+                </instruction>
                 <p>
-                  Parametric equations for <m>\ell</m>
-                  (separated using commas)
-                  are <var name="$p" evaluator="$pev" width="50"/>.
+                  <var name="$p" evaluator="$pev" width="50"/>.
                 </p>
 
-                <p>
-                  Symmetric equations for <m>\ell</m> are <var name="DNE" width="50"/>.
+                <instruction>
+                  Give symmetric equations for <m>\ell</m>.
                   (Enter <c>DNE</c> if they are not defined.)
+                </instruction>
+                <p>
+                  <var name="DNE" width="50"/>.
                 </p>
               </statement>
           </webwork>
@@ -1699,20 +1720,27 @@
                   and is orthogonal to both lines.
                 </p>
 
+                <instruction>
+                  Give a vector equation for <m>\ell</m>.
+                </instruction>
                 <p>
-                  A vector equation for <m>\ell</m> is
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
+                <instruction>
+                  Give parametric equations for <m>\ell</m>
+                  (separated using commas).
+                </instruction>
                 <p>
-                  Parametric equations for <m>\ell</m>
-                  (separated using commas)
-                  are <var name="$p" evaluator="$pev" width="50"/>.
+                  <var name="$p" evaluator="$pev" width="50"/>.
                 </p>
 
-                <p>
-                  Symmetric equations for <m>\ell</m> are <var name="$s" evaluator="$sev" width="50"/>.
+                <instruction>
+                  Give symmetric equations for <m>\ell</m>.
                   (Enter <c>DNE</c> if they are not defined.)
+                </instruction>
+                <p>
+                  <var name="$s" evaluator="$sev" width="50"/>.
                 </p>
               </statement>
           </webwork>
@@ -1815,20 +1843,27 @@
                   and is orthogonal to both lines.
                 </p>
 
+                <instruction>
+                  Give a vector equation for <m>\ell</m>.
+                </instruction>
                 <p>
-                  A vector equation for <m>\ell</m> is
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
+                <instruction>
+                  Give parametric equations for <m>\ell</m>
+                  (separated using commas).
+                </instruction>
                 <p>
-                  Parametric equations for <m>\ell</m>
-                  (separated using commas)
-                  are <var name="$p" evaluator="$pev" width="50"/>.
+                  <var name="$p" evaluator="$pev" width="50"/>.
                 </p>
 
-                <p>
-                  Symmetric equations for <m>\ell</m> are <var name="$s" evaluator="$sev" width="50"/>.
+                <instruction>
+                  Give symmetric equations for <m>\ell</m>.
                   (Enter <c>DNE</c> if they are not defined.)
+                </instruction>
+                <p>
+                  <var name="$s" evaluator="$sev" width="50"/>.
                 </p>
               </statement>
           </webwork>
@@ -1919,20 +1954,27 @@
                   parallel to <m>\vec d = \la 0,1\ra</m>.
                 </p>
 
+                <instruction>
+                  Give a vector equation for <m>\ell</m>.
+                </instruction>
                 <p>
-                  A vector equation for <m>\ell</m> is
                   <m>\ell(t)=</m><var name="$v" evaluator="$vev" width="30"/>.
                 </p>
 
-                <p>
-                  Parametric equations for <m>\ell</m>
+                <instruction>
+                  Give parametric equations for <m>\ell</m>
                   (separated using commas)
-                  are <var name="$p" evaluator="$pev" width="50"/>.
+                </instruction>
+                <p>
+                  <var name="$p" evaluator="$pev" width="50"/>.
                 </p>
 
-                <p>
-                  Symmetric equations for <m>\ell</m> are <var name="DNE" width="50"/>.
+                <instruction>
+                  Give symmetric equations for <m>\ell</m>.
                   (Enter <c>DNE</c> if they are not defined.)
+                </instruction>
+                <p>
+                  <var name="DNE" width="50"/>.
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -779,8 +779,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            functions <m>z=f(x,y)</m>, <m>x=g(t)</m> and <m>y=h(t)</m> are given.
+            Given the functions <m>z=f(x,y)</m>, <m>x=g(t)</m> and <m>y=h(t)</m>:
           </p>
 
           <p>
@@ -849,16 +848,22 @@
 
               <statement>
                 <p>
-                  Given <m>z=x^2-y^2</m>, <m>x=t</m>,
-                  and <m>y=t^2-1</m>, use the Multivariable Chain Rule to compute:
+                  <m>z=x^2-y^2</m>, <m>x=t</m>,
+                  and <m>y=t^2-1</m>; <m>t=1</m>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\lz{z}{t}</m>.
+                </instruction>
                 <p>
-                  <m>\lz{z}{t}=</m><var name="$dzdt" evaluator="$ev" width="30"/>
+                  <var name="$dzdt" evaluator="$ev" width="30"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\lz{z}{t}</m> at the indicated <m>t</m>-value.
+                </instruction>
                 <p>
-                  <m>\lzoa{z}{t}{t=1}=</m><var name="$dzdt1" width="15"/>
+                  <var name="$dzdt1" width="15"/>
                 </p>
               </statement>
           </webwork>
@@ -915,16 +920,21 @@
 
               <statement>
                 <p>
-                  Given <m>z=\frac{x}{y^2+1}</m>, <m>x=\cos(t)</m>,
-                  and <m>y=\sin(t)</m>, use the Multivariable Chain Rule to compute:
+                  <m>z=\frac{x}{y^2+1}</m>, <m>x=\cos(t)</m>,
+                  and <m>y=\sin(t)</m>; <m>t=\pi/2</m>
+                </p>
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\lz{z}{t}</m>.
+                </instruction>
+                <p>
+                  <var name="$dzdt" evaluator="$ev" width="30"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\lz{z}{t}</m> at the indicated <m>t</m>-value.
+                </instruction>
                 <p>
-                  <m>\lz{z}{t}=</m><var name="$dzdt" evaluator="$ev" width="30"/>
-                </p>
-
-                <p>
-                  <m>\lzoa{z}{t}{t=\pi/2}=</m><var name="$dzdt1" width="15"/>
+                  <var name="$dzdt1" width="15"/>
                 </p>
               </statement>
           </webwork>
@@ -982,16 +992,22 @@
 
               <statement>
                 <p>
-                  Given <m>z=\cos(x) \sin(y)</m>, <m>x=\pi t</m>,
-                  and <m>y=2\pi t+\pi/2</m>, use the Multivariable Chain Rule to compute:
+                  <m>z=\cos(x) \sin(y)</m>, <m>x=\pi t</m>,
+                  and <m>y=2\pi t+\pi/2</m>; <m>t=3</m>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\lz{z}{t}</m>.
+                </instruction>
                 <p>
-                  <m>\lz{z}{t}=</m><var name="$dzdt" evaluator="$ev" width="30"/>
+                  <var name="$dzdt" evaluator="$ev" width="30"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\lz{z}{t}</m> at the indicated <m>t</m>-value.
+                </instruction>
                 <p>
-                  <m>\lzoa{z}{t}{t=3}=</m><var name="$dzdt1" width="15"/>
+                  <var name="$dzdt1" width="15"/>
                 </p>
               </statement>
           </webwork>
@@ -1239,9 +1255,9 @@
 
         <introduction>
           <p>
-            In the following exercises,
+            Given the
             functions <m>z=f(x,y)</m>,
-            <m>x=g(s,t)</m> and <m>y=h(s,t)</m> are given.
+            <m>x=g(s,t)</m> and <m>y=h(s,t)</m>:
           </p>
 
           <p>
@@ -1326,25 +1342,36 @@
 
               <statement>
                 <p>
-                  Given <m>z=\cos\mathopen{}\left(\pi x+\frac{\pi}2y\right)\mathclose{}</m>,
-                  <m>x=st^2</m>,
-                  and <m>y=s^2t</m>, use the Multivariable Chain Rule to compute:
+                  <m>z=\cos\mathopen{}\left(\pi x+\frac{\pi}2y\right)\mathclose{}</m>,
+                  <m>x=st^2</m>, and <m>y=s^2t</m>; <m>s=1</m>, <m>t=0</m>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\plz{z}{s}</m>.
+                </instruction>
                 <p>
-                  <m>\plz{z}{s}=</m><var name="$dzds" evaluator="$dzdsev" width="50"/>
+                  <var name="$dzds" evaluator="$dzdsev" width="50"/>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\plz{z}{t}</m>.
+                </instruction>
                 <p>
-                  <m>\plz{z}{t}=</m><var name="$dzdt" evaluator="$dzdtev" width="50"/>
+                  <var name="$dzdt" evaluator="$dzdtev" width="50"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\plz{z}{s}</m> at <m>s=1</m>, <m>t=0</m>.
+                </instruction>
                 <p>
-                  <m>\plzoa{z}{s}{s=1,t=1}=</m><var name="$dzds1" width="15"/>
+                  <var name="$dzds1" width="15"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\plz{z}{t}</m> at <m>s=1</m>, <m>t=0</m>.
+                </instruction>
                 <p>
-                  <m>\plzoa{z}{t}{s=1,t=1}=</m><var name="$dzdt1" width="15"/>
+                  <var name="$dzdt1" width="15"/>
                 </p>
               </statement>
           </webwork>
@@ -1380,24 +1407,36 @@
 
               <statement>
                 <p>
-                  Given <m>z=x^2+y^2</m>, <m>x=s\cos(t)</m>,
-                  and <m>y=s\sin(t)</m>, use the Multivariable Chain Rule to compute:
+                  <m>z=x^2+y^2</m>, <m>x=s\cos(t)</m>,
+                  and <m>y=s\sin(t)</m>; <m>s=2</m>, <m>t=\pi/4</m>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\plz{z}{s}</m>.
+                </instruction>
                 <p>
-                  <m>\plz{z}{s}=</m><var name="$dzds" evaluator="$dzdsev" width="50"/>
+                  <var name="$dzds" evaluator="$dzdsev" width="50"/>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\plz{z}{t}</m>.
+                </instruction>
                 <p>
-                  <m>\plz{z}{t}=</m><var name="$dzdt" evaluator="$dzdtev" width="50"/>
+                  <var name="$dzdt" evaluator="$dzdtev" width="50"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\plz{z}{s}</m> at <m>s=2</m>, <m>t=\pi/4</m>.
+                </instruction>
                 <p>
-                  <m>\plzoa{z}{s}{s=2,t=\pi/4}=</m><var name="$dzds1" width="15"/>
+                  <var name="$dzds1" width="15"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\plz{z}{t}</m> at <m>s=2</m>, <m>t=\pi/4</m>.
+                </instruction>
                 <p>
-                  <m>\plzoa{z}{t}{s=2,t=\pi/4}=</m><var name="$dzdt1" width="15"/>
+                  <var name="$dzdt1" width="15"/>
                 </p>
               </statement>
           </webwork>
@@ -1434,24 +1473,36 @@
 
               <statement>
                 <p>
-                  Given <m>z=e^{-(x^2+y^2)}</m>, <m>x=t</m>,
-                  and <m>y=st^2</m>, use the Multivariable Chain Rule to compute:
+                  <m>z=e^{-(x^2+y^2)}</m>, <m>x=t</m>,
+                  and <m>y=st^2</m>, <m>s=1</m>, <m>t=1</m>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\plz{z}{s}</m>.
+                </instruction>
                 <p>
-                  <m>\plz{z}{s}=</m><var name="$dzds" evaluator="$dzdsev" width="50"/>
+                  <var name="$dzds" evaluator="$dzdsev" width="50"/>
                 </p>
 
+                <instruction>
+                  Use the Multivariable Chain Rule to compute <m>\plz{z}{t}</m>.
+                </instruction>
                 <p>
-                  <m>\plz{z}{t}=</m><var name="$dzdt" evaluator="$dzdtev" width="50"/>
+                  <var name="$dzdt" evaluator="$dzdtev" width="50"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\plz{z}{s}</m> at <m>s=1</m>, <m>t=1</m>.
+                </instruction>
                 <p>
-                  <m>\plzoa{z}{s}{s=1,t=1}=</m><var name="$dzds1" width="15"/>
+                  <var name="$dzds1" width="15"/>
                 </p>
 
+                <instruction>
+                  Evaluate <m>\plz{z}{t}</m> at <m>s=1</m>, <m>t=1</m>.
+                </instruction>
                 <p>
-                  <m>\plzoa{z}{t}{s=1,t=1}=</m><var name="$dzdt1" width="15"/>
+                  <var name="$dzdt1" width="15"/>
                 </p>
               </statement>
           </webwork>
@@ -1462,8 +1513,8 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            find <m>\lz{y}{x}</m> using Implicit Differentiation and <xref ref="thm_implicit_deriv_chain">Theorem</xref>.
+            The given equation defines <m>y</m> implicitly as a function of <m>x</m>.
+            Find <m>\lz{y}{x}</m> using Implicit Differentiation and <xref ref="thm_implicit_deriv_chain">Theorem</xref>.
           </p>
         </introduction>
 
@@ -1497,10 +1548,11 @@
 
               <statement>
                 <p>
-                  Given the implictly defined curve <m>\left(3x^2+2y^3\right)^4=2</m>,
-                  use Implicit Differentiation and <xref ref="thm_implicit_deriv_chain">Theorem</xref> to find <m>\lz{y}{x}</m>.
+                  <m>\left(3x^2+2y^3\right)^4=2</m>
                 </p>
-
+                <instruction>
+                  Find <m>\lz{y}{x}</m>:
+                </instruction>
                 <p>
                   <var name="$dydx" width="40"/>
                 </p>
@@ -1539,9 +1591,11 @@
 
               <statement>
                 <p>
-                  Given the implictly defined curve <m>\ln\mathopen{}\left(x^2+xy+y^2\right)\mathclose{}=1</m>,
-                  use Implicit Differentiation and <xref ref="thm_implicit_deriv_chain">Theorem</xref> to find <m>\lz{y}{x}</m>.
+                  <m>\ln\mathopen{}\left(x^2+xy+y^2\right)\mathclose{}=1</m>
                 </p>
+                <instruction>
+                  Find <m>\lz{y}{x}</m>:
+                </instruction>
 
                 <p>
                   <var name="$dydx" width="40"/>
@@ -1555,7 +1609,7 @@
 
         <introduction>
           <p>
-            In the following exercises, find <m>\lz{z}{t}</m>,
+            Find <m>\lz{z}{t}</m>,
             or <m>\plz{z}{s}</m> and <m>\plz{z}{t}</m>,
             using the supplied information.
           </p>
@@ -1586,12 +1640,14 @@
 
               <statement>
                 <p>
-                  Given <m>\plz{z}{x} = 1</m>,
-                  <m>\plz{z}{y} = -3</m>, <m>\lz{x}{t} = 6</m>, and <m>\lz{y}{t} = 2</m>,
+                  <m>\plz{z}{x} = 1</m>,
+                  <m>\plz{z}{y} = -3</m>, <m>\lz{x}{t} = 6</m>, and <m>\lz{y}{t} = 2</m>.
                 </p>
-
+                <instruction>
+                  Find <m>\lz{z}{t}</m>:
+                </instruction>
                 <p>
-                  <m>\lz{z}{t}=</m><var name="$dzdt" width="20"/>
+                  <var name="$dzdt" width="20"/>
                 </p>
               </statement>
           </webwork>
@@ -1632,17 +1688,23 @@
 
               <statement>
                 <p>
-                  Given <m>\plz{z}{x} = 2</m>,
+                  <m>\plz{z}{x} = 2</m>,
                   <m>\plz{z}{y} = 1</m>, <m>\plz{x}{s} = -2</m>,
-                  <m>\plz{x}{t} = 3</m>, <m>\plz{y}{s} = 2</m> and <m>\plz{y}{t} = -1</m>,
+                  <m>\plz{x}{t} = 3</m>, <m>\plz{y}{s} = 2</m> and <m>\plz{y}{t} = -1</m>
                 </p>
 
+                <instruction>
+                  Find <m>\plz{z}{s}</m>:
+                </instruction>
                 <p>
-                  <m>\plz{z}{s}=</m><var name="$dzds" width="20"/>
+                  <var name="$dzds" width="20"/>
                 </p>
 
+                <instruction>
+                  Find <m>\plz{z}{t}</m>:
+                </instruction>
                 <p>
-                  <m>\plz{z}{t}=</m><var name="$dzdt" width="20"/>
+                  <var name="$dzdt" width="20"/>
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -1343,7 +1343,7 @@
 
         <introduction>
           <p>
-            In the following exercises, find the critical points of the given function.
+            Find the critical points of the given function.
             Use the Second Derivative Test to determine if each critical point corresponds to a relative maximum, minimum,
             or saddle point.
           </p>
@@ -1381,52 +1381,43 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = x^2+4x+y^2-9y+3xy</m>.
+                  <m>f(x,y) = x^2+4x+y^2-9y+3xy</m>
+                </p>
+                <instruction>
                   List all critical points
                   (or report that there are <c>none</c>)
-                  of <m>f</m> where the Second Derivative Test:
+                  of <m>f</m> where the Second Derivative Test indicates the critical point is a relative maximum.
+                </instruction>
+                <p>
+                  <var name="$max" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a relative minimum.
+                </instruction>
 
-                  <ol label="a">
-                    <li>
-                      <p>
-                        indicates the critical point is a relative maximum.
-                      </p>
+                <p>
+                  <var name="$min" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a saddle point.
+                </instruction>
+                <p>
+                  <var name="$sad" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test is inconclusive.
+                </instruction>
 
-                      <p>
-                        <var name="$max" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a relative minimum.
-                      </p>
-
-                      <p>
-                        <var name="$min" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a saddle point.
-                      </p>
-
-                      <p>
-                        <var name="$sad" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        is inconclusive.
-                      </p>
-
-                      <p>
-                        <var name="$inc" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                <p>
+                  <var name="$inc" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1463,52 +1454,43 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \frac{1}{x^2+y^2+1}</m>.
+                  <m>f(x,y) = \frac{1}{x^2+y^2+1}</m>
+                </p>
+                <instruction>
                   List all critical points
                   (or report that there are <c>none</c>)
-                  of <m>f</m> where the Second Derivative Test:
+                  of <m>f</m> where the Second Derivative Test indicates the critical point is a relative maximum.
+                </instruction>
+                <p>
+                  <var name="$max" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a relative minimum.
+                </instruction>
 
-                  <ol label="a">
-                    <li>
-                      <p>
-                        indicates the critical point is a relative maximum.
-                      </p>
+                <p>
+                  <var name="$min" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a saddle point.
+                </instruction>
+                <p>
+                  <var name="$sad" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test is inconclusive.
+                </instruction>
 
-                      <p>
-                        <var name="$max" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a relative minimum.
-                      </p>
-
-                      <p>
-                        <var name="$min" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a saddle point.
-                      </p>
-
-                      <p>
-                        <var name="$sad" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        is inconclusive.
-                      </p>
-
-                      <p>
-                        <var name="$inc" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                <p>
+                  <var name="$inc" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1551,52 +1533,43 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \frac13x^3-x+\frac13y^3-4y</m>.
+                  <m>f(x,y) = \frac13x^3-x+\frac13y^3-4y</m>
+                </p>
+                <instruction>
                   List all critical points
                   (or report that there are <c>none</c>)
-                  of <m>f</m> where the Second Derivative Test:
+                  of <m>f</m> where the Second Derivative Test indicates the critical point is a relative maximum.
+                </instruction>
+                <p>
+                  <var name="$max" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a relative minimum.
+                </instruction>
 
-                  <ol label="a">
-                    <li>
-                      <p>
-                        indicates the critical point is a relative maximum.
-                      </p>
+                <p>
+                  <var name="$min" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a saddle point.
+                </instruction>
+                <p>
+                  <var name="$sad" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test is inconclusive.
+                </instruction>
 
-                      <p>
-                        <var name="$max" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a relative minimum.
-                      </p>
-
-                      <p>
-                        <var name="$min" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a saddle point.
-                      </p>
-
-                      <p>
-                        <var name="$sad" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        is inconclusive.
-                      </p>
-
-                      <p>
-                        <var name="$inc" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                <p>
+                  <var name="$inc" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1637,52 +1610,43 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = x^4-2x^2+y^3-27y-15</m>.
+                  <m>f(x,y) = x^4-2x^2+y^3-27y-15</m>
+                </p>
+                <instruction>
                   List all critical points
                   (or report that there are <c>none</c>)
-                  of <m>f</m> where the Second Derivative Test:
+                  of <m>f</m> where the Second Derivative Test indicates the critical point is a relative maximum.
+                </instruction>
+                <p>
+                  <var name="$max" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a relative minimum.
+                </instruction>
 
-                  <ol label="a">
-                    <li>
-                      <p>
-                        indicates the critical point is a relative maximum.
-                      </p>
+                <p>
+                  <var name="$min" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a saddle point.
+                </instruction>
+                <p>
+                  <var name="$sad" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test is inconclusive.
+                </instruction>
 
-                      <p>
-                        <var name="$max" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a relative minimum.
-                      </p>
-
-                      <p>
-                        <var name="$min" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a saddle point.
-                      </p>
-
-                      <p>
-                        <var name="$sad" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        is inconclusive.
-                      </p>
-
-                      <p>
-                        <var name="$inc" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                <p>
+                  <var name="$inc" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1728,52 +1692,43 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \sqrt{x^2+y^2}</m>.
+                  <m>f(x,y) = \sqrt{x^2+y^2}</m>
+                </p>
+                <instruction>
                   List all critical points
                   (or report that there are <c>none</c>)
-                  of <m>f</m> where the Second Derivative Test:
+                  of <m>f</m> where the Second Derivative Test indicates the critical point is a relative maximum.
+                </instruction>
+                <p>
+                  <var name="$max" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a relative minimum.
+                </instruction>
 
-                  <ol label="a">
-                    <li>
-                      <p>
-                        indicates the critical point is a relative maximum.
-                      </p>
+                <p>
+                  <var name="$min" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test
+                  indicates the critical point is a saddle point.
+                </instruction>
+                <p>
+                  <var name="$sad" width="30"/>
+                </p>
+                <instruction>
+                  List all critical points
+                  (or report that there are <c>none</c>)
+                  of <m>f</m> where the Second Derivative Test is inconclusive.
+                </instruction>
 
-                      <p>
-                        <var name="$max" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a relative minimum.
-                      </p>
-
-                      <p>
-                        <var name="$min" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        indicates the critical point is a saddle point.
-                      </p>
-
-                      <p>
-                        <var name="$sad" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        is inconclusive.
-                      </p>
-
-                      <p>
-                        <var name="$inc" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                <p>
+                  <var name="$inc" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1784,8 +1739,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            find the absolute maximum and minimum of the function subject to the given constraint.
+            Find the absolute maximum and minimum of the function subject to the given constraint.
           </p>
         </introduction>
 

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -21,7 +21,7 @@
     </definition>
 
     <figure xml:id="vid-multi-function-notation">
-      <caption>Video introduction to mutlivariable function notation</caption>
+      <caption>Video introduction to multivariable function notation</caption>
       <video youtube="w4K2L9-OPk8"/>
     </figure>
 

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -1299,43 +1299,32 @@
 
               <statement>
                 <p>
-                  Let <m>S = \left\{(x,y)\mid y\neq x^2\right\}</m>.
+                  <m>S = \left\{(x,y)\mid y\neq x^2\right\}</m>
                 </p>
 
+                <instruction>
+                  Give one boundary point of <m>S</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Give one boundary point of <m>S</m>.
-                      </p>
-
-                      <p>
-                        <var name="$bp" evaluator="$bpev" width="10"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Give one interior point in <m>S</m>.
-                      </p>
-
-                      <p>
-                        <var name="$ip" evaluator="$ipev" width="10"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>S</m> is <var name="$ocn" form="popup"/>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>S</m> is <var name="$bu" form="popup"/>.
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$bp" evaluator="$bpev" width="10"/>
+                </p>
+                <instruction>
+                  Give one interior point in <m>S</m>.
+                </instruction>
+                <p>
+                  <var name="$ip" evaluator="$ipev" width="10"/>
+                </p>
+                <instruction>
+                  State whether <m>S</m> is open, closed, or neither.
+                </instruction>
+                <p>
+                  <var name="$ocn" form="popup"/>
+                </p>
+                <instruction>
+                  State whether <m>S</m> is bounded or unbounded.
+                </instruction>
+                <p>
+                  <var name="$bu" form="popup"/>
                 </p>
               </statement>
           </webwork>
@@ -1404,43 +1393,33 @@
 
               <statement>
                 <p>
-                  Let <m>S = \left\{(x,y)\mid y \gt \sin(x)\right\}</m>.
+                  <m>S = \left\{(x,y)\mid y \gt \sin(x)\right\}</m>.
                 </p>
 
+                <instruction>
+                  Give one boundary point of <m>S</m>.
+                </instruction>
+
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Give one boundary point of <m>S</m>.
-                      </p>
-
-                      <p>
-                        <var name="$bp" evaluator="$bpev" width="10"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Give one interior point in <m>S</m>.
-                      </p>
-
-                      <p>
-                        <var name="$ip" evaluator="$ipev" width="10"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>S</m> is <var name="$ocn" form="popup"/>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>S</m> is <var name="$bu" form="popup"/>.
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$bp" evaluator="$bpev" width="10"/>
+                </p>
+                <instruction>
+                  Give one interior point in <m>S</m>.
+                </instruction>
+                <p>
+                  <var name="$ip" evaluator="$ipev" width="10"/>
+                </p>
+                <instruction>
+                  State whether <m>S</m> is open, closed, or neither.
+                </instruction>
+                <p>
+                  <var name="$ocn" form="popup"/>
+                </p>
+                <instruction>
+                  State whether <m>S</m> is bounded or unbounded.
+                </instruction>
+                <p>
+                  <var name="$bu" form="popup"/>
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -1320,7 +1320,7 @@
 
         <introduction>
           <p>
-            In the following exercises, a function <m>f(x,y)</m>,
+            A function <m>f(x,y)</m>,
             a vector <m>\vec v</m> and a point <m>P</m> are given.
             Give the parametric equations of the following directional tangent lines to <m>z=f(x,y)</m> at <m>P</m>:
           </p>
@@ -1445,42 +1445,27 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = 3\cos(x) \sin(y)</m> and <m>P=(\pi/3, \pi/6)</m>.
+                  <m>f(x,y) = 3\cos(x) \sin(y)</m>, <m>\vec v = \la 1,2\ra</m>, <m>P=(\pi/3, \pi/6)</m>
                 </p>
 
+                <instruction>
+                  Find parametric equations for the directional tangent line <m>\ell_{x}</m> at <m>P</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find parametric equations for the directional tangent line <m>\ell_{x}</m> at <m>P</m>.
-                      </p>
+                  <var name="$p[0]" evaluator="$pev[0]" width="50"/>
+                </p>
 
-                      <p>
-                        <var name="$p[0]" evaluator="$pev[0]" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find parametric equations for the directional tangent line <m>\ell_{y}</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$p[1]" evaluator="$pev[1]" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find parametric equations for the directional tangent line <m>\ell_{\vec{v}}</m> at <m>P</m>,
-                        where <m>\vec v = \la 1,2\ra</m>.
-                      </p>
-
-                      <p>
-                        <var name="$p[2]" evaluator="$pev[2]" width="50"/>
-                      </p>
-                    </li>
-                  </ol>
+                <instruction>
+                  Find parametric equations for the directional tangent line <m>\ell_{y}</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$p[1]" evaluator="$pev[1]" width="50"/>
+                </p>
+                <instruction>
+                  Find parametric equations for the directional tangent line <m>\ell_{\vec{v}}</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$p[2]" evaluator="$pev[2]" width="50"/>
                 </p>
               </statement>
           </webwork>
@@ -1581,42 +1566,26 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = x^2-2x-y^2+4y</m> and <m>P=(1, 2)</m>.
+                  <m>f(x,y) = x^2-2x-y^2+4y</m>, <m>\vec v = \la 1,1\ra</m>, <m>P=(1, 2)</m>
                 </p>
 
+                <instruction>
+                  Find parametric equations for the directional tangent line <m>\ell_{x}</m> at <m>P</m>.
+                </instruction>
                 <p>
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find parametric equations for the directional tangent line <m>\ell_{x}</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$p[0]" evaluator="$pev[0]" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find parametric equations for the directional tangent line <m>\ell_{y}</m> at <m>P</m>.
-                      </p>
-
-                      <p>
-                        <var name="$p[1]" evaluator="$pev[1]" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find parametric equations for the directional tangent line <m>\ell_{\vec{v}}</m> at <m>P</m>,
-                        where <m>\vec v = \la 1,1\ra</m>.
-                      </p>
-
-                      <p>
-                        <var name="$p[2]" evaluator="$pev[2]" width="50"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$p[0]" evaluator="$pev[0]" width="50"/>
+                </p>
+                <instruction>
+                  Find parametric equations for the directional tangent line <m>\ell_{y}</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$p[1]" evaluator="$pev[1]" width="50"/>
+                </p>
+                <instruction>
+                  Find parametric equations for the directional tangent line <m>\ell_{\vec{v}}</m> at <m>P</m>.
+                </instruction>
+                <p>
+                  <var name="$p[2]" evaluator="$pev[2]" width="50"/>
                 </p>
               </statement>
           </webwork>
@@ -1627,8 +1596,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            a function <m>f(x,y)</m> and a point <m>P</m> are given.
+            A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find the equation of the normal line to <m>z=f(x,y)</m> at <m>P</m>.
             Note: these are the same functions as in <xref ref="x12_06_ex_05">Exercises</xref>
             <mdash/> <xref ref="x12_06_ex_08"/>.
@@ -1708,9 +1676,11 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = 3\cos(x) \sin(y)</m> and <m>P=(\pi/3, \pi/6)</m>.
-                  Find parametric equations for the normal line at <m>P</m>.
+                  <m>f(x,y) = 3\cos(x) \sin(y)</m> and <m>P=(\pi/3, \pi/6)</m>
                 </p>
+                <instruction>
+                  Find parametric equations for the normal line at <m>P</m>.
+                </instruction>
 
                 <p>
                   <var name="$n" evaluator="$nev" width="50"/>
@@ -1792,10 +1762,11 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = x^2-2x-y^2+4y</m> and <m>P=(1,2)</m>.
-                  Find parametric equations for the normal line at <m>P</m>.
+                  <m>f(x,y) = x^2-2x-y^2+4y</m> and <m>P=(1,2)</m>
                 </p>
-
+                <instruction>
+                  Find parametric equations for the normal line at <m>P</m>.
+                </instruction>
                 <p>
                   <var name="$n" evaluator="$nev" width="50"/>
                 </p>
@@ -1808,8 +1779,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            a function <m>f(x,y)</m> and a point <m>P</m> are given.
+            A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find the two points that are <m>2</m> units from the surface <m>z=f(x,y)</m> at <m>P</m>.
             Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
           </p>
@@ -1889,8 +1859,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            a function <m>f(x,y)</m> and a point <m>P</m> are given.
+            A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find an equation of the tangent plane to <m>z=f(x,y)</m> at <m>P</m>.
             Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
           </p>
@@ -1922,10 +1891,12 @@
 
               <statement>
                 <p>
-                  Find an equation of the tangent plane to
-                  <m>f(x,y) = 3\cos(x) \sin(y)</m> at <m>P=(\pi/3, \pi/6)</m>.
+                  <m>f(x,y) = 3\cos(x) \sin(y)</m>, <m>P=(\pi/3, \pi/6)</m>.
                 </p>
 
+                <instruction>
+                  Find an equation of the tangent plane to <m>z=f(x,y)</m> at <m>P</m>.
+                </instruction>
                 <p>
                   <var name="$t" width="40"/>
                 </p>
@@ -1960,9 +1931,11 @@
 
               <statement>
                 <p>
-                  Find an equation of the tangent plane to <m>f(x,y) = x^2-2x-y^2+4y</m> at <m>P=(1,2)</m>.
+                  <m>f(x,y) = x^2-2x-y^2+4y</m>, <m>P=(1,2)</m>
                 </p>
-
+                <instruction>
+                  Find an equation of the tangent plane to <m>z=f(x,y)</m> at <m>P</m>.
+                </instruction>
                 <p>
                   <var name="$t" width="40"/>
                 </p>
@@ -1975,8 +1948,8 @@
 
         <introduction>
           <p>
-            In the following exercises, an implicitly defined function of <m>x</m>,
-            <m>y</m> and <m>z</m> is given along with a point <m>P</m> that lies on the surface.
+            An implicitly defined function of <m>x</m>,
+            <m>y</m> and <m>z</m> is given, along with a point <m>P</m> that lies on the surface.
             Use the gradient <m>\nabla F</m> to:
 
             <ol label="a">
@@ -2088,30 +2061,20 @@
 
               <statement>
                 <p>
-                  Given <m>z^2-\frac{x^2}{4} - \frac{y^2}9=0</m>,
-                  at <m>P = (4,-3,\sqrt{5})</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find parametric equations for the normal line.
-                      </p>
-
-                      <p>
-                        <var name="$n" evaluator="$nev" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find an equation of the tangent plane.
-                      </p>
-
-                      <p>
-                        <var name="$t" width="50"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <m>z^2-\frac{x^2}{4} - \frac{y^2}9=0</m>,
+                  at <m>P = (4,-3,\sqrt{5})</m>
+                </p>
+                <instruction>
+                  Find parametric equations for the normal line.
+                </instruction>
+                <p>
+                  <var name="$n" evaluator="$nev" width="50"/>
+                </p>
+                <instruction>
+                  Find an equation of the tangent plane.
+                </instruction>
+                <p>
+                  <var name="$t" width="50"/>
                 </p>
               </statement>
           </webwork>
@@ -2208,30 +2171,21 @@
 
               <statement>
                 <p>
-                  Given <m>\sin(xy)+\cos(yz)=0</m>,
-                  at <m>P = (2, \pi/12, 4)</m>:
+                  <m>\sin(xy)+\cos(yz)=0</m>,
+                  at <m>P = (2, \pi/12, 4)</m>
+                </p>
 
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find parametric equations for the normal line.
-                      </p>
-
-                      <p>
-                        <var name="$n" evaluator="$nev" width="50"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find an equation of the tangent plane.
-                      </p>
-
-                      <p>
-                        <var name="$t" width="50"/>
-                      </p>
-                    </li>
-                  </ol>
+                <instruction>
+                  Find parametric equations for the normal line.
+                </instruction>
+                <p>
+                  <var name="$n" evaluator="$nev" width="50"/>
+                </p>
+                <instruction>
+                  Find an equation of the tangent plane.
+                </instruction>
+                <p>
+                  <var name="$t" width="50"/>
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -59,7 +59,7 @@
         <caption>A sketch of the enclosure in <xref ref="ex_opt1">Example</xref>.
       </caption>
         <sidebyside widths="47% 47%" margins="0%">
-          <image>
+          <image xml:id="img_opt1b">
             <description></description>
             <latex-image>
 
@@ -101,7 +101,7 @@
             </latex-image>
           </image>
 
-          <image>
+          <image xml:id="img_opt1b2">
             <description></description>
             <latex-image>
 
@@ -318,7 +318,7 @@
               <caption>A sketch of the enclosure in
                 <xref ref="ex_opt2">Example</xref></caption>
               <sidebyside widths="47% 47%" margins="0%">
-                <image>
+                <image xml:id="img_opt2a">
                   <description></description>
                   <latex-image>
 
@@ -357,7 +357,7 @@
                   </latex-image>
                 </image>
 
-                <image>
+                <image xml:id="img_opt2b">
                   <description></description>
                   <latex-image>
 

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -529,7 +529,7 @@
           we look at values of <m>t</m> greater/less than <m>3/5</m> on a number line:
         </p>
 
-        <image xml:id="img_parcalc4X" width="47%">
+        <image xml:id="img_parcalc4X" width="70%">
           <description></description>
           <latex-image>
 

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -1432,16 +1432,21 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = x^3-3x+y^2-6y</m>.
-                  Find:
+                  <m>f(x,y) = x^3-3x+y^2-6y</m> at <m>(-1,3)</m>.
                 </p>
 
+                <instruction>
+                  Find <m>f_x(-1,3)</m>.
+                </instruction>
                 <p>
-                  <m>f_x(-1,3)=</m><var name="$fx" width="10"/>
+                  <var name="$fx" width="10"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_y(-1,3)</m>.
+                </instruction>
                 <p>
-                  <m>f_y(-1,3)=</m><var name="$fy" width="10"/>
+                  <var name="$fy" width="10"/>
                 </p>
               </statement>
           </webwork>
@@ -1479,16 +1484,22 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \ln(xy)</m>.
+                  <m>f(x,y) = \ln(xy)</m> at <m>(-2,-3)</m>
                   Find:
                 </p>
 
+                <instruction>
+                  Find <m>f_x(-2,-3)</m>.
+                </instruction>
                 <p>
-                  <m>f_x(-2,-3)=</m><var name="$fx" width="10"/>
+                  <var name="$fx" width="10"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_y(-2,-3)</m>.
+                </instruction>
                 <p>
-                  <m>f_y(-2,-3)=</m><var name="$fy" width="10"/>
+                  <var name="$fy" width="10"/>
                 </p>
               </statement>
           </webwork>
@@ -1544,32 +1555,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = y^3+3xy^2+3x^2y+x^3</m>.
-                  Find:
+                  <m>f(x,y) = y^3+3xy^2+3x^2y+x^3</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -1614,32 +1642,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \frac{4}{xy}</m>.
-                  Find:
+                  <m>f(x,y) = \frac{4}{xy}</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -1686,32 +1731,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = e^{x+2y}</m>.
-                  Find:
+                  <m>f(x,y) = e^{x+2y}</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -1758,32 +1820,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = (x+y)^3</m>.
-                  Find:
+                  <m>f(x,y) = (x+y)^3</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -1830,32 +1909,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \sin\mathopen{}\left(5x^2+2y^3\right)\mathclose{}</m>.
-                  Find:
+                  <m>f(x,y) = \sin\mathopen{}\left(5x^2+2y^3\right)\mathclose{}</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -1875,32 +1971,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \sqrt{4xy^2+1}</m>.
-                  Find:
+                  <m>f(x,y) = \sqrt{4xy^2+1}</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -1975,32 +2088,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = 5x-17y</m>.
-                  Find:
+                  <m>f(x,y) = 5x-17y</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -2045,32 +2175,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = \ln(x^2+y)</m>.
-                  Find:
+                  <m>f(x,y) = \ln(x^2+y)</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -2117,32 +2264,49 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y) = 5e^x\sin(y)+9</m>.
-                  Find:
+                  <m>f(x,y) = 5e^x\sin(y)+9</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xx}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xx}(x,y)=</m><var name="$fxx" width="40"/>
+                  <var name="$fxx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{xy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{xy}(x,y)=</m><var name="$fxy" width="40"/>
+                  <var name="$fxy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yx}(x,y)</m>
+                </instruction>
                 <p>
-                  <m>f_{yx}(x,y)=</m><var name="$fyx" width="40"/>
+                  <var name="$fyx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yy}(x,y)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yy}(x,y)=</m><var name="$fyy" width="40"/>
+                  <var name="$fyy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -2186,12 +2350,11 @@
 
               <statement>
                 <p>
-                  Form a function <m>f(x,y)</m> such that
-                  <m>f_x = x+y</m> and <m>f_y = x+y</m>.
+                  <m>f_x = x+y</m> and <m>f_y = x+y</m>
                 </p>
 
                 <p>
-                  <m>f(x,y)=</m><var name="$f" evaluator="$fev" width="40"/>
+                  <var name="$f" evaluator="$fev" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -2225,12 +2388,11 @@
 
               <statement>
                 <p>
-                  Form a function <m>f(x,y)</m> such that
-                  <m>f_x = \frac{2x}{x^2+y^2}</m> and <m>f_y = \frac{2y}{x^2+y^2}</m>.
+                  <m>f_x = \frac{2x}{x^2+y^2}</m> and <m>f_y = \frac{2y}{x^2+y^2}</m>
                 </p>
 
                 <p>
-                  <m>f(x,y)=</m><var name="$f" evaluator="$fev" width="40"/>
+                  <var name="$f" evaluator="$fev" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -2282,28 +2444,42 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y,z) = x^3y^2+x^3z+y^2z</m>.
-                  Find:
+                  <m>f(x,y,z) = x^3y^2+x^3z+y^2z</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y,z)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y,z)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{z}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{z}(x,y,z)=</m><var name="$fz" width="40"/>
+                  <var name="$fz" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yz}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yz}(x,y,z)=</m><var name="$fyz" width="40"/>
+                  <var name="$fyz" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{zy}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{zy}(x,y,z)=</m><var name="$fzy" width="40"/>
+                  <var name="$fzy" width="40"/>
                 </p>
               </statement>
           </webwork>
@@ -2346,28 +2522,42 @@
 
               <statement>
                 <p>
-                  Let <m>f(x,y,z) = \ln(xyz)</m>.
-                  Find:
+                  <m>f(x,y,z) = \ln(xyz)</m>
                 </p>
 
+                <instruction>
+                  Find <m>f_{x}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{x}(x,y,z)=</m><var name="$fx" width="40"/>
+                  <var name="$fx" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{y}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{y}(x,y,z)=</m><var name="$fy" width="40"/>
+                  <var name="$fy" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{z}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{z}(x,y,z)=</m><var name="$fz" width="40"/>
+                  <var name="$fz" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{yz}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{yz}(x,y,z)=</m><var name="$fyz" width="40"/>
+                  <var name="$fyz" width="40"/>
                 </p>
 
+                <instruction>
+                  Find <m>f_{zy}(x,y,z)</m>.
+                </instruction>
                 <p>
-                  <m>f_{zy}(x,y,z)=</m><var name="$fzy" width="40"/>
+                  <var name="$fzy" width="40"/>
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -1169,12 +1169,18 @@
                   A plane passes through <m>(1,3,5)</m> and has normal vector <m>\vec n= \la 0,2,4\ra</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                   <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1256,12 +1262,18 @@
                   <m>(6,4,9)</m> and <m>(3,3,3)</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1350,12 +1362,18 @@
                   <m>\vec\ell_1(t) = \la 5,0,3\ra + t\la -1,1,1\ra</m> and <m>\vec\ell_2(t) = \la 1,4,7\ra + t\la 3,0,-3\ra</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1444,12 +1462,18 @@
                   <m>\vec\ell_1(t) = \la 1,1,1\ra + t\la 4,1,3\ra</m> and <m>\vec\ell_2(t) = \la 2,2,2\ra + t\la 4,1,3\ra</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1536,12 +1560,18 @@
                   A plane contains the point <m>(5,7,3)</m> and the line <m>\vec\ell(t) = \begin{cases}x\amp=t\\y\amp=t\\z\amp=t\end{cases}</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1595,12 +1625,18 @@
                   A plane contains the point <m>(5,7,3)</m> and is orthogonal to the line <m>\vec\ell(t) = \la 4,5,6\ra+ t\la 1,1,1\ra</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1654,12 +1690,18 @@
                   A plane contains the point <m>(4,1,1)</m> and is orthogonal to the line <m>\begin{cases}x\amp=4+4t\\y\amp=1+t\\z\amp=1+t\end{cases}</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1714,12 +1756,18 @@
                   <m>(-4,7,2)</m> and is parallel to the plane <m>3(x-2)+8(y+1) -10z=0</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>
@@ -1773,12 +1821,18 @@
                   A plane contains the point <m>(1,2,3)</m> and is parallel to the plane <m>x=5</m>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in standard form is:
+                </instruction>
                 <p>
-                  An equation for this plane in standard form is <var name="$st" evaluator="$stev" width="30"/>.
+                  <var name="$st" evaluator="$stev" width="30"/>.
                 </p>
 
+                <instruction>
+                  An equation for this plane in general form is:
+                </instruction>
                 <p>
-                  An equation for this plane in general form is <var name="$ge" evaluator="$geev" width="30"/>.
+                  <var name="$ge" evaluator="$geev" width="30"/>.
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -1025,29 +1025,19 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \la t,\cos(t) \ra</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find <m>\unittangent(t)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$T" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find <m>\unittangent(\pi/4)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$Ta" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\vrt = \la t,\cos(t) \ra</m>, <m>t=\pi/4</m>.
+                </p>
+                <instruction>
+                  Find <m>\unittangent(t)</m>.
+                </instruction>
+                <p>
+                  <var name="$T" width="30"/>
+                </p>
+                <instruction>
+                  Find <m>\unittangent(\pi/4)</m>.
+                </instruction>
+                <p>
+                  <var name="$Ta" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1086,29 +1076,19 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \la \cos(t) , \sin(t) \ra</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        Find <m>\unittangent(t)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$T" width="30"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find <m>\unittangent(\pi)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$Ta" width="30"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\vrt = \la \cos(t) , \sin(t) \ra</m>, <m>t=\pi</m>.
+                </p>
+                <instruction>
+                  Find <m>\unittangent(t)</m>.
+                </instruction>
+                <p>
+                  <var name="$T" width="30"/>
+                </p>
+                <instruction>
+                  Find <m>\unittangent(\pi)</m>.
+                </instruction>
+                <p>
+                  <var name="$Ta" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1535,7 +1515,7 @@
           <p>
             In the following exercises,
             find <m>a_\text{T}</m> and <m>a_\text{N}</m> given <m>\vrt</m>.
-            Sketch <m>\vrt</m> on the indicated interval,
+            Be sure you can sketch <m>\vrt</m> on the indicated interval,
             and comment on the relative sizes of <m>a_\text{T}</m> and
             <m>a_\text{N}</m> at the indicated <m>t</m> values.
           </p>
@@ -1592,58 +1572,44 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \la t,1/t \ra</m> on <m>(0,4]</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        <m>a_{T}=</m><var name="$aT" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}=</m><var name="$aN" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{T}(1)=</m><var name="$aT1" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}(1)=</m><var name="$aN1" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{T}(2)=</m><var name="$aT2" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}(2)=</m><var name="$aN2" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Sketch <m>\vrt</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Comment on the relative sizes of <m>a_{T}(1)</m>,
-                        <m>a_{N}(1)</m>, <m>a_{T}(2)</m>, and <m>a_{N}(2)</m>.
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\vrt = \la t,1/t \ra</m> on <m>(0,4]</m>;
+                  consider <m>t=1</m> and <m>t=2</m>.
+                </p>
+                <instruction>
+                  Find <m>a_{T}</m>:
+                </instruction>
+                <p>
+                  <var name="$aT" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}</m>:
+                </instruction>
+                <p>
+                  <var name="$aN" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{T}(1)</m>:
+                </instruction>
+                <p>
+                  <var name="$aT1" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}(1)</m>:
+                </instruction>
+                <p>
+                  <var name="$aN1" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{T}(2)</m>:
+                </instruction>
+                <p>
+                  <var name="$aT2" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}(2)</m>:
+                </instruction>
+                <p>
+                  <var name="$aN2" width="20"/>
                 </p>
               </statement>
               <solution>
@@ -1710,60 +1676,44 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \la \cos(t^2),\sin(t^2) \ra</m> on <m>(0,2\pi]</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        <m>a_{T}=</m><var name="$aT" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}=</m><var name="$aN" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{T}\mathopen{}\left(\sqrt{\pi/2}\right)\mathclose{}=</m><var name="$aT1" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}\mathopen{}\left(\sqrt{\pi/2}\right)\mathclose{}=</m><var name="$aN1" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{T}\mathopen{}\left(\sqrt{\pi}\right)\mathclose{}=</m><var name="$aT2" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}\mathopen{}\left(\sqrt{\pi}\right)\mathclose{}=</m><var name="$aN2" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Sketch <m>\vrt</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Comment on the relative sizes of <m>a_{T}\mathopen{}\left(\sqrt{\pi/2}\right)\mathclose{}</m>,
-                        <m>a_{N}\mathopen{}\left(\sqrt{\pi/2}\right)\mathclose{}</m>,
-                        <m>a_{T}\mathopen{}\left(\sqrt{\pi}\right)\mathclose{}</m>,
-                        and <m>a_{N}\mathopen{}\left(\sqrt{\pi}\right)\mathclose{}</m>.
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\vrt = \la \cos(t^2),\sin(t^2) \ra</m> on <m>(0,2\pi]</m>;
+                  consider <m>t=\pi/2</m> and <m>t=\pi</m>.
+                </p>
+                <instruction>
+                  Find <m>a_{T}</m>:
+                </instruction>
+                <p>
+                  <var name="$aT" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}</m>:
+                </instruction>
+                <p>
+                  <var name="$aN" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{T}\mathopen{}\left(\sqrt{\pi/2}\right)\mathclose{}</m>:
+                </instruction>
+                <p>
+                  <var name="$aT1" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}\mathopen{}\left(\sqrt{\pi/2}\right)\mathclose{}</m>:
+                </instruction>
+                <p>
+                  <var name="$aN1" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{T}\mathopen{}\left(\sqrt{\pi}\right)\mathclose{}</m>:
+                </instruction>
+                <p>
+                  <var name="$aT2" width="20"/>
+                </p>
+                <instruction>
+                  <m>a_{N}\mathopen{}\left(\sqrt{\pi}\right)\mathclose{}</m>:
+                </instruction>
+                <p>
+                  <var name="$aN2" width="20"/>
                 </p>
               </statement>
               <solution>
@@ -1831,58 +1781,44 @@
 
               <statement>
                 <p>
-                  Given <m>\vrt = \la 5\cos(t) ,4\sin(t) , 3\sin(t) \ra</m> on <m>[0,2\pi]</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        <m>a_{T}=</m><var name="$aT" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}=</m><var name="$aN" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{T}(0)=</m><var name="$aT1" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}(0)=</m><var name="$aN1" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{T}(\pi/2)=</m><var name="$aT2" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_{N}(\pi/2)=</m><var name="$aN2" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Sketch <m>\vrt</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Comment on the relative sizes of <m>a_{T}(0)</m>,
-                        <m>a_{N}(0)</m>, <m>a_{T}(\pi/2)</m>, and <m>a_{N}(\pi/2)</m>.
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\vrt = \la 5\cos(t) ,4\sin(t) , 3\sin(t) \ra</m> on <m>[0,2\pi]</m>;
+                  consider <m>t=0</m> and <m>t=\pi/2</m>.
+                </p>
+                <instruction>
+                  Find <m>a_{T}</m>:
+                </instruction>
+                <p>
+                  <var name="$aT" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}</m>:
+                </instruction>
+                <p>
+                  <var name="$aN" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{T}(0)</m>:
+                </instruction>
+                <p>
+                  <var name="$aT1" width="20"/>
+                </p>
+                <instruction>
+                   Find <m>a_{N}(0)</m>:
+                 </instruction>
+                 <p>
+                   <var name="$aN1" width="20"/>
+                  </p>
+                <instruction>
+                  Find <m>a_{T}(\pi/2)</m>:
+                </instruction>
+                <p>
+                  <var name="$aT2" width="20"/>
+                </p>
+                <instruction>
+                  Find <m>a_{N}(\pi/2)</m>:
+                </instruction>
+                <p>
+                  <var name="$aN2" width="20"/>
                 </p>
               </statement>
               <solution>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -990,7 +990,7 @@
 
         <introduction>
           <p>
-            In the following exercises, given <m>\vrt</m>,
+            Given <m>\vrt</m>,
             find <m>\unittangent(t)</m> and evaluate it at the indicated value of <m>t</m>.
           </p>
         </introduction>
@@ -1099,8 +1099,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            find the equation of the line tangent to the curve at the indicated <m>t</m>-value using the unit tangent vector.
+            Find the equation of the line tangent to the curve at the indicated <m>t</m>-value using the unit tangent vector.
             Note: these are the same problems as in <xref ref="x11_04_ex_05">Exercises</xref>
             <mdash/> <xref ref="x11_04_ex_08"/>.
           </p>

--- a/ptx/sec_triple_int.ptx
+++ b/ptx/sec_triple_int.ptx
@@ -3137,8 +3137,7 @@
 
         <introduction>
           <p>
-            In the following exercises,
-            two surfaces <m>f_1(x,y)</m> and
+            Two surfaces <m>f_1(x,y)</m> and
             <m>f_2(x,y)</m> and a region <m>R</m> in the <m>x</m>,
             <m>y</m> plane are given.
             Set up and evaluate the double integral that finds the volume between these surfaces over <m>R</m>.
@@ -3174,10 +3173,10 @@
 
               <statement>
                 <p>
-                  Evaluate the double integral that finds the volme between the surfaces
-                  <m>z=f_1(x,y) = x^2+y^2</m> and <m>z=f_2(x,y) = -x^2-y^2</m>,
-                  over <m>R</m>,
-                  the square with corners <m>(0,0)</m> and <m>(2,3)</m>.
+                  <m>z=f_1(x,y) = x^2+y^2</m> and <m>z=f_2(x,y) = -x^2-y^2</m>;
+                </p>
+                <p>
+                  <m>R</m> is the square with corners <m>(0,0)</m> and <m>(2,3)</m>.
                 </p>
 
                 <p>
@@ -3218,9 +3217,11 @@
 
               <statement>
                 <p>
-                  Evaluate the double integral that finds the volme between the surfaces
-                  <m>z=f_1(x,y) = 2x^2+2y^2+3</m> and <m>z=f_2(x,y) = 6-x^2-y^2</m>,
-                  over <m>R</m>, the disc <m>x^2+y^2\leq1</m>.
+                  <m>z=f_1(x,y) = 2x^2+2y^2+3</m> and <m>z=f_2(x,y) = 6-x^2-y^2</m>;
+                </p>
+
+                <p>
+                  <m>R</m> is the disc <m>x^2+y^2\leq1</m>.
                 </p>
 
                 <p>

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -2519,7 +2519,7 @@
             making angles with the vertical of <m>\theta</m> and <m>\varphi</m> as shown in the figure below.
           </p>
 
-            <image xml:id="img-10-02-exset-05" width="47%">
+            <image xml:id="img-10-02-exset-05" width="30%">
               <latex-image>
                 \begin{tikzpicture}
                   \filldraw[thick,black,fill=gray!30] (-.5,0) -- (.5,0) -- (1,-1) -- (-1,-1)--cycle;
@@ -2630,7 +2630,7 @@
             as shown in the figure below.
           </p>
 
-            <image xml:id="img-10-02-exset-06" width="47%">
+            <image xml:id="img-10-02-exset-06" width="30%">
               <latex-image>
                 \begin{tikzpicture}
                   \draw [dashed] (-1.5,-.2) -- (2,-.2);

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -1326,12 +1326,18 @@
                   A position function <m>\vrt</m> is <m>\la 3t^2-2t+1, -t^2+t+14\ra</m>.
                 </p>
 
+                <instruction>
+                  The velocity function <m>\vvt</m> is:
+                </instruction>
                 <p>
-                  The velocity function <m>\vvt</m> is <var name="$velocity" width="30"/>.
+                   <var name="$velocity" width="30"/>
                 </p>
 
+                <instruction>
+                  The acceleration function <m>\vat</m> is:
+                </instruction>
                 <p>
-                  The acceleration function <m>\vat</m> is <var name="$acceleration" width="30"/>.
+                  <var name="$acceleration" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1370,12 +1376,18 @@
                   A position function <m>\vrt</m> is <m>\la t/10,-\cos(t) ,\sin(t) \ra</m>.
                 </p>
 
+                <instruction>
+                  The velocity function <m>\vvt</m> is:
+                </instruction>
                 <p>
-                  The velocity function <m>\vvt</m> is <var name="$velocity" width="30"/>.
+                  <var name="$velocity" width="30"/>
                 </p>
 
+                <instruction>
+                  The acceleration function <m>\vat</m> is:
+                </instruction>
                 <p>
-                  The acceleration function <m>\vat</m> is <var name="$acceleration" width="30"/>.
+                  <var name="$acceleration" width="30"/>
                 </p>
               </statement>
           </webwork>
@@ -1519,26 +1531,25 @@
 
               <statement>
                 <p>
-                  A position function <m>\vrt</m> is <m>\la t^2,t^2-t^3 \ra</m>.
-                  Find the speed of the object in terms of <m>t</m>.
+                  <m>\vrt = \la t^2,t^2-t^3 \ra</m> on <m>[-1,1]</m>
                 </p>
-
+                <instruction>
+                  Find the speed of the object in terms of <m>t</m>.
+                </instruction>
                 <p>
                   <var name="$speed" width="30"/>
                 </p>
 
-                <p>
-                  On <m>[-1,1]</m>, the speed is minimized at what times?
-                </p>
-
+                <instruction>
+                  Find where the speed is minimized on the given interval.
+                </instruction>
                 <p>
                   <var name="$mins" width="10"/>
                 </p>
 
-                <p>
-                  And the speed is maximized at what times?
-                </p>
-
+                <instruction>
+                  Find where the speed is maximized on the given interval.
+                </instruction>
                 <p>
                   <var name="$maxs" width="10"/>
                 </p>
@@ -1601,26 +1612,25 @@
 
               <statement>
                 <p>
-                  A position function <m>\vrt</m> is <m>\la \sec(t) ,\tan(t) \ra</m>.
-                  Find the speed of the object in terms of <m>t</m>.
+                  <m>\vrt=\la \sec(t) ,\tan(t) \ra</m> on <m>[0,\pi/4]</m>.
                 </p>
-
+                <instruction>
+                  Find the speed of the object in terms of <m>t</m>.
+                </instruction>
                 <p>
                   <var name="$speed" width="30"/>
                 </p>
 
-                <p>
-                  On <m>[0,\pi/4]</m>, the speed is minimized at what times?
-                </p>
-
+                <instruction>
+                  Find where the speed is minimized on the given interval.
+                </instruction>
                 <p>
                   <var name="$mins" width="10"/>
                 </p>
 
-                <p>
-                  And the speed is maximized at what times?
-                </p>
-
+                <instruction>
+                  Find where the speed is maximized on the given interval.
+                </instruction>
                 <p>
                   <var name="$maxs" width="10"/>
                 </p>
@@ -1682,26 +1692,25 @@
 
               <statement>
                 <p>
-                  A position function <m>\vrt</m> is <m>\la t^2-t,t^2+t,t \ra</m>.
-                  Find the speed of the object in terms of <m>t</m>.
+                  <m>\vrt=\la t^2-t,t^2+t,t \ra</m> on <m>[0,1]</m>.
                 </p>
-
+                <instruction>
+                  Find the speed of the object in terms of <m>t</m>.
+                </instruction>
                 <p>
                   <var name="$speed" width="30"/>
                 </p>
 
-                <p>
-                  On <m>[0,1]</m>, the speed is minimized at what times?
-                </p>
-
+                <instruction>
+                  Find where the speed is minimized on the given interval.
+                </instruction>
                 <p>
                   <var name="$mins" width="10"/>
                 </p>
 
-                <p>
-                  And the speed is maximized at what times?
-                </p>
-
+                <instruction>
+                  Find where the speed is maximized on the given interval.
+                </instruction>
                 <p>
                   <var name="$maxs" width="10"/>
                 </p>
@@ -2079,37 +2088,31 @@
                 <p>
                   An object has position function <m>\vrt = \la 5\cos(t) ,-5\sin(t) \ra</m>,
                   where distances are measured in feet and time is in seconds.
-                  Over <m>[0,\pi]</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        What is the displacement?
-                        <var name="$disp" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the distance traveled?
-                        <var name="$dist" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the average velocity?
-                        <var name="$avvel" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the average speed?
-                        <var name="$avspe" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
+                  Over <m>[0,\pi]</m>.
+                </p>
+                <instruction>
+                  What is the displacement?
+                </instruction>
+                <p>
+                  <var name="$disp" width="20"/>
+                </p>
+                <instruction>
+                  What is the distance traveled?
+                </instruction>
+                <p>
+                  <var name="$dist" width="20"/>
+                </p>
+                <instruction>
+                  What is the average velocity?
+                </instruction>
+                <p>
+                  <var name="$avvel" width="20"/>
+                </p>
+                <instruction>
+                  What is the average speed?
+                </instruction>
+                <p>
+                  <var name="$avspe" width="20"/>
                 </p>
               </statement>
           </webwork>
@@ -2151,37 +2154,31 @@
                 <p>
                   An object has velocity function <m>\vvt = \la 1,2,-1 \ra</m>,
                   where distances are measured in feet and time is in seconds.
-                  Over <m>[0,10]</m>:
-
-                  <ol label="a">
-                    <li>
-                      <p>
-                        What is the displacement?
-                        <var name="$disp" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the distance traveled?
-                        <var name="$dist" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the average velocity?
-                        <var name="$avvel" width="20"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        What is the average speed?
-                        <var name="$avspe" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
+                  Over <m>[0,10]</m>.
+                </p>
+                <instruction>
+                  What is the displacement?
+                </instruction>
+                <p>
+                  <var name="$disp" width="20"/>
+                </p>
+                <instruction>
+                  What is the distance traveled?
+                </instruction>
+                <p>
+                  <var name="$dist" width="20"/>
+                </p>
+                <instruction>
+                  What is the average velocity?
+                </instruction>
+                <p>
+                  <var name="$avvel" width="20"/>
+                </p>
+                <instruction>
+                  What is the average speed?
+                </instruction>
+                <p>
+                  <var name="$avspe" width="20"/>
                 </p>
               </statement>
           </webwork>
@@ -2232,7 +2229,7 @@
                 </p>
 
                 <p>
-                  <ol>
+                  <ol label="a">
                     <li>
                       <p>
                         At what <m>t</m>-values must David release the stone in his sling in order to hit Goliath?
@@ -2349,7 +2346,7 @@
                 </p>
 
                 <p>
-                  <ol>
+                  <ol label="a">
                     <li>
                       <p>
                         Show that as hit, the ball hits the wall.
@@ -2430,7 +2427,7 @@
                 </p>
 
                 <p>
-                  <ol>
+                  <ol label="a">
                     <li>
                       <p>
                         If the ball is thrown at a rate of 50mph,

--- a/style/apex-latex-novid.xsl
+++ b/style/apex-latex-novid.xsl
@@ -46,7 +46,7 @@
 <!-- define tcolorboxes for theorem and friends -->
 
 <xsl:template match="list" mode="tcb-style">
-    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+    <xsl:text>enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
 </xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">

--- a/style/apex-latex-novid.xsl
+++ b/style/apex-latex-novid.xsl
@@ -45,10 +45,9 @@
 
 <!-- define tcolorboxes for theorem and friends -->
 
-<!-- don't colour a list if it's inside an insight -->
-<!-- <xsl:template match="list[not(parent::insight)]" mode="tcb-style">
-    <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=blue!60!black!20, colframe=blue!30!black!50, colback=white!95!bluepen, coltitle=black, titlerule=-0.3pt,</xsl:text>
-</xsl:template> -->
+<xsl:template match="list" mode="tcb-style">
+    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+</xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">
     <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=red!60!black!20, colframe=red!30!black!50, colback=white!95!red, coltitle=black, titlerule=-0.3pt,</xsl:text>
@@ -94,14 +93,13 @@
 </xsl:template>
 
 <!-- use original APEX geometry definitions -->
-<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=32pt,bottom=1in,footskip=29pt'"/>
+<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=20pt,bottom=1in,footskip=29pt'"/>
 
 <!-- apply exercise geometry -->
-<xsl:template match="exercises" mode="latex-division-heading">
-    <xsl:if test="self::exercises">
-        <!-- \newgeometry includes a \clearpage -->
-        <xsl:apply-templates select="." mode="new-geometry"/>
-    </xsl:if>
+
+<xsl:template match="exercises|appendix|solutions" mode="latex-division-heading">
+    <!-- \newgeometry includes a \clearpage -->
+    <xsl:apply-templates select="." mode="new-geometry"/>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="division-environment-name" />
     <!-- possibly numberless -->
@@ -128,41 +126,8 @@
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- exercise geometry for backmatter appendix -->
-<xsl:template match="appendix" mode="latex-division-heading">
-  <xsl:if test="self::appendix">
-      <!-- \newgeometry includes a \clearpage -->
-      <xsl:apply-templates select="." mode="new-geometry"/>
-  </xsl:if>
-    <xsl:text>\begin{</xsl:text>
-    <xsl:apply-templates select="." mode="division-environment-name" />
-    <!-- possibly numberless -->
-    <xsl:apply-templates select="." mode="division-environment-name-suffix" />
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="title-full"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- subtitle here -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="title-short"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="author" mode="name-list"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- subtitle here -->
-    <!-- <xsl:text>An epigraph here\\with two lines\\-Rob</xsl:text> -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="latex-id" />
-    <xsl:text>}</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
-</xsl:template>
-
 <!-- define exercise geometry -->
-<xsl:template match="exercises|appendix" mode="new-geometry">
+<xsl:template match="exercises|appendix|solutions" mode="new-geometry">
     <xsl:text>\newgeometry{</xsl:text>
     <xsl:text>inner=72pt</xsl:text>
     <xsl:text>, outer=72pt</xsl:text>
@@ -174,18 +139,22 @@
 </xsl:template>
 
 <!-- restore geometry for next section -->
-<xsl:template match="exercises" mode="latex-division-footing">
+<xsl:template match="exercises|appendix|solutions" mode="latex-division-footing">
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="." mode="division-environment-name" />
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="self::exercises">
-        <!-- \restoregeometry includes a \clearpage -->
-        <xsl:text>\restoregeometry&#xa;</xsl:text>
-    </xsl:if>
+      <!-- \restoregeometry includes a \clearpage -->
+    <xsl:text>\restoregeometry&#xa;</xsl:text>
 </xsl:template>
 
+<!-- tabular in sidebyside without scaling -->
+<xsl:template match="tabular[ancestor::sidebyside]">
+    <xsl:text>{%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="tabular-inclusion"/>
+    <xsl:text>}%&#xa;</xsl:text>
+</xsl:template>
 
 <!-- figures in the margin -->
 <!-- load marginnote package -->
@@ -205,7 +174,7 @@
 </xsl:template>
 
 <!-- latex-image, asymptote, and tabular can all go in margin -->
-<xsl:template match="figure[not(ancestor::sidebyside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
+<xsl:template match="figure[not(ancestor::sidebyside) and not(ancestor::aside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
     <xsl:text>\marginnote{%&#xa;</xsl:text>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>

--- a/style/apex-latex-novid.xsl
+++ b/style/apex-latex-novid.xsl
@@ -160,6 +160,40 @@
 <!-- load marginnote package -->
 <xsl:param name="latex.preamble.early" select="'\usepackage{marginnote}'"/>
 
+<!-- margin figures within a tcolorbox get shifted with xelatex -->
+<!-- this shifts them back into place -->
+<xsl:param name="latex.preamble.late" select="'
+\makeatletter
+\def\pgfsys@hboxsynced#1{%
+  {%
+    \pgfsys@beginscope%
+    \setbox\pgf@hbox=\hbox{%
+      \hskip\pgf@pt@x%
+      \raise\pgf@pt@y\hbox{%
+        \pgf@pt@x=0pt%
+        \pgf@pt@y=0pt%
+        \special{pdf: content q}%
+        \pgflowlevelsynccm%
+        \pgfsys@invoke{q -1 0 0 -1 0 0 cm}%
+        \special{pdf: content -1 0 0 -1 0 0 cm q}% translate to original coordinate system
+        \pgfsys@invoke{0 J [] 0 d}% reset line cap and dash
+        \wd#1=0pt%
+        \ht#1=0pt%
+        \dp#1=0pt%
+        \box#1%
+        \pgfsys@invoke{n Q Q Q}%
+      }%
+      \hss%
+    }%
+    \wd\pgf@hbox=0pt%
+    \ht\pgf@hbox=0pt%
+    \dp\pgf@hbox=0pt%
+    \pgfsys@hbox\pgf@hbox%
+    \pgfsys@endscope%
+  }%
+}
+\makeatother'"/>
+
 <!-- we want images in margin to be the full margin width -->
 <xsl:template match="figure/image[not(ancestor::sidebyside) and (descendant::latex-image or descendant::asymptote) and not(ancestor::exercise)]">
     <xsl:text>\begin{image}</xsl:text>

--- a/style/apex-latex-print-novid.xsl
+++ b/style/apex-latex-print-novid.xsl
@@ -45,10 +45,9 @@
 
 <!-- define tcolorboxes for theorem and friends -->
 
-<!-- don't colour a list if it's inside an insight -->
-<!-- <xsl:template match="list[not(parent::insight)]" mode="tcb-style">
-    <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=white, colframe=black, colback=white, coltitle=black, titlerule=-0.3pt,</xsl:text>
-</xsl:template> -->
+<xsl:template match="list" mode="tcb-style">
+    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+</xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">
     <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=white, colframe=black, colback=white, coltitle=black, titlerule=-0.3pt,</xsl:text>
@@ -93,7 +92,7 @@
 </xsl:template>
 
 <!-- use original APEX geometry definitions -->
-<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=32pt,bottom=1in,footskip=29pt'"/>
+<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=20pt,bottom=1in,footskip=29pt'"/>
 
 <!-- apply exercise geometry -->
 <xsl:template match="exercises" mode="latex-division-heading">
@@ -161,7 +160,7 @@
 </xsl:template>
 
 <!-- define exercise geometry -->
-<xsl:template match="exercises|appendix" mode="new-geometry">
+<xsl:template match="exercises|appendix|solutions" mode="new-geometry">
     <xsl:text>\newgeometry{</xsl:text>
     <xsl:text>inner=72pt</xsl:text>
     <xsl:text>, outer=72pt</xsl:text>
@@ -173,18 +172,22 @@
 </xsl:template>
 
 <!-- restore geometry for next section -->
-<xsl:template match="exercises" mode="latex-division-footing">
+<xsl:template match="exercises|appendix|solutions" mode="latex-division-footing">
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="." mode="division-environment-name" />
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="self::exercises">
-        <!-- \restoregeometry includes a \clearpage -->
-        <xsl:text>\restoregeometry&#xa;</xsl:text>
-    </xsl:if>
+      <!-- \restoregeometry includes a \clearpage -->
+    <xsl:text>\restoregeometry&#xa;</xsl:text>
 </xsl:template>
 
+<!-- tabular in sidebyside without scaling -->
+<xsl:template match="tabular[ancestor::sidebyside]">
+    <xsl:text>{%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="tabular-inclusion"/>
+    <xsl:text>}%&#xa;</xsl:text>
+</xsl:template>
 
 <!-- figures in the margin -->
 <!-- load marginnote package -->
@@ -204,7 +207,7 @@
 </xsl:template>
 
 <!-- latex-image, asymptote, and tabular can all go in margin -->
-<xsl:template match="figure[not(ancestor::sidebyside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
+<xsl:template match="figure[not(ancestor::sidebyside) and not(ancestor::aside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
     <xsl:text>\marginnote{%&#xa;</xsl:text>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>

--- a/style/apex-latex-print-novid.xsl
+++ b/style/apex-latex-print-novid.xsl
@@ -46,7 +46,7 @@
 <!-- define tcolorboxes for theorem and friends -->
 
 <xsl:template match="list" mode="tcb-style">
-    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+    <xsl:text>enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
 </xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">

--- a/style/apex-latex-print-novid.xsl
+++ b/style/apex-latex-print-novid.xsl
@@ -193,6 +193,40 @@
 <!-- load marginnote package -->
 <xsl:param name="latex.preamble.early" select="'\usepackage{marginnote}'"/>
 
+<!-- margin figures within a tcolorbox get shifted with xelatex -->
+<!-- this shifts them back into place -->
+<xsl:param name="latex.preamble.late" select="'
+\makeatletter&#xa;
+\def\pgfsys@hboxsynced#1{%&#xa;
+  {%&#xa;
+    \pgfsys@beginscope%&#xa;
+    \setbox\pgf@hbox=\hbox{%&#xa;
+      \hskip\pgf@pt@x%&#xa;
+      \raise\pgf@pt@y\hbox{%&#xa;
+        \pgf@pt@x=0pt%&#xa;
+        \pgf@pt@y=0pt%&#xa;
+        \special{pdf: content q}%&#xa;
+        \pgflowlevelsynccm%&#xa;
+        \pgfsys@invoke{q -1 0 0 -1 0 0 cm}%&#xa;
+        \special{pdf: content -1 0 0 -1 0 0 cm q}% translate to original coordinate system&#xa;
+        \pgfsys@invoke{0 J [] 0 d}% reset line cap and dash&#xa;
+        \wd#1=0pt%&#xa;
+        \ht#1=0pt%&#xa;
+        \dp#1=0pt%&#xa;
+        \box#1%&#xa;
+        \pgfsys@invoke{n Q Q Q}%&#xa;
+      }%&#xa;
+      \hss%&#xa;
+    }%&#xa;
+    \wd\pgf@hbox=0pt%&#xa;
+    \ht\pgf@hbox=0pt%&#xa;
+    \dp\pgf@hbox=0pt%&#xa;
+    \pgfsys@hbox\pgf@hbox%&#xa;
+    \pgfsys@endscope%&#xa;
+  }%&#xa;
+}&#xa;
+\makeatother'"/>
+
 <!-- we want images in margin to be the full margin width -->
 <xsl:template match="figure/image[not(ancestor::sidebyside) and (descendant::latex-image or descendant::asymptote) and not(ancestor::exercise)]">
     <xsl:text>\begin{image}</xsl:text>

--- a/style/apex-latex-print-style.xsl
+++ b/style/apex-latex-print-style.xsl
@@ -45,10 +45,9 @@
 
 <!-- define tcolorboxes for theorem and friends -->
 
-<!-- don't colour a list if it's inside an insight -->
-<!-- <xsl:template match="list[not(parent::insight)]" mode="tcb-style">
-    <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=white, colframe=black, colback=white, coltitle=black, titlerule=-0.3pt,</xsl:text>
-</xsl:template> -->
+<xsl:template match="list" mode="tcb-style">
+    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+</xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">
     <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=white, colframe=black, colback=white, coltitle=black, titlerule=-0.3pt,</xsl:text>
@@ -93,7 +92,7 @@
 </xsl:template>
 
 <!-- use original APEX geometry definitions -->
-<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=32pt,bottom=1in,footskip=29pt'"/>
+<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=20pt,bottom=1in,footskip=29pt'"/>
 
 <!-- apply exercise geometry -->
 <xsl:template match="exercises" mode="latex-division-heading">
@@ -173,18 +172,22 @@
 </xsl:template>
 
 <!-- restore geometry for next section -->
-<xsl:template match="exercises" mode="latex-division-footing">
+<xsl:template match="exercises|appendix|solutions" mode="latex-division-footing">
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="." mode="division-environment-name" />
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="self::exercises">
-        <!-- \restoregeometry includes a \clearpage -->
-        <xsl:text>\restoregeometry&#xa;</xsl:text>
-    </xsl:if>
+      <!-- \restoregeometry includes a \clearpage -->
+    <xsl:text>\restoregeometry&#xa;</xsl:text>
 </xsl:template>
 
+<!-- tabular in sidebyside without scaling -->
+<xsl:template match="tabular[ancestor::sidebyside]">
+    <xsl:text>{%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="tabular-inclusion"/>
+    <xsl:text>}%&#xa;</xsl:text>
+</xsl:template>
 
 <!-- figures in the margin -->
 <!-- load marginnote package -->
@@ -204,7 +207,7 @@
 </xsl:template>
 
 <!-- latex-image, asymptote, and tabular can all go in margin -->
-<xsl:template match="figure[not(ancestor::sidebyside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
+<xsl:template match="figure[not(ancestor::sidebyside) and not(ancestor::aside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
     <xsl:text>\marginnote{%&#xa;</xsl:text>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>

--- a/style/apex-latex-print-style.xsl
+++ b/style/apex-latex-print-style.xsl
@@ -193,6 +193,40 @@
 <!-- load marginnote package -->
 <xsl:param name="latex.preamble.early" select="'\usepackage{marginnote}'"/>
 
+<!-- margin figures within a tcolorbox get shifted with xelatex -->
+<!-- this shifts them back into place -->
+<xsl:param name="latex.preamble.late" select="'
+  \makeatletter&#xa;
+  \def\pgfsys@hboxsynced#1{%&#xa;
+    {%&#xa;
+      \pgfsys@beginscope%&#xa;
+      \setbox\pgf@hbox=\hbox{%&#xa;
+        \hskip\pgf@pt@x%&#xa;
+        \raise\pgf@pt@y\hbox{%&#xa;
+          \pgf@pt@x=0pt%&#xa;
+          \pgf@pt@y=0pt%&#xa;
+          \special{pdf: content q}%&#xa;
+          \pgflowlevelsynccm%&#xa;
+          \pgfsys@invoke{q -1 0 0 -1 0 0 cm}%&#xa;
+          \special{pdf: content -1 0 0 -1 0 0 cm q}% translate to original coordinate system&#xa;
+          \pgfsys@invoke{0 J [] 0 d}% reset line cap and dash&#xa;
+          \wd#1=0pt%&#xa;
+          \ht#1=0pt%&#xa;
+          \dp#1=0pt%&#xa;
+          \box#1%&#xa;
+          \pgfsys@invoke{n Q Q Q}%&#xa;
+        }%&#xa;
+        \hss%&#xa;
+      }%&#xa;
+      \wd\pgf@hbox=0pt%&#xa;
+      \ht\pgf@hbox=0pt%&#xa;
+      \dp\pgf@hbox=0pt%&#xa;
+      \pgfsys@hbox\pgf@hbox%&#xa;
+      \pgfsys@endscope%&#xa;
+    }%&#xa;
+  }&#xa;
+  \makeatother'"/>
+
 <!-- we want images in margin to be the full margin width -->
 <xsl:template match="figure/image[not(ancestor::sidebyside) and (descendant::latex-image or descendant::asymptote) and not(ancestor::exercise)]">
     <xsl:text>\begin{image}</xsl:text>

--- a/style/apex-latex-print-style.xsl
+++ b/style/apex-latex-print-style.xsl
@@ -46,7 +46,7 @@
 <!-- define tcolorboxes for theorem and friends -->
 
 <xsl:template match="list" mode="tcb-style">
-    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+    <xsl:text>enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
 </xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">

--- a/style/apex-latex-style.xsl
+++ b/style/apex-latex-style.xsl
@@ -160,6 +160,40 @@
 <!-- load marginnote package -->
 <xsl:param name="latex.preamble.early" select="'\usepackage{marginnote}'"/>
 
+<!-- margin figures within a tcolorbox get shifted with xelatex -->
+<!-- this shifts them back into place -->
+<xsl:param name="latex.preamble.late" select="'
+\makeatletter&#xa;
+\def\pgfsys@hboxsynced#1{%&#xa;
+  {%&#xa;
+    \pgfsys@beginscope%&#xa;
+    \setbox\pgf@hbox=\hbox{%&#xa;
+      \hskip\pgf@pt@x%&#xa;
+      \raise\pgf@pt@y\hbox{%&#xa;
+        \pgf@pt@x=0pt%&#xa;
+        \pgf@pt@y=0pt%&#xa;
+        \special{pdf: content q}%&#xa;
+        \pgflowlevelsynccm%&#xa;
+        \pgfsys@invoke{q -1 0 0 -1 0 0 cm}%&#xa;
+        \special{pdf: content -1 0 0 -1 0 0 cm q}% translate to original coordinate system&#xa;
+        \pgfsys@invoke{0 J [] 0 d}% reset line cap and dash&#xa;
+        \wd#1=0pt%&#xa;
+        \ht#1=0pt%&#xa;
+        \dp#1=0pt%&#xa;
+        \box#1%&#xa;
+        \pgfsys@invoke{n Q Q Q}%&#xa;
+      }%&#xa;
+      \hss%&#xa;
+    }%&#xa;
+    \wd\pgf@hbox=0pt%&#xa;
+    \ht\pgf@hbox=0pt%&#xa;
+    \dp\pgf@hbox=0pt%&#xa;
+    \pgfsys@hbox\pgf@hbox%&#xa;
+    \pgfsys@endscope%&#xa;
+  }%&#xa;
+}&#xa;
+\makeatother'"/>
+
 <!-- we want images in margin to be the full margin width -->
 <xsl:template match="figure/image[not(ancestor::sidebyside) and (descendant::latex-image or descendant::asymptote) and not(ancestor::exercise)]">
     <xsl:text>\begin{image}</xsl:text>

--- a/style/apex-latex-style.xsl
+++ b/style/apex-latex-style.xsl
@@ -46,7 +46,7 @@
 <!-- define tcolorboxes for theorem and friends -->
 
 <xsl:template match="list" mode="tcb-style">
-    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+    <xsl:text>enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
 </xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">

--- a/style/apex-latex-style.xsl
+++ b/style/apex-latex-style.xsl
@@ -45,10 +45,9 @@
 
 <!-- define tcolorboxes for theorem and friends -->
 
-<!-- don't colour a list if it's inside an insight -->
-<!-- <xsl:template match="list[not(parent::insight)]" mode="tcb-style">
-    <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=blue!60!black!20, colframe=blue!30!black!50, colback=white!95!bluepen, coltitle=black, titlerule=-0.3pt,</xsl:text>
-</xsl:template> -->
+<xsl:template match="list" mode="tcb-style">
+    <xsl:text>listptxstyle/.style={enhanced jigsaw,middle=1ex, blockspacingstyle, opacityback=0, opacitybacktitle=0, coltitle=black, frame hidden, titlerule=-0.3pt,</xsl:text>
+</xsl:template>
 
 <xsl:template match="insight" mode="tcb-style">
     <xsl:text>fonttitle=\normalfont\bfseries, colbacktitle=red!60!black!20, colframe=red!30!black!50, colback=white!95!red, coltitle=black, titlerule=-0.3pt,</xsl:text>
@@ -94,14 +93,12 @@
 </xsl:template>
 
 <!-- use original APEX geometry definitions -->
-<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=32pt,bottom=1in,footskip=29pt'"/>
+<xsl:param name="latex.geometry" select="'inner=1in,textheight=9in,textwidth=320pt,marginparwidth=150pt,marginparsep=20pt,bottom=1in,footskip=29pt'"/>
 
 <!-- apply exercise geometry -->
-<xsl:template match="exercises" mode="latex-division-heading">
-    <xsl:if test="self::exercises">
-        <!-- \newgeometry includes a \clearpage -->
-        <xsl:apply-templates select="." mode="new-geometry"/>
-    </xsl:if>
+<xsl:template match="exercises|appendix|solutions" mode="latex-division-heading">
+    <!-- \newgeometry includes a \clearpage -->
+    <xsl:apply-templates select="." mode="new-geometry"/>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="division-environment-name" />
     <!-- possibly numberless -->
@@ -128,41 +125,9 @@
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- exercise geometry for backmatter appendix -->
-<xsl:template match="appendix" mode="latex-division-heading">
-  <xsl:if test="self::appendix">
-      <!-- \newgeometry includes a \clearpage -->
-      <xsl:apply-templates select="." mode="new-geometry"/>
-  </xsl:if>
-    <xsl:text>\begin{</xsl:text>
-    <xsl:apply-templates select="." mode="division-environment-name" />
-    <!-- possibly numberless -->
-    <xsl:apply-templates select="." mode="division-environment-name-suffix" />
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="title-full"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- subtitle here -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="title-short"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="author" mode="name-list"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- subtitle here -->
-    <!-- <xsl:text>An epigraph here\\with two lines\\-Rob</xsl:text> -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="latex-id" />
-    <xsl:text>}</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
-</xsl:template>
 
 <!-- define exercise geometry -->
-<xsl:template match="exercises|appendix" mode="new-geometry">
+<xsl:template match="exercises|appendix|solutions" mode="new-geometry">
     <xsl:text>\newgeometry{</xsl:text>
     <xsl:text>inner=72pt</xsl:text>
     <xsl:text>, outer=72pt</xsl:text>
@@ -174,16 +139,21 @@
 </xsl:template>
 
 <!-- restore geometry for next section -->
-<xsl:template match="exercises" mode="latex-division-footing">
+<xsl:template match="exercises|appendix|solutions" mode="latex-division-footing">
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="." mode="division-environment-name" />
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="self::exercises">
-        <!-- \restoregeometry includes a \clearpage -->
-        <xsl:text>\restoregeometry&#xa;</xsl:text>
-    </xsl:if>
+      <!-- \restoregeometry includes a \clearpage -->
+    <xsl:text>\restoregeometry&#xa;</xsl:text>
+</xsl:template>
+
+<!-- tabular in sidebyside without scaling -->
+<xsl:template match="tabular[ancestor::sidebyside]">
+    <xsl:text>{%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="tabular-inclusion"/>
+    <xsl:text>}%&#xa;</xsl:text>
 </xsl:template>
 
 <!-- figures in the margin -->
@@ -204,7 +174,7 @@
 </xsl:template>
 
 <!-- latex-image, asymptote, and tabular can all go in margin -->
-<xsl:template match="figure[not(ancestor::sidebyside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
+<xsl:template match="figure[not(ancestor::sidebyside) and not(ancestor::aside) and not(descendant::sidebyside) and (descendant::latex-image or descendant::asymptote or descendant::tabular) and not(ancestor::exercise)]">
     <xsl:text>\marginnote{%&#xa;</xsl:text>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>


### PR DESCRIPTION
In later chapters there are a number of sections where roughly half the exercises are coded for WeBWorK, and half are not.
The two do not look good side by side in print.

I've tried to streamline things so that everything comes out the same. (Building LaTeX right now, so wait for confirmation tomorrow.)

There were also a few minor things I caught while proofreading the PDF.