### PR TITLE
Corrected annotation in fig_anti1

### DIFF
--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -127,11 +127,11 @@
 
         \node[] (integral)
         {$\displaystyle\int$};
-        \node[above left of=integral, anchor=south east] (l1) {Integration Symbol};
+        \node[above left of=integral, anchor=south east] (l1) {Integral symbol};
         \draw[-&gt;] (l1) edge [out=-90, in=180] (integral);
         \node[right of=integral] (integrand)
         {$\displaystyle f(x)$};
-        \node[below of=integrand, anchor=north east] (l2) {Integration Symbol};
+        \node[below of=integrand, anchor=north east] (l2) {Integrand function};
         \draw[-&gt;] (l2) edge [out=0, in=-90] (integrand);
         \node[right of=integrand] (differential)
         {$\displaystyle dx$};
@@ -141,13 +141,13 @@
         {$\displaystyle =$};
         \node[right of=equals] (antiderivative)
         {$\displaystyle F(x)$};
-        \node[below of=antiderivative, anchor=north west] (l4) {One Antiderivative};
+        \node[below of=antiderivative, anchor=north west] (l4) {Any antiderivative of $f$};
         \draw[-&gt;] (l4) edge [out=180, in=-90] (antiderivative);
         \node[right of=antiderivative] (plus)
         {$\displaystyle {+}$};
         \node[right of=plus] (constant)
         {$\displaystyle C$};
-        \node[above right of=constant, anchor=south west] (l5) {Constant of Integration};
+        \node[above right of=constant, anchor=south west] (l5) {Constant of integration};
         \draw[-&gt;] (l5) edge [out=-90, in=0] (constant);
 
         \end{tikzpicture}


### PR DESCRIPTION
In Section 5.1, figure 5.1.5 (integral notation), the integrand function is mislabeled as "Integration Symbol" at line 134. 

I also made a couple other minor changes to the annotation text for clarity and to suit my preferred style, see the diff for details.