### PR TITLE
ignore endpoint types in WW problems

### DIFF
--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -1101,6 +1101,7 @@
               $f = Formula("x^2 - 2*$r x + ($r)^2")->reduce;
               $inflecs = List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,inf)"));
               $dn = List(Compute("None"));
             </pg-code>
@@ -1158,6 +1159,7 @@
               $f = Formula("-x^2 + $a x + $b")->reduce;
               $inflecs = List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Compute("None"));
               $dn = List(Interval("(-inf,inf)"));
             </pg-code>
@@ -1216,6 +1218,7 @@
               $f = Formula("x^3 - $s x + $c")->reduce;
               $inflecs = List(0);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[0,inf)"));
               $dn = List(Interval("(-inf,0]"));
             </pg-code>
@@ -1278,6 +1281,7 @@
               $i = Fraction(-2*$b,6*$a);
               $inflecs = List($i);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[$i,inf)"));
               $dn = List(Interval("(-inf,$i]"));
               ($up,$dn) = ($dn,$up) if ($a &lt; 0);
@@ -1346,6 +1350,7 @@
               ($i,$j) = num_sort($i,0);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
             </pg-code>
@@ -1433,6 +1438,7 @@
               ($i,$j) = num_sort($i,$j);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               ($up,$dn) = ($dn,$up) if ($a &lt; 0);
@@ -1496,6 +1502,7 @@
               $f = Formula("$a x^4 + $b x^3 + $c x^2 + $d x + $e")->reduce;
               $inflecs = List($r);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,inf)"));
               $dn = List(Compute("none"));
             </pg-code>
@@ -1550,6 +1557,7 @@
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-pi/2,pi/2)"));
               $dn = List(Interval("(-3pi/2,-pi/2)"),Interval("(pi/2,3pi/2)"));
             </pg-code>
@@ -1630,6 +1638,7 @@
               ($i,$j) = num_sort($i,$j);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
             </pg-code>
@@ -1689,6 +1698,7 @@
               $f = Formula("1/(x^2 + $b x + $c)")->reduce;
               $inflecs = List(Compute("none"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$r)"),Interval("($s,inf)"));
               $dn = List(Interval("($r,$s)"));
             </pg-code>
@@ -1743,6 +1753,7 @@
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-pi,-pi/4]"),Interval("[3pi/4,pi)"));
               $dn = List(Interval("[-pi/4,3pi/4]"));
             </pg-code>
@@ -1797,6 +1808,7 @@
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,-2-sqrt(2)]"),Interval("[-2+sqrt(2),inf)"));
               $dn = List(Interval("[-2-sqrt(2),-2+sqrt(2)]"));
             </pg-code>
@@ -1851,6 +1863,7 @@
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[1/e^(3/2),inf)"));
               $dn = List(Interval("(0,1/e^(3/2)]"));
             </pg-code>
@@ -1905,6 +1918,7 @@
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,-1/sqrt(2)]"),Interval("[1/sqrt(2),inf)"));
               $dn = List(Interval("[-1/sqrt(2),1/sqrt(2)]"));
             </pg-code>
@@ -1974,6 +1988,7 @@
               $f = Formula("x^2 - 2*$r x + ($r)^2")->reduce;
               $inflecs = List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,inf)"));
               $dn = List(Compute("None"));
               Context("Fraction");
@@ -2031,6 +2046,7 @@
               $f = Formula("-x^2 + $a x + $b")->reduce;
               $inflecs = List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Compute("None"));
               $dn = List(Interval("(-inf,inf)"));
               Context("Fraction");
@@ -2090,6 +2106,7 @@
               $f = Formula("x^3 - $s x + $c")->reduce;
               $inflecs = List(0);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[0,inf)"));
               $dn = List(Interval("(-inf,0]"));
               Context("Fraction");
@@ -2170,6 +2187,7 @@
               $i = Fraction(-2*$b,6*$a);
               $inflecs = List($i);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[$i,inf)"));
               $dn = List(Interval("(-inf,$i]"));
               ($up,$dn) = ($dn,$up) if ($a &lt; 0);
@@ -2237,6 +2255,7 @@
               ($i,$j) = num_sort($i,0);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               $crit = List($r);
@@ -2323,6 +2342,7 @@
               ($i,$j) = num_sort($i,$j);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               ($up,$dn) = ($dn,$up) if ($a &lt; 0);
@@ -2385,6 +2405,7 @@
               $f = Formula("$a x^4 + $b x^3 + $c x^2 + $d x + $e")->reduce;
               $inflecs = List($r);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,inf)"));
               $dn = List(Compute("none"));
               $crit = List($r);
@@ -2438,6 +2459,7 @@
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-pi/2,pi/2)"));
               $dn = List(Interval("(-3pi/2,-pi/2)"),Interval("(pi/2,3pi/2)"));
               $crit = List(Compute("-pi"),0,Compute("pi"));
@@ -2517,6 +2539,7 @@
               ($i,$j) = num_sort($i,$j);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               $crit = List($r);
@@ -2575,6 +2598,7 @@
               $f = Formula("1/(x^2 + $b x + $c)")->reduce;
               $inflecs = List(Compute("none"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$r)"),Interval("($s,inf)"));
               $dn = List(Interval("($r,$s)"));
               Context("Fraction");
@@ -2634,6 +2658,7 @@
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-pi,-pi/4]"),Interval("[3pi/4,pi)"));
               $dn = List(Interval("[-pi/4,3pi/4]"));
               $crit = List(Compute("-3pi/4"),Compute("pi/4"));
@@ -2687,6 +2712,7 @@
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,-2-sqrt(2)]"),Interval("[-2+sqrt(2),inf)"));
               $dn = List(Interval("[-2-sqrt(2),-2+sqrt(2)]"));
               $crit = List(-2,0);
@@ -2740,6 +2766,7 @@
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[1/e^(3/2),inf)"));
               $dn = List(Interval("(0,1/e^(3/2)]"));
               $crit = List(Compute("e^(-1/2)"));
@@ -2793,6 +2820,7 @@
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,-1/sqrt(2)]"),Interval("[1/sqrt(2),inf)"));
               $dn = List(Interval("[-1/sqrt(2),1/sqrt(2)]"));
               $crit = List(0);
@@ -2859,6 +2887,7 @@
               $f = Formula("x^2 - 2*$r x + ($r)^2")->reduce;
               $inflecs = List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,inf)"));
               $dn = List(Compute("None"));
               Context("Fraction");
@@ -2909,6 +2938,7 @@
               $f = Formula("-x^2 + $a x + $b")->reduce;
               $inflecs = List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Compute("None"));
               $dn = List(Interval("(-inf,inf)"));
               Context("Fraction");
@@ -2961,6 +2991,7 @@
               $f = Formula("x^3 - $s x + $c")->reduce;
               $inflecs = List(0);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[0,inf)"));
               $dn = List(Interval("(-inf,0]"));
               Context("Fraction");
@@ -3034,6 +3065,7 @@
               $i = Fraction(-2*$b,6*$a);
               $inflecs = List($i);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[$i,inf)"));
               $dn = List(Interval("(-inf,$i]"));
               ($up,$dn) = ($dn,$up) if ($a &lt; 0);
@@ -3095,6 +3127,7 @@
               ($i,$j) = num_sort($i,0);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               $crit = List($r);
@@ -3174,6 +3207,7 @@
               ($i,$j) = num_sort($i,$j);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               ($up,$dn) = ($dn,$up) if ($a &lt; 0);
@@ -3230,6 +3264,7 @@
               $f = Formula("$a x^4 + $b x^3 + $c x^2 + $d x + $e")->reduce;
               $inflecs = List($r);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,inf)"));
               $dn = List(Compute("none"));
               $crit = List($r);
@@ -3276,6 +3311,7 @@
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-pi/2,pi/2)"));
               $dn = List(Interval("(-3pi/2,-pi/2)"),Interval("(pi/2,3pi/2)"));
               $crit = List(Compute("-pi"),0,Compute("pi"));
@@ -3348,6 +3384,7 @@
               ($i,$j) = num_sort($i,$j);
               $inflecs = List($i,$j);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$i]"),Interval("[$j,inf)"));
               $dn = List(Interval("[$i,$j]"));
               $crit = List($r);
@@ -3399,6 +3436,7 @@
               $f = Formula("1/(x^2 + $b x + $c)")->reduce;
               $inflecs = List(Compute("none"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,$r)"),Interval("($s,inf)"));
               $dn = List(Interval("($r,$s)"));
               Context("Fraction");
@@ -3447,6 +3485,7 @@
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-pi,-pi/4]"),Interval("[3pi/4,pi)"));
               $dn = List(Interval("[-pi/4,3pi/4]"));
               $crit = List(Compute("-3pi/4"),Compute("pi/4"));
@@ -3493,6 +3532,7 @@
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,-2-sqrt(2)]"),Interval("[-2+sqrt(2),inf)"));
               $dn = List(Interval("[-2-sqrt(2),-2+sqrt(2)]"));
               $crit = List(-2,0);
@@ -3539,6 +3579,7 @@
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("[1/e^(3/2),inf)"));
               $dn = List(Interval("(0,1/e^(3/2)]"));
               $crit = List(Compute("e^(-1/2)"));
@@ -3585,6 +3626,7 @@
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $up = List(Interval("(-inf,-1/sqrt(2)]"),Interval("[1/sqrt(2),inf)"));
               $dn = List(Interval("[-1/sqrt(2),1/sqrt(2)]"));
               $crit = List(0);

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -1161,7 +1161,7 @@
               </li>
               <li>
                 <p>
-                  Create a number line to determine the intervals on which <m>f</m> is increasing and decreasing.
+                  Create a number line to determine the maximal intervals on which <m>f</m> is increasing and decreasing.
                 </p>
               </li>
               <li>
@@ -1182,6 +1182,7 @@
               $m = ($r+$s)/2;
               $crit=List("$m");
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $f = Formula("x^2-($r+$s)x+$r*$s")->reduce;
               $domain = Compute("(-inf,inf)");
               $inc = List(Interval("[$m,inf)"));
@@ -1267,6 +1268,7 @@
               ($m,$n) = num_sort(0,$m);
               $crit=List($m,$n);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $f = Formula("x^3 + $a x^2 + $b")->reduce;
               $domain = Compute("(-inf,inf)");
               $inc = List(Interval("(-inf,$m]"),Interval("[$n,inf)"));
@@ -1360,6 +1362,7 @@
               ($m,$n) = num_sort($s,$t);
               $crit=List($m,$n);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $A = $b*$d/3;
               $B = -($b*$c+$a*$d)/2;
               $C = $a*$c;
@@ -1446,6 +1449,7 @@
               $r = non_zero_random(-5,5,1);
               $crit=List($r);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $A = 1;
               $B = -3*$r;
               $C = 3*($r)**2;
@@ -1532,6 +1536,7 @@
               $r = non_zero_random(-5,5,1);
               $crit=List($r);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $A = 1;
               $B = -2*$r;
               $C = ($r)**2+random(1,9,1);
@@ -1619,6 +1624,7 @@
               $T = ($t)**2;
               $crit=List(0);
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $f = Formula("(x^2-$R)/(x^2-$T)")->reduce;
               $domain = Compute("(-inf,-$t)U(-$t,$t)U($t,inf)");
               $inc = List(Interval("[0,$t)"),Interval("($t,inf)"));
@@ -1706,6 +1712,7 @@
               $rs = $r*$s;
               $crit = ($rs > 0) ? List(Compute(-sqrt($rs)),-Compute(-sqrt($rs))) : List(Compute("None"));
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $f = Formula("x/(x^2-($r+$s)x+$rs)")->reduce;
               $domain = Compute("(-inf,$r)U($r,$s)U($s,inf)");
               if ($r > 0) {
@@ -1802,6 +1809,7 @@
               $r = non_zero_random(-9,9,1);
               $crit = List($r,3*$r);
               Context("Interval")->flags->set(reduceConstants=>0);
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $f = Formula("(x-$r)^(2/3)/x");
               $domain = Compute("(-inf,0)U(0,inf)");
               if ($r > 0) {
@@ -1889,6 +1897,7 @@
           <webwork>
             <pg-code>
               Context("Interval");
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $domain = Compute("(-inf,inf)");
               $crit = List("-3pi/4,-pi/4,pi/4,3pi/4");
               $inc = List(Interval("(-pi,-3pi/4)"),Interval("(-pi/4,pi/4)"),Interval("(3pi/4,pi)"));
@@ -1986,6 +1995,7 @@
               }
               $a = ($b)**($n-1);
               Context("Interval")->flags->set(reduceConstants=>0);
+              Context()->flags->set(ignoreEndpointTypes => 1);
               $domain = Compute("(-inf,inf)");
               $f = Formula("x^$n - $a*$n x")->reduce;
               if ($n % 2 == 0) {
@@ -2079,7 +2089,6 @@
       <exercise>
         <webwork>
           <pg-code>
-            Context("Interval");
             Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
             $c=Formula("1/2");
           </pg-code>
@@ -2105,7 +2114,6 @@
       <exercise>
         <webwork>
           <pg-code>
-            Context("Interval");
             Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
             $c=Formula("acos(2/pi),-acos(2/pi)");
           </pg-code>


### PR DESCRIPTION
This makes it so that when the question is "where is x^3 concave up" and the answer is "[0,inf)", the student can get away with answering "(0,inf)".