### PR TITLE
fix to l'Hosptital statements to permit it to apply to all exercises …

### DIFF
--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -63,8 +63,9 @@
           <me>
             \lim_{x\to c} \frac{f(x)}{g(x)} = \lim_{x\to c} \frac{\fp(x)}{g'(x)}
           </me>,
-          provided that the limit on the right exists.
+          provided that the limit on the right exists, or is <m>\pm\infty</m>.
         </p>
+	<p>This result applies to one-sided limits as well.</p>
       </statement>
     </theorem>
 
@@ -185,7 +186,7 @@
                 <me>
                   \lim_{x\to a} \frac{f(x)}{g(x)} = \lim_{x\to a}\frac{\fp(x)}{g'(x)}
                 </me>,
-                provided that the limit on the right exists.
+                provided that the limit on the right exists, or is <m>\pm\infty</m>.
               </p>
             </li>
 
@@ -204,6 +205,7 @@
             </li>
           </ol>
         </p>
+	<p>These results apply to one-sided limits as well.</p>
       </statement>
     </theorem>
 


### PR DESCRIPTION
In the l'Hospital's Rule section there are exercises and examples which involve one-sided limits or which lead to infinite limits, which are technically not covered by the LHR as it is currently stated. The current statement requires that the limit of the right side exists (which excludes infinity).

See, for example Example 4.1.6 part 2, and exercises 22-24, 39, etc.

I have added some clauses to the statement of the LHRs to include one-sided and infinite limits.

Credit for this find goes to Efren Ruiz.