### PR TITLE
fixed aspect ratio of rose curve asy figure

### DIFF
--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -1105,7 +1105,7 @@
 
                   pair xbounds=(-0.25,1.25);
                   pair ybounds=(-.25,.25);
-                  pair zbounds=(-.25,.5);
+                  pair zbounds=(-.25,.25);
 
                   xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
                   yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice));//,Arrow3(size=3mm));


### PR DESCRIPTION
I just happened to randomly notice this one. 
In Example 10.5.24: Surface area determined by a polar curve 
https://opentext.uleth.ca/apex-video/sec_polarcalc.html#ex_polcalc8

The asymptote figure of the surface of revolution looks squashed when viewed down the x-axis, it appears that this just an aspect ratio issue caused by a typo in setting up the plot bounds. I haven't rebuilt the figure to check that this fix is correct, but I don't see why it wouldn't be.