### PR TITLE
fix implicit form of deriv ln(u) in chainrule

### DIFF
--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -480,7 +480,7 @@
     we use <m>u</m> as a generic function of <m>x</m>.
     We then say
     <me>
-      \lzoo{\ln(u)} = \frac{u'}{u}
+      \lzoo{x}{\ln(u)} = \frac{u'}{u}
     </me>.
   </p>
 


### PR DESCRIPTION
In the chain rule section, the implicit form of the chain rule for natural logs has a typo/error.
 
https://opentext.uleth.ca/apex-video/sec_chainrule.html#p-2635

The \lzoo latex macro is missing its first argument.