### PR TITLE
fix to problem #7 answer from extreme values

### DIFF
--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1097,7 +1097,7 @@
               for my $A ('A'..'G') {Context()->strings->add($A=>{})};
               $absmax = List("B");
               $absmin = List("None");
-              $relmax = List("G");
+              $relmax = List("B", "G");
               $relmin = List("C","F");
             </pg-code>
             <statement>

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1097,7 +1097,7 @@
               for my $A ('A'..'G') {Context()->strings->add($A=>{})};
               $absmax = List("B");
               $absmin = List("None");
-              $relmax = List("B");
+              $relmax = List("G");
               $relmin = List("C","F");
             </pg-code>
             <statement>


### PR DESCRIPTION
[Problem #7 from Extreme Values](https://opentext.uleth.ca/apex-video/sec_extreme_values.html#exercisegroup-53) has an incorrect answer to the relative maximum part. Point B is listed as both a relative and absolute max (probably not intended), but more importantly, G is not listed as a relative max.

I know nothing about WebWork coding, so hopefully this patch is correct!