### PR TITLE
Webwork edits

### DIFF
--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1234,8 +1234,8 @@
         <exercise>
           <webwork>
             <pg-code>
-              Context()->variables->set(x=>{limits=>[0,4]});
               $F = FormulaUpToConstant("2x+x*(ln(x))^2-2x*ln(x)");
+              $F->{limits} = [1,5];
             </pg-code>
             <statement>
               <p>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1234,6 +1234,7 @@
         <exercise>
           <webwork>
             <pg-code>
+              Context()->variables->set(x=>{limits=>[0,4]});
               $F = FormulaUpToConstant("2x+x*(ln(x))^2-2x*ln(x)");
             </pg-code>
             <statement>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1257,6 +1257,7 @@
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-$b,-$b+4]});
               $F = FormulaUpToConstant("2x+(x+$b)*ln(x+$b)^2-2*(x+$b)*ln(x+$b)")->reduce;
+              $F->{limits} = [-$b+1,-$b+5];
             </pg-code>
             <statement>
               <p>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1255,7 +1255,7 @@
               $f = Formula("(ln(x+$b))^2")->reduce;
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-$b,-$b+4]});
-              $F = FormulaUpToConstant("(x+$b)*(ln(x+$b)^2-2*ln(x+$b))")->reduce;
+              $F = FormulaUpToConstant("2*(x+$b)+(x+$b)*(ln(x+$b)^2-2*(x+$b)*ln(x+$b))")->reduce;
             </pg-code>
             <statement>
               <p>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1256,7 +1256,7 @@
               $f = Formula("(ln(x+$b))^2")->reduce;
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-$b,-$b+4]});
-              $F = FormulaUpToConstant("2x+(x+$b)*ln(x+$b)^2-2*(x+$b)*ln(x+$b)")->reduce;
+              $F = FormulaUpToConstant("2(x+$b)+(x+$b)*ln(x+$b)^2-2*(x+$b)*ln(x+$b)")->reduce;
               $F->{limits} = [-$b+1,-$b+5];
             </pg-code>
             <statement>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1234,7 +1234,7 @@
         <exercise>
           <webwork>
             <pg-code>
-              $F = FormulaUpToConstant("2x+x*(ln(abs(x)))^2-2x*ln(abs(x))");
+              $F = FormulaUpToConstant("2x+x*(ln(x))^2-2x*ln(x)");
             </pg-code>
             <statement>
               <p>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1256,7 +1256,7 @@
               $f = Formula("(ln(x+$b))^2")->reduce;
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-$b,-$b+4]});
-              $F = FormulaUpToConstant("2*(x+$b)+(x+$b)*(ln(x+$b)^2-2*(x+$b)*ln(x+$b))")->reduce;
+              $F = FormulaUpToConstant("2x+(x+$b)*ln(x+$b)^2-2*(x+$b)*ln(x+$b)")->reduce;
             </pg-code>
             <statement>
               <p>


### PR DESCRIPTION
One of my students caught two incorrect answers in webwork exercises.

In the first: there should be no absolute value inside the logarithm, because we begin with a logarithm in the integrand, so the domain is correct without it. I think I can just remove it without trouble. (i.e. I don't think I need to specify test points?)

In the second, the answer is just wrong. I think this was one that I once caught in the LaTeX version of the book, but that probably happened after the initial conversion began, but before I was involved. We should just be taking the answer from the previous problem and shifting by `$b`.