### PR TITLE
Update l'Hospital's rule and updates for schema changes

### DIFF
--- a/ptx/appendix_back_reference.ptx
+++ b/ptx/appendix_back_reference.ptx
@@ -585,7 +585,7 @@
       <sidebyside>
         <p>
           <alert>Triangles</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 <m>h=a\sin \theta</m>
@@ -623,7 +623,7 @@
 
         <p>
           <alert>Right Circular Cone</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Volume = <m>\frac 13 \pi r^2h</m>
@@ -663,7 +663,7 @@
       <sidebyside>
         <p>
           <alert>Parallelograms</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Area = <m>bh</m>
@@ -689,7 +689,7 @@
 
         <p>
           <alert>Right Circular Cylinder</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Volume = <m>\pi r^2h</m>
@@ -729,7 +729,7 @@
       <sidebyside>
         <p>
           <alert>Trapezoids</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Area = <m>\frac12(a+b)h</m>
@@ -755,7 +755,7 @@
 
         <p>
           <alert>Sphere</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Volume = <m>\frac43\pi r^3</m>
@@ -793,7 +793,7 @@
       <sidebyside>
         <p>
           <alert>Circles</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Area = <m>\pi r^2</m>
@@ -824,7 +824,7 @@
 
         <p>
           <alert>General Cone</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Area of Base = <m>A</m>
@@ -868,7 +868,7 @@
       <sidebyside>
         <p>
           <alert>Sectors of Circles</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 <m>\theta</m> in radians
@@ -906,7 +906,7 @@
 
         <p>
           <alert>General Right Cylinder</alert>
-          <ul label="">
+          <ul marker="">
             <li>
               <p>
                 Area of Base = <m>A</m>

--- a/ptx/preface.ptx
+++ b/ptx/preface.ptx
@@ -19,8 +19,8 @@
 			The third text covers topics common in <q>Calc 3</q> or <q>multivariable calc:</q>
 			parametric equations, polar coordinates, vector-valued functions, and functions of more than one variable,
 			found in Chapters 10 through 15.
-			All three are available separately for free at <url href="http://apexcalculus.com">apexcalculus.com</url>,
-			and HTML versions of the book can be found at <url href="http://opentext.uleth.ca/calculus.html">opentext.uleth.ca</url>.
+			All three are available separately for free at <url href="https://apexcalculus.com" visual="apexcalculus.com">apexcalculus.com</url>,
+			and HTML versions of the book can be found at <url href="https://opentext.uleth.ca/calculus.html" visual="opentext.uleth.ca/calculus.html">opentext.uleth.ca</url>.
 		</p>
 
 		<p>
@@ -32,7 +32,7 @@
 			Printing the entire text as one volume makes for a large, heavy, cumbersome book.
 			One can certainly only print the pages they currently need, but some prefer to have a nice,
 			bound copy of the text. Therefore this text has been split into these three manageable parts,
-			each of which can be purchased for about $15 at <url href="http://amazon.com">Amazon.com</url>.
+			each of which can be purchased for about $15 at <url href="https://amazon.com" visual="amazon.com">Amazon.com</url>.
 		</p>
 	</paragraphs>
 
@@ -141,11 +141,11 @@
 		<p>
 			We encourage others to adapt this work to fit their own needs.
 			One might add sections that are <q>missing</q> or remove sections that your students won't need.
-			The source files can be found at <url href="https://github.com/APEXCalculus">github.com/APEXCalculus</url>.
+			The source files can be found at <url href="https://github.com/APEXCalculus" visual="github.com/APEXCalculus">github.com/APEXCalculus</url>.
 		</p>
 
 		<p>
-			You can learn more at <url href="http://www.vmi.edu/APEX">www.vmi.edu/APEX</url>.
+			You can learn more at <url href="https://www.vmi.edu/APEX" visual="www.vmi.edu/APEX">www.vmi.edu/APEX</url>.
 		</p>
 	</paragraphs>
 
@@ -157,7 +157,7 @@
 			  <li>
 			    <p>
 			      The underlying source code has been completely rewritten,
-						to use the <url href="https://pretextbook.org"><pretext /></url> language,
+						to use the <url href="https://pretextbook.org" visual="pretextbook.org"><pretext /></url> language,
 						instead of the original <m>\LaTeX</m>.
 			    </p>
 			  </li>
@@ -165,7 +165,7 @@
 				  <p>
 				    Using <pretext /> allows us to produce the books in multiple formats,
 						including <init>HTML</init>, which is both more accessible and more interactive than the original <init>PDF</init>.
-						<init>HTML</init> versions of the book can be found at <url href="https://opentext.uleth.ca/calculus.html">opentext.uleth.ca</url>.
+						<init>HTML</init> versions of the book can be found at <url href="https://opentext.uleth.ca/calculus.html" visual="opentext.uleth.ca/calculus.html">opentext.uleth.ca</url>.
 				  </p>
 				</li>
 				<li>
@@ -196,7 +196,7 @@
 				  <p>
 				    <q>Large</q> mathematical corrections and adjustments.
 						There were a number of places in Version 3.0 where a definition/theorem was not correct as stated.
-						See <url href="http://apexcalculus.com">www.apexcalculus.com</url> for more information.
+						See <url href="https://apexcalculus.com" visual="apexcalculus.com">www.apexcalculus.com</url> for more information.
 				  </p>
 				</li>
 				<li>

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -1399,7 +1399,6 @@
         </exercise>
 
       </exercisegroup>
-      <exercisegroup cols="2">
 
       <exercise>
         <statement>
@@ -1421,50 +1420,48 @@
       </exercise>
 
   <!-- Exercise 17 -->
-        <exercise>
-          <webwork>
-              <pg-code>
-                $x0 = Compute("pi/6");
-                $x1 = Compute("5*pi/6");
-                $x2 = Compute("3*pi/2");
-              <!-- f(x0) > g(x0), but g(x2) > f(x2) -->
-                $f = Formula("sin(x)");
-                $g = Formula("cos(2x)");
-                $F = Formula("-cos(x)");
-                $G = Formula("sin(2x)/2");
-                $D1 = Formula("$F-$G");
-                $area1 = $D1->eval(x=>$x1) - $D1->eval(x=>$x0);
-                $D2 = Formula("-$D1");
-                $area2 = $D2->eval(x=>$x2) - $D2->eval(x=>$x1);
-                $area = $area1 + $area2;
-              </pg-code>
-              <statement>
-                <p>
-                  The functions <m>f(x) = \cos(2x)</m> and
-                  <m>g(x) = \sin(x)</m> intersect infinitely many times,
-                  forming an infinite number of repeated, enclosed regions.
-                  Find the areas of these regions.
-                </p>
+      <exercise>
+        <webwork>
+            <pg-code>
+              $x0 = Compute("pi/6");
+              $x1 = Compute("5*pi/6");
+              $x2 = Compute("3*pi/2");
+            <!-- f(x0) > g(x0), but g(x2) > f(x2) -->
+              $f = Formula("sin(x)");
+              $g = Formula("cos(2x)");
+              $F = Formula("-cos(x)");
+              $G = Formula("sin(2x)/2");
+              $D1 = Formula("$F-$G");
+              $area1 = $D1->eval(x=>$x1) - $D1->eval(x=>$x0);
+              $D2 = Formula("-$D1");
+              $area2 = $D2->eval(x=>$x2) - $D2->eval(x=>$x1);
+              $area = $area1 + $area2;
+            </pg-code>
+            <statement>
+              <p>
+                The functions <m>f(x) = \cos(2x)</m> and
+                <m>g(x) = \sin(x)</m> intersect infinitely many times,
+                forming an infinite number of repeated, enclosed regions.
+                Find the areas of these regions.
+              </p>
 
-                <p>
-                  Sum of repeated areas: <var name="$area" width="10"/>
-                </p>
-              <!-- 3sqrt(3)/2 + 3sqrt(3)/4 corresponding to the two non-symmetric areas-->
-              </statement>
-              <solution>
-                <p>
-                  On regions such as <m>[\pi/6,5\pi/6]</m>,
-                  the area is <m>3\sqrt{3}/2</m>.
-                  On regions such as <m>[-\pi/2,\pi/6]</m>,
-                  the area is <m>3\sqrt{3}/4</m>.
-                </p>
-              </solution>
-          </webwork>
-        </exercise>
+              <p>
+                Sum of repeated areas: <var name="$area" width="10"/>
+              </p>
+            <!-- 3sqrt(3)/2 + 3sqrt(3)/4 corresponding to the two non-symmetric areas-->
+            </statement>
+            <solution>
+              <p>
+                On regions such as <m>[\pi/6,5\pi/6]</m>,
+                the area is <m>3\sqrt{3}/2</m>.
+                On regions such as <m>[-\pi/2,\pi/6]</m>,
+                the area is <m>3\sqrt{3}/4</m>.
+              </p>
+            </solution>
+        </webwork>
+      </exercise>
 
-      </exercisegroup>
       <exercisegroup cols="2">
-
         <introduction>
           <p>
             In the following exercises, find the area of the enclosed region in two ways:
@@ -1930,133 +1927,130 @@
         </exercise>
 
       </exercisegroup>
-      <exercisegroup cols="2">
   <!-- Exercise 27 -->
-        <exercise xml:id="x07_01_ex_29">
-          <!-- <webwork>
-              <pg-code> -->
-              <!-- Trapezoidal Rule, n = 6 -->
-                <!-- $a = 0;
-                $b = 6;
-                $n = 5;
-                $delta_x = ($b - $a)/$n;
-                @y = (0, 4.9, 5.2, 7.3, 4.5, 0);
-                @coeffs = (1, 2, 2, 2, 2, 1);
-                $area = 0;
-                $size = scalar @y;
-                foreach $i (0..$size) {
-                    $area += $coeffs[$i] * $y[$i];
-                }
-                $area = $area*$delta_x/2;
-                $area_ft = $area * 100 * 100;
-                $area = NumberWithUnits("$area cm^2");
-                $area_ft = NumberWithUnits("$area_ft ft^2");
-              </pg-code> -->
-              <statement>
-                <p>
-                  Use the Trapezoidal Rule to approximate the area of the pictured lake whose lengths,
-                  in hundreds of feet,
-                  are measured in 100-foot increments.
-                </p>
-
-              <!-- START figures/fig_07_01_ex_29.tex -->
-                  <image xml:id="img_07_01_ex_29">
-                    <description></description>
-                    <latex-image>
-
-                    \begin{tikzpicture}[yscale=.6]
-
-                    \draw [firstcolor,thick,fill=firstcolor!15,smooth] plot coordinates {(0,1.)(0.1013,1.899)(0.3567,2.785)(0.6934,3.42)(1.039,3.569)(1.355,3.224)(1.646,2.705)(1.925,2.355)(2.2,2.473)(2.475,2.968)(2.75,3.529)(3.025,3.844)(3.3,3.709)(3.575,3.249)(3.85,2.651)(4.125,2.098)(4.389,1.661)(4.624,1.285)(4.807,0.9071)(4.921,0.4743)(4.958,0)(4.921,-0.4743)(4.807,-0.9071)(4.624,-1.279)(4.389,-1.625)(4.125,-1.986)(3.85,-2.401)(3.575,-2.843)(3.3,-3.233)(3.025,-3.487)(2.75,-3.536)(2.475,-3.397)(2.2,-3.111)(1.925,-2.718)(1.646,-2.263)(1.355,-1.792)(1.039,-1.352)(0.6934,-0.9844)(0.3567,-0.6744)(0.1013,-0.3653)(0,0)(0,1)};
-
-                    \draw (1,3.56) -- (1,-1.35) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.9};
-                    \draw (2,2.37) -- (2,-2.8) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 5.2};
-                    \draw (3,3.8) -- (3,-3.5) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 7.3};
-                    \draw (4,2.35) -- (4,-2.15) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.5};
-
-                    \end{tikzpicture}
-
-                    </latex-image>
-                  </image>
-                <!-- figures/fig_07_01_ex_29.tex END -->
-
-                <!-- <p>
-                  Area: <var name="$area_ft" width="20"/>
-                </p> -->
-     <!-- 262,800 ft^2 -->
-              </statement>
-              <answer>
-              <!-- This solution uses n = 6, but I don't see why that would be true. -->
+      <exercise xml:id="x07_01_ex_29">
+        <!-- <webwork>
+            <pg-code> -->
+            <!-- Trapezoidal Rule, n = 6 -->
+              <!-- $a = 0;
+              $b = 6;
+              $n = 5;
+              $delta_x = ($b - $a)/$n;
+              @y = (0, 4.9, 5.2, 7.3, 4.5, 0);
+              @coeffs = (1, 2, 2, 2, 2, 1);
+              $area = 0;
+              $size = scalar @y;
+              foreach $i (0..$size) {
+                  $area += $coeffs[$i] * $y[$i];
+              }
+              $area = $area*$delta_x/2;
+              $area_ft = $area * 100 * 100;
+              $area = NumberWithUnits("$area cm^2");
+              $area_ft = NumberWithUnits("$area_ft ft^2");
+            </pg-code> -->
+            <statement>
               <p>
-                219,000 ft<m>^2</m>
+                Use the Trapezoidal Rule to approximate the area of the pictured lake whose lengths,
+                in hundreds of feet,
+                are measured in 100-foot increments.
               </p>
 
-              </answer>
-          <!-- </webwork> -->
-        </exercise>
-  <!-- Exercise 28 -->
-        <exercise xml:id="x07_01_ex_30">
-          <!-- <webwork>
-              <pg-code> -->
-              <!-- Simpson's Rule, n = 6 -->
-                <!-- $a = 0;
-                $b = 6;
-                $n = 6;
-                $delta_x = ($b - $a)/$n;
-                @y = (0, 4.25, 6.6, 7.7, 6.45, 4.9, 0);
-                @coeffs = (1, 4, 2, 4, 2, 4, 1);
-                $area = 0;
-                $size = scalar @y;
-                foreach $i (0..$size) {
-                    $area += $coeffs[$i] * $y[$i];
-                }
-                $area = $area*$delta_x/3;
-                $area_ft = $area * 100 * 200;
-                $area = NumberWithUnits("$area cm^2");
-                $area_ft = NumberWithUnits("$area_ft ft^2");
-              </pg-code> -->
-              <statement>
-                <p>
-                  Use Simpson's Rule to approximate the area of the pictured lake whose lengths,
-                  in hundreds of feet,
-                  are measured in 200-foot increments.
-                </p>
+            <!-- START figures/fig_07_01_ex_29.tex -->
+                <image xml:id="img_07_01_ex_29">
+                  <description></description>
+                  <latex-image>
+
+                  \begin{tikzpicture}[yscale=.6]
+
+                  \draw [firstcolor,thick,fill=firstcolor!15,smooth] plot coordinates {(0,1.)(0.1013,1.899)(0.3567,2.785)(0.6934,3.42)(1.039,3.569)(1.355,3.224)(1.646,2.705)(1.925,2.355)(2.2,2.473)(2.475,2.968)(2.75,3.529)(3.025,3.844)(3.3,3.709)(3.575,3.249)(3.85,2.651)(4.125,2.098)(4.389,1.661)(4.624,1.285)(4.807,0.9071)(4.921,0.4743)(4.958,0)(4.921,-0.4743)(4.807,-0.9071)(4.624,-1.279)(4.389,-1.625)(4.125,-1.986)(3.85,-2.401)(3.575,-2.843)(3.3,-3.233)(3.025,-3.487)(2.75,-3.536)(2.475,-3.397)(2.2,-3.111)(1.925,-2.718)(1.646,-2.263)(1.355,-1.792)(1.039,-1.352)(0.6934,-0.9844)(0.3567,-0.6744)(0.1013,-0.3653)(0,0)(0,1)};
+
+                  \draw (1,3.56) -- (1,-1.35) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.9};
+                  \draw (2,2.37) -- (2,-2.8) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 5.2};
+                  \draw (3,3.8) -- (3,-3.5) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 7.3};
+                  \draw (4,2.35) -- (4,-2.15) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.5};
+
+                  \end{tikzpicture}
+
+                  </latex-image>
+                </image>
+              <!-- figures/fig_07_01_ex_29.tex END -->
+
+              <!-- <p>
+                Area: <var name="$area_ft" width="20"/>
+              </p> -->
+   <!-- 262,800 ft^2 -->
+            </statement>
+            <answer>
+            <!-- This solution uses n = 6, but I don't see why that would be true. -->
+            <p>
+              219,000 ft<m>^2</m>
+            </p>
+
+            </answer>
+        <!-- </webwork> -->
+      </exercise>
+<!-- Exercise 28 -->
+      <exercise xml:id="x07_01_ex_30">
+        <!-- <webwork>
+            <pg-code> -->
+            <!-- Simpson's Rule, n = 6 -->
+              <!-- $a = 0;
+              $b = 6;
+              $n = 6;
+              $delta_x = ($b - $a)/$n;
+              @y = (0, 4.25, 6.6, 7.7, 6.45, 4.9, 0);
+              @coeffs = (1, 4, 2, 4, 2, 4, 1);
+              $area = 0;
+              $size = scalar @y;
+              foreach $i (0..$size) {
+                  $area += $coeffs[$i] * $y[$i];
+              }
+              $area = $area*$delta_x/3;
+              $area_ft = $area * 100 * 200;
+              $area = NumberWithUnits("$area cm^2");
+              $area_ft = NumberWithUnits("$area_ft ft^2");
+            </pg-code> -->
+            <statement>
+              <p>
+                Use Simpson's Rule to approximate the area of the pictured lake whose lengths,
+                in hundreds of feet,
+                are measured in 200-foot increments.
+              </p>
 
 
-                <!-- START figures/fig_07_01_ex_30.tex -->
-                  <image xml:id="img_07_01_ex_30">
-                    <description></description>
-                    <latex-image>
+              <!-- START figures/fig_07_01_ex_30.tex -->
+                <image xml:id="img_07_01_ex_30">
+                  <description></description>
+                  <latex-image>
 
-                    \begin{tikzpicture}[yscale=.6]
+                  \begin{tikzpicture}[yscale=.6]
 
-                    \draw [firstcolor,thick,fill=firstcolor!15,smooth] plot coordinates {(0,2.)(0.1013,2.717)(0.3567,3.238)(0.6934,3.594)(1.039,3.818)(1.355,3.948)(1.646,4.035)(1.925,4.132)(2.2,4.28)(2.475,4.428)(2.75,4.471)(3.025,4.307)(3.305,3.88)(3.607,3.287)(3.952,2.652)(4.361,2.098)(4.815,1.661)(5.253,1.285)(5.614,0.9071)(5.843,0.4705)(5.938,-0.04167)(5.919,-0.6295)(5.807,-1.293)(5.624,-2.009)(5.389,-2.703)(5.125,-3.29)(4.849,-3.692)(4.562,-3.892)(4.243,-3.929)(3.871,-3.846)(3.432,-3.674)(2.956,-3.409)(2.484,-3.028)(2.057,-2.511)(1.692,-1.869)(1.363,-1.168)(1.039,-0.4819)(0.6934,0.1248)(0.3567,0.679)(0.1013,1.273)(0,2.)};
+                  \draw [firstcolor,thick,fill=firstcolor!15,smooth] plot coordinates {(0,2.)(0.1013,2.717)(0.3567,3.238)(0.6934,3.594)(1.039,3.818)(1.355,3.948)(1.646,4.035)(1.925,4.132)(2.2,4.28)(2.475,4.428)(2.75,4.471)(3.025,4.307)(3.305,3.88)(3.607,3.287)(3.952,2.652)(4.361,2.098)(4.815,1.661)(5.253,1.285)(5.614,0.9071)(5.843,0.4705)(5.938,-0.04167)(5.919,-0.6295)(5.807,-1.293)(5.624,-2.009)(5.389,-2.703)(5.125,-3.29)(4.849,-3.692)(4.562,-3.892)(4.243,-3.929)(3.871,-3.846)(3.432,-3.674)(2.956,-3.409)(2.484,-3.028)(2.057,-2.511)(1.692,-1.869)(1.363,-1.168)(1.039,-0.4819)(0.6934,0.1248)(0.3567,0.679)(0.1013,1.273)(0,2.)};
 
-                    \draw (1,3.8) -- (1,-.45) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.25};
-                    \draw (2,4.15) -- (2,-2.45) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 6.6};
-                    \draw (3,4.3) -- (3,-3.4) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 7.7};
-                    \draw (4,2.6) -- (4,-3.85) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 6.45};
-                    \draw (5,1.45) -- (5,-3.45) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.9};
+                  \draw (1,3.8) -- (1,-.45) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.25};
+                  \draw (2,4.15) -- (2,-2.45) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 6.6};
+                  \draw (3,4.3) -- (3,-3.4) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 7.7};
+                  \draw (4,2.6) -- (4,-3.85) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 6.45};
+                  \draw (5,1.45) -- (5,-3.45) node [shift={(-3pt,0pt)},rotate=90,pos=.5] { 4.9};
 
-                    \end{tikzpicture}
+                  \end{tikzpicture}
 
-                    </latex-image>
-                  </image>
-              <!-- figures/fig_07_01_ex_30.tex END -->
+                  </latex-image>
+                </image>
+            <!-- figures/fig_07_01_ex_30.tex END -->
 
-                <!-- <p>
-                  Area: <var name="$area_ft" width="20"/>
-                </p> -->
-     <!-- 623,333 ft^2 -->
-              </statement>
-              <answer>
-                <p>
-                  <m>623,333 \,\text{ft}^2</m>
-                </p>
-              </answer>
-          <!-- </webwork> -->
-        </exercise>
-
-      </exercisegroup>
+              <!-- <p>
+                Area: <var name="$area_ft" width="20"/>
+              </p> -->
+   <!-- 623,333 ft^2 -->
+            </statement>
+            <answer>
+              <p>
+                <m>623,333 \,\text{ft}^2</m>
+              </p>
+            </answer>
+        <!-- </webwork> -->
+      </exercise>
     </subexercises>
   </exercises>
 </section>

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -261,7 +261,7 @@
           </me>?
         </p>
         <p>
-          <ol label="a">
+          <ol marker="a">
             <li><m>y = C \left ( 1 + \ln(x) \right )^2</m></li>
             <li><m>y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m></li>
             <li><m>y = C e^{-3x} + \sqrt{\sin(x)}</m></li>
@@ -275,7 +275,7 @@
           We substitute each potential solution into the differential equation to see if it satisfies the equation.
         </p>
         <p>
-          <ol label="a">
+          <ol marker="a">
             <li>
               <p>
                 Testing the potential solution <m>y = C \left ( 1 + \ln(x) \right )^2</m>:

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -48,7 +48,7 @@
           separable, both, or neither.
         </p>
         <p>
-          <ol label="a" cols="2">
+          <ol marker="a" cols="2">
             <li><m>\displaystyle \yp = xy</m></li>
             <li><m>\displaystyle \yp = e^y + 3x</m></li>
             <li><m>\displaystyle \yp - (\cos(x))y = \cos(x)</m></li>
@@ -58,7 +58,7 @@
       </statement>
       <solution>
         <p>
-          <ol label="a">
+          <ol marker="a">
             <li>
               <p>Both.
                 We identify <m>p(x) = -x</m> and <m>q(x) = 0</m>.

--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -432,8 +432,8 @@
           This integral <em>cannot</em> be evaluated in terms of elementary functions so we will approximate it with Simpson's Method with <m>n=4</m>.
         </p>
 
-        <figure xml:id="fig_arc3">
-          <caption>A table of values of <m>y=\sqrt{1+\cos^2(x) }</m> to evaluate a definite integral in <xref ref="ex_arc3">Example</xref></caption>
+        <table xml:id="fig_arc3">
+          <title>A table of values of <m>y=\sqrt{1+\cos^2(x) }</m> to evaluate a definite integral in <xref ref="ex_arc3">Example</xref></title>
           <tabular>
             <row bottom="minor">
               <cell><m>x</m></cell><cell><m>\sqrt{1+\cos^2(x) }</m></cell>
@@ -454,7 +454,7 @@
               <cell><m>\pi</m></cell><cell><m>\sqrt{2}</m></cell>
             </row>
           </tabular>
-        </figure>
+        </table>
 
         <p>
           <xref ref="fig_arc3">Figure</xref>

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -702,7 +702,7 @@
         Our angle <m>\varphi</m> is known as the <term>elevation angle</term>.
         The angle used in other conventions that is measured from the positive <m>z</m>-axis
         (often identified with the north pole) is known as the <term>polar angle</term>.
-        For further discussion, the <url href="https://en.wikipedia.org/wiki/Spherical_coordinate_system">Wikipedia article</url>
+        For further discussion, the <url href="https://en.wikipedia.org/wiki/Spherical_coordinate_system" visual="en.wikipedia.org/wiki/Spherical_coordinate_system">Wikipedia article</url>
         is quite useful.
       </p>
     </convention>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -1905,7 +1905,7 @@
               when it is <m>25^\circ</m>F outside with a wind of <m>w</m> mph.
             </p>
             <p>
-              <ol label="a">
+              <ol marker="a">
                 <li>
                   <p>
                     What are the units of <m>W'(w)</m>?
@@ -1927,7 +1927,7 @@
           </statement>
           <solution>
             <p>
-              <ol label="a">
+              <ol marker="a">
                 <li>
                   <p>
                     <m>^\circ</m>F/mph
@@ -1966,7 +1966,7 @@
               Find the derivatives of the following functions.
             </p>
             <p>
-              <ol label="a">
+              <ol marker="a">
                 <li>
                   <p>
                     <m>f(x) = <var name="$f"/></m>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -117,7 +117,7 @@
         <p>
           Let <m>P(t)</m> represent the world population <m>t</m> minutes after 12:00 a.m., January 1, 2012.
           It is fairly accurate to say that <m>P(0) = 7{,}028{,}734{,}178</m>
-          (<url href="www.prb.org"/>).
+          (<url href="https://www.prb.org" visual="www.prb.org"/>).
           It is also fairly accurate to state that <m>P'(0) = 156</m>;
           that is, at midnight on January 1, 2012,
           the population of the world was growing by about 156

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -361,7 +361,7 @@
         <p>
           Let <m>f(x) = 3x^2+5x-7</m>.
           Find:
-          <ol cols="2" label="a.">
+          <ol cols="2" marker="a">
             <li>
               <p>
                 <m>\fp(1)</m>
@@ -389,7 +389,7 @@
         <video xml:id="vid_deriv_intro_ex_v1" youtube="EheTlvVDaGg q_XfRMmSEmc"/>
 
         <p>
-          <ol label="a.">
+          <ol marker="a">
             <li>
               <p>
                 We compute this directly using <xref ref="def_derivative_at_a_point">Definition</xref>.

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -852,7 +852,7 @@
       <exercisegroup cols="2">
         <introduction>
           <p>
-            <ol label="a.">
+            <ol marker="a">
               <li>
                 Use the Product Rule to differentiate the function.
               </li>
@@ -946,7 +946,7 @@
       <exercisegroup cols="2">
         <introduction>
           <p>
-            <ol label="a.">
+            <ol marker="a">
               <li>
                 Use the Quotient Rule to differentiate the function.
               </li>

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -1539,14 +1539,14 @@
     </subexercises>
 
     <subexercises>
-      <introduction>
-        <p>
-          The following exercises explore some issues related to surveying in which
-          distances are approximated using other measured distances and measured angles.
-          <em>(Hint: Convert all angles to radians before computing.)</em>
-        </p>
-      </introduction>
       <exercisegroup cols="2">
+        <introduction>
+          <p>
+            The following exercises explore some issues related to surveying in which
+            distances are approximated using other measured distances and measured angles.
+            <em>(Hint: Convert all angles to radians before computing.)</em>
+          </p>
+        </introduction>
         <!-- Exercise 35: Error in length of wall -->
         <exercise xml:id="exer_04_04_ex_35">
            <webwork>

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1351,7 +1351,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         In the direction of <m>\vec v = \la 3,4\ra</m>
@@ -1407,7 +1407,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         Find the directional derivative in the direction of <m>\vec v=\la 1,1\ra</m>.
@@ -1443,7 +1443,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         In the direction of <m>\vec v = \la 1,-1\ra</m>.
@@ -1498,7 +1498,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         Find the directional derivative in the direction of <m>\vec v=\la 3,1\ra</m>.
@@ -1534,7 +1534,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         In the direction of <m>\vec v = \la -2,5\ra</m>
@@ -1588,7 +1588,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         Find the directional derivative in the direction of <m>\vec v=\la 3,3\ra</m>.
@@ -1624,7 +1624,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -1943,7 +1943,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Find <m>\nabla F(x,y,z)</m>.

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -1672,7 +1672,7 @@
           <p>
             For the given integral,
 
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Evaluate the given iterated integral, and
@@ -1914,7 +1914,7 @@
           <p>
             In the following exercises:
 
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Sketch the region <m>R</m> given by the problem.

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -1220,7 +1220,7 @@
         <introduction>
           <p>
             A function <m>f(x)</m> is given.
-            <ol label="a.">
+            <ol marker="a">
               <li>
                 <p>
                   Find the possible points of inflection of <m>f</m>.

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -596,8 +596,8 @@
         the maximum value is <m>45</m> and the minimum value is <m>-7</m>.
       </p>
 
-      <figure xml:id="table_ext4">
-        <caption>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in <xref ref="ex_extval4">Example</xref></caption>
+      <table xml:id="table_ext4">
+        <title>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in <xref ref="ex_extval4">Example</xref></title>
         <tabular>
           <row bottom="medium">
             <cell><m>x</m></cell>
@@ -616,7 +616,7 @@
             <cell><m>45</m></cell>
           </row>
         </tabular>
-      </figure>
+      </table>
 
     </solution>
   </example>
@@ -698,8 +698,8 @@
 
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
-        <figure xml:id="table_ext5">
-          <caption>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref></caption>
+        <table xml:id="table_ext5">
+          <title>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref></title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -718,7 +718,7 @@
               <cell><m>3</m></cell>
             </row>
           </tabular>
-        </figure>
+        </table>
 
         <figure xml:id="fig_extval5">
           <caption>A graph of <m>f(x)</m> on <m>[-4,2]</m> as in <xref ref="ex_extval5">Example</xref></caption>
@@ -788,8 +788,8 @@
 
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
-        <figure xml:id="table_ext6">
-          <caption>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref></caption>
+        <table xml:id="table_ext6">
+          <title>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref></title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -816,7 +816,7 @@
               <cell><m>-0.65</m></cell>
             </row>
           </tabular>
-        </figure>
+        </table>
 
         <figure xml:id="fig_extval6">
           <caption>A graph of <m>f(x)=\cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m> as in <xref ref="ex_extval6">Example</xref></caption>
@@ -884,8 +884,8 @@
             <!-- figures/fig_extval7.tex END -->
         </figure>
 
-        <figure xml:id="table_ext7">
-          <caption>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref></caption>
+        <table xml:id="table_ext7">
+          <title>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref></title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -904,7 +904,7 @@
               <cell><m>0</m></cell>
             </row>
           </tabular>
-        </figure>
+        </table>
 
       </sidebyside>
 

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -1177,7 +1177,7 @@
         <introduction>
           <p>
             A function <m>f(x)</m> is given.
-            <ol label="a.">
+            <ol marker="a">
               <li>
                 <p>
                   Give the domain of <m>f</m>.

--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -58,15 +58,37 @@
           Let <m>\lim\limits_{x\to c}f(x) = 0</m> and <m>\lim\limits_{x\to c}g(x)=0</m>,
           where <m>f</m> and <m>g</m> are differentiable functions on an open interval <m>I</m> containing <m>c</m>,
           and <m>g'(x)\neq 0</m> on <m>I</m> except possibly at <m>c</m>.
-          Then <idx><h>limit</h><h>l'Hospital's Rule</h></idx>
+          If <idx><h>limit</h><h>l'Hospital's Rule</h></idx>
               <idx><h>l'Hospital's Rule</h><h>zero over zero</h></idx>
           <me>
-            \lim_{x\to c} \frac{f(x)}{g(x)} = \lim_{x\to c} \frac{\fp(x)}{g'(x)}
+            \lim_{x\to c} \frac{\fp(x)}{g'(x)}=L
           </me>,
-          provided that the limit on the right exists.
+          then
+          <me>
+            \lim_{x\to c} \frac{f(x)}{g(x)}=L
+          </me>,
+          where <m>L</m> is a real number, or <m>L=\pm \infty</m>.
+          The result applies to one-sided limits as well.
         </p>
       </statement>
     </theorem>
+
+    <aside>
+      <p>
+        To use <xref ref="thm_LHR"/> in practice,
+        notice that there are two conditions we need to check.
+        First, the original limit needs to be of the <q><m>0/0</m></q> form.
+        Second, the new limit (involving the derivatives of <m>f</m> and <m>g</m>)
+        must exist (or be infinite).
+      </p>
+
+      <p>
+        In some cases, the new limit will also be <m>0/0</m>,
+        in which case we can apply l'Hospital's rule again.
+        The rule can be applied repeatedly (taking additional derivatives),
+        as long as we reach a step where the limit exists.
+      </p>
+    </aside>
 
     <p>
       We demonstrate the use of l'Hospital's Rule in the following examples;
@@ -177,15 +199,20 @@
               <p>
                 Let <m>\lim\limits_{x\to a}f(x) = \pm\infty</m> and <m>\lim\limits_{x\to a}g(x)=\pm \infty</m>,
                 where <m>f</m> and <m>g</m> are differentiable on an open interval <m>I</m> containing <m>a</m>.
-                Then
+                If
 
                 <idx><h>limit</h><h>l'Hospital's Rule</h></idx>
                 <idx><h>l'Hospital's Rule</h><h>infinity over infinity</h></idx>
 
                 <me>
-                  \lim_{x\to a} \frac{f(x)}{g(x)} = \lim_{x\to a}\frac{\fp(x)}{g'(x)}
+                  \lim_{x\to a}\frac{\fp(x)}{g'(x)}=L
                 </me>,
-                provided that the limit on the right exists.
+                then
+                <me>
+                  \lim_{x\to a}\frac{f(x)}{g(x)}=L
+                </me>,
+                where <m>L</m> is a real number, or <m>L=\pm\infty</m>.
+                The result applies to one-sided limits as well.
               </p>
             </li>
 
@@ -194,11 +221,16 @@
                 Let <m>f</m> and <m>g</m> be differentiable functions on the open interval
                 <m>(a,\infty)</m> for some value <m>a</m>,
                 where <m>g'(x)\neq 0</m> on <m>(a,\infty)</m> and
-                <m>\lim\limits_{x\to\infty} f(x)/g(x)</m> returns either 0/0 or <m>\infty/\infty</m>.
-                Then
+                <m>\lim\limits_{x\to\infty} f(x)/g(x)</m> returns either <m>0/0</m> or <m>\infty/\infty</m>.
+                If
                 <me>
-                  \lim_{x\to \infty} \frac{f(x)}{g(x)} = \lim_{x\to \infty}\frac{\fp(x)}{g'(x)}
-                </me>.
+                  \lim_{x\to \infty}\frac{\fp(x)}{g'(x)}=L
+                </me>,
+                then
+                <me>
+                  \lim_{x\to \infty}\frac{f(x)}{g(x)}=L
+                </me>,
+                where <m>L</m> is a real number, or <m>L=\pm \infty</m>.
                 A similar statement can be made for limits where <m>x</m> approaches <m>-\infty</m>.
               </p>
             </li>

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -150,7 +150,7 @@
           <mrow>\lim_{x\to 2} f(x)\amp=2\amp\lim_{x\to 2} g(x)\amp= 3\amp p(x)\amp = 3x^2-5x+7</mrow>
         </md>.
         Find the following limits:
-        <ol cols="3" label="a.">
+        <ol cols="3" marker="a">
           <li><m>\lim\limits_{x\to 2}(f(x) + g(x))</m></li>
           <li><m>\lim\limits_{x\to 2}(5f(x) + g(x)^2)</m></li>
           <li xml:id="polynomial-limit-example">
@@ -164,7 +164,7 @@
     <solution>
       <video width="98%" youtube="8x42kGfu9ts" xml:id="vid_limit_analytic_using_prop"/>
       <p>
-        <ol label="a.">
+        <ol marker="a">
           <li>
             <p>
               Using the <xref ref="sum-difference-limit-rule" text="title"/> property,
@@ -354,7 +354,7 @@
     <statement>
       <p>
         Evaluate the following limits.
-        <ol cols="2" label="a.">
+        <ol cols="2" marker="a">
           <li><m>\lim\limits_{x\to \pi} \cos(x)</m></li>
           <li><m>\lim\limits_{x\to 3} \left(\sec^2(x) - \tan^2(x)\right)</m></li>
           <li><m>\lim\limits_{x\to \pi/2}(\cos(x)\sin(x))</m></li>
@@ -365,7 +365,7 @@
     </statement>
     <solution>
       <p>
-        <ol label="a.">
+        <ol marker="a">
           <li>
             <p>
               This is a straightforward application of

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1402,6 +1402,11 @@
       <title>Problems</title>
 
       <exercisegroup cols="2">
+        <introduction>
+          <p>
+            Use the graph to determine if the function is continuous at the given point.
+          </p>
+        </introduction>
         <exercise>
           <webwork>
             <pg-code>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -622,7 +622,7 @@
               <!-- figures/fig_hzasy1.tex END -->
             </figure>
 
-            <figure xml:id="fig_hzasy1b"><caption/>
+            <table xml:id="fig_hzasy1b"><caption/>
               <tabular>
                 <row bottom="minor">
                   <cell><m>x</m></cell>
@@ -653,7 +653,7 @@
                   <cell><m>0.999996</m></cell>
                 </row>
               </tabular>
-            </figure>
+            </table>
           </sidebyside>
         </figure>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -622,7 +622,7 @@
               <!-- figures/fig_hzasy1.tex END -->
             </figure>
 
-            <table xml:id="fig_hzasy1b"><caption/>
+            <table xml:id="fig_hzasy1b"><title/>
               <tabular>
                 <row bottom="minor">
                   <cell><m>x</m></cell>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -192,8 +192,8 @@
       we are only concerned with the values of the function when <m>x</m> is <em>near</em> 1.
     </p>
 
-    <figure xml:id="table_sinx_1">
-      <caption>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>1</m></caption>
+    <table xml:id="table_sinx_1">
+      <title>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>1</m></title>
       <tabular>
         <row bottom="medium">
           <cell><m>x</m></cell>
@@ -228,7 +228,7 @@
           <cell>0.810189</cell>
         </row>
       </tabular>
-    </figure>
+    </table>
 
     <p>
       Now approximate <m>\lim_{x\to 0} \frac{\sin(x)}{x}</m> numerically.
@@ -242,8 +242,8 @@
       only on the behavior of the function <em>near</em> <m>0</m>.
     </p>
 
-    <figure xml:id="table_sinx_2">
-      <caption>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>0</m></caption>
+    <table xml:id="table_sinx_2">
+      <title>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>0</m></title>
       <tabular>
         <row bottom="medium">
           <cell><m>x</m></cell>
@@ -278,7 +278,7 @@
           <cell>0.9983341665</cell>
         </row>
       </tabular>
-    </figure>
+    </table>
 
     <p>
       This numerical method gives confidence to say that <m>1</m> is a good approximation of
@@ -348,8 +348,8 @@
             <!-- figures/fig_limit1.tex END -->
           </figure>
 
-          <figure xml:id="table_limit1">
-            <caption>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref></caption>
+          <table xml:id="table_limit1">
+            <title>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref></title>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -384,7 +384,7 @@
                 <cell><m>0.289773</m></cell>
               </row>
             </tabular>
-          </figure>
+          </table>
         </sidebyside>
 
         <p>
@@ -494,8 +494,8 @@
             <!-- figures/fig_limit2.tex END -->
           </figure>
 
-          <figure xml:id="table_limit2">
-            <caption>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref></caption>
+          <table xml:id="table_limit2">
+            <title>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref></title>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -526,7 +526,7 @@
                 <cell><m>0.99</m></cell>
               </row>
             </tabular>
-          </figure>
+          </table>
         </sidebyside>
 
         <p>
@@ -641,8 +641,8 @@
             <!-- figures/fig_nolimit1.tex END -->
           </figure>
 
-          <figure xml:id="table_nolimit1">
-            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref></caption>
+          <table xml:id="table_nolimit1">
+            <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref></title>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -673,7 +673,7 @@
                 <cell><m>1.1</m></cell>
               </row>
             </tabular>
-          </figure>
+          </table>
         </sidebyside>
       </solution>
     </example>
@@ -717,8 +717,8 @@
             <!-- figures/fig_nolimit2.tex END -->
           </figure>
 
-          <figure xml:id="table_nolimit2">
-            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref></caption>
+          <table xml:id="table_nolimit2">
+            <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref></title>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -749,7 +749,7 @@
                 <cell><m>100</m>.</cell>
               </row>
             </tabular>
-          </figure>
+          </table>
         </sidebyside>
 
         <p>
@@ -936,8 +936,8 @@
           </sidebyside>
         </figure>
 
-        <figure xml:id="table_nolimit3c">
-          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref></caption>
+        <table xml:id="table_nolimit3c">
+          <title>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref></title>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -972,7 +972,7 @@
               <cell><m>0.420548</m></cell>
             </row>
           </tabular>
-        </figure>
+        </table>
 
         <p>
           It can be shown that in reality,
@@ -1189,8 +1189,8 @@
       The table gives us reason to assume the value of the limit is about <m>8.5</m>.
     </p>
 
-    <figure xml:id="table_diff_quot_smallh">
-      <caption>The difference quotient evaluated at values of <m>h</m> near <m>0</m></caption>
+    <table xml:id="table_diff_quot_smallh">
+      <title>The difference quotient evaluated at values of <m>h</m> near <m>0</m></title>
       <tabular>
         <row bottom="medium">
           <cell><m>h</m></cell>
@@ -1221,7 +1221,7 @@
           <cell><m>7.75</m></cell>
         </row>
       </tabular>
-    </figure>
+    </table>
     <figure xml:id="vid_limit_intro_limit_diff_quot_ex">
       <caption>Video examples for difference quotients: once with direct computation, and then by simplifying first</caption>
       <video  youtube="lNI90Y321b0 uUyZHfTYlBQ"/>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -147,7 +147,7 @@
         as shown in <xref ref="fig_onesided1">Figure</xref>.
         Find each of the following:
 
-        <ol cols="2" label="a.">
+        <ol cols="2" marker="a">
           <li>
             <m>\lim_{x\to 1^-} f(x)</m>
           </li>
@@ -210,7 +210,7 @@
       </p>
 
       <p>
-        <ol label="a.">
+        <ol marker="a">
           <li>
             <p>
               As <m>x</m> goes to <m>1</m> <em>from the left</em>,
@@ -347,7 +347,7 @@
                    .
         <!-- as shown in <xref ref="fig_onesidedb">Figure</xref>.-->
         Evaluate the following:
-        <ol cols="2" label="a.">
+        <ol cols="2" marker="a">
           <li>
             <m>\lim_{x\to 1^-} f(x)</m>
           </li>
@@ -384,7 +384,7 @@
       </p>
 
       <p>
-        <ol label="a.">
+        <ol marker="a">
           <li>
             <p>
               As <m>x</m> approaches <m>1</m> from the left,
@@ -528,7 +528,7 @@
         Let <m>f(x) =\begin{cases} (x-1)^2 \amp 0\leq x\leq 2, x\neq 1\\ 1 \amp x=1
         \end{cases}</m> as shown in <xref ref="fig_onesidedc">Figure</xref>.
         Evaluate the following:
-        <ol cols="2" label="a.">
+        <ol cols="2" marker="a">
           <li>
             <m>\lim_{x\to 1^-} f(x)</m>
           </li>
@@ -587,7 +587,7 @@
         Let <m>f(x) = \begin{cases} x^2 \amp 0\leq x\leq 1 \\ 2-x \amp 1\lt x\leq 2
         \end{cases}</m> as shown in <xref ref="fig_onesidedd">Figure</xref>.
         Evaluate the following:
-        <ol cols="2" label="a.">
+        <ol cols="2" marker="a">
           <li>
             <m>\lim_{x\to 1^-} f(x)</m>
           </li>

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -899,7 +899,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Use the Multivariable Chain Rule to compute <m>\lz{z}{t}</m>.
@@ -1377,7 +1377,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Use the Multivariable Chain Rule to compute

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -779,8 +779,8 @@
           <m>1/\sqrt{c}</m>, centered at the origin.
         </p>
 
-        <figure xml:id="fig_multi4">
-          <caption>A table of <m>c</m> values and the corresponding radius <m>r</m> of the spheres of constant value in <xref ref="ex_multi4">Example</xref></caption>
+        <table xml:id="fig_multi4">
+          <title>A table of <m>c</m> values and the corresponding radius <m>r</m> of the spheres of constant value in <xref ref="ex_multi4">Example</xref></title>
           <tabular>
             <row>
               <cell><m>c</m></cell>
@@ -827,8 +827,7 @@
               <cell>4.</cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           <xref ref="fig_multi4">Figure</xref>

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -1441,7 +1441,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Find the domain <m>D</m> of the given function.

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -2005,7 +2005,7 @@
             <m>y</m> and <m>z</m> is given, along with a point <m>P</m> that lies on the surface.
             Use the gradient <m>\nabla F</m> to:
 
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   find the equation of the normal line to the surface at <m>P</m>, and

--- a/ptx/sec_newton.ptx
+++ b/ptx/sec_newton.ptx
@@ -228,7 +228,7 @@
         To begin, we compute <m>\fp(x)=3x^2-2x</m>.
         Then we apply the Newton's Method algorithm,
         outlined in <xref ref="idea_Newton">Key Idea</xref>.
-        <ul label="" cols="2">
+        <ul marker="" cols="2">
           <li>
             <p>
               <m>\begin{aligned}

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -1067,7 +1067,7 @@
           <!-- <caption/> -->
           <!-- <video youtube="uc4xJsi99bk"/> -->
         <!-- </figure> -->
-        <url href="https://www.youtube.com/embed/uc4xJsi99bk">https://youtu.be/uc4xJsi99bk</url>
+        <url href="https://www.youtube.com/embed/uc4xJsi99bk" visual="youtu.be/uc4xJsi99bk"/>
       </p>
     </aside>
     <!--<video youtube="uc4xJsi99bk"/>-->

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -26,7 +26,7 @@
       but there are many elementary functions of which we cannot compute an antiderivative.
       For example,
       the following functions do not have antiderivatives that we can express with elementary functions:
-      <ul label="" cols="3">
+      <ul marker="" cols="3">
         <li><m>e^{x^2}</m>,</li>
         <li><m>\sin(x^3)</m>,</li>
         <li><m>\frac{\sin(x)}{x}</m>.</li>
@@ -47,7 +47,7 @@
 
     <p>
       We will apply the methods we learn in this section to the following definite integrals:
-      <ul label="" cols="3">
+      <ul marker="" cols="3">
         <li><m>\int_0^1 e^{-x^2} \, dx</m>,</li>
         <li><m>\int_{-\frac{\pi}{4}}^{\frac{\pi}{2}} \sin(x^3) \, dx</m>,</li>
         <li><m>\int_{0.5}^{4\pi} \frac{\sin(x)}{x} \, dx</m>,</li>

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -333,8 +333,8 @@
           <m>\sin(x^3)</m> evaluated at these points.
         </p>
 
-        <figure xml:id="fig_num2a">
-          <caption>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2">Example</xref></caption>
+        <table xml:id="fig_num2a">
+          <title>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2">Example</xref></title>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -415,8 +415,7 @@
               <cell><m>-0.6700</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           Once this table is created,
@@ -637,8 +636,8 @@
           it will again be useful to create a table of values as shown in <xref ref="fig_num3b">Figure</xref>.
         </p>
 
-        <figure xml:id="fig_num3b">
-          <caption>A table of values of <m>e^{-x^2}</m></caption>
+        <table xml:id="fig_num3b">
+          <title>A table of values of <m>e^{-x^2}</m></title>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -673,8 +672,7 @@
               <cell><m>0.3679</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           The leftmost trapezoid has legs of length <m>1</m> and <m>0.9607</m> and a height of 0.2.
@@ -834,8 +832,8 @@
           <m>0+0.2(1/2)=0.1</m> and each successive midpoint is <m>0.2</m> from the last.
         </p>
 
-        <figure xml:id="fig_num3_2b">
-          <caption>A table of values of <m>e^{-x^2}</m></caption>
+        <table xml:id="fig_num3_2b">
+          <title>A table of values of <m>e^{-x^2}</m></title>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -866,8 +864,7 @@
               <cell><m>0.4449</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           So we have
@@ -1230,7 +1227,7 @@
           <caption>A table of values to approximate <m>\int_0^1e^{-x^2}\, dx</m>, along with a graph of the function</caption>
           <sidebyside widths="40% 54%">
 
-          <figure xml:id="fig_num5a">
+          <table xml:id="fig_num5a">
             <caption/>
 
             <tabular>
@@ -1266,8 +1263,7 @@
                 <cell></cell>
               </row>
             </tabular>
-
-          </figure>
+          </table>
 
           <figure xml:id="fig_num5b">
           <!-- START figures/fig_num5b.tex -->
@@ -1352,8 +1348,8 @@
           Again, <m>\dx = (\pi/2+\pi/4)/10 \approx 0.236</m>.
         </p>
 
-        <figure xml:id="fig_num6a">
-          <caption>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6">Example</xref></caption>
+        <table xml:id="fig_num6a">
+          <title>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6">Example</xref></title>
           <tabular>
             <row bottom="minor">
               <cell><m>x_i</m></cell>
@@ -1404,8 +1400,7 @@
               <cell><m>-0.6700</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           Simpson's Rule states that
@@ -1870,8 +1865,8 @@
           The data is given in <xref ref="fig_num8">Figure</xref>.
           Approximate the distance they traveled.
         </p>
-        <figure xml:id="fig_num8">
-          <caption>Speed data collected at 30 second intervals for <xref ref="ex_num8">Example</xref></caption>
+        <table xml:id="fig_num8">
+          <title>Speed data collected at 30 second intervals for <xref ref="ex_num8">Example</xref></title>
           <tabular>
             <row>
               <cell>Time</cell><cell>Speed</cell>
@@ -1980,8 +1975,7 @@
               <cell><m>0</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
       </statement>
       <solution>
         <p>

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -1227,9 +1227,7 @@
           <caption>A table of values to approximate <m>\int_0^1e^{-x^2}\, dx</m>, along with a graph of the function</caption>
           <sidebyside widths="40% 54%">
 
-          <table xml:id="fig_num5a">
-            <caption/>
-
+          <table xml:id="fig_num5a"><title/>
             <tabular>
               <row>
                 <cell><m>x_i</m></cell>

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -137,8 +137,7 @@
         <figure xml:id="fig_pareq1">
           <caption>A table of values of the parametric equations in <xref ref="ex_pareq1">Example</xref> along with a sketch of their graph</caption>
           <sidebyside valign="bottom" widths="47% 47%">
-            <figure xml:id="fig_pareq1a">
-              <caption/>
+            <table xml:id="fig_pareq1a"><title/>
               <tabular>
                 <row>
                   <cell><m>t</m></cell>
@@ -176,7 +175,7 @@
                   <cell><m>3</m></cell>
                 </row>
               </tabular>
-            </figure>
+            </table>
             <figure xml:id="fig_pareq1b">
               <caption/>
               <!-- START figures/fig_pareq1.tex -->
@@ -240,8 +239,7 @@
         <figure xml:id="fig_pareq2">
           <caption>A table of values of the parametric equations in <xref ref="ex_pareq2">Example</xref> along with a sketch of their graph</caption>
           <sidebyside valign="bottom" widths="47% 47%">
-            <figure xml:id="fig_pareq2a">
-              <caption/>
+            <table xml:id="fig_pareq2a"><title/>
               <tabular>
                 <row>
                   <cell><m>t</m></cell>
@@ -279,7 +277,7 @@
                   <cell><m>0</m></cell>
                 </row>
               </tabular>
-            </figure>
+            </table>
             <figure xml:id="fig_pareq2b">
               <caption/>
               <!-- START figures/fig_pareq2.tex -->

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -2139,7 +2139,7 @@
                 </p>
 
                 <p>
-                  <ol cols="2" label="a">
+                  <ol cols="2" marker="a">
                     <li>
                       <p>
                         <m>A=P(2,\pi/4)</m>
@@ -2223,7 +2223,7 @@
               </p>
 
               <p>
-                <ol cols="2" label="a">
+                <ol cols="2" marker="a">
                   <li>
                     <p>
                       <m>A=P(3,\pi)</m>

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -601,8 +601,7 @@
         <figure xml:id="fig_polar4">
           <caption>Graphing a polar function in <xref ref="ex_polar4">Example</xref> by plotting points</caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
-            <figure xml:id="fig_polar4a">
-              <caption/>
+            <table xml:id="fig_polar4a"><title/>
               <tabular halign="center">
                 <row bottom="minor">
                   <cell><m>\theta</m></cell><cell><m>r=1+\cos(\theta)</m></cell>
@@ -623,7 +622,7 @@
                   <cell><m>7 \pi/4</m></cell><cell><m>1.70711</m></cell>
                 </row>
               </tabular>
-            </figure>
+            </table>
 
             <figure xml:id="fig_polar4b">
               <!-- START figures/fig_polar4.tex -->
@@ -760,8 +759,8 @@
           we numbered each point in the table and on the graph.
         </p>
 
-        <figure xml:id="fig_polar5table">
-          <caption>Table of points for plotting a polar curve in <xref ref="ex_polar5"/></caption>
+        <table xml:id="fig_polar5table">
+          <title>Table of points for plotting a polar curve in <xref ref="ex_polar5"/></title>
           <tabular halign="center">
             <row bottom="minor"><cell>Pt.</cell><cell><m>\theta</m></cell><cell><m>\cos(2\theta)</m></cell></row>
             <row><cell><m>1</m></cell><cell><m>0</m></cell><cell><m>1</m></cell></row>
@@ -782,7 +781,7 @@
             <row><cell><m>16</m></cell><cell><m>11\pi/6</m></cell><cell><m>0.5</m></cell></row>
             <row><cell><m>17</m></cell><cell><m>2\pi</m></cell><cell><m>1</m></cell></row>
           </tabular>
-        </figure>
+        </table>
 
         <p>
           Using more points

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -1546,7 +1546,7 @@
 
   <p>
     Sequences are a great source of mathematical inquiry.
-    The On-Line Encyclopedia of Integer Sequences (<url href="http://oeis.org"/>) contains thousands of sequences and their formulae.
+    The On-Line Encyclopedia of Integer Sequences (<url href="https://oeis.org" visual="oeis.org"/>) contains thousands of sequences and their formulae.
     (As of this writing, there are 328,977 sequences in the database.)
     Perusing this database quickly demonstrates that a single sequence can represent several different
     <q>real life</q> phenomena.

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -3539,7 +3539,7 @@
         </p>
 
         <p>
-          <ol cols="2" label="(a)">
+          <ol cols="2" marker="a">
             <li><m>\ds x^2-y^2-\frac{z^2}{9}=0</m></li>
             <li><m>\ds x^2-y^2-z^2=1</m></li>
             <li><m>\ds z^2-x^2-y^2=1</m></li>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -880,7 +880,7 @@
         </p>
 
         <table xml:id="fig_tannorm7a">
-          <caption>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7">Example</xref></caption>
+          <title>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7">Example</xref></title>
           <tabular>
             <row>
               <cell><m>t</m></cell>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -879,7 +879,7 @@
           and not in changing its direction.
         </p>
 
-        <figure xml:id="fig_tannorm7a">
+        <table xml:id="fig_tannorm7a">
           <caption>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7">Example</xref></caption>
           <tabular>
             <row>
@@ -923,9 +923,7 @@
               <cell><m>12.7</m></cell>
             </row>
           </tabular>
-
-        </figure>
-
+        </table>
       </solution>
     </example>
 

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -1329,7 +1329,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Confirm that <m>\unittangent(a)</m> is as stated.

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -871,8 +871,8 @@
           A table of these values is given in <xref ref="fig_taypoly4a">Figure</xref>.
         </p>
 
-        <tabular xml:id="fig_taypoly4a">
-          <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></caption>
+        <table xml:id="fig_taypoly4a">
+          <title>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></title>
           <tabular>
             <row>
               <cell><m>f(x) = \cos(x)</m></cell>

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -64,8 +64,8 @@
 
       </figure>
       <!-- figures/fig_taypolyintroa.tex END -->
-      <figure xml:id="fig_taypolyintroa_2">
-        <caption>Derivatives of <m>f</m> evaluated at <m>0</m></caption>
+      <table xml:id="fig_taypolyintroa_2">
+        <title>Derivatives of <m>f</m> evaluated at <m>0</m></title>
         <tabular>
           <row>
             <cell><m>f(0) = 2</m></cell>
@@ -83,8 +83,7 @@
             <cell><m>f^{(5)}(0)=-19</m></cell>
           </row>
         </tabular>
-
-      </figure>
+      </table>
 
     </sidebyside>
 
@@ -301,8 +300,8 @@
                 as shown in <xref ref="fig_taypoly1a">Figure</xref>.
               </p>
 
-              <figure xml:id="fig_taypoly1a">
-                <caption>The derivatives of <m>f(x)=e^x</m> evaluated at <m>x=0</m></caption>
+              <table xml:id="fig_taypoly1a">
+                <title>The derivatives of <m>f(x)=e^x</m> evaluated at <m>x=0</m></title>
                 <tabular>
                   <row>
                     <cell><m>f(x) = e^x</m></cell>
@@ -330,7 +329,7 @@
                     <cell><m>f\,^{(n)}(0) = 1</m></cell>
                   </row>
                 </tabular>
-              </figure>
+              </table>
 
               <p>
                 By the definition of the Maclaurin polynomial, we have
@@ -439,8 +438,8 @@
                 <m>1\cdot 2\cdot 3=3!</m>.
               </p>
 
-              <figure xml:id="fig_taypoly2a">
-                <caption>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></caption>
+              <table xml:id="fig_taypoly2a">
+                <title>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></title>
                 <tabular>
                   <row>
                     <cell><m>f(x) = \ln(x)</m></cell>
@@ -483,7 +482,7 @@
                     <cell><m>(-1)^{n+1}(n-1)!</m></cell>
                   </row>
                 </tabular>
-              </figure>
+              </table>
 
               <p>
                 Notice that the coefficients alternate in sign starting at <m>n=1</m>.
@@ -872,9 +871,8 @@
           A table of these values is given in <xref ref="fig_taypoly4a">Figure</xref>.
         </p>
 
-        <figure xml:id="fig_taypoly4a">
-          <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated
-          at <m>x=0</m></caption>
+        <tabular xml:id="fig_taypoly4a">
+          <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></caption>
           <tabular>
             <row>
               <cell><m>f(x) = \cos(x)</m></cell>
@@ -927,8 +925,7 @@
               <cell><m>f^{(9)}(0) = 0</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           Notice how the derivatives, evaluated at <m>x=0</m>, follow a certain
@@ -1043,8 +1040,8 @@
                 This is done in <xref ref="fig_taypoly5a">Figure</xref>.
               </p>
 
-              <figure xml:id="fig_taypoly5a">
-                <caption>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></caption>
+              <table xml:id="fig_taypoly5a">
+                <title>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></title>
                 <tabular>
                   <row>
                     <cell><m>f(x) = \sqrt{x}</m></cell>
@@ -1072,8 +1069,7 @@
                     <cell><m>\ds f^{(4)}(4) = \frac{-15}{2048}</m></cell>
                   </row>
                 </tabular>
-
-              </figure>
+              </table>
 
               <p>
                 These values allow us to form the Taylor polynomial <m>p_4(x)</m>:

--- a/ptx/sec_taylor_poly_early.ptx
+++ b/ptx/sec_taylor_poly_early.ptx
@@ -374,7 +374,7 @@
         held until 2008! He was also a staunch foe of the Jacobite Rebellion,
         and was instrumental in the defence of Edinburgh against the army of
         Bonnie Prince Charlie. (For more details, see
-        <url href="https://en.wikipedia.org/wiki/Colin_Maclaurin">Wikipedia</url>.)
+        <url href="https://en.wikipedia.org/wiki/Colin_Maclaurin" visual="en.wikipedia.org/wiki/Colin_Maclaurin">Wikipedia</url>.)
       </p>
     </aside>
 

--- a/ptx/sec_taylor_poly_early.ptx
+++ b/ptx/sec_taylor_poly_early.ptx
@@ -64,8 +64,8 @@
 
       </figure>
       <!-- figures/fig_taypolyintroa.tex END -->
-      <figure xml:id="fig_taypolyintroa_2">
-        <caption>Derivatives of <m>f</m> evaluated at <m>0</m></caption>
+      <table xml:id="fig_taypolyintroa_2">
+        <title>Derivatives of <m>f</m> evaluated at <m>0</m></title>
         <tabular>
           <row>
             <cell><m>f(0) = 2</m></cell>
@@ -83,9 +83,7 @@
             <cell><m>f^{(5)}(0)=-19</m></cell>
           </row>
         </tabular>
-
-      </figure>
-
+      </table>
     </sidebyside>
 
     <p>
@@ -421,8 +419,8 @@
                 as shown in <xref ref="fig_taypoly1a">Figure</xref>.
               </p>
 
-              <figure xml:id="fig_taypoly1a">
-                <caption>The derivatives of <m>f(x)=e^x</m> evaluated at <m>x=0</m></caption>
+              <table xml:id="fig_taypoly1a">
+                <title>The derivatives of <m>f(x)=e^x</m> evaluated at <m>x=0</m></title>
                 <tabular>
                   <row>
                     <cell><m>f(x) = e^x</m></cell>
@@ -450,7 +448,7 @@
                     <cell><m>f\,^{(n)}(0) = 1</m></cell>
                   </row>
                 </tabular>
-              </figure>
+              </table>
 
               <p>
                 By the definition of the Maclaurin polynomial, we have
@@ -558,8 +556,8 @@
                 <m>1\cdot 2\cdot 3=3!</m>.
               </p>
 
-              <figure xml:id="fig_taypoly2a">
-                <caption>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></caption>
+              <table xml:id="fig_taypoly2a">
+                <title>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></title>
                 <tabular>
                   <row>
                     <cell><m>f(x) = \ln(x)</m></cell>
@@ -602,7 +600,7 @@
                     <cell><m>(-1)^{n+1}(n-1)!</m></cell>
                   </row>
                 </tabular>
-              </figure>
+              </table>
 
               <p>
                 Notice that the coefficients alternate in sign starting at <m>n=1</m>.
@@ -1031,7 +1029,7 @@
           A table of these values is given in <xref ref="fig_taypoly4a">Figure</xref>.
         </p>
 
-        <figure xml:id="fig_taypoly4a">
+        <table xml:id="fig_taypoly4a">
           <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated
           at <m>x=0</m></caption>
           <tabular>
@@ -1086,8 +1084,7 @@
               <cell><m>f^{(9)}(0) = 0</m></cell>
             </row>
           </tabular>
-
-        </figure>
+        </table>
 
         <p>
           Notice how the derivatives, evaluated at <m>x=0</m>, follow a certain
@@ -1202,8 +1199,8 @@
                 This is done in <xref ref="fig_taypoly5a">Figure</xref>.
               </p>
 
-              <figure xml:id="fig_taypoly5a">
-                <caption>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></caption>
+              <table xml:id="fig_taypoly5a">
+                <title>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></title>
                 <tabular>
                   <row>
                     <cell><m>f(x) = \sqrt{x}</m></cell>
@@ -1231,8 +1228,7 @@
                     <cell><m>\ds f^{(4)}(4) = \frac{-15}{2048}</m></cell>
                   </row>
                 </tabular>
-
-              </figure>
+              </table>
 
               <p>
                 These values allow us to form the Taylor polynomial <m>p_4(x)</m>:

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -94,8 +94,8 @@
         we created the table shown in <xref ref="fig_ts1">Table</xref>.
       </p>
 
-      <figure xml:id="fig_ts1">
-        <caption>A table of the derivatives of <m>f(x)=\cos (x)</m> evaluated at <m>x=0</m></caption>
+      <table xml:id="fig_ts1">
+        <title>A table of the derivatives of <m>f(x)=\cos (x)</m> evaluated at <m>x=0</m></title>
         <tabular>
           <row>
             <cell><m>f(x) = \cos(x)</m></cell>
@@ -148,8 +148,7 @@
             <cell><m>f^{(9)}(0) = 0</m></cell>
           </row>
         </tabular>
-
-      </figure>
+      </table>
 
       <p>
         Notice how <m>f^{(n)}(0)=0</m> when <m>n</m> is odd,
@@ -224,8 +223,8 @@
         not just finding a finite set of coefficients for a polynomial.
       </p>
 
-      <figure xml:id="fig_ts2">
-        <caption>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></caption>
+      <table xml:id="fig_ts2">
+        <title>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></title>
         <tabular>
           <row>
             <cell><m>f(x) = \ln(x)</m></cell>
@@ -273,8 +272,7 @@
             <cell><m>(-1)^{n+1}(n-1)!</m></cell>
           </row>
         </tabular>
-
-      </figure>
+      </table>
 
       <p>
         Since <m>f(1) = \ln(1) = 0</m>,

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1650,7 +1650,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         in component form: <var name="$comp" width="10"/>
@@ -1689,7 +1689,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         in component form: <var name="$comp" width="10"/>
@@ -1728,7 +1728,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         in component form: <var name="$comp" width="10"/>
@@ -1767,7 +1767,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         in component form: <var name="$comp" width="10"/>

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -703,7 +703,7 @@
       </p>
     </statement>
     <solution>
-      <video width="98%" youtube="zvqs7hveXc" xml:id="vid-vectors-intro-scalarmult"/>
+      <video width="98%" youtube="-zvqs7hveXc" xml:id="vid-vectors-intro-scalarmult"/>
       <p>
         <ol>
           <li>

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -150,7 +150,7 @@
           <caption>Sketching the vector-valued function of <xref ref="ex_vvf1">Example</xref></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <table xml:id="fig_vvf1a">
-              <caption/>
+              <title/>
               <tabular>
                 <row>
                   <cell><m>t</m></cell>

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -149,7 +149,7 @@
         <figure xml:id="fig_vvf1">
           <caption>Sketching the vector-valued function of <xref ref="ex_vvf1">Example</xref></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
-            <figure xml:id="fig_vvf1a">
+            <table xml:id="fig_vvf1a">
               <caption/>
               <tabular>
                 <row>
@@ -188,7 +188,7 @@
                   <cell>1/5</cell>
                 </row>
               </tabular>
-            </figure>
+            </table>
 
             <figure xml:id="fig_vvf1b">
               <caption/>

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -1793,7 +1793,7 @@
           </p>
 
           <p>
-            <ol label="a">
+            <ol marker="a">
               <li>
                 <p>
                   Show that the positions are the same at the indicated <m>t_0</m> and <m>s_0</m> values;
@@ -2248,7 +2248,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         At what <m>t</m>-values must David release the stone in his sling in order to hit Goliath?
@@ -2324,7 +2324,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         At what angle of elevation should she hold the crossbow to hit her target?
@@ -2365,7 +2365,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         Show that as hit, the ball hits the wall.
@@ -2446,7 +2446,7 @@
                 </p>
 
                 <p>
-                  <ol label="a">
+                  <ol marker="a">
                     <li>
                       <p>
                         If the ball is thrown at a rate of 50mph,

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -967,690 +967,687 @@
     </subexercises>
     <subexercises>
       <title>Problems</title>
-      <exercisegroup cols="2">
-        <title/>
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>100</mag><unit base="foot"/></quantity> rope, weighing
-              <quantity><mag>0.1</mag><unit base="pound"/><per base="foot"/></quantity>,
-              hangs over the edge of a tall building.
-            </p>
-
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    How much work is done pulling the entire rope to the top of the building?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    How much rope is pulled in when half of the total work is done?
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    500 ft<ndash/>lb
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    <m>100-50\sqrt{2} \approx 29.29</m> ft
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>50</mag><unit base="meter"/></quantity> rope,
-              with a mass density of <quantity><mag>0.2</mag><unit prefix="kilo" base="gram"/><per base="meter"/></quantity>,
-              hangs over the edge of a tall building.
-            </p>
-
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    How much work is done pulling the entire rope to the top of the building?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    How much work is done pulling in the first 20 m?
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    2450 J
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    1568 J
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A rope of length <m>\ell</m> <quantity><unit base="foot"/></quantity> hangs over the edge of tall cliff.
-              (Assume the cliff is taller than the length of the rope.)
-              The rope has a weight density of <m>d</m> <quantity><unit base="pound"/><per base="foot"/></quantity>.
-            </p>
-
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    How much work is done pulling the entire rope to the top of the cliff?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    What percentage of the total work is done pulling in the first half of the rope?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    How much rope is pulled in when half of the total work is done?
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>\frac12\cdot d\cdot l^2</m> ft<ndash/>lb
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    75 %
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    <m>\ell(1-\sqrt{2}/2) \approx 0.2929\ell</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>20</mag><unit base="meter"/></quantity> rope with mass density of <quantity><mag>0.5</mag><unit prefix="kilo" base="gram"/><per base="meter"/></quantity>  hangs over the edge of a <quantity><mag>10</mag><unit base="meter"/></quantity> building.
-              How much work is done pulling the rope to the top?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              735 J
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A crane lifts a <quantity><mag>2000</mag><unit base="pound"/></quantity>  load vertically <quantity><mag>30</mag><unit base="foot"/></quantity> with a <quantity><mag>1</mag><unit base="inch"/></quantity>  cable weighing <quantity><mag>1.68</mag><unit base="pound"/><per base="foot"/></quantity>.
-            </p>
-
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    How much work is done lifting the cable alone?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    How much work is done lifting the load alone?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Could one conclude that the work done lifting the cable is negligible compared to the work done lifting the load?
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    756 ft<ndash/>lb
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    60,000 ft<ndash/>lb
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Yes, for the cable accounts for about 1% of the total work.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A<quantity><mag>100</mag><unit base="pound"/></quantity> bag of sand is lifted uniformly <quantity><mag>120</mag><unit base="foot"/></quantity> in one minute.
-              Sand leaks from the bag at a rate of <quantity><mag>1/4</mag><unit base="pound"/><per base="second"/></quantity>.
-              What is the total work done in lifting the bag?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              11,100 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A box weighing <quantity><mag>2</mag><unit base="pound"/></quantity> lifts <quantity><mag>10</mag><unit base="pound"/></quantity> of sand vertically <quantity><mag>50</mag><unit base="foot"/></quantity>.
-              A crack in the box allows the sand to leak out such that <quantity><mag>9</mag><unit base="pound"/></quantity> of sand is in the box at the end of the trip.
-              Assume the sand leaked out at a uniform rate.
-              What is the total work done in lifting the box and sand?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              575 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A force of <quantity><mag>1000</mag><unit base="pound"/></quantity>  compresses a spring <quantity><mag>3</mag><unit base="inch"/></quantity>.
-              How much work is performed in compressing the spring?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              125 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A force of <quantity><mag>2</mag><unit base="newton"/></quantity> stretches a spring <quantity><mag>5</mag><unit prefix="centi" base="meter"/></quantity>.
-              How much work is performed in stretching the spring?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              0.05 J
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A force of <quantity><mag>50</mag><unit base="pound"/></quantity> compresses a spring from a natural length of <quantity><mag>18</mag><unit base="inch"/></quantity> to <quantity><mag>12</mag><unit base="inch"/></quantity>.
-              How much work is performed in compressing the spring?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              12.5 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A force of <quantity><mag>20</mag><unit base="pound"/></quantity> stretches a spring from a natural length of <quantity><mag>6</mag><unit base="inch"/></quantity> to <quantity><mag>8</mag><unit base="inch"/></quantity>.
-              How much work is performed in stretching the spring?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              5/3 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A force of <quantity><mag>7</mag><unit base="newton"/></quantity> stretches a spring from a natural length of <quantity><mag>11</mag><unit prefix="centi" base="meter"/></quantity> to <quantity><mag>21</mag><unit prefix="centi" base="meter"/></quantity>.
-              How much work is performed in stretching the spring from a length of <quantity><mag>16</mag><unit prefix="centi" base="meter"/></quantity> to <quantity><mag>21</mag><unit prefix="centi" base="meter"/></quantity>?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              0.2625 = 21/80 J
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A force of <m>f</m> <quantity><unit base="newton"/></quantity>
-              stretches a spring <m>d</m> <quantity><unit base="meter"/></quantity> from its natural length.
-              How much work is performed in stretching the spring?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <m>f\cdot d/2</m> J
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>20</mag><unit base="pound"/></quantity> weight is attached to a spring.
-              The weight rests on the spring,
-              compressing the spring from a natural length of <quantity><mag>1</mag><unit base="foot"/></quantity> to <quantity><mag>6</mag><unit base="inch"/></quantity>.
-            </p>
-
-            <p>
-              How much work is done in lifting the box <quantity><mag>1.5</mag><unit base="foot"/></quantity> (i.e, the spring will be stretched <quantity><mag>1</mag><unit base="foot"/></quantity> beyond its natural length)?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              45 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>20</mag><unit base="pound"/></quantity> weight is attached to a spring.
-              The weight rests on the spring,
-              compressing the spring from a natural length of <quantity><mag>1</mag><unit base="foot"/></quantity> to <quantity><mag>6</mag><unit base="inch"/></quantity>.
-            </p>
-
-            <p>
-              How much work is done in lifting the box <quantity><mag>6</mag><unit base="inch"/></quantity> (i.e, bringing the spring back to its natural length)?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              5 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>5</mag><unit base="meter"/></quantity> tall cylindrical tank with radius of <quantity><mag>2</mag><unit base="meter"/></quantity> is filled with <quantity><mag>3</mag><unit base="meter"/></quantity> of gasoline,
-              with a mass density of <quantity><mag>737.22</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
-              Compute the total work performed in pumping all the gasoline to the top of the tank.
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <m>953,284</m> J
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A <quantity><mag>6</mag><unit base="foot"/></quantity> cylindrical tank with a radius of <quantity><mag>3</mag><unit base="foot"/></quantity> is filled with water,
-              which has a weight density of <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
-              The water is to be pumped to a point <quantity><mag>2</mag><unit base="foot"/></quantity> above the top of the tank.
-            </p>
-
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    How much work is performed in pumping all the water from the tank?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    How much work is performed in pumping <quantity><mag>3</mag><unit base="foot"/></quantity> of water from the tank?
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    At what point is 1/2 of the total work done?
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    52,929.6 ft<ndash/>lb
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    18,525.3 ft<ndash/>lb
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    When <quantity><mag>3.83</mag><unit base="foot"/></quantity> of water have been pumped from the tank,
-                    leaving about <quantity><mag>2.17</mag><unit base="foot"/></quantity> in the tank.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A gasoline tanker is filled with gasoline with a weight density of <quantity><mag>45.93</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
-              The dispensing valve at the base is jammed shut,
-              forcing the operator to empty the tank via pumping the gas to a point <quantity><mag>1</mag><unit base="foot"/></quantity> above the top of the tank.
-              Assume the tank is a perfect cylinder, <quantity><mag>20</mag><unit base="foot"/></quantity> long with a diameter of <quantity><mag>7.5</mag><unit base="foot"/></quantity>.
-              How much work is performed in pumping all the gasoline from the tank?
-            </p>
-          </statement>
-          <answer>
-            <p>
-              192,767 ft<ndash/>lb.
-              Note that the tank is oriented horizontally.
-              Let the origin be the center of one of the circular ends of the tank.
-              Since the radius is <quantity><mag>3.75</mag><unit base="foot"/></quantity>, the fluid is being pumped to <m>y=4.75</m>;
-              thus the distance the gas travels is <m>h(y)=4.75-y</m>.
-              A differential element of water is a rectangle,
-              with length 20 and width <m>2\sqrt{3.75^2-y^2}</m>.
-              Thus the force required to move that slab of gas is <m>F(y) = 40\cdot45.93\cdot\sqrt{3.75^2-y^2}dy</m>.
-              Total work is <m>\int_{-3.75}^{3.75} 40\cdot45.93\cdot(4.75-y)\sqrt{3.75^2-y^2}\, dy</m>.
-              This can be evaluated without actual integration;
-              split the integral into <m>\int_{-3.75}^{3.75} 40\cdot45.93\cdot(4.75)\sqrt{3.75^2-y^2}\, dy + \int_{-3.75}^{3.75} 40\cdot45.93\cdot(-y)\sqrt{3.75^2-y^2}\, dy</m>.
-              The first integral can be evaluated as measuring half the area of a circle;
-              the latter integral can be shown to be 0 without much difficulty.
-              (Use substitution and realize the bounds are both 0.)
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A fuel oil storage tank is <quantity><mag>10</mag><unit base="foot"/></quantity> deep with trapezoidal sides, <quantity><mag>5</mag><unit base="foot"/></quantity> at the top and <quantity><mag>2</mag><unit base="foot"/></quantity> at the bottom,
-              and is <quantity><mag>15</mag><unit base="foot"/></quantity> wide
-              (see diagram below).
-              Given that fuel oil weighs <quantity><mag>55.46</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>,
-              find the work performed in pumping all the oil from the tank to a point <quantity><mag>3</mag><unit base="foot"/></quantity> above the top of the tank.
-            </p>
-
-              <image xml:id="img_pump4b" width="90%">
-                <description></description>
-                <latex-image>
-
-                \begin{tikzpicture}[x={(1,0)},z={(0,1)},y={(.5,.87)},xscale=.4,yscale=.3]
-
-                \draw [thick] (0,0,0) -- node [above,rotate=90,pos=.5] {10} (0,0,-10) -- node [below, pos=.5] {2} (2,0,-10) -- node [right, pos=.5] {15} (2,5,-10) -- (5,5,0)
-                              (5,5,0) -- (5,0,0)
-                              (5,0,0) -- (0,0,0) -- (0,5,0) -- node [above,pos=.5] { 5}(5,5,0)
-                              (5,0,0) -- (2,0,-10);
-
-                \draw [thick,dashed] (0,0,-10) -- (0,5,-10) -- (2,5,-10)
-                                    (0,5,-10) -- (0,5,0);
-
-                \end{tikzpicture}
-
-                </latex-image>
-              </image>
-
-          </statement>
-          <answer>
-            <p>
-              212,135 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A conical water tank is <quantity><mag>5</mag><unit base="meter"/></quantity> deep with a top radius of <quantity><mag>3</mag><unit base="meter"/></quantity>.
-              (This is similar to <xref ref="ex_pump2">Example</xref>.)
-              The tank is filled with pure water,
-              with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
-            </p>
-
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Find the work performed in pumping all the water to the top of the tank.
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Find the work performed in pumping the top <quantity><mag>2.5</mag><unit base="meter"/></quantity> of water to the top of the tank.
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Find the work performed in pumping the top half of the water,
-                    by volume, to the top of the tank.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    approx. 577,000 J
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    approx. 399,000 J
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    approx 110,000 J (By volume,
-                    half of the water is between the base of the cone and a height of 3.9685 m.
-                    If one rounds this to <quantity><mag>4</mag><unit base="meter"/></quantity>, the work is approx 104,000 J.)
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A water tank has the shape of a truncated cone,
-              with dimensions given below,
-              and is filled with water with a weight density of <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
-              Find the work performed in pumping all water to a point <quantity><mag>1</mag><unit base="foot"/></quantity> above the top of the tank.
-            </p>
-
-              <image xml:id="img_pump4bX" width="90%">
-                <description></description>
-                <latex-image>
-
-                \begin{tikzpicture}[xscale=.7,yscale=.5]
-
-                \draw [thick] (0,0) circle (1)
-                              (-1,.1) -- (-1.5,-1.9)
-                              (1,.1) -- (1.5,-1.9);
-
-                \draw (0,0)-- node [above,pos=.5] {2 ft} (1,0)
-                      (0,-2) -- node [above,pos=.5] {5 ft} (1.5,-2)
-                      (1.7,0) -- (2.3,0)
-                      (1.7,-2) -- (2.3,-2)
-                      (2,0) -- node [pos=.5,right] {10 ft} (2,-2);
-
-                \draw [thick] (-1.5,-2) arc (180:360:1.5);
-                \draw [thick,dashed] (-1.5,-2) arc (180:0:1.5);
-
-                \end{tikzpicture}
-
-                </latex-image>
-              </image>
-
-          </statement>
-          <answer>
-            <p>
-              187,214 ft<ndash/>lb
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A water tank has the shape of an inverted pyramid,
-              with dimensions given below,
-              and is filled with water with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
-              Find the work performed in pumping all water to a point <quantity><mag>5</mag><unit base="meter"/></quantity> above the top of the tank.
-            </p>
-
-                    <image xml:id="img_pump4bX1" width="90%">
-                      <description></description>
-                      <latex-image>
-
-                      \begin{tikzpicture}[xscale=.7,yscale=.7]
-
-                      \draw [thick] (0,0) -- node [pos=.5,left]{2 m} (1,1) --node [above,pos=.5] {2 m} (3,1) -- (2,0) -- cycle
-                                    (0,0) -- (1.5,-2)
-                                    (3,1) -- (1.5,-2)
-                                    (2,0) -- (1.5,-2);
-
-                      \draw [thick,dashed] (1,1) -- (1.5,-2);
-
-                      \draw (3,.5) -- (3.6,.5)
-                            (3,-2) -- (3.6,-2)
-                            (3.3,.5) -- node [pos=.5,right] {7 m} (3.3,-2);
-
-                      \end{tikzpicture}
-
-                      </latex-image>
-                    </image>
-          </statement>
-          <answer>
-            <p>
-              617,400 J
-            </p>
-          </answer>
-        </exercise>
-
-        <exercise>
-          <statement>
-            <p>
-              A water tank has the shape of an truncated,
-              inverted pyramid, with dimensions given below,
-              and is filled with water with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
-              Find the work performed in pumping all water to a point <quantity><mag>1</mag><unit base="meter"/></quantity> above the top of the tank.
-            </p>
-
-                    <image xml:id="img_pump4bX2" width="90%">
-                      <description></description>
-                      <latex-image>
-
-                        \begin{tikzpicture}[xscale=.7,yscale=.7]
-
-                        \draw [thick] (0,0) node (A) {} -- node [pos=.5,left] {5 m} (1,1) node (B) {} -- node [above,pos=.5] {5 m} (3,1) node (C) {} -- (2,0) node (D) {} -- cycle;
-
-                        \begin{scope}[scale=.75,shift={(.5,-3)}]
-                          \draw [thick] (0,0) node (AA) {} -- (1,1) node (BB) {} -- (3,1) node (CC) {} -- node [right,pos=.5] {2 m} (2,0) node (DD) {} -- node [pos=.5,below] {2 m} (0,0);
-                        \end{scope}
-
-                        \draw [dashed,thick] (BB.center) -- (B.center);
-
-                        \draw [thick] (AA.center) -- (A.center)
-                                      (DD.center) -- (D.center)
-                                      (CC.center) -- (C.center);
-
-                        \draw (3.4,1) -- (4,1)
-                              (3.4,-1.5) -- (4,-1.5)
-                              (3.7,1) -- node [pos=.5,right] { 9 m} (3.7,-1.5);
-
-                        \end{tikzpicture}
-
-                      </latex-image>
-                    </image>
-
-          </statement>
-          <answer>
-            <p>
-              4,917,150 J
-            </p>
-          </answer>
-        </exercise>
-      </exercisegroup>
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>100</mag><unit base="foot"/></quantity> rope, weighing
+            <quantity><mag>0.1</mag><unit base="pound"/><per base="foot"/></quantity>,
+            hangs over the edge of a tall building.
+          </p>
+
+          <p>
+            <ol>
+              <li>
+                <p>
+                  How much work is done pulling the entire rope to the top of the building?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  How much rope is pulled in when half of the total work is done?
+                </p>
+              </li>
+            </ol>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  500 ft<ndash/>lb
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  <m>100-50\sqrt{2} \approx 29.29</m> ft
+                </p>
+              </li>
+            </ol>
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>50</mag><unit base="meter"/></quantity> rope,
+            with a mass density of <quantity><mag>0.2</mag><unit prefix="kilo" base="gram"/><per base="meter"/></quantity>,
+            hangs over the edge of a tall building.
+          </p>
+
+          <p>
+            <ol>
+              <li>
+                <p>
+                  How much work is done pulling the entire rope to the top of the building?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  How much work is done pulling in the first 20 m?
+                </p>
+              </li>
+            </ol>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  2450 J
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  1568 J
+                </p>
+              </li>
+            </ol>
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A rope of length <m>\ell</m> <quantity><unit base="foot"/></quantity> hangs over the edge of tall cliff.
+            (Assume the cliff is taller than the length of the rope.)
+            The rope has a weight density of <m>d</m> <quantity><unit base="pound"/><per base="foot"/></quantity>.
+          </p>
+
+          <p>
+            <ol>
+              <li>
+                <p>
+                  How much work is done pulling the entire rope to the top of the cliff?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  What percentage of the total work is done pulling in the first half of the rope?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  How much rope is pulled in when half of the total work is done?
+                </p>
+              </li>
+            </ol>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  <m>\frac12\cdot d\cdot l^2</m> ft<ndash/>lb
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  75 %
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  <m>\ell(1-\sqrt{2}/2) \approx 0.2929\ell</m>
+                </p>
+              </li>
+            </ol>
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>20</mag><unit base="meter"/></quantity> rope with mass density of <quantity><mag>0.5</mag><unit prefix="kilo" base="gram"/><per base="meter"/></quantity>  hangs over the edge of a <quantity><mag>10</mag><unit base="meter"/></quantity> building.
+            How much work is done pulling the rope to the top?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            735 J
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A crane lifts a <quantity><mag>2000</mag><unit base="pound"/></quantity>  load vertically <quantity><mag>30</mag><unit base="foot"/></quantity> with a <quantity><mag>1</mag><unit base="inch"/></quantity>  cable weighing <quantity><mag>1.68</mag><unit base="pound"/><per base="foot"/></quantity>.
+          </p>
+
+          <p>
+            <ol>
+              <li>
+                <p>
+                  How much work is done lifting the cable alone?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  How much work is done lifting the load alone?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Could one conclude that the work done lifting the cable is negligible compared to the work done lifting the load?
+                </p>
+              </li>
+            </ol>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  756 ft<ndash/>lb
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  60,000 ft<ndash/>lb
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Yes, for the cable accounts for about 1% of the total work.
+                </p>
+              </li>
+            </ol>
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A<quantity><mag>100</mag><unit base="pound"/></quantity> bag of sand is lifted uniformly <quantity><mag>120</mag><unit base="foot"/></quantity> in one minute.
+            Sand leaks from the bag at a rate of <quantity><mag>1/4</mag><unit base="pound"/><per base="second"/></quantity>.
+            What is the total work done in lifting the bag?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            11,100 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A box weighing <quantity><mag>2</mag><unit base="pound"/></quantity> lifts <quantity><mag>10</mag><unit base="pound"/></quantity> of sand vertically <quantity><mag>50</mag><unit base="foot"/></quantity>.
+            A crack in the box allows the sand to leak out such that <quantity><mag>9</mag><unit base="pound"/></quantity> of sand is in the box at the end of the trip.
+            Assume the sand leaked out at a uniform rate.
+            What is the total work done in lifting the box and sand?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            575 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A force of <quantity><mag>1000</mag><unit base="pound"/></quantity>  compresses a spring <quantity><mag>3</mag><unit base="inch"/></quantity>.
+            How much work is performed in compressing the spring?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            125 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A force of <quantity><mag>2</mag><unit base="newton"/></quantity> stretches a spring <quantity><mag>5</mag><unit prefix="centi" base="meter"/></quantity>.
+            How much work is performed in stretching the spring?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            0.05 J
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A force of <quantity><mag>50</mag><unit base="pound"/></quantity> compresses a spring from a natural length of <quantity><mag>18</mag><unit base="inch"/></quantity> to <quantity><mag>12</mag><unit base="inch"/></quantity>.
+            How much work is performed in compressing the spring?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            12.5 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A force of <quantity><mag>20</mag><unit base="pound"/></quantity> stretches a spring from a natural length of <quantity><mag>6</mag><unit base="inch"/></quantity> to <quantity><mag>8</mag><unit base="inch"/></quantity>.
+            How much work is performed in stretching the spring?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            5/3 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A force of <quantity><mag>7</mag><unit base="newton"/></quantity> stretches a spring from a natural length of <quantity><mag>11</mag><unit prefix="centi" base="meter"/></quantity> to <quantity><mag>21</mag><unit prefix="centi" base="meter"/></quantity>.
+            How much work is performed in stretching the spring from a length of <quantity><mag>16</mag><unit prefix="centi" base="meter"/></quantity> to <quantity><mag>21</mag><unit prefix="centi" base="meter"/></quantity>?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            0.2625 = 21/80 J
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A force of <m>f</m> <quantity><unit base="newton"/></quantity>
+            stretches a spring <m>d</m> <quantity><unit base="meter"/></quantity> from its natural length.
+            How much work is performed in stretching the spring?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>f\cdot d/2</m> J
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>20</mag><unit base="pound"/></quantity> weight is attached to a spring.
+            The weight rests on the spring,
+            compressing the spring from a natural length of <quantity><mag>1</mag><unit base="foot"/></quantity> to <quantity><mag>6</mag><unit base="inch"/></quantity>.
+          </p>
+
+          <p>
+            How much work is done in lifting the box <quantity><mag>1.5</mag><unit base="foot"/></quantity> (i.e, the spring will be stretched <quantity><mag>1</mag><unit base="foot"/></quantity> beyond its natural length)?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            45 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>20</mag><unit base="pound"/></quantity> weight is attached to a spring.
+            The weight rests on the spring,
+            compressing the spring from a natural length of <quantity><mag>1</mag><unit base="foot"/></quantity> to <quantity><mag>6</mag><unit base="inch"/></quantity>.
+          </p>
+
+          <p>
+            How much work is done in lifting the box <quantity><mag>6</mag><unit base="inch"/></quantity> (i.e, bringing the spring back to its natural length)?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            5 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>5</mag><unit base="meter"/></quantity> tall cylindrical tank with radius of <quantity><mag>2</mag><unit base="meter"/></quantity> is filled with <quantity><mag>3</mag><unit base="meter"/></quantity> of gasoline,
+            with a mass density of <quantity><mag>737.22</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
+            Compute the total work performed in pumping all the gasoline to the top of the tank.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <m>953,284</m> J
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A <quantity><mag>6</mag><unit base="foot"/></quantity> cylindrical tank with a radius of <quantity><mag>3</mag><unit base="foot"/></quantity> is filled with water,
+            which has a weight density of <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
+            The water is to be pumped to a point <quantity><mag>2</mag><unit base="foot"/></quantity> above the top of the tank.
+          </p>
+
+          <p>
+            <ol>
+              <li>
+                <p>
+                  How much work is performed in pumping all the water from the tank?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  How much work is performed in pumping <quantity><mag>3</mag><unit base="foot"/></quantity> of water from the tank?
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  At what point is 1/2 of the total work done?
+                </p>
+              </li>
+            </ol>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  52,929.6 ft<ndash/>lb
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  18,525.3 ft<ndash/>lb
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  When <quantity><mag>3.83</mag><unit base="foot"/></quantity> of water have been pumped from the tank,
+                  leaving about <quantity><mag>2.17</mag><unit base="foot"/></quantity> in the tank.
+                </p>
+              </li>
+            </ol>
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A gasoline tanker is filled with gasoline with a weight density of <quantity><mag>45.93</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
+            The dispensing valve at the base is jammed shut,
+            forcing the operator to empty the tank via pumping the gas to a point <quantity><mag>1</mag><unit base="foot"/></quantity> above the top of the tank.
+            Assume the tank is a perfect cylinder, <quantity><mag>20</mag><unit base="foot"/></quantity> long with a diameter of <quantity><mag>7.5</mag><unit base="foot"/></quantity>.
+            How much work is performed in pumping all the gasoline from the tank?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            192,767 ft<ndash/>lb.
+            Note that the tank is oriented horizontally.
+            Let the origin be the center of one of the circular ends of the tank.
+            Since the radius is <quantity><mag>3.75</mag><unit base="foot"/></quantity>, the fluid is being pumped to <m>y=4.75</m>;
+            thus the distance the gas travels is <m>h(y)=4.75-y</m>.
+            A differential element of water is a rectangle,
+            with length 20 and width <m>2\sqrt{3.75^2-y^2}</m>.
+            Thus the force required to move that slab of gas is <m>F(y) = 40\cdot45.93\cdot\sqrt{3.75^2-y^2}dy</m>.
+            Total work is <m>\int_{-3.75}^{3.75} 40\cdot45.93\cdot(4.75-y)\sqrt{3.75^2-y^2}\, dy</m>.
+            This can be evaluated without actual integration;
+            split the integral into <m>\int_{-3.75}^{3.75} 40\cdot45.93\cdot(4.75)\sqrt{3.75^2-y^2}\, dy + \int_{-3.75}^{3.75} 40\cdot45.93\cdot(-y)\sqrt{3.75^2-y^2}\, dy</m>.
+            The first integral can be evaluated as measuring half the area of a circle;
+            the latter integral can be shown to be 0 without much difficulty.
+            (Use substitution and realize the bounds are both 0.)
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A fuel oil storage tank is <quantity><mag>10</mag><unit base="foot"/></quantity> deep with trapezoidal sides, <quantity><mag>5</mag><unit base="foot"/></quantity> at the top and <quantity><mag>2</mag><unit base="foot"/></quantity> at the bottom,
+            and is <quantity><mag>15</mag><unit base="foot"/></quantity> wide
+            (see diagram below).
+            Given that fuel oil weighs <quantity><mag>55.46</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>,
+            find the work performed in pumping all the oil from the tank to a point <quantity><mag>3</mag><unit base="foot"/></quantity> above the top of the tank.
+          </p>
+
+            <image xml:id="img_pump4b" width="90%">
+              <description></description>
+              <latex-image>
+
+              \begin{tikzpicture}[x={(1,0)},z={(0,1)},y={(.5,.87)},xscale=.4,yscale=.3]
+
+              \draw [thick] (0,0,0) -- node [above,rotate=90,pos=.5] {10} (0,0,-10) -- node [below, pos=.5] {2} (2,0,-10) -- node [right, pos=.5] {15} (2,5,-10) -- (5,5,0)
+                            (5,5,0) -- (5,0,0)
+                            (5,0,0) -- (0,0,0) -- (0,5,0) -- node [above,pos=.5] { 5}(5,5,0)
+                            (5,0,0) -- (2,0,-10);
+
+              \draw [thick,dashed] (0,0,-10) -- (0,5,-10) -- (2,5,-10)
+                                  (0,5,-10) -- (0,5,0);
+
+              \end{tikzpicture}
+
+              </latex-image>
+            </image>
+
+        </statement>
+        <answer>
+          <p>
+            212,135 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A conical water tank is <quantity><mag>5</mag><unit base="meter"/></quantity> deep with a top radius of <quantity><mag>3</mag><unit base="meter"/></quantity>.
+            (This is similar to <xref ref="ex_pump2">Example</xref>.)
+            The tank is filled with pure water,
+            with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
+          </p>
+
+          <p>
+            <ol>
+              <li>
+                <p>
+                  Find the work performed in pumping all the water to the top of the tank.
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Find the work performed in pumping the top <quantity><mag>2.5</mag><unit base="meter"/></quantity> of water to the top of the tank.
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Find the work performed in pumping the top half of the water,
+                  by volume, to the top of the tank.
+                </p>
+              </li>
+            </ol>
+          </p>
+        </statement>
+        <answer>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  approx. 577,000 J
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  approx. 399,000 J
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  approx 110,000 J (By volume,
+                  half of the water is between the base of the cone and a height of 3.9685 m.
+                  If one rounds this to <quantity><mag>4</mag><unit base="meter"/></quantity>, the work is approx 104,000 J.)
+                </p>
+              </li>
+            </ol>
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A water tank has the shape of a truncated cone,
+            with dimensions given below,
+            and is filled with water with a weight density of <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
+            Find the work performed in pumping all water to a point <quantity><mag>1</mag><unit base="foot"/></quantity> above the top of the tank.
+          </p>
+
+            <image xml:id="img_pump4bX" width="90%">
+              <description></description>
+              <latex-image>
+
+              \begin{tikzpicture}[xscale=.7,yscale=.5]
+
+              \draw [thick] (0,0) circle (1)
+                            (-1,.1) -- (-1.5,-1.9)
+                            (1,.1) -- (1.5,-1.9);
+
+              \draw (0,0)-- node [above,pos=.5] {2 ft} (1,0)
+                    (0,-2) -- node [above,pos=.5] {5 ft} (1.5,-2)
+                    (1.7,0) -- (2.3,0)
+                    (1.7,-2) -- (2.3,-2)
+                    (2,0) -- node [pos=.5,right] {10 ft} (2,-2);
+
+              \draw [thick] (-1.5,-2) arc (180:360:1.5);
+              \draw [thick,dashed] (-1.5,-2) arc (180:0:1.5);
+
+              \end{tikzpicture}
+
+              </latex-image>
+            </image>
+
+        </statement>
+        <answer>
+          <p>
+            187,214 ft<ndash/>lb
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A water tank has the shape of an inverted pyramid,
+            with dimensions given below,
+            and is filled with water with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
+            Find the work performed in pumping all water to a point <quantity><mag>5</mag><unit base="meter"/></quantity> above the top of the tank.
+          </p>
+
+          <image xml:id="img_pump4bX1" width="90%">
+            <description></description>
+            <latex-image>
+
+            \begin{tikzpicture}[xscale=.7,yscale=.7]
+
+            \draw [thick] (0,0) -- node [pos=.5,left]{2 m} (1,1) --node [above,pos=.5] {2 m} (3,1) -- (2,0) -- cycle
+                          (0,0) -- (1.5,-2)
+                          (3,1) -- (1.5,-2)
+                          (2,0) -- (1.5,-2);
+
+            \draw [thick,dashed] (1,1) -- (1.5,-2);
+
+            \draw (3,.5) -- (3.6,.5)
+                  (3,-2) -- (3.6,-2)
+                  (3.3,.5) -- node [pos=.5,right] {7 m} (3.3,-2);
+
+            \end{tikzpicture}
+
+            </latex-image>
+          </image>
+        </statement>
+        <answer>
+          <p>
+            617,400 J
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A water tank has the shape of an truncated,
+            inverted pyramid, with dimensions given below,
+            and is filled with water with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
+            Find the work performed in pumping all water to a point <quantity><mag>1</mag><unit base="meter"/></quantity> above the top of the tank.
+          </p>
+
+          <image xml:id="img_pump4bX2" width="90%">
+            <description></description>
+            <latex-image>
+
+              \begin{tikzpicture}[xscale=.7,yscale=.7]
+
+              \draw [thick] (0,0) node (A) {} -- node [pos=.5,left] {5 m} (1,1) node (B) {} -- node [above,pos=.5] {5 m} (3,1) node (C) {} -- (2,0) node (D) {} -- cycle;
+
+              \begin{scope}[scale=.75,shift={(.5,-3)}]
+                \draw [thick] (0,0) node (AA) {} -- (1,1) node (BB) {} -- (3,1) node (CC) {} -- node [right,pos=.5] {2 m} (2,0) node (DD) {} -- node [pos=.5,below] {2 m} (0,0);
+              \end{scope}
+
+              \draw [dashed,thick] (BB.center) -- (B.center);
+
+              \draw [thick] (AA.center) -- (A.center)
+                            (DD.center) -- (D.center)
+                            (CC.center) -- (C.center);
+
+              \draw (3.4,1) -- (4,1)
+                    (3.4,-1.5) -- (4,-1.5)
+                    (3.7,1) -- node [pos=.5,right] { 9 m} (3.7,-1.5);
+
+              \end{tikzpicture}
+
+            </latex-image>
+          </image>
+
+        </statement>
+        <answer>
+          <p>
+            4,917,150 J
+          </p>
+        </answer>
+      </exercise>
     </subexercises>
   </exercises>
 </section>


### PR DESCRIPTION
This pull request takes care of the changes to l"Hospital's rule that were requested in #142 but never followed through on.

There are also a few project-wide changes to address flaws in our markup, or changes to PreTeXt in the past year:

- There were a few exercise groups without introductions, that I think were inserted just to get a two-column layout. I've either added an introduction or removed the exercise group, as seemed appropriate
- URLs now need to have a `@visual` attribute. This has been addressed.
- tabulars can no longer go in a figure; they have to be in a table. As needed, figure/caption has been changed to table/title
- the syntax for specifying the format of a list appears to have changed from `label` to `marker`. I've made this change.