### PR TITLE
Readme patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Preparation for generating APEX Calculus from source:
 Software requirements:
 - a recent LaTeX distribution
 - [Sage](https://www.sagemath.org/)
-- Python (version 3.10 or later)
+- Python (version 3.8 or later)
 - the PreTeXt CLI (do `pip install pretextbook`)
 - [pdf2svg](https://github.com/jalios/pdf2svg-windows)
 - ImageMagick and pageres (installed as `pageres-cli` using node.js and npm) are recommended but not neeeded at this time

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Configuration:
 
 To build HTML, run `pretext build html -g` for your first run.
 The `-g` option generates all images and WebWork representations.
-If you haven't made any changes to these, you can use `pretext build html` on subsequent builds speed up the process.
+If you haven't made any changes to these, you can use `pretext build html` on subsequent builds to speed up the process.
 
 To build a version without videos, run `pretext build html-novideo`
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Note that Asymptote compilation is done remotely, so Asymptote does not need to 
 
 Configuration:
 
-- In the `project.ptx` file, change the URL for the WeBWorK server to your local server
-- In `publication/publication.ptx`, change the `baseurl` to the URL where your copy will be hosted
+- In `publication/publication.ptx`, change the `baseurl` to the URL where your copy will be hosted, and set the `webwork` server to your local server.
+- If you need a newer version of Pretext than included with PreTeXt CLI (or wish to set a custom stylesheet), add `<xsl>../pretext/xsl/pretext-html.xsl</xsl>` tags to `project.ptx` targets.
 
-To build HTML, run `pretext build html -d -w` for your first run.
-The `-d` option generates all the images in the book; `-w` generates the WeBWorK exercises.
-If you haven't made any changes to these, you can use `pretext build html` on subsequent builds.
+To build HTML, run `pretext build html -g` for your first run.
+The `-g` option generates all images and WebWork representations.
+If you haven't made any changes to these, you can use `pretext build html` on subsequent builds speed up the process.
 
 To build a version without videos, run `pretext build html-novideo`
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,19 @@ Note that Asymptote compilation is done remotely, so Asymptote does not need to 
 Configuration:
 
 - In `publication/publication.ptx`, change the `baseurl` to the URL where your copy will be hosted, and set the `webwork` server to your local server.
-- If you need a newer version of Pretext than included with PreTeXt CLI (or wish to set a custom stylesheet), add `<xsl>../pretext/xsl/pretext-html.xsl</xsl>` tags to `project.ptx` targets.
+- If you wish to set a custom stylesheet, place it in the `style` folder, and add `<xsl>style/custom-style.xsl</xsl>` tags to the appropriate targets in the `project.ptx` file, where you should of course replace `custom-style.xsl` with whatever you named your style file.
+- You can also use `<xsl>...</xsl>` tags in `project.ptx` to point to a newer version of one of the PreTeXt XSL files than the one that ships with the CLI. (This is not officially supported, so use with caution.)
 
 To build HTML, run `pretext build html -g` for your first run.
-The `-g` option generates all images and WebWork representations.
+The `-g` option generates all images and WeBWorK representations.
 If you haven't made any changes to these, you can use `pretext build html` on subsequent builds to speed up the process.
+
+You can also generate individual components. Run `pretext generate --help` for suggestions on what is possible.
+For example, to build only Asymptote images for HTML, you can run `pretext generate -t html asymptote`.
 
 To build a version without videos, run `pretext build html-novideo`
 
-To build PDF, run `pretext build latex`, or `pretext build latex -d -w`
+To build PDF, run `pretext build latex`, or `pretext build latex -g`
 if you need to build images or WeBWorK exercises.
 
 The following variations are also available:


### PR DESCRIPTION
Patch for README issues raised in issue #186

I did not change the python version requirement.

I added the line about custom `<xsl>` style since the version I got with my pretext cli did not support the options `<knowl example="no" example-solution="no"/>` out of the box, and I needed to point to a bleeding edge version to make it work.