### PR TITLE
Adjust image labels and add text below images to describe region

### DIFF
--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -1801,8 +1801,8 @@
 
         <introduction>
           <p>
-            In the following exercises, a region of the Cartesian plane is shaded.
-            Use the Disk/Washer Method to find the volume of the solid of revolution formed by revolving the region about the <m>x</m>-axis.
+            Use the Disk/Washer Method to find the volume of the solid of revolution
+            formed by revolving the given region about the <m>x</m>-axis.
           </p>
         </introduction>
 
@@ -1811,7 +1811,9 @@
               <pg-code>
               </pg-code> -->
               <statement>
-
+                <p>
+                  The region between <m>y=3-x^2</m> and the <m>x</m> axis:
+                </p>
               <!-- START figures/fig_07_02_ex_05.tex -->
                   <image xml:id="img_07_02_ex_05">
                     <description></description>
@@ -1835,9 +1837,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_05.tex END -->
-                <p>
-                  The region between <m>y=3-x^2</m> and the <m>x</m> axis.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1852,6 +1851,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=5x</m> and the <m>x</m> axis,
+                  for <m>1\leq x\leq 2</m>:
+                </p>
 
               <!-- START figures/fig_07_02_ex_06.tex -->
                   <image xml:id="img_07_02_ex_06">
@@ -1876,10 +1879,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_06.tex END -->
-                <p>
-                  The region between <m>y=5x</m> and the <m>x</m> axis,
-                  for <m>1\leq x\leq 2</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1894,6 +1893,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>:
+                </p>
 
               <!-- START figures/fig_07_02_ex_07.tex -->
                   <image xml:id="img_07_02_ex_07">
@@ -1918,10 +1921,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_07.tex END -->
-                <p>
-                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
-                  for <m>0\leq x\leq \pi/2</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1936,6 +1935,9 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>:
+                </p>
 
               <!-- START figures/fig_07_02_ex_04.tex -->
                   <image xml:id="img_07_02_ex_04">
@@ -1964,9 +1966,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_04.tex END -->
-                <p>
-                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1991,6 +1990,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region bounded by the curve <m>y=3-x^2</m>,
+                  the <m>x</m> axis, and the <m>y</m> axis:
+                </p>
 
               <!-- START figures/fig_07_02_ex_09.tex -->
                   <image xml:id="img_07_02_ex_09">
@@ -2015,10 +2018,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_09.tex END -->
-                <p>
-                  The region bounded by the curve <m>y=3-x^2</m>,
-                  the <m>x</m> axis, and the <m>y</m> axis.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -2033,6 +2032,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=5x</m> and the <m>y</m> axis,
+                  for <m>5\leq y\leq 10</m>:
+                </p>
 
               <!-- START figures/fig_07_02_ex_10.tex -->
                   <image xml:id="img_07_02_ex_10">
@@ -2057,10 +2060,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_10.tex END -->
-                <p>
-                  The region between <m>y=5x</m> and the <m>y</m> axis,
-                  for <m>5\leq y\leq 10</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -2075,7 +2074,16 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>:
+                </p>
 
+                <p>
+                  (Hint: Integration By Parts will be necessary, twice.
+                  First let <m>u = \arccos^2x</m>,
+                  then let <m>u=\arccos x</m>.)
+                </p>
               <!-- START figures/fig_07_02_ex_11.tex -->
                   <image xml:id="img_07_02_ex_11">
                     <description></description>
@@ -2099,15 +2107,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_11.tex END -->
-                <p>
-                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
-                  for <m>0\leq x\leq \pi/2</m>.
-                </p>
-                <p>
-                  (Hint: Integration By Parts will be necessary, twice.
-                  First let <m>u = \arccos^2x</m>,
-                  then let <m>u=\arccos x</m>.)
-                </p>
               </statement>
               <answer>
                 <p>
@@ -2122,6 +2121,9 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>:
+                </p>
 
               <!-- START figures/fig_07_02_ex_08.tex -->
                   <image xml:id="img_07_02_ex_08">
@@ -2150,9 +2152,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_08.tex END -->
-                <p>
-                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
-                </p>
               </statement>
               <answer>
                 <p>

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -1980,8 +1980,8 @@
 
         <introduction>
           <p>
-            In the following exercises, a region of the Cartesian plane is shaded.
-            Use the Disk/Washer Method to find the volume of the solid of revolution formed by revolving the region about the <m>y</m>-axis.
+            Use the Disk/Washer Method to find the volume of the solid of revolution
+            formed by revolving the given region about the <m>y</m>-axis.
           </p>
         </introduction>
 
@@ -2166,8 +2166,8 @@
 
         <introduction>
           <p>
-            In the following exercises, a region of the Cartesian plane is described.
-            Use the Disk/Washer Method to find the volume of the solid of revolution formed by rotating the region about each of the given axes.
+            Use the Disk/Washer Method to find the volume of the solid of revolution
+            formed by rotating the given region about each of the given axes.
           </p>
         </introduction>
 
@@ -2594,8 +2594,7 @@
 
         <introduction>
           <p>
-            In the following exercises, a solid is described.
-            Orient the solid along the <m>x</m>-axis such that a cross-sectional area function <m>A(x)</m> can be obtained,
+            Orient the given solid along the <m>x</m>-axis such that a cross-sectional area function <m>A(x)</m> can be obtained,
             then apply <xref ref="thm_volume_by_cross_section">Theorem</xref>
             to find the volume of the solid.
           </p>

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -1826,7 +1826,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=-1.73:1.73] {3-x^2};
-                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=50] {3-x^2} node [shift={(-5pt,80pt)} ,black] { $y=3-x^2$};
+                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=50] {3-x^2} node [shift={(-15pt,90pt)} ,black] { $y=3-x^2$};
 
                     \end{axis}
 
@@ -1835,7 +1835,9 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_05.tex END -->
-
+                <p>
+                  The region between <m>y=3-x^2</m> and the <m>x</m> axis.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1865,7 +1867,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=1:2] {5*x} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-30pt,-10pt)},black] { $y=5x$};
+                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-30pt,-5pt)},black] { $y=5x$};
 
                     \end{axis}
 
@@ -1874,7 +1876,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_06.tex END -->
-
+                <p>
+                  The region between <m>y=5x</m> and the <m>x</m> axis,
+                  for <m>1\leq x\leq 2</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1903,8 +1908,8 @@
                     xmin=-.1,xmax=1.7
                     ]
 
-                    \addplot [firstcurvestyle,areastyle,domain=0:1.57] {cos(deg(x)} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=0:1.57] {cos(deg(x)} node [shift={(-20pt,55pt)},black] { $y=\cos(x) $};
+                    \addplot [firstcurvestyle,areastyle,domain=0:1.57] {cos(deg(x))} \closedcycle;
+                    \addplot [firstcurvestyle,-,domain=0:1.57] {cos(deg(x))} node [shift={(-20pt,65pt)},black] { $y=\cos(x) $};
 
                     \end{axis}
 
@@ -1913,7 +1918,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_07.tex END -->
-
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1945,9 +1953,9 @@
                     \addplot [firstcurvestyle,areastyle,domain=0:1,samples=60] {sqrt(x)};
 
                     \addplot [firstcurvestyle,-,domain=0:.05] {sqrt(x)};
-                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-55pt,-15pt)} ,black] { $y=\sqrt{x}$};
+                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-55pt,-5pt)} ,black] { $y=\sqrt{x}$};
 
-                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-40pt)},black] { $y=x$};
+                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-45pt)},black] { $y=x$};
 
                     \end{axis}
 
@@ -1956,7 +1964,9 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_04.tex END -->
-
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1996,7 +2006,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=0:1.73] {3-x^2} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=50] {3-x^2} node [shift={(-5pt,80pt)},black] { $y=3-x^2$};
+                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=50] {3-x^2} node [shift={(-15pt,90pt)},black] { $y=3-x^2$};
 
                     \end{axis}
 
@@ -2005,7 +2015,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_09.tex END -->
-
+                <p>
+                  The region bounded by the curve <m>y=3-x^2</m>,
+                  the <m>x</m> axis, and the <m>y</m> axis.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -2035,7 +2048,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle] coordinates {(1,5) (2,10) (0,10) (0,5) (1,5)};
-                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-20pt,-30pt)},black] { $y=5x$};
+                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-20pt,-40pt)},black] { $y=5x$};
 
                     \end{axis}
 
@@ -2044,7 +2057,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_10.tex END -->
-
+                <p>
+                  The region between <m>y=5x</m> and the <m>y</m> axis,
+                  for <m>5\leq y\leq 10</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -2074,7 +2090,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=0:1.57] {cos(deg(x))} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=0:1.57] {cos(deg(x)} node [shift={(-20pt,55pt)},black] { $y=\cos(x) $};
+                    \addplot [firstcurvestyle,-,domain=0:1.57] {cos(deg(x))} node [shift={(-20pt,65pt)},black] { $y=\cos(x) $};
 
                     \end{axis}
 
@@ -2083,7 +2099,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_11.tex END -->
-
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>.
+                </p>
                 <p>
                   (Hint: Integration By Parts will be necessary, twice.
                   First let <m>u = \arccos^2x</m>,
@@ -2120,9 +2139,9 @@
                     \addplot [firstcurvestyle,areastyle,domain=0:1,samples=60] {sqrt(x)};
 
                     \addplot [firstcurvestyle,-,domain=0:.05] {sqrt(x)};
-                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-55pt,-15pt)} ,black] { $y=\sqrt{x}$};
+                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-60pt,-10pt)} ,black] { $y=\sqrt{x}$};
 
-                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-40pt)},black] { $y=x$};
+                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-45pt)},black] { $y=x$};
 
                     \end{axis}
 
@@ -2131,7 +2150,9 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_08.tex END -->
-
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                </p>
               </statement>
               <answer>
                 <p>

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -1425,6 +1425,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region bounded by the curve <m>y=3-x^2</m>,
+                  the <m>x</m> axis, and the <m>y</m> axis:
+                </p>
               <!-- START figures/fig_07_02_ex_09.tex -->
                   <image xml:id="img_07_02_ex_09X">
                     <description></description>
@@ -1448,10 +1452,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_09.tex END -->
-                <p>
-                  The region bounded by the curve <m>y=3-x^2</m>,
-                  the <m>x</m> axis, and the <m>y</m> axis.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1466,6 +1466,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=5x</m> and the <m>x</m> axis,
+                  for <m>1\leq x\leq 2</m>:
+                </p>
               <!-- START figures/fig_07_02_ex_06.tex -->
                   <image xml:id="img_07_02_ex_06X">
                     <description></description>
@@ -1489,10 +1493,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_06.tex END -->
-                <p>
-                  The region between <m>y=5x</m> and the <m>x</m> axis,
-                  for <m>1\leq x\leq 2</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1507,6 +1507,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>:
+                </p>
               <!-- START figures/fig_07_02_ex_11.tex -->
                   <image xml:id="img_07_02_ex_11X">
                     <description></description>
@@ -1530,10 +1534,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_11.tex END -->
-                <p>
-                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
-                  for <m>0\leq x\leq \pi/2</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1548,6 +1548,9 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>:
+                </p>
               <!-- START figures/fig_07_02_ex_08.tex -->
                   <image xml:id="img_07_02_ex_08XX">
                     <description></description>
@@ -1575,9 +1578,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_08.tex END -->
-                <p>
-                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1602,6 +1602,9 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=3-x^2</m> and the <m>x</m> axis:
+                </p>
               <!-- START figures/fig_07_02_ex_05.tex -->
                   <image xml:id="img_07_02_ex_05X">
                     <description></description>
@@ -1625,9 +1628,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_05.tex END -->
-                <p>
-                  The region between <m>y=3-x^2</m> and the <m>x</m> axis.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1642,6 +1642,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=5x</m> and the <m>y</m> axis,
+                  for <m>5\leq y\leq 10</m>:
+                </p>
               <!-- START figures/fig_07_02_ex_10.tex -->
                   <image xml:id="img_07_02_ex_10X">
                     <description></description>
@@ -1665,10 +1669,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_10.tex END -->
-                <p>
-                  The region between <m>y=5x</m> and the <m>y</m> axis,
-                  for <m>5\leq y\leq 10</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1683,6 +1683,10 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>:
+                </p>
               <!-- START figures/fig_07_02_ex_07.tex -->
                   <image xml:id="img_07_02_ex_07X">
                     <description></description>
@@ -1706,10 +1710,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_07.tex END -->
-                <p>
-                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
-                  for <m>0\leq x\leq \pi/2</m>.
-                </p>
               </statement>
               <answer>
                 <p>
@@ -1724,6 +1724,9 @@
               <pg-code>
               </pg-code> -->
               <statement>
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>:
+                </p>
               <!-- START figures/fig_07_02_ex_04.tex -->
                   <image xml:id="img_07_02_ex_04X">
                     <description></description>
@@ -1751,9 +1754,6 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_04.tex END -->
-                <p>
-                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
-                </p>
               </statement>
               <answer>
                 <p>

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -1415,8 +1415,8 @@
 
         <introduction>
           <p>
-            In the following exercises, a region of the Cartesian plane is shaded.
-            Use the Shell Method to find the volume of the solid of revolution formed by revolving the region about the <m>y</m>-axis.
+            Use the Shell Method to find the volume of the solid of revolution formed by
+            revolving the given region about the <m>y</m>-axis.
           </p>
         </introduction>
 
@@ -1592,8 +1592,8 @@
 
         <introduction>
           <p>
-            In the following exercises, a region of the Cartesian plane is shaded.
-            Use the Shell Method to find the volume of the solid of revolution formed by revolving the region about the <m>x</m>-axis.
+            Use the Shell Method to find the volume of the solid of revolution formed by
+            revolving the given region about the <m>x</m>-axis.
           </p>
         </introduction>
 
@@ -1768,8 +1768,8 @@
 
         <introduction>
           <p>
-            In the following exercises, a region of the Cartesian plane is described.
-            Use the Shell Method to find the volume of the solid of revolution formed by rotating the region about each of the given axes.
+            Use the Shell Method to find the volume of the solid of revolution formed
+            by revloving the given region about each of the given axes.
           </p>
         </introduction>
 

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -1439,7 +1439,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=0:1.73] {3-x^2} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=40] {3-x^2} node [shift={(-5pt,80pt)},black] { $y=3-x^2$};
+                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=40] {3-x^2} node [shift={(-15pt,90pt)},black] { $y=3-x^2$};
 
                     \end{axis}
 
@@ -1448,6 +1448,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_09.tex END -->
+                <p>
+                  The region bounded by the curve <m>y=3-x^2</m>,
+                  the <m>x</m> axis, and the <m>y</m> axis.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1476,7 +1480,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=1:2] {5*x} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-30pt,-10pt)},black] { $y=5x$};
+                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-35pt,-10pt)},black] { $y=5x$};
 
                     \end{axis}
 
@@ -1485,6 +1489,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_06.tex END -->
+                <p>
+                  The region between <m>y=5x</m> and the <m>x</m> axis,
+                  for <m>1\leq x\leq 2</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1513,7 +1521,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=0:1.57] {cos(deg(x))} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=0:1.57,samples=30] {cos(deg(x)} node [shift={(-20pt,55pt)},black] { $y=\cos(x) $};
+                    \addplot [firstcurvestyle,-,domain=0:1.57,samples=30] {cos(deg(x))} node [shift={(-20pt,65pt)},black] { $y=\cos(x) $};
 
                     \end{axis}
 
@@ -1522,6 +1530,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_11.tex END -->
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1552,9 +1564,9 @@
                     \addplot [firstcurvestyle,areastyle,domain=0:1,samples=60] {sqrt(x)};
 
                     \addplot [firstcurvestyle,-,domain=0:.05] {sqrt(x)};
-                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-55pt,-15pt)} ,black] { $y=\sqrt{x}$};
+                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-65pt,-15pt)} ,black] { $y=\sqrt{x}$};
 
-                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-40pt)},black] { $y=x$};
+                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-45pt)},black] { $y=x$};
 
                     \end{axis}
 
@@ -1563,6 +1575,9 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_08.tex END -->
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1601,7 +1616,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=-1.73:1.73] {3-x^2};
-                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=40] {3-x^2} node [shift={(-5pt,80pt)},black] { $y=3-x^2$};
+                    \addplot [firstcurvestyle,-,domain=-1.73:1.73,samples=40] {3-x^2} node [shift={(-15pt,90pt)},black] { $y=3-x^2$};
 
                     \end{axis}
 
@@ -1610,6 +1625,9 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_05.tex END -->
+                <p>
+                  The region between <m>y=3-x^2</m> and the <m>x</m> axis.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1638,7 +1656,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle] coordinates {(1,5) (2,10) (0,10) (0,5) (1,5)};
-                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-20pt,-30pt)},black] { $y=5x$};
+                    \addplot [firstcurvestyle,-,domain=0:2.1] {5*x} node [shift={(-20pt,-40pt)},black] { $y=5x$};
 
                     \end{axis}
 
@@ -1647,6 +1665,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_10.tex END -->
+                <p>
+                  The region between <m>y=5x</m> and the <m>y</m> axis,
+                  for <m>5\leq y\leq 10</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1675,7 +1697,7 @@
                     ]
 
                     \addplot [firstcurvestyle,areastyle,domain=0:1.57] {cos(deg(x))} \closedcycle;
-                    \addplot [firstcurvestyle,-,domain=0:1.57,samples=30] {cos(deg(x)} node [shift={(-20pt,55pt)},black] { $y=\cos(x) $};
+                    \addplot [firstcurvestyle,-,domain=0:1.57,samples=30] {cos(deg(x))} node [shift={(-20pt,65pt)},black] { $y=\cos(x) $};
 
                     \end{axis}
 
@@ -1684,6 +1706,10 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_07.tex END -->
+                <p>
+                  The region between <m>y=\cos(x)</m> and the <m>x</m> axis,
+                  for <m>0\leq x\leq \pi/2</m>.
+                </p>
               </statement>
               <answer>
                 <p>
@@ -1714,9 +1740,9 @@
                     \addplot [firstcurvestyle,areastyle,domain=0:1,samples=60] {sqrt(x)};
 
                     \addplot [firstcurvestyle,-,domain=0:.05] {sqrt(x)};
-                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-55pt,-15pt)} ,black] { $y=\sqrt{x}$};
+                    \addplot [firstcurvestyle,-,domain=.05:1,samples=30] {sqrt(x)} node [shift={(-65pt,-15pt)} ,black] { $y=\sqrt{x}$};
 
-                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-40pt)},black] { $y=x$};
+                    \addplot [firstcurvestyle,-,domain=0:1] {x} node [shift={(-30pt,-45pt)},black] { $y=x$};
 
                     \end{axis}
 
@@ -1725,6 +1751,9 @@
                     </latex-image>
                   </image>
               <!-- figures/fig_07_02_ex_04.tex END -->
+                <p>
+                  The region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                </p>
               </statement>
               <answer>
                 <p>


### PR DESCRIPTION
Addresses the issue noticed by @grady in #161.

I've added text below each image to describe the region, and I've also adjusted the node shifts for the labels so that they fit in the image, and bit better with the curves than before.