### PR TITLE
Fixes to images in sec-ABC and sec-work, and triangle fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ APEX.pl
 # logs and error reports
 .error_schema.log
 cli.log
-requirements.txt

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -1840,7 +1840,7 @@
               </pg-code>
               <statement>
                 <p>
-                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>,and <m>(<var name="$s3"/>)</m>
+                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>, and <m>(<var name="$s3"/>)</m>
                 </p>
 
                 <p>
@@ -1865,7 +1865,7 @@
               </pg-code>
               <statement>
                 <p>
-                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>,and <m>(<var name="$s3"/>)</m>
+                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>, and <m>(<var name="$s3"/>)</m>
                 </p>
 
                 <p>
@@ -1879,9 +1879,9 @@
         <exercise>
           <webwork>
               <pg-code>
-                @p1 = (-1,1);
+                @p1 = (1,1);
                 @p2 = (3,3);
-                @p3 = (3,3);
+                @p3 = (0,4);
                 $area = 1/2*($p1[1]*($p2[0]-$p3[0])+$p2[1]*($p3[0]-$p1[0]) + $p3[1]*($p1[0] - $p2[0]));
                 $area = Formula(abs($area));
                 $s1 = join(", ", @p1);
@@ -1890,7 +1890,7 @@
               </pg-code>
               <statement>
                 <p>
-                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>,and <m>(<var name="$s3"/>)</m>
+                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>, and <m>(<var name="$s3"/>)</m>
                 </p>
 
                 <p>
@@ -1915,7 +1915,7 @@
               </pg-code>
               <statement>
                 <p>
-                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>,and <m>(<var name="$s3"/>)</m>
+                  <m>(<var name="$s1"/>)</m>,<m>(<var name="$s2"/>)</m>, and <m>(<var name="$s3"/>)</m>
                 </p>
 
                 <p>
@@ -1956,7 +1956,7 @@
               </p>
 
             <!-- START figures/fig_07_01_ex_29.tex -->
-                <image xml:id="img_07_01_ex_29">
+                <image xml:id="img_07_01_ex_29" width="47%">
                   <description></description>
                   <latex-image>
 
@@ -2019,7 +2019,7 @@
 
 
               <!-- START figures/fig_07_01_ex_30.tex -->
-                <image xml:id="img_07_01_ex_30">
+                <image xml:id="img_07_01_ex_30" width="47%">
                   <description></description>
                   <latex-image>
 

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -787,7 +787,8 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=\frac12 x +3</m> and <m>y=\frac12\cos(x)+1</m>,
+                  for <m>0\leq x\leq 2\pi</m>.
                 </p>
 
                 <!-- START figures/fig_07_01_ex_04.tex -->
@@ -806,8 +807,8 @@
                     xmin=-1,xmax=7
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.9:6.5,samples=40] {.5*cos(deg(x))+1} node [shift={(-25pt,7pt)} ,black] { $y=\frac12\cos(x) +1$};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.9:6.5] {.5*x+3}node [shift={(-30pt,0pt)} ,black] { $y=\frac12x+3$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.9:6.5,samples=40] {.5*cos(deg(x))+1} node [shift={(-50pt,7pt)} ,black] { $y=\frac12\cos(x) +1$};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.9:6.5] {.5*x+3}node [shift={(-50pt,-5pt)} ,black] { $y=\frac12x+3$};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:2*pi}];
 
@@ -846,7 +847,8 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=-3x^3+3x+2</m> and <m>y=x^2+x-1</m>,
+                  for <m>-1\leq x\leq 1</m>.
                 </p>
 
               <!-- START figures/fig_07_01_ex_05.tex -->
@@ -864,8 +866,8 @@
                     xmin=-1.1,xmax=1.1
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-1.05:1.05] {x^2+x-1} node [shift={(-35pt,-60pt)},black] { $y=x^2+x-1$};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-1.05:1.05,samples=60] {-3*x^3+3*x+2} node [shift={(-120pt,25pt)},black] { $y=-3x^3+3x+2$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-1.05:1.05] {x^2+x-1} node [shift={(-40pt,-65pt)},black] { $y=x^2+x-1$};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-1.05:1.05,samples=60] {-3*x^3+3*x+2} node [shift={(-140pt,30pt)},black] { $y=-3x^3+3x+2$};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=-1:1}];
 
@@ -904,7 +906,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=1</m> and <m>y=2</m>, for <m>0\leq x\leq \pi</m>.
                 </p>
 
               <!-- START figures/fig_07_01_ex_10.tex -->
@@ -920,12 +922,12 @@
                     extra x ticks={3.14,1.57},
                     extra x tick labels={$\pi$,$\pi/2$},
                     ytick={-1,1,2,3},
-                    ymin=-.5,ymax=2.2,
+                    ymin=-.5,ymax=2.4,
                     xmin=-.1,xmax=3.5
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-] {1} node [shift={(-70pt,-5pt)},black] { $y=1$};
-                    \addplot [name path=B,firstcurvestyle,-] {2} node [shift={(-70pt,5pt)},black] { $y=2$};
+                    \addplot [name path=A,firstcurvestyle,-] {1} node [shift={(-100pt,-10pt)},black] { $y=1$};
+                    \addplot [name path=B,firstcurvestyle,-] {2} node [shift={(-100pt,10pt)},black] { $y=2$};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi}];
 
@@ -964,7 +966,8 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=\sin(x)+1</m> and <m>y=\sin(x)</m>,
+                  for <m>0\leq x\leq \pi</m>.
                 </p>
 
               <!-- START figures/fig_07_01_ex_06.tex -->
@@ -984,8 +987,8 @@
                     xmin=-.1,xmax=3.5
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))} node [shift={(-70pt,45pt)} ,black] { $y=\sin(x) $};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))+1} node [shift={(-45pt,80pt)} ,black] { $y=\sin(x) +1$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))} node [shift={(-80pt,45pt)} ,black] { $y=\sin(x) $};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))+1} node [shift={(-45pt,85pt)} ,black] { $y=\sin(x) +1$};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi}];
 
@@ -1010,8 +1013,7 @@
           <!-- </webwork> -->
         </exercise>
   <!-- Exercise 8 -->
-  <!--TODO: The wrong graph is used in this one. Needs updating.-->
-        <!-- <exercise> -->
+        <exercise>
           <!-- <webwork>
               <pg-code>
                 $x0 = Compute("0");
@@ -1024,53 +1026,54 @@
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
               </pg-code>
                -->
-              <!-- <statement>
+              <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=\sin(4x)</m> and <m>y=\sec^2(x)</m>,
+                  for <m>0\leq x\leq \pi/4</m>.
                 </p>
-                <sidebyside width="47%"> -->
+
               <!-- START figures/fig_07_01_ex_07.tex -->
-                  <!-- <image xml:id="img_07_01_ex_07">
-                    <description></description>
-                    <latex-image>
+                <image xml:id="img_07_01_ex_07">
+                  <description></description>
+                  <latex-image>
 
-                    \begin{tikzpicture}
+                  \begin{tikzpicture}
 
-                    \begin{axis}[
-                    axis on top,
-                    xtick=\empty,
-                    extra x ticks={3.14,1.57},
-                    extra x tick labels={$\pi$,$\pi/2$},
-                    ytick={-1,1,2,3},
-                    ymin=-.5,ymax=2.2,
-                    xmin=-.1,xmax=3.5
-                    ]
+                  \begin{axis}[
+                  axis on top,
+                  xtick=\empty,
+                  extra x ticks={0.785,0.392},
+                  extra x tick labels={$\pi/4$,$\pi/8$},
+                  ytick={-1,1,2,3},
+                  ymin=-.5,ymax=2.2,
+                  xmin=-.1,xmax=1
+                  ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))} node [shift={(-70pt,45pt)} ,black] { $y=\sin(x) $};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))+1} node [shift={(-45pt,80pt)} ,black] { $y=\sin(x) +1$};
+                  \addplot [name path=A,firstcurvestyle,-,domain=-.1:.9,samples=60] {sin(deg(4*x))} node [shift={(-65pt,40pt)} ,black] { $y=\sin(4x) $};
+                  \addplot [name path=B,firstcurvestyle,-,domain=-.1:.9,samples=60] {sec(deg(x))^2} node [shift={(-60pt,-40pt)} ,black] { $y=\sec^2(x)$};
 
-                    \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi}];
+                  \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi/4}];
 
-                    \end{axis}
+                  \end{axis}
 
-                    \end{tikzpicture}
+                  \end{tikzpicture}
 
-                    </latex-image>
-                  </image> -->
+                  </latex-image>
+                </image>
               <!-- figures/fig_07_01_ex_07.tex END -->
-                <!-- </sidebyside> -->
+
                 <!-- <p>
                   <var name="$area" width="10"/>
                 </p> -->
     <!-- 1/2 -->
-              <!-- </statement>
+              </statement>
               <answer>
                 <p>
                   <m>1/2</m>
                 </p>
-              </answer> -->
+              </answer>
           <!-- </webwork> -->
-        <!-- </exercise> -->
+        </exercise>
   <!-- Exercise 9 -->
         <exercise>
           <!-- <webwork>
@@ -1086,7 +1089,8 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=\sin(x)</m> and <m>y=\cos(x)</m>,
+                  for <m>\pi/4\leq x\leq 5\pi/4</m>.
                 </p>
 
               <!-- START figures/fig_07_01_ex_08.tex -->
@@ -1105,8 +1109,8 @@
                     xmin=-.1,xmax=4.1
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:4.1,samples=40] {sin(deg(x))} node [shift={(-30pt,80pt)},black] { $y=\sin(x) $};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:4.1,samples=40] {cos(deg(x))} node [shift={(-115pt,0pt)},black] { $y=\cos(x) $};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:4.1,samples=40] {sin(deg(x))} node [shift={(-30pt,90pt)},black] { $y=\sin(x) $};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:4.1,samples=40] {cos(deg(x))} node [shift={(-125pt,-5pt)},black] { $y=\cos(x) $};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=pi/4:5*pi/4}];
 
@@ -1145,7 +1149,8 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Find the area of the shaded region in the graph below.
+                  Between <m>y=2^x</m> and <m>y=4^x</m>,
+                  for <m>0\leq x\leq 1</m>.
                 </p>
 
               <!-- START figures/fig_07_01_ex_09.tex -->
@@ -1162,7 +1167,7 @@
                     ]
 
                     \addplot [name path=A,firstcurvestyle,-,domain=-.1:1.1] {2^x} node [shift={(-25pt,-20pt)},black] { $y=2^x$};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:1.1] {4^x} node [shift={(-40pt,-30pt)},black] { $y=4^x$};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:1.1] {4^x} node [shift={(-45pt,-30pt)},black] { $y=4^x$};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:1}];
 
@@ -1190,7 +1195,8 @@
         <exercise>
           <statement>
             <p>
-              Find the area of the shaded region in the graph below.
+              Bounded by the curves <m>y=\sqrt{x}+1</m>, <m>y=\sqrt{2-x}+1</m>,
+              and <m>y=1</m>.
             </p>
             <image xml:id="img_07_01_ex_31a">
               <description></description>
@@ -1205,12 +1211,12 @@
               ]
 
               \addplot [name path=A,firstcurvestyle,-,domain=0:1,samples=40] {1};
-              \addplot [name path=B,firstcurvestyle,-,domain=0:1,samples=40] ({x^2},{x+1}) node [pos=.8,above left,black] { $y=\sqrt{x}+1$};
+              \addplot [name path=B,firstcurvestyle,-,domain=0:1,samples=40] ({x^2},{x+1}) node [pos=.85,above left,black] { $y=\sqrt{x}+1$};
 
               \addplot [firstcurvestyle,areastyle] fill between [of=A and B];
 
               \addplot [name path=C,firstcurvestyle,-,domain=1:2,samples=2] {1};
-              \addplot [name path=D,firstcurvestyle,-,domain=0:1,samples=40] ({-x^2+2},{x+1}) node [pos=.8,above right,black] { $y=\sqrt{2-x}+1$};
+              \addplot [name path=D,firstcurvestyle,-,domain=0:1,samples=40] ({-x^2+2},{x+1}) node [pos=.9,above right,black] { $y=\sqrt{2-x}+1$};
 
               \addplot [firstcurvestyle,areastyle] fill between [of=C and D];
 
@@ -1504,6 +1510,9 @@
                 $area = $area1 + $area2;
               </pg-code> -->
               <statement>
+                <p>
+                  Bounded by <m>y=x^2+1</m>, <m>y=\frac14(x-3)^2+1</m>, and <m>y=1</m>.
+                </p>
 
               <!-- START figures/fig_07_01_ex_18.tex -->
                   <image xml:id="img_07_01_ex_18">
@@ -1520,8 +1529,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates {(0,1.)(0.1,1.01)(0.2,1.04)(0.3,1.09)(0.4,1.16)(0.5,1.25)(0.6,1.36)(0.7,1.49)(0.8,1.64)(0.9,1.81)(1.,2.)(1.1,1.903)(1.2,1.81)(1.3,1.723)(1.4,1.64)(1.5,1.563)(1.6,1.49)(1.7,1.423)(1.8,1.36)(1.9,1.303)(2.,1.25)(2.1,1.203)(2.2,1.16)(2.3,1.123)(2.4,1.09)(2.5,1.063)(2.6,1.04)(2.7,1.023)(2.8,1.01)(2.9,1.003)(3.,1.)(0,1)};
 
-                    \addplot [firstcurvestyle,-,domain=1:3] {.25*(x-3)^2+1} node [shift={(-25pt,40pt)},black] { $y=\frac14(x-3)^2+1$};
-                    \addplot [firstcurvestyle,-,domain=0:1] {x^2+1} node [shift={(-27pt,-15pt)},black] { $y=x^2+1$};
+                    \addplot [firstcurvestyle,-,domain=1:3] {.25*(x-3)^2+1} node [shift={(-20pt,40pt)},black] { $y=\frac14(x-3)^2+1$};
+                    \addplot [firstcurvestyle,-,domain=0:1] {x^2+1} node [shift={(-40pt,-15pt)},black] { $y=x^2+1$};
                     \addplot [firstcurvestyle,-,domain=0:3] {1} node [pos=.5,below,black] { $y=1$} (axis cs:3,1);
 
                     \end{axis}
@@ -1565,6 +1574,9 @@
                 $area = $area1 + $area2;
               </pg-code> -->
               <statement>
+                <p>
+                  Bounded by <m>y=\sqrt{x}</m>, <m>y=-2x+3</m>, and <m>y=-\frac12 x</m>.
+                </p>
 
               <!-- START figures/fig_07_01_ex_19.tex -->
                   <image xml:id="img_07_01_ex_19">
@@ -1581,9 +1593,9 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates { (0,0)(0.02,0.1414)(0.04,0.2)(0.06,0.2449)(0.08,0.2828)(0.1,0.3162)(0.2,0.4472)(0.3,0.5477)(0.4,0.6325)(0.5,0.7071)(0.6,0.7746)(0.7,0.8367)(0.8,0.8944)(0.9,0.9487)(1.,1.)(2,-1)(0,0)};
 
-                    \addplot [firstcurvestyle,-,domain=0:1,samples=60] {sqrt(x)} node [shift={(-25pt,-3pt)} ,black] { $y=\sqrt{x}$};
-                    \addplot [firstcurvestyle,-,domain=0:2] {-.5*x} node [pos=.3,shift={(5pt,-20pt)},black] { $y=-\frac12x$};
-                    \addplot [firstcurvestyle,-,domain=1:2] {-2*x+3} node [pos=.5,shift={(20pt,15pt)},black] { $y=-2x+3$};
+                    \addplot [firstcurvestyle,-,domain=0:1,samples=60] {sqrt(x)} node [shift={(-40pt,-10pt)} ,black] { $y=\sqrt{x}$};
+                    \addplot [firstcurvestyle,-,domain=0:2] {-.5*x} node [pos=.3,shift={(5pt,-25pt)},black] { $y=-\frac12x$};
+                    \addplot [firstcurvestyle,-,domain=1:2] {-2*x+3} node [pos=.5,shift={(25pt,25pt)},black] { $y=-2x+3$};
 
                     \end{axis}
 
@@ -1619,6 +1631,9 @@
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
               </pg-code> -->
               <statement>
+                <p>
+                  Between the curves <m>y=x+2</m> and <m>y=x^2</m>.
+                </p>
 
               <!-- START figures/fig_07_01_ex_20.tex -->
                   <image xml:id="img_07_01_ex_20">
@@ -1635,8 +1650,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates { (-1.,1.)(-0.9,0.81)(-0.8,0.64)(-0.7,0.49)(-0.6,0.36)(-0.5,0.25)(-0.4,0.16)(-0.3,0.09)(-0.2,0.04)(-0.1,0.01)(0,0)(0.1,0.01)(0.2,0.04)(0.3,0.09)(0.4,0.16)(0.5,0.25)(0.6,0.36)(0.7,0.49)(0.8,0.64)(0.9,0.81)(1.,1.)(1.1,1.21)(1.2,1.44)(1.3,1.69)(1.4,1.96)(1.5,2.25)(1.6,2.56)(1.7,2.89)(1.8,3.24)(1.9,3.61)(2.,4.)(-1,1)};
 
-                    \addplot [firstcurvestyle,-,domain=-1:2] {x^2} node [shift={(0pt,-40pt)} ,black] { $y=x^2$};
-                    \addplot [firstcurvestyle,-,domain=-1:2] {x+2} node [pos=.5,shift={(10pt,25pt)},black] { $y=x+2$} (axis cs:-1,1);
+                    \addplot [firstcurvestyle,-,domain=-1:2] {x^2} node [shift={(0pt,-60pt)} ,black] { $y=x^2$};
+                    \addplot [firstcurvestyle,-,domain=-1:2] {x+2} node [pos=.5,shift={(10pt,35pt)},black] { $y=x+2$} (axis cs:-1,1);
 
                     \end{axis}
 
@@ -1679,6 +1694,9 @@
                 $area = $area1 + $area2;
               </pg-code> -->
               <statement>
+                <p>
+                  Between the curves <m>x=-\frac12 y+1</m> and <m>x=\frac12 y^2</m>.
+                </p>
 
               <!-- START figures/fig_07_01_ex_21.tex -->
                   <image xml:id="img_07_01_ex_21">
@@ -1695,8 +1713,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates {(2.,-2.)(1.805,-1.9)(1.62,-1.8)(1.445,-1.7)(1.28,-1.6)(1.125,-1.5)(0.98,-1.4)(0.845,-1.3)(0.72,-1.2)(0.605,-1.1)(0.5,-1.)(0.405,-0.9)(0.32,-0.8)(0.245,-0.7)(0.18,-0.6)(0.125,-0.5)(0.08,-0.4)(0.045,-0.3)(0.02,-0.2)(0.005,-0.1)(0,0)(0.005,0.1)(0.02,0.2)(0.045,0.3)(0.08,0.4)(0.125,0.5)(0.18,0.6)(0.245,0.7)(0.32,0.8)(0.405,0.9)(0.5,1.)(2,-2)};
 
-                    \addplot [firstcurvestyle,-,domain=-2:1] ({.5*x^2},x) node [shift={(5pt,-100pt)},black] { $x=\frac12y^2$};
-                    \addplot [firstcurvestyle,-,domain=-2:1] ({-.5*x+1},x) node [pos=.85,shift={(30pt,0pt)},black] { $x=-\frac12y+1$};
+                    \addplot [firstcurvestyle,-,domain=-2:1] ({.5*x^2},x) node [shift={(5pt,-110pt)},black] { $x=\frac12y^2$};
+                    \addplot [firstcurvestyle,-,domain=-2:1] ({-.5*x+1},x) node [pos=.85,shift={(40pt,0pt)},black] { $x=-\frac12y+1$};
 
                     \end{axis}
 
@@ -1739,6 +1757,10 @@
                 $area = $area1 + $area2;
               </pg-code> -->
               <statement>
+                <p>
+                  Bounded by <m>y=x^{1/3}</m>, <m>y=\sqrt{x-1/2}</m>,
+                  <m>y=0</m>, and <m>x=1</m>.
+                </p>
 
               <!-- START figures/fig_07_01_ex_22.tex -->
                   <image xml:id="img_07_01_ex_22">
@@ -1754,8 +1776,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates { (0,0)(0.01,0.2154)(0.02,0.2714)(0.03,0.3107)(0.04,0.342)(0.05,0.3684)(0.06,0.3915)(0.07,0.4121)(0.08,0.4309)(0.09,0.4481)(0.1,0.4642)(0.12,0.4932)(0.14,0.5192)(0.16,0.5429)(0.18,0.5646)(0.2,0.5848)(0.22,0.6037)(0.24,0.6214)(0.26,0.6383)(0.28,0.6542)(0.3,0.6694)(0.4,0.7368)(0.5,0.7937)(0.6,0.8434)(0.7,0.8879)(0.8,0.9283)(0.9,0.9655)(1.,1.)(1.,0.7071)(0.9,0.6325)(0.8,0.5477)(0.7,0.4472)(0.6,0.3162)(0.59,0.3)(0.58,0.2828)(0.57,0.2646)(0.56,0.2449)(0.55,0.2236)(0.54,0.2)(0.53,0.1732)(0.52,0.1414)(0.51,0.1)(0.5,0)(0,0)};
 
-                    \addplot [firstcurvestyle,-,domain=0:1] (x^3,x) node [shift={(-25pt,0pt)},black] { $y=x^{1/3}$};
-                    \addplot [firstcurvestyle,-,domain=0:.7071] ({(x)^2+.5},x) node [shift={(-20pt,-45pt)},black] { $y=\sqrt{x-1/2}$};
+                    \addplot [firstcurvestyle,-,domain=0:1] (x^3,x) node [shift={(-40pt,0pt)},black] { $y=x^{1/3}$};
+                    \addplot [firstcurvestyle,-,domain=0:.7071] ({(x)^2+.5},x) node [shift={(-20pt,-50pt)},black] { $y=\sqrt{x-1/2}$};
 
                     \end{axis}
 
@@ -1780,6 +1802,10 @@
 
         <exercise>
           <statement>
+            <p>
+              Bounded by the curves <m>y=\sqrt{x}+1</m>, <m>y=\sqrt{2-x}+1</m>,
+              and <m>y=1</m>.
+            </p>
           <image xml:id="img_07_01_ex_31">
             <description></description>
             <latex-image>
@@ -1793,12 +1819,12 @@
                  ]
 
                 \addplot [name path=A,firstcurvestyle,-,domain=0:1,samples=40] {1};
-                \addplot [name path=B,firstcurvestyle,-,domain=0:1,samples=40] ({x^2},{x+1}) node [pos=.8,above left,black] { $y=\sqrt{x}+1$};
+                \addplot [name path=B,firstcurvestyle,-,domain=0:1,samples=40] ({x^2},{x+1}) node [pos=.85,above left,black] { $y=\sqrt{x}+1$};
 
                 \addplot [firstcurvestyle,areastyle] fill between [of=A and B];
 
                 \addplot [name path=C,firstcurvestyle,-,domain=1:2,samples=2] {1};
-                \addplot [name path=D,firstcurvestyle,-,domain=0:1,samples=40] ({-x^2+2},{x+1}) node [pos=.8,above right,black] { $y=\sqrt{2-x}+1$};
+                \addplot [name path=D,firstcurvestyle,-,domain=0:1,samples=40] ({-x^2+2},{x+1}) node [pos=.9,above right,black] { $y=\sqrt{2-x}+1$};
 
                 \addplot [firstcurvestyle,areastyle] fill between [of=C and D];
 

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -535,11 +535,12 @@
                   (-1,35) node [left] { 35} -- (1,35);
 
             \draw (2,12) -- (4,12) (2,35) -- (4,35)
-                  (3,12) -- node [pos=.5,fill=white,rotate=90] { $35-y_i$} (3,35);
+                  (3,12) -- node [pos=2,rotate=90] { $35-y_i$} (3,18)
+                  (3,29) -- (3,35);
 
             \begin{scope}[xscale=4,shift={(4.5,0)}]
 
-              \draw (0,30) -- node [pos=.5,above] { $10$} (2.9,29.22);
+              \draw (0,30) -- node [pos=.5,above,shift={(-4pt,-1pt)}] { $10$} (2.9,29.22);
               \draw [thick] (3,30) --(3,0) arc (0:-180:3) -- (-3,30);
               \draw [thick](0,30) circle (3);
               \draw [thick,dashed] (3,0) arc (0:180:3);
@@ -550,7 +551,7 @@
                 \draw [dashed] (3,\y) arc (0:180:3);
               }
 
-              \draw (5.6,14) node { $\left.\rule{0pt}{.3cm}\right\}\Delta y_i$};
+              \draw (5.9,14) node { $\left.\rule{0pt}{.3cm}\right\}\Delta y_i$};
               \draw [left color=firstcolor,right color=firstcolor!15,thick] (0,16) circle (3);
               \draw [left color=firstcolor,right color=firstcolor!15,thick] (-3,16) -- (-3,12)  arc (180:360:3) -- (3,16) arc (360:180:3);
 
@@ -643,17 +644,18 @@
               (-1,35) node [left] { 35} -- (1,35)
               (-1,14) node [left] { $y$} -- (1,14);
 
-        \draw (2,14) -- (4,14) (2,35)--(4,35)
-			        (3,14) -- node [pos=.5,fill=white,rotate=90] { $35-y$} (3,35);
+        \draw (2,12) -- (4,12) (2,35) -- (4,35)
+              (3,12) -- node [pos=2,rotate=90] { $35-y_i$} (3,18)
+              (3,29) -- (3,35);
 
         \begin{scope}[xscale=4,shift={(4.5,0)}]
 
-          \draw (0,30) -- node [pos=.5,above] { $10$} (2.9,29.22);
+          \draw (0,30) -- node [pos=.5,above,shift={(-4pt,-1pt)}] { $10$} (2.9,29.22);
           \draw [thick] (3,30) --(3,0) arc (0:-180:3) -- (-3,30);
           \draw [thick] (0,30) circle (3);
           \draw [thick,dashed] (3,0) arc (0:180:3);
           \draw [left color=firstcolor,right color=firstcolor!15,thick,draw=firstcolor] (0,14) circle (3);
-          \draw [-&gt;] (5.75,16) node [above] { $V(y)=100\pi dy$} -- (2,14);
+          \draw [-&gt;] (4,16) node [above] { $V(y)=100\pi dy$} -- (2,14);
 
         \end{scope}
 
@@ -710,16 +712,17 @@
                   (-1,35) node [left] { 3} -- (1,35)
                   (-1,14) node [left] { $y$} -- (1,14);
 
-            \draw (2,14) -- (4,14)  (2,35)--(4,35)
-		            	(3,14) -- node [pos=.5,fill=white,rotate=90] { $3-y$} (3,35);
+                  \draw (2,12) -- (4,12) (2,35) -- (4,35)
+                        (3,12) -- node [pos=2,rotate=90] { $35-y_i$} (3,18)
+                        (3,29) -- (3,35);
 
-            \begin{scope}[xscale=4,shift={(4.5,0)}]
+            \begin{scope}[xscale=4,shift={(5,0)}]
 
-              \draw (0,30) -- node [pos=.5,above] { $2$} (2.9,29.22);
+              \draw (0,30) -- node [pos=.5,above,shift={(-4pt,-1pt)}] { $2$} (2.9,29.22);
               \draw [thick](3,30) -- (0,0) -- (-3,30);
               \draw [thick] (0,30) circle (3);
               \draw [left color=firstcolor,right color=firstcolor!15,thick,draw=firstcolor] (0,14) circle (1.4);
-              \draw [-&gt;] (3.4,6) node [below,shift={(10pt,0pt)}] { $V(y)=\pi(\frac y5+2)^2 dy$} -- (0,14);
+              \draw [-&gt;] (5,6.5) node [below,shift={(10pt,0pt)}] { $V(y)=\pi(\frac y5+2)^2 dy$} -- (0,14);
 
             \end{scope}
 
@@ -770,7 +773,7 @@
         <figure xml:id="fig_pump3">
           <caption>The cross-section of a swimming pool filled with water in <xref ref="ex_pump3">Example</xref></caption>
           <!-- START figures/fig_pump4.tex -->
-          <image xml:id="img_pump3">
+          <image xml:id="img_pump3" width="47%">
             <description></description>
             <latex-image>
 
@@ -796,7 +799,7 @@
         <figure xml:id="fig_pump_3a">
           <caption>Orienting the pool and showing differential elements for <xref ref="ex_pump3">Example</xref></caption>
           <!-- START figures/fig_pump4b.tex -->
-          <image xml:id="img_pump3a">
+          <image xml:id="img_pump3a" width="47%">
             <description></description>
             <latex-image>
 
@@ -1440,7 +1443,7 @@
             find the work performed in pumping all the oil from the tank to a point <quantity><mag>3</mag><unit base="foot"/></quantity> above the top of the tank.
           </p>
 
-            <image xml:id="img_pump4b" width="90%">
+            <image xml:id="img_pump4b" width="47%">
               <description></description>
               <latex-image>
 
@@ -1535,7 +1538,7 @@
             Find the work performed in pumping all water to a point <quantity><mag>1</mag><unit base="foot"/></quantity> above the top of the tank.
           </p>
 
-            <image xml:id="img_pump4bX" width="90%">
+            <image xml:id="img_pump4bX" width="47%">
               <description></description>
               <latex-image>
 
@@ -1576,7 +1579,7 @@
             Find the work performed in pumping all water to a point <quantity><mag>5</mag><unit base="meter"/></quantity> above the top of the tank.
           </p>
 
-          <image xml:id="img_pump4bX1" width="90%">
+          <image xml:id="img_pump4bX1" width="47%">
             <description></description>
             <latex-image>
 
@@ -1614,7 +1617,7 @@
             Find the work performed in pumping all water to a point <quantity><mag>1</mag><unit base="meter"/></quantity> above the top of the tank.
           </p>
 
-          <image xml:id="img_pump4bX2" width="90%">
+          <image xml:id="img_pump4bX2" width="47%">
             <description></description>
             <latex-image>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pretextbook == 1.0.1


### PR DESCRIPTION
Addresses issues noted in #166:

- one of the axis labels in an image in `sec-work` was being cropped. My fix here is crude: move the image to the left of the axis. If someone can think of a better way to avoid cropping, I'm happy to make that change
- a triangle in `sec-ABC` was not actually a triangle. It is now.

Also fixed:

- two more images in `sec-work` did not render nicely: the radius length at the top of the cylinder collided with the circle, and the label along the axis was in a box with a white fill that shows up when the solution gets its light pink background. They look a bit better now, IMO
- several images needed smaller widths

In addition, because it didn't seem like it needed its own PR: I changed the `.gitignore` so that the `requirements.txt` file used by the CLI is committed. (This indicates what version of the CLI was most recently used to build the book.)