### PR TITLE
update publication files to use separate webwork courses for colour/print

### DIFF
--- a/publication/publication-novid-print.ptx
+++ b/publication/publication-novid-print.ptx
@@ -8,7 +8,7 @@
         <version include="print taypoly-late"/>
     </source>
 
-    <webwork server="https://webwork-dev.uleth.ca"/>
+    <webwork server="https://webwork-dev.uleth.ca" course="apex-print"/>
 
     <common>
       <tableofcontents level="3"/>

--- a/publication/publication-novid-print.ptx
+++ b/publication/publication-novid-print.ptx
@@ -4,7 +4,7 @@
 
     <!-- Relative path, relative to "main" source file -->
     <source>
-        <directories external="../assets" generated="../generated-assets"/>
+        <directories external="../assets" generated="../generated-assets-print"/>
         <version include="print taypoly-late"/>
     </source>
 

--- a/publication/publication-novid.ptx
+++ b/publication/publication-novid.ptx
@@ -8,7 +8,7 @@
         <version include="color taypoly-late"/>
     </source>
 
-    <webwork server="https://webwork-dev.uleth.ca"/>
+    <webwork server="https://webwork-dev.uleth.ca" course="apex-main"/>
 
     <common>
       <tableofcontents level="3"/>

--- a/publication/publication-print.ptx
+++ b/publication/publication-print.ptx
@@ -8,7 +8,7 @@
         <version include="print video taypoly-late"/>
     </source>
 
-    <webwork server="https://webwork-dev.uleth.ca"/>
+    <webwork server="https://webwork-dev.uleth.ca" course="apex-print"/>
 
     <common>
       <tableofcontents level="3"/>

--- a/publication/publication-print.ptx
+++ b/publication/publication-print.ptx
@@ -4,7 +4,7 @@
 
     <!-- Relative path, relative to "main" source file -->
     <source>
-        <directories external="../assets" generated="../generated-assets"/>
+        <directories external="../assets" generated="../generated-assets-print"/>
         <version include="print video taypoly-late"/>
     </source>
 

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -8,7 +8,7 @@
         <version include="color video taypoly-late"/>
     </source>
 
-    <webwork server="https://webwork-dev.uleth.ca"/>
+    <webwork server="https://webwork-dev.uleth.ca" course="apex-main"/>
 
     <common>
       <tableofcontents level="3"/>


### PR DESCRIPTION
When WeBWorK images are generated, the TikZ settings come from the APEX.pl file rather than the publisher file or docinfo.

So if you are trying to produce a print version, the webwork server will not give you black and white images.

I've set up two different courses on my webwork server; one uses colour and the other does not.
This updates the publication files to select one course or the other, depending on what you want the images to look like.