### PR TITLE
Remaining edits

### DIFF
--- a/ptx/chapter_mult_int.ptx
+++ b/ptx/chapter_mult_int.ptx
@@ -5,7 +5,7 @@
   <title>Multiple Integration</title>
   <introduction>
     <p>
-      The <xref ref="chapter_multi">Chapter</xref> introduced multivariable functions and we applied concepts of differential calculus to these functions.
+      <xref ref="chapter_multi">Chapter</xref> introduced multivariable functions and we applied concepts of differential calculus to these functions.
       We learned how we can view a function of two variables as a surface in space,
       and learned how partial derivatives convey information about how the surface is changing in any direction.
     </p>

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -325,6 +325,7 @@
     <p xml:id="vidint_int_FTC_proof" component="video">
       As its name suggests, the Fundamental Theorem of Calculus is an important result.
       In fact, it's sufficiently important that it's worth taking a moment to understand why it's true.
+      A proof is given in <xref ref="vid_int_FTC_proof"/>.
     </p>
 
     <figure xml:id="vid_int_FTC_proof" component="video">
@@ -951,7 +952,7 @@
     <p xml:id="vidint_int_FTC_ex_5" component="video">
       One of the things we have to be careful about when finding the area between curves is that the curves might cross,
       so that the distinction between <q>upper curve</q> and <q>lower curve</q> can change.
-      The following video example illustrates this phenomenon.
+      The video example in <xref ref="vid_int_FTC_ex_5"/> illustrates this phenomenon.
     </p>
 
     <figure xml:id="vid_int_FTC_ex_5" component="video">

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <section xml:id="sec_Graphical_Numerical">
   <title>Graphical and Numerical Solutions to Differential Equations</title>
   <introduction>

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <section xml:id="sec_Linear">
   <title>First Order Linear Differential Equations</title>
   <introduction>

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <section xml:id="sec_Modeling">
   <title>Modeling with Differential Equations</title>
   <introduction>

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <section xml:id="sec_Separable">
   <title>Separable Differential Equations</title>
   <introduction>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -144,7 +144,7 @@
 
     <p xml:id="vidint-deriv_basic_rules_exp_func" component="video">
       <xref ref="thm_deriv_common"/> states that the natural exponential function has a remarkable propery:
-      it is equal to its own derivative! The following video explains why this is the case.
+      it is equal to its own derivative! The video in <xref ref="vid_deriv_basic_rules_exp_func"/> explains why this is the case.
     </p>
 
     <figure xml:id="vid_deriv_basic_rules_exp_func" component="video">
@@ -312,7 +312,7 @@
       While we will be mainly focused on <em>using</em> these rules,
       it can also be interesting to see where they come from.
       Fortunately, it is not too difficult to establish these rules using the definition of the derivative.
-      The video below shows why the sum rule is true.
+      The video in <xref ref="vid_deriv_basic_rules_proofs"/> shows why the sum rule is true.
     </p>
 
     <figure xml:id="vid_deriv_basic_rules_proofs" component="video">

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -935,7 +935,7 @@
       without logarithmic differentiation.
       But the method is also useful in cases where the product and quotient rules could be used,
       but logarithmic differentiation is simpler.
-      The following video provides such an example.
+      The video in <xref ref="vid_deriv_impl_ex_5"/> provides such an example.
     </p>
 
     <figure xml:id="vid_deriv_impl_ex_5" component="video">

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -473,7 +473,7 @@
       but this is actually not necessary.
       One can in fact prove that a function has to be continuous at any point where it is differentiable.
       Or, in other words, a function cannot be differentiable at a point of discontinuity.
-      This is explained in the following video.
+      This is explained in the video in <xref ref="vid_deriv_intro_diff_imp_cont"/>.
     </p>
 
     <figure xml:id="vid_deriv_intro_diff_imp_cont" component="video">
@@ -958,7 +958,7 @@
         <p xml:id="vidint_deriv_intro_deriv_cos" component="video">
           Using similar techniques, we can show that the derivative of <m>\cos(x)</m>
           is <m>-\sin(x)</m>. See if you can show this yourself; if you get stuck,
-          you can check out the next video.
+          you can check out the video in <xref ref="vid_deriv_intro_deriv_cos"/>.
         </p>
 
         <figure xml:id="vid_deriv_intro_deriv_cos" component="video">
@@ -1244,7 +1244,7 @@
 
     <p xml:id="vidint_deriv_intro_ex_2" component="video">
       For one more example involving piecewise-defined functions,
-      we turn to the following video.
+      we turn to the video in <xref ref="vid_deriv_intro_ex_2"/>.
     </p>
 
     <figure xml:id="vid_deriv_intro_ex_2" component="video">

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -55,7 +55,7 @@
 
   <p xml:id="vidint_derive_inverse_examples" component="video">
     For a refresher on how to determine the inverse of a given function,
-    watch the following video.
+    watch the video in <xref ref="vid_deriv_inverse_examples"/>.
   </p>
 
   <figure xml:id="vid_deriv_inverse_examples" component="video">
@@ -265,7 +265,7 @@
     To make sense of this, we employ a technique known as <em>restriction of domain</em>:
     instead of considering the entire domain of the sine function,
     we consider a portion of it, on which the function is one-to-one,
-    as explained in the following video.
+    as explained in <xref ref="vid_deriv_inverse_restrict_domain"/>.
   </p>
 
   <figure xml:id="vid_deriv_inverse_restrict_domain" component="video">

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -267,7 +267,7 @@
   <p xml:id="vidint_deriv_prod_quite_ex_4_func" component="video">
     Now that we have the hang of the product rule pattern,
     it's not much more difficult to move on to products of four or more functions,
-    as the following video demonstrates.
+    as the video in <xref ref="vid_deriv_prod_quot_ex_4_func"/> demonstrates.
   </p>
   <figure xml:id="vid_deriv_prod_quot_ex_4_func" component="video">
     <caption>Taking the derivative of a product of four functions</caption>

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -300,7 +300,7 @@
     When students first encounter differentials,
     they are often left wondering why <m>dy</m> and <m>\Delta y</m> are different,
     while <m>dx</m> and <m>\Delta x</m> are the same.
-    This next video attempts to offer an explanation.
+    The video in <xref ref="vid_deriv_apps_diff_dx_eq_delta_x"/> attempts to offer an explanation.
   </p>
 
   <figure xml:id="vid_deriv_apps_diff_dx_eq_delta_x" component="video">

--- a/ptx/sec_fluid_force.ptx
+++ b/ptx/sec_fluid_force.ptx
@@ -775,13 +775,13 @@
     allowing us to take a limit and find the exact answer through a definite integral.
   </p>
 
-  <p>
+  <!-- <p>
     The next chapter addresses an entirely different topic:
     sequences and series.
     In short, a sequence is a list of numbers,
     where a series is the summation of a list of numbers.
     These seemingly-simple ideas lead to very powerful mathematics.
-  </p>
+  </p> -->
 
   <exercises>
     <subexercises>

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -239,7 +239,7 @@
     Rolle's Theorem is presented here as a stepping stone toward the Mean Value Theorem,
     but it's a useful result in its own right.
     It often turns up as a tool in mathematical problem solving.
-    The following video illustrates one such use of Rolle's Theorem.
+    The video in <xref ref="vid_graphs_MVT_ex_1"/> illustrates one such use of Rolle's Theorem.
   </p>
 
   <figure xml:id="vid_graphs_MVT_ex_1" component="video">

--- a/ptx/sec_greensthm.ptx
+++ b/ptx/sec_greensthm.ptx
@@ -877,7 +877,7 @@
     <p xml:id="vidint-veccalc-greens-proof" component="video">
       Since Green's Theorem is an important result,
       it's worth taking a minute (or 12) to see why it's true,
-      in the following video.
+      in the video in <xref ref+"vid-veccalc-greens-proof"/>.
     </p>
 
     <figure xml:id="vid-veccalc-greens-proof" component="video">
@@ -976,7 +976,7 @@
       (as opposed to simply-connected).
       If a bounded region has a <q>hole</q>, its boundary will consist of more than one curve:
       the outer boundary, as well as the boundary of the hole.
-      Green's Theorem applies in this situation as well, as the following video explains.
+      Green's Theorem applies in this situation as well, as the video in <xref ref="vid-veccalc-greens-multiply"/> explains.
     </p>
 
     <figure xml:id="vid-veccalc-greens-multiply" component="video">

--- a/ptx/sec_greensthm.ptx
+++ b/ptx/sec_greensthm.ptx
@@ -877,7 +877,7 @@
     <p xml:id="vidint-veccalc-greens-proof" component="video">
       Since Green's Theorem is an important result,
       it's worth taking a minute (or 12) to see why it's true,
-      in the video in <xref ref+"vid-veccalc-greens-proof"/>.
+      in the video in <xref ref="vid-veccalc-greens-proof"/>.
     </p>
 
     <figure xml:id="vid-veccalc-greens-proof" component="video">

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -984,7 +984,7 @@
 
     <p xml:id="vidint-hyperbolic-int-hypsub" component="video">
       Hyperbolic functions can be used as an alternative to trigonometric substitution,
-      as illustrated in the following video.
+      as illustrated in <xref ref="vid-hyperbolic-int-hypsub"/>.
     </p>
 
     <figure xml:id="vid-hyperbolic-int-hypsub" component="video">

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -535,7 +535,7 @@
 
   <p xml:id="vidint_limit_analytic_lim_sin_props" component="video">
     The Squeeze Theorem can be used to show that limits of <m>\sin(x)</m>
-    can be done by direct substitution, as the following videos illustrate.
+    can be done by direct substitution, as the videos in <xref ref="vid_limit_analytic_lim_sin_0"/> illustrate.
   </p>
 
   <figure xml:id="vid_limit_analytic_lim_sin_0" component="video">
@@ -699,7 +699,8 @@
 
   <p xml:id="vidint_limit_analytic_trig_lim" component="video">
     With the limit <m>\lim\limits_{\theta\to 0} \frac{\sin(\theta)}{\theta}=1</m> finally established,
-    we can move on to other limits involving trigonometric functions, as the following video demonstrates.
+    we can move on to other limits involving trigonometric functions,
+    as the video in <xref ref="vid_limit_analytic_trig_lim"/> demonstrates.
   </p>
 
   <figure xml:id="vid_limit_analytic_trig_lim" component="video">

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -631,7 +631,7 @@
   </theorem>
 
   <p xml:id="vidint_limit_con_using_prop" component="video">
-    As the following video example illustrates,
+    As the video example in <xref ref="vid_limit_con_using_prop"/> illustrates,
     the above theorems allow us to quickly construct new continuous functions from old ones.
   </p>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -664,7 +664,7 @@
     </example>
 
     <p xml:id="vidint_limit_at_inf_ex_using_defn" component="video">
-      The following video shows how to prove the result from <xref ref="ex_hzasy1"/> using the limit definition.
+      The video in <xref ref="vid_limit_at_inf_ex_using_defn"/> shows how to prove the result from <xref ref="ex_hzasy1"/> using the limit definition.
     </p>
 
     <figure xml:id="vid_limit_at_inf_ex_using_defn" component="video">
@@ -1099,7 +1099,7 @@
     </example>
 
     <p xml:id="vidint_limit_at_inf_ex_rad" component="video">
-      The following video provides another example similar to <xref ref="ex_hzasy4"/>.
+      The video in <xref ref="vid_limit_at_inf_ex_rad"/> provides another example similar to <xref ref="ex_hzasy4"/>.
     </p>
     <figure xml:id="vid_limit_at_inf_ex_rad" component="video">
       <caption>Limits at infinity with a radical function</caption>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -1185,7 +1185,7 @@
       (where the <m>x</m>-axis would represent <m>h</m> values and the
       <m>y</m>-axis would represent values of the difference quotient)
       we settle for making a table.
-      See <xref ref="table_diff_quot_smallh">Figure</xref>.
+      See <xref ref="table_diff_quot_smallh"/>.
       The table gives us reason to assume the value of the limit is about <m>8.5</m>.
     </p>
 

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -326,7 +326,7 @@
 
         <p>
           It is useful to write out the endpoints of the subintervals in a table;
-          in <xref ref="fig_num2a">Figure</xref>,
+          in <xref ref="fig_num2a"/>,
           we give the exact values of the endpoints,
           their decimal approximations,
           and decimal approximations of
@@ -633,7 +633,7 @@
       <solution>
         <p>
           To compute the areas of the 5 trapezoids in <xref ref="fig_num3a">Figure</xref>,
-          it will again be useful to create a table of values as shown in <xref ref="fig_num3b">Figure</xref>.
+          it will again be useful to create a table of values as shown in <xref ref="fig_num3b"/>.
         </p>
 
         <table xml:id="fig_num3b">
@@ -752,7 +752,7 @@
       </statement>
       <solution>
         <p>
-          We refer back to <xref ref="fig_num2a">Figure</xref>
+          We refer back to <xref ref="fig_num2a"/>
           for the table of values of <m>\sin(x^3)</m>.
           Recall that <m>\dx = 3\pi/40 \approx 0.236</m>.
           Thus we have:
@@ -1220,7 +1220,7 @@
       <solution>
         <p>
           We begin by making a table of values as we have in the past,
-          as shown in <xref ref="fig_num5a">Figure</xref>.
+          as shown in <xref ref="fig_num5a"/>.
         </p>
 
         <figure xml:id="fig_num5">
@@ -1340,7 +1340,7 @@
       </statement>
       <solution>
         <p>
-          <xref ref="fig_num6a">Figure</xref>
+          <xref ref="fig_num6a"/>
           shows the table of values that we used in the past for this problem,
           shown here again for convenience.
           Again, <m>\dx = (\pi/2+\pi/4)/10 \approx 0.236</m>.
@@ -1860,7 +1860,7 @@
       <statement>
         <p>
           One of the authors drove his daughter home from school while she recorded their speed every 30 seconds.
-          The data is given in <xref ref="fig_num8">Figure</xref>.
+          The data is given in <xref ref="fig_num8"/>.
           Approximate the distance they traveled.
         </p>
         <table xml:id="fig_num8">

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -669,7 +669,7 @@
 
   <p xml:id="vidint_deriv_apps_opt_box_no_top" component="video">
     Before you begin the exercises, here is one more example,
-    presented in video form.
+    presented in video form in <xref ref="vid_deriv_apps_opt_box_no_top"/>.
   </p>
 
   <figure xml:id="vid_deriv_apps_opt_box_no_top" component="video">

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -95,9 +95,9 @@
       </p>
 
       <p xml:id="vidint_deriv_apps_rel_rates_circ_area" component="video">
-        This problem was relatively straighforward,
+        This problem was relatively straightforward,
         owing to the linear relationship between radius and circumference.
-        The next video explores what would happen if we had instead been asked for the rate at which the area is changing.
+        The video in <xref ref="vid_deriv_apps_rel_rates_circ_area"/> explores what would happen if we had instead been asked for the rate at which the area is changing.
       </p>
 
       <figure xml:id="vid_deriv_apps_rel_rates_circ_area" component="video">

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -716,7 +716,8 @@
     </p>
 
     <p xml:id="vidint-veccalc-surfint-examples" component="video">
-      The following videos present some additional examples involving surface integrals of vector fields.
+      The videos in <xref first="vid-veccalc-surfint-flux-cube" last="vid-veccalc-surfint-flux-sphere" text="custom">Figures</xref>
+      present some additional examples involving surface integrals of vector fields.
       Note that computing flux a cross a cube requires us to consider all six faces.
       This is a case where the Divergence Theorem can greatly simplify matters.
       For integrals over spheres, there are often simplifications possible,

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -716,7 +716,7 @@
     </p>
 
     <p xml:id="vidint-veccalc-surfint-examples" component="video">
-      The videos in <xref first="vid-veccalc-surfint-flux-cube" last="vid-veccalc-surfint-flux-sphere" text="custom">Figures</xref>
+      The videos in <xref first="vid-veccalc-surfint-flux-cube" last="vid-veccalc-surfint-flux-sphere"/>
       present some additional examples involving surface integrals of vector fields.
       Note that computing flux a cross a cube requires us to consider all six faces.
       This is a case where the Divergence Theorem can greatly simplify matters.

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -22,7 +22,7 @@
     <p>
       In <xref ref="fig_taypolyintroa_1">Figure</xref>,
       we see a function <m>y=f(x)</m> graphed.
-      The table in <xref ref="fig_taypolyintroa_2">Figure</xref>
+      The table in <xref ref="fig_taypolyintroa_2">Table</xref>
       shows that <m>f(0)=2</m> and <m>\fp(0) = 1</m>;
       therefore, the tangent line to <m>f</m> at <m>x=0</m> is
       <m>p_1(x) = 1(x-0)+2 = x+2</m>.
@@ -92,7 +92,7 @@
       it does not, for instance, match the concavity of <m>f</m>.
       We can find a polynomial, <m>p_2(x)</m>,
       that does match the concavity near <m>0</m> without much difficulty, though.
-      The table in <xref ref="fig_taypolyintroa_2">Figure</xref>
+      The table in <xref ref="fig_taypolyintroa_2">Table</xref>
       gives the following information:
       <me>
         f(0) = 2 \qquad \fp(0) = 1\qquad \fp'(0) = 2
@@ -156,7 +156,7 @@
       first <m>n</m> derivatives of <m>f</m>.
       <xref ref="fig_taypolyintrob">Figure</xref>
       shows <m>p_4(x)= -x^4/2-x^3/6+x^2+x+2</m>,
-      whose first four derivatives at 0 match those of <m>f</m>. (Using the table in <xref ref="fig_taypolyintroa_2">Figure</xref>,
+      whose first four derivatives at 0 match those of <m>f</m>. (Using the table in <xref ref="fig_taypolyintroa_2">Table</xref>,
       start with <m>p_4^{(4)}(x)=-12</m> and solve the related initial-value problem.)
     </p>
 
@@ -253,7 +253,7 @@
       </p>
     </aside>
 
-    <figure xml:id="vid_deriv_apps_taylor_poly_determ_coeffs" component="video-taypoly-early">
+    <figure xml:id="vid_deriv_apps_taylor_poly_determ_coeffs" component="video">
       <caption>Determining the coefficients of a Taylor polynomial</caption>
       <video youtube="v8mPY7fu1e0"/>
     </figure>
@@ -416,7 +416,7 @@
                 We start with creating a table of the derivatives of <m>e^x</m>
                 evaluated at <m>x=0</m>.
                 In this particular case, this is relatively simple,
-                as shown in <xref ref="fig_taypoly1a">Figure</xref>.
+                as shown in <xref ref="fig_taypoly1a">Table</xref>.
               </p>
 
               <table xml:id="fig_taypoly1a">
@@ -546,7 +546,7 @@
                 evaluated at <m>x=1</m>.
                 While this is not as straightforward as it was in the previous
                 example, a pattern does emerge (for <m>n\ge 1</m>),
-                as shown in <xref ref="fig_taypoly2a">Figure</xref>.
+                as shown in <xref ref="fig_taypoly2a">Table</xref>.
 
                 Notice in the table below that each time we take a derivative
                 (starting at the second derivative),
@@ -1026,7 +1026,7 @@
           We now set out to compute <m>p_9(x)</m>.
           We again need a table of the derivatives of
           <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m>.
-          A table of these values is given in <xref ref="fig_taypoly4a">Figure</xref>.
+          A table of these values is given in <xref ref="fig_taypoly4a">Table</xref>.
         </p>
 
         <table xml:id="fig_taypoly4a">
@@ -1195,7 +1195,7 @@
             <li>
               <p>
                 We begin by evaluating the derivatives of <m>f</m> at <m>x=4</m>.
-                This is done in <xref ref="fig_taypoly5a">Figure</xref>.
+                This is done in <xref ref="fig_taypoly5a">Table</xref>.
               </p>
 
               <table xml:id="fig_taypoly5a">

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -565,22 +565,22 @@
                     <cell><m>f(1) = 0</m></cell>
                   </row>
                   <row>
-                    <cell><m>\fp(x) = 1/x</m></cell>
+                    <cell><m>\fp(x) = \frac{1}{x}</m></cell>
                     <cell><m>\Rightarrow</m></cell>
                     <cell><m>\fp(1) = 1</m></cell>
                   </row>
                   <row>
-                    <cell><m>\fp'(x) = -1/x^2</m></cell>
+                    <cell><m>\fp'(x) = -\frac{1}{x^2}</m></cell>
                     <cell><m>\Rightarrow</m></cell>
                     <cell><m>\fp'(1) = -1</m></cell>
                   </row>
                   <row>
-                    <cell><m>\fp''(x) = 2/x^3</m></cell>
+                    <cell><m>\fp''(x) = \frac{2}{x^3}</m></cell>
                     <cell><m>\Rightarrow</m></cell>
                     <cell><m>\fp''(1) = 2</m></cell>
                   </row>
                   <row>
-                    <cell><m>f^{(4)}(x) = -6/x^4</m></cell>
+                    <cell><m>f^{(4)}(x) = -\frac{6}{x^4}</m></cell>
                     <cell><m>\Rightarrow</m></cell>
                     <cell><m>f^{(4)}(1) = -6</m></cell>
                   </row>
@@ -595,9 +595,9 @@
                     <cell><m>f^{(n)}(1) =</m></cell>
                   </row>
                   <row>
-                    <cell><m>\ds \frac{(-1)^{n+1}(n-1)!}{x^n}</m></cell>
+                    <cell><m>\frac{(-1)^{n+1}(n-1)!}{x^n}</m></cell>
                     <cell></cell>
-                    <cell><m>(-1)^{n+1}(n-1)!</m></cell>
+                    <cell><m>\!\!(-1)^{n+1}(n-1)!</m></cell>
                   </row>
                 </tabular>
               </table>

--- a/ptx/sec_trigint.ptx
+++ b/ptx/sec_trigint.ptx
@@ -572,7 +572,7 @@
     <p xml:id="vidint-int-trig-ex-tan3sec3" component="video">
       When we have an odd power of <m>\tan(x)</m> (and <m>\sec(x)</m> to any power of at least one),
       we can split off a factor of <m>\tan(x)\sec(x)</m> and use the substitution <m>u=\sec(x)</m>,
-      as the following video illustrates.
+      as the video in <xref ref="vid-int-trig-ex-tan3sec3"/> illustrates.
     </p>
 
     <figure xml:id="vid-int-trig-ex-tan3sec3" component="video">
@@ -644,7 +644,7 @@
       are often among the more intimidating tasks for beginning calculus students.
       However, larger odd powers are best handled not by doing the integral directly,
       but by employing a <em>reduction forumula</em>.
-      The video below shows how to obtain a reduction formula for the integral of <m>\sec^{2k+1}(x)</m>;
+      The video in <xref ref="vid-int-trig-ex-secant-power-reduction"/> shows how to obtain a reduction formula for the integral of <m>\sec^{2k+1}(x)</m>;
       this formula allows us to express the integral in terms of an integral where the power of <m>\sec(x)</m>
       is reduced by two.
       <idx><h>reduction formula</h><h>trigonometric integral</h></idx>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pretextbook == 1.0.1
+pretextbook == 1.0.2


### PR DESCRIPTION
These are the last few changes that I made as I was getting this year's PDF ready for publication.

Main items:

- the files for the differential equations chapter were missing the xml identifier at the top
- a lot of xrefs were to figures that have now become tables, so those were changed
- in the video versions, there were a few places with language like, "in the following video" that doesn't work when the video is a figure in the margin for PDF. These have all been replaced with proper xrefs
- one table was adjusted to fit better
- some typos were corrected