### PR TITLE
typo

### DIFF
--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -186,7 +186,7 @@
               we find that
               <md>
                 <mrow>\lim_{x\to 2}(5f(x) + g(x)^2) \amp = \lim_{x\to 2}(5f(x))+\lim_{x\to 2}(g(x)^2)</mrow>
-                <mrow>\amp = 5\lim_{x\to 2}f(x) + \mathopen{}\left(\lim_{x\to 2}g(x)\right)\mathclose{}</mrow>
+                <mrow>\amp = 5\lim_{x\to 2}f(x) + \mathopen{}\left(\lim_{x\to 2}g(x)\right)^2\mathclose{}</mrow>
                 <mrow>\amp = 5\cdot 2 + 3^2 = 19</mrow>
               </md>.
             </p>


### PR DESCRIPTION
There was an exponent missing at one step in a solution.