### PR TITLE
Add labels to videos for Runestone

### DIFF
--- a/ptx/chapter_limits.ptx
+++ b/ptx/chapter_limits.ptx
@@ -16,7 +16,7 @@
     </p>
     <figure xml:id="vid_limit_intro_calc_overview" component="video">
       <caption>Overview of Calculus</caption>
-      <video youtube="37n0cZn6Lyc"/>
+      <video youtube="37n0cZn6Lyc" label="vid_limit_intro_calc_overview"/>
     </figure>
 
   </introduction>

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -9,7 +9,7 @@
 
   <figure xml:id="vid-intapp-area-intro" component="video">
     <caption>Video introduction to <xref ref="sec_ABC">Section</xref></caption>
-    <video youtube="HAWBGypgKoQ"/>
+    <video youtube="HAWBGypgKoQ" label="vid-intapp-area-intro"/>
   </figure>
 
   <p>
@@ -246,7 +246,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="qbhOWW70UyM" xml:id="vid-intapp-area-example1" component="video"/>
+      <video width="98%" youtube="qbhOWW70UyM" xml:id="vid-intapp-area-example1" label="vid-intapp-area-example1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -302,7 +302,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="4wap7fFasZk" xml:id="vid-intapp-area-example2" component="video"/>
+      <video width="98%" youtube="4wap7fFasZk" xml:id="vid-intapp-area-example2" label="vid-intapp-area-example2" component="video"/>
     </solution>
     <solution>
       <p>
@@ -381,7 +381,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="GhdqEHPbPm0" xml:id="vid-intapp-area-example3" component="video"/>
+      <video width="98%" youtube="GhdqEHPbPm0" xml:id="vid-intapp-area-example3" label="vid-intapp-area-example3" component="video"/>
     </solution>
     <solution>
       <p>
@@ -538,7 +538,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="tdFHE8cjDAY" xml:id="vid-intapp-area-example4" component="video"/>
+      <video width="98%" youtube="tdFHE8cjDAY" xml:id="vid-intapp-area-example4" label="vid-intapp-area-example4" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -6,7 +6,7 @@
 
     <figure xml:id="vid_int_FTC_intro" component="video">
       <caption>Video introduction to <xref ref="sec_FTC"/></caption>
-      <video youtube="8d3R9MSwKuk"/>
+      <video youtube="8d3R9MSwKuk" label="vid_int_FTC_intro"/>
     </figure>
 
     <p>
@@ -97,7 +97,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="zVyMghQRLcI" xml:id="vid_int_FTC_ex_1" component="video"/>
+        <video width="98%" youtube="zVyMghQRLcI" xml:id="vid_int_FTC_ex_1" label="vid_int_FTC_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -231,7 +231,7 @@
 
     <figure xml:id="vid_int_FTC_part_I" component="video">
       <caption>Video presentation of <xref ref="thm_FTC1"/></caption>
-      <video youtube="TE3kZRIso-Q"/>
+      <video youtube="TE3kZRIso-Q" label="vid_int_FTC_part_I"/>
     </figure>
 
 
@@ -249,7 +249,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="7tHmgPcUZG4" xml:id="vid_int_FTC_ex_2" component="video"/>
+        <video width="98%" youtube="7tHmgPcUZG4" xml:id="vid_int_FTC_ex_2" label="vid_int_FTC_ex_2" component="video"/>
       </solution>
       <solution>
 
@@ -325,7 +325,7 @@
 
     <figure xml:id="vid_int_FTC_part_II" component="video">
       <caption>Video presentation of <xref ref="thm_FTC2"/></caption>
-      <video youtube="jU_WUPjamFQ"/>
+      <video youtube="jU_WUPjamFQ" label="vid_int_FTC_part_II"/>
     </figure>
 
     <p xml:id="vidint_int_FTC_proof" component="video">
@@ -336,7 +336,7 @@
 
     <figure xml:id="vid_int_FTC_proof" component="video">
       <caption>Proving the Fundamental Theorem of Calculus</caption>
-      <video youtube="8doi_Al_lmg"/>
+      <video youtube="8doi_Al_lmg" label="vid_int_FTC_proof"/>
     </figure>
 
 
@@ -417,7 +417,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="FbansQszRDI LeYpAXQS5cI" xml:id="vid_int_FTC_ex_3" component="video"/>
+        <video width="98%" youtube="FbansQszRDI LeYpAXQS5cI" xml:id="vid_int_FTC_ex_3" label="vid_int_FTC_ex_3" component="video"/>
       </solution>
       <solution>
 
@@ -714,7 +714,7 @@
 
     <figure xml:id="vid_int_FTC_chain_rule_FTC" component="video">
       <caption>Video presentation of <xref ref="sec-FTC-chain"/> and <xref ref="ex_ftc11"/></caption>
-      <video youtube="fywjn8-evpE"/>
+      <video youtube="fywjn8-evpE" label="vid_int_FTC_chain_rule_FTC"/>
     </figure>
 
     <p>
@@ -762,7 +762,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="nGS4ENM8arI" xml:id="vid_int_FTC_examples_2" component="video"/>
+        <video width="98%" youtube="nGS4ENM8arI" xml:id="vid_int_FTC_examples_2" label="vid_int_FTC_examples_2" component="video"/>
       </solution>
       <solution>
 
@@ -782,7 +782,7 @@
     <title>Area Between Curves</title>
     <figure xml:id="vid_int_FTC_area_between_curves" component="video">
       <caption>Video introduction to <xref ref="sec-FTC-ABC"/></caption>
-      <video youtube="UufnFHBnv88"/>
+      <video youtube="UufnFHBnv88" label="vid_int_FTC_area_between_curves"/>
     </figure>
 
     <p>
@@ -901,7 +901,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="su2CXdpYPdo" xml:id="vid_int_FTC_ex_4" component="video"/>
+        <video width="98%" youtube="su2CXdpYPdo" xml:id="vid_int_FTC_ex_4" label="vid_int_FTC_ex_4" component="video"/>
       </solution>
       <solution>
 
@@ -972,7 +972,7 @@
 
     <figure xml:id="vid_int_FTC_ex_5" component="video">
       <caption>Finding the area between curves that intersect multiple times</caption>
-      <video youtube="Bgji1b7Wdr4"/>
+      <video youtube="Bgji1b7Wdr4" label="vid_int_FTC_ex_5"/>
     </figure>
 
   </subsection>
@@ -1146,7 +1146,7 @@
 
     <figure xml:id="vid_int_FTC_MVT_int" component="video">
       <caption>Video presentation of <xref ref="thm_mvt2"/></caption>
-      <video youtube="KD90CwK0PJk"/>
+      <video youtube="KD90CwK0PJk" label="vid_int_FTC_MVT_int"/>
     </figure>
 
 
@@ -1395,7 +1395,7 @@
 
     <figure xml:id="vid_int_FTC_avg_val" component="video">
       <caption>Video presentation of <xref ref="def_av_val"/></caption>
-      <video youtube="Gz9r9zF5asU"/>
+      <video youtube="Gz9r9zF5asU" label="vid_int_FTC_avg_val"/>
     </figure>
 
     <p>

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -15,7 +15,7 @@
     </p>
     <figure xml:id="vid-diffeq-basic-intro" component="video">
       <caption>Video introduction to <xref ref="sec_Graphical_Numerical">Section</xref></caption>
-      <video youtube="aevFioTbghg"/>
+      <video youtube="aevFioTbghg" label="vid-diffeq-basic-intro"/>
     </figure>
   </introduction>
   <subsection>
@@ -138,7 +138,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="PAn_TrwF27M" xml:id="vid-diffeq-basic-example1" component="video"/>
+        <video width="98%" youtube="PAn_TrwF27M" xml:id="vid-diffeq-basic-example1" label="vid-diffeq-basic-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -231,7 +231,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="ByArQF0qdH0" xml:id="vid-diffeq-basic-example2" component="video"/>
+        <video width="98%" youtube="ByArQF0qdH0" xml:id="vid-diffeq-basic-example2" label="vid-diffeq-basic-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -277,7 +277,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="bf_WyPauK0Y" xml:id="vid-diffeq-basic-verify" component="video"/>
+        <video width="98%" youtube="bf_WyPauK0Y" xml:id="vid-diffeq-basic-verify" label="vid-diffeq-basic-verify" component="video"/>
       </solution>
       <solution>
         <p>
@@ -357,7 +357,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="B0gxkvJf9oY" xml:id="vid-diffeq-basic-verify-implicit" component="video"/>
+        <video width="98%" youtube="B0gxkvJf9oY" xml:id="vid-diffeq-basic-verify-implicit" label="vid-diffeq-basic-verify-implicit" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -19,7 +19,7 @@
 
   <figure xml:id="vid-int-parts-intro" component="video">
     <caption>Video introduction to <xref ref="sec_IBP"/></caption>
-    <video youtube="v7KGuoM-cgU"/>
+    <video youtube="v7KGuoM-cgU" label="vid-int-parts-intro"/>
   </figure>
 
   <p>
@@ -106,7 +106,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="gKtzlaH2EPo" xml:id="vid-int-parts-ex-onestep" component="video"/>
+      <video width="98%" youtube="gKtzlaH2EPo" xml:id="vid-int-parts-ex-onestep" label="vid-int-parts-ex-onestep" component="video"/>
     </solution>
     <solution>
       <p>
@@ -306,7 +306,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="j9pCcQMSjbg" xml:id="vid-int-parts-ex-twostep" component="video"/>
+      <video width="98%" youtube="j9pCcQMSjbg" xml:id="vid-int-parts-ex-twostep" label="vid-int-parts-ex-twostep" component="video"/>
     </solution>
     <solution>
 
@@ -406,7 +406,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="z0A1v2Zkfns" xml:id="vid-int-parts-ex-exp-times-cos" component="video"/>
+      <video width="98%" youtube="z0A1v2Zkfns" xml:id="vid-int-parts-ex-exp-times-cos" label="vid-int-parts-ex-exp-times-cos" component="video"/>
     </solution>
     <solution>
       <p>
@@ -526,7 +526,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="NGkLj7djFSw" xml:id="vid-int-parts-ex-log" component="video"/>
+      <video width="98%" youtube="NGkLj7djFSw" xml:id="vid-int-parts-ex-log" label="vid-int-parts-ex-log" component="video"/>
     </solution>
     <solution>
       <p>
@@ -591,7 +591,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="md3-8bv5E5M" xml:id="vid-int-parts-ex-arctan" component="video"/>
+      <video width="98%" youtube="md3-8bv5E5M" xml:id="vid-int-parts-ex-arctan" label="vid-int-parts-ex-arctan" component="video"/>
     </solution>
     <solution>
       <p>
@@ -644,7 +644,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="0j0vM0nosYs" xml:id="vid-int-parts-ex-sub-first" component="video"/>
+        <video width="98%" youtube="0j0vM0nosYs" xml:id="vid-int-parts-ex-sub-first" label="vid-int-parts-ex-sub-first" component="video"/>
       </solution>
       <solution>
         <p>
@@ -708,7 +708,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="O9_0B2gatMo" xml:id="vid-int-parts-ex-definite" component="video"/>
+        <video width="98%" youtube="O9_0B2gatMo" xml:id="vid-int-parts-ex-definite" label="vid-int-parts-ex-definite" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -21,7 +21,7 @@
     </p>
     <figure xml:id="vid-diffeq-linear-intro" component="video">
       <caption>Introduction to <xref ref="sec_Linear"/>, and presentation of <xref ref="ex_identify_linear"/></caption>
-      <video youtube="aGk_H6jc5BE"/>
+      <video youtube="aGk_H6jc5BE" label="vid-diffeq-linear-intro"/>
     </figure>
   </introduction>
   <subsection>
@@ -170,7 +170,7 @@
 
     <figure xml:id="vid-diffeq-linear-general-solution" component="video">
       <caption>Using an integrating factor to solve a linear differential equation</caption>
-      <video youtube="f-Bea35N11g"/>
+      <video youtube="f-Bea35N11g" label="vid-diffeq-linear-general-solution"/>
     </figure>
     <p>
       Consider the first order linear equation
@@ -331,7 +331,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="fgeo61eY3qo" xml:id="vid-diffeq-linear-example1" component="video"/>
+        <video width="98%" youtube="fgeo61eY3qo" xml:id="vid-diffeq-linear-example1" label="vid-diffeq-linear-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -398,7 +398,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qB_aSFCQfcE" xml:id="vid-diffeq-linear-example2" component="video"/>
+        <video width="98%" youtube="qB_aSFCQfcE" xml:id="vid-diffeq-linear-example2" label="vid-diffeq-linear-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -444,7 +444,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="XsFRAzdk7WI" xml:id="vid-diffeq-linear-example3" component="video"/>
+        <video width="98%" youtube="XsFRAzdk7WI" xml:id="vid-diffeq-linear-example3" label="vid-diffeq-linear-example3" component="video"/>
       </solution>
       <solution>
         <p>
@@ -557,7 +557,7 @@
 
     <figure xml:id="vid-diffeq-linear-falling-objects" component="video">
       <caption>Video presentation of <xref first="ex_falling_object" last="ex_falling_object1">Examples</xref></caption>
-      <video youtube="skI9GlhB3dc"/>
+      <video youtube="skI9GlhB3dc" label="vid-diffeq-linear-falling-objects"/>
     </figure>
 
     <example xml:id="ex_falling_object1">

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -85,7 +85,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="EC18tbH7SQw" xml:id="vid-diffeq-model-bacterial-growth" component="video"/>
+        <video width="98%" youtube="EC18tbH7SQw" xml:id="vid-diffeq-model-bacterial-growth" label="vid-diffeq-model-bacterial-growth" component="video"/>
       </solution>
       <solution>
         <p>
@@ -178,7 +178,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="tEMLcz1yvFI" xml:id="vid-diffeq-model-newton-cooling" component="video"/>
+        <video width="98%" youtube="tEMLcz1yvFI" xml:id="vid-diffeq-model-newton-cooling" label="vid-diffeq-model-newton-cooling" component="video"/>
       </solution>
       <solution>
         <p>
@@ -266,7 +266,7 @@
 
     <figure xml:id="vid-diffeq-model-disease12" component="video">
       <caption>Video presentation of <xref first="ex_disease_exponential" last="ex_disease_newton">Examples</xref></caption>
-      <video youtube="UjRpT852su4"/>
+      <video youtube="UjRpT852su4" label="vid-diffeq-model-disease12"/>
     </figure>
     <example xml:id="ex_disease_newton">
       <title>Disease Spread 2</title>
@@ -339,7 +339,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="vV8Jy231gLk" xml:id="vid-diffeq-model-disease3" component="video"/>
+        <video width="98%" youtube="vV8Jy231gLk" xml:id="vid-diffeq-model-disease3" label="vid-diffeq-model-disease3" component="video"/>
       </solution>
       <solution>
         <p>
@@ -482,7 +482,7 @@
 
     <figure xml:id="vid-diffeq-model-ratein-rateout-intro" component="video">
       <caption>Introduction to Rate-in Rate-out problems</caption>
-      <video youtube="G3nvU0Jc5pw"/>
+      <video youtube="G3nvU0Jc5pw" label="vid-diffeq-model-ratein-rateout-intro"/>
     </figure>
     <p>
       Though we stick to relatively simple examples,
@@ -529,7 +529,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="Au4n_QP73Ko" xml:id="vid-diffeq-model-ratein-rateout-example1" component="video"/>
+        <video width="98%" youtube="Au4n_QP73Ko" xml:id="vid-diffeq-model-ratein-rateout-example1" label="vid-diffeq-model-ratein-rateout-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -666,7 +666,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="P3fkhn-TQEk" xml:id="vid-diffeq-model-ratein-ratout-example2" component="video"/>
+        <video width="98%" youtube="P3fkhn-TQEk" xml:id="vid-diffeq-model-ratein-ratout-example2" label="vid-diffeq-model-ratein-ratout-example2" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -15,7 +15,7 @@
     </p>
     <figure xml:id="vid-diffeq-separable-intro" component="video">
       <caption>Video introduction to <xref ref="sec_Separable">Section</xref></caption>
-      <video youtube="tIkZsA3kK6o"/>
+      <video youtube="tIkZsA3kK6o" label="vid-diffeq-separable-intro"/>
     </figure>
     <definition xml:id="def_Separable">
       <title>Separable Differential Equation</title>
@@ -137,7 +137,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="pDXfO52xNVw" xml:id="vid-diffeq-separable-example1" component="video"/>
+        <video width="98%" youtube="pDXfO52xNVw" xml:id="vid-diffeq-separable-example1" label="vid-diffeq-separable-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -236,7 +236,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="Bl3ugfR-Guw" xml:id="vid-diffeq-separable-example-ivp" component="video"/>
+        <video width="98%" youtube="Bl3ugfR-Guw" xml:id="vid-diffeq-separable-example-ivp" label="vid-diffeq-separable-example-ivp" component="video"/>
       </solution>
       <solution>
         <p>
@@ -280,7 +280,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="OharserepNU" xml:id="vido-diffeq-separable-example3" component="video"/>
+        <video width="98%" youtube="OharserepNU" xml:id="vido-diffeq-separable-example3" label="vido-diffeq-separable-example3" component="video"/>
       </solution>
       <solution>
         <p>
@@ -315,7 +315,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="nLItalqug6A" xml:id="vid-diffeq-separable-example-logistic" component="video"/>
+        <video width="98%" youtube="nLItalqug6A" xml:id="vid-diffeq-separable-example-logistic" label="vid-diffeq-separable-example-logistic" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_alt_series.ptx
+++ b/ptx/sec_alt_series.ptx
@@ -81,7 +81,7 @@
 
   <figure xml:id="vid-seqseries-ast-def-alt-series" component="video">
     <caption>Video presentation of <xref ref="def_alt_series"/> and <xref ref="thm_alt_series_test"/></caption>
-    <video youtube="-W6wco1HZYo"/>
+    <video youtube="-W6wco1HZYo" label="vid-seqseries-ast-def-alt-series"/>
   </figure>
 
   <p>
@@ -216,7 +216,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="WmsfSSlc-W0" xml:id="vid-seqseries-ast-example1" component="video"/>
+      <video width="98%" youtube="WmsfSSlc-W0" xml:id="vid-seqseries-ast-example1" label="vid-seqseries-ast-example1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -332,7 +332,7 @@
 
   <figure xml:id="vid-seqseries-ast-approximation-theorem" component="video">
     <caption>Video presentation of <xref ref="thm_alt_series_approx"/></caption>
-    <video youtube="xtsP2Kfy6Bk"/>
+    <video youtube="xtsP2Kfy6Bk" label="vid-seqseries-ast-approximation-theorem"/>
   </figure>
 
   <p>
@@ -394,7 +394,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="f_iiMYNpqXE" xml:id="vid-seqseries-ast-approx-example" component="video"/>
+      <video width="98%" youtube="f_iiMYNpqXE" xml:id="vid-seqseries-ast-approx-example" label="vid-seqseries-ast-approx-example" component="video"/>
     </solution>
     <solution>
       <p>
@@ -533,7 +533,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="l02aGt0Ce5M" xml:id="vid-seqseries-ast-abs-conv-example" component="video"/>
+      <video width="98%" youtube="l02aGt0Ce5M" xml:id="vid-seqseries-ast-abs-conv-example" label="vid-seqseries-ast-abs-conv-example" component="video"/>
     </solution>
     <solution>
       <p>
@@ -620,7 +620,7 @@
 
   <figure xml:id="vid-seqseries-ast-abssolute" component="video">
     <caption>Video presentation of <xref ref="def_abs_converge"/> and <xref ref="thm_abs_convergence"/></caption>
-    <video youtube="d0enMDgDON8"/>
+    <video youtube="d0enMDgDON8" label="vid-seqseries-ast-abssolute"/>
   </figure>
   <theorem xml:id="thm_abs_convergence">
     <title>Absolute Convergence Theorem</title>

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -5,7 +5,7 @@
 
     <figure xml:id="vid_int_antider_intro" component="video">
       <caption>Video introduction to <xref ref="sec_antider"/></caption>
-      <video youtube="z1XH1JTUKTU"/>
+      <video youtube="z1XH1JTUKTU" label="vid_int_antider_intro"/>
     </figure>
 
     <p>
@@ -66,7 +66,7 @@
 
     <figure xml:id="vid_int_antider_defn_indef_int" component="video">
       <caption>Video presentation of <xref ref="def_antider"/></caption>
-      <video youtube="BRAjDVVn4H4"/>
+      <video youtube="BRAjDVVn4H4" label="vid_int_antider_defn_indef_int"/>
     </figure>
 
 
@@ -197,7 +197,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="W-FUL0ApGL8" xml:id="vid_int_antider_ex_1" component="video"/>
+        <video width="98%" youtube="W-FUL0ApGL8" xml:id="vid_int_antider_ex_1" label="vid_int_antider_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -271,7 +271,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="3DFPqGHX7Yw" xml:id="vid_int_antider_ex_2" component="video"/>
+        <video width="98%" youtube="3DFPqGHX7Yw" xml:id="vid_int_antider_ex_2" label="vid_int_antider_ex_2" component="video"/>
       </solution>
       <solution>
 
@@ -505,7 +505,7 @@
     <title>Initial Value Problems</title>
     <figure xml:id="vid_int_antider_init_val_prob" component="video">
       <caption>Introducing initial value problems</caption>
-      <video youtube="Oo6OHiiGbOc"/>
+      <video youtube="Oo6OHiiGbOc" label="vid_int_antider_init_val_prob"/>
     </figure>
 
     <p>
@@ -547,7 +547,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="3K_gWY4lmOs" xml:id="vid_int_antider_ex_3" component="video"/>
+        <video width="98%" youtube="3K_gWY4lmOs" xml:id="vid_int_antider_ex_3" label="vid_int_antider_ex_3" component="video"/>
       </solution>
       <solution>
 
@@ -620,7 +620,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="MB1dLY4lOew" xml:id="vid_int_antider_ex_4" component="video"/>
+        <video width="98%" youtube="MB1dLY4lOew" xml:id="vid_int_antider_ex_4" label="vid_int_antider_ex_4" component="video"/>
       </solution>
       <solution>
 

--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -24,7 +24,7 @@
 
     <figure xml:id="vid-intapp-arclength-intro" component="video">
       <caption>Video introduction to <xref ref="sec_arc_length"/></caption>
-      <video youtube="r8JJru-DcAw"/>
+      <video youtube="r8JJru-DcAw" label="vid-intapp-arclength-intro"/>
     </figure>
 
     <p>
@@ -292,7 +292,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="0NPr4wZlTi8" xml:id="vid-intapp-arclength-example1" component="video"/>
+        <video width="98%" youtube="0NPr4wZlTi8" xml:id="vid-intapp-arclength-example1" label="vid-intapp-arclength-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -350,7 +350,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="mJlyz_9yiao" xml:id="vid-intapp-arclength-example2" component="video"/>
+        <video width="98%" youtube="mJlyz_9yiao" xml:id="vid-intapp-arclength-example2" label="vid-intapp-arclength-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -490,7 +490,7 @@
 
     <figure xml:id="vid-intapp-surfarea-intro" component="video">
       <caption>Video introduction to <xref ref="sec_surface_area_revolution"/></caption>
-      <video youtube="uVgiUPdoPZM"/>
+      <video youtube="uVgiUPdoPZM" label="vid-intapp-surfarea-intro"/>
     </figure>
 
     <figure xml:id="fig_surface_intro">
@@ -803,7 +803,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="93PbhwUx21c 8yxzb4B8FEc" xml:id="vid-intapp-surfarea-example1" component="video"/>
+        <video width="98%" youtube="93PbhwUx21c 8yxzb4B8FEc" xml:id="vid-intapp-surfarea-example1" label="vid-intapp-surfarea-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -965,7 +965,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="ne-11oB6EXw pXUigmvFdys" xml:id="vid-intapp-surfarea-example2" component="video"/>
+        <video width="98%" youtube="ne-11oB6EXw pXUigmvFdys" xml:id="vid-intapp-surfarea-example2" label="vid-intapp-surfarea-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1079,7 +1079,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="L4ogGgyzmvs" xml:id="vid-intapp-surfarea-example3" component="video"/>
+        <video width="98%" youtube="L4ogGgyzmvs" xml:id="vid-intapp-surfarea-example3" label="vid-intapp-surfarea-example3" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -11,7 +11,7 @@
 
     <figure xml:id="vid-planecurves-conic-intro" component="video">
       <caption>Video introduction to <xref ref="sec_conic_sections"/></caption>
-      <video youtube="NAPXAQHSgdk"/>
+      <video youtube="NAPXAQHSgdk" label="vid-planecurves-conic-intro"/>
     </figure>
 
     <p>
@@ -106,7 +106,7 @@
 
     <figure xml:id="vid-planecurves-conic-parabola-intro" component="video">
       <caption>Video introduction to the parabola</caption>
-      <video youtube="tnyEnnE2AS8"/>
+      <video youtube="tnyEnnE2AS8" label="vid-planecurves-conic-parabola-intro"/>
     </figure>
 
     <definition xml:id="def_parabola">
@@ -250,7 +250,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="dk8lrQac8Qg" xml:id="vid-planecurves-conic-parabola-example1" component="video"/>
+        <video width="98%" youtube="dk8lrQac8Qg" xml:id="vid-planecurves-conic-parabola-example1" label="vid-planecurves-conic-parabola-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -306,7 +306,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="R8oJdTbZXh4" xml:id="vid-planecurves-conic-parabola-example2" component="video"/>
+        <video width="98%" youtube="R8oJdTbZXh4" xml:id="vid-planecurves-conic-parabola-example2" label="vid-planecurves-conic-parabola-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -474,7 +474,7 @@
 
     <figure xml:id="vid-planecurves-conic-ellipse-intro" component="video">
       <caption>Video introduction to the ellipse</caption>
-      <video youtube="eAKfJphIwIE"/>
+      <video youtube="eAKfJphIwIE" label="vid-planecurves-conic-ellipse-intro"/>
     </figure>
     <definition xml:id="def_ellipse">
       <title>Ellipse</title>
@@ -688,7 +688,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="NVqlZCWDDnI" xml:id="vid-planecurves-conic-ellipse-example1" component="video"/>
+        <video width="98%" youtube="NVqlZCWDDnI" xml:id="vid-planecurves-conic-ellipse-example1" label="vid-planecurves-conic-ellipse-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -712,7 +712,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="U3uhopYrG8o" xml:id="vid-planecurves-conic-ellipse-example2" component="video"/>
+        <video width="98%" youtube="U3uhopYrG8o" xml:id="vid-planecurves-conic-ellipse-example2" label="vid-planecurves-conic-ellipse-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1051,7 +1051,7 @@
 
     <figure xml:id="vid-planecurves-conic-hyperbola-intro" component="video">
       <caption>Video introduction to hyperbolas</caption>
-      <video youtube="9aLDYQrTaBo"/>
+      <video youtube="9aLDYQrTaBo" label="vid-planecurves-conic-hyperbola-intro"/>
     </figure>
 
     <p>
@@ -1295,7 +1295,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="0YVNci7ZOfo" xml:id="vid-planecurves-conic-hyperbola-example1" component="video"/>
+          <video width="98%" youtube="0YVNci7ZOfo" xml:id="vid-planecurves-conic-hyperbola-example1" label="vid-planecurves-conic-hyperbola-example1" component="video"/>
         </solution>
         <solution>
           <p>
@@ -1366,7 +1366,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="b-1_3ATvn9A" xml:id="vid-planecurves-conic-hyperbola-example2" component="video"/>
+          <video width="98%" youtube="b-1_3ATvn9A" xml:id="vid-planecurves-conic-hyperbola-example2" label="vid-planecurves-conic-hyperbola-example2" component="video"/>
         </solution>
         <solution>
           <p>

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -13,7 +13,7 @@
 
     <figure xml:id="vid-vectors-crossprod-intro" component="video">
       <caption>Video introduction to <xref ref="sec_cross_product"/></caption>
-      <video youtube="63syRlBjyh0"/>
+      <video youtube="63syRlBjyh0" label="vid-vectors-crossprod-intro"/>
     </figure>
 
     <p>
@@ -67,7 +67,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="kFpmnYBVQt4" xml:id="vid-vectors-crossprod-example" component="video"/>
+        <video width="98%" youtube="kFpmnYBVQt4" xml:id="vid-vectors-crossprod-example" label="vid-vectors-crossprod-example" component="video"/>
       </solution>
       <solution>
         <p>
@@ -157,7 +157,7 @@
 
     <figure xml:id="vid-vectors-crossprod-detformula" component="video">
       <caption>Video presentation of the determinant formula for the cross product</caption>
-      <video youtube="geWK0Qpl6_Y"/>
+      <video youtube="geWK0Qpl6_Y" label="vid-vectors-crossprod-detformula"/>
     </figure>
 
     <p>
@@ -174,7 +174,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="6-PGDOhhYbg" xml:id="vid-vectors-crossprod-det-eg" component="video"/>
+        <video width="98%" youtube="6-PGDOhhYbg" xml:id="vid-vectors-crossprod-det-eg" label="vid-vectors-crossprod-det-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -314,7 +314,7 @@
 
     <figure xml:id="vid-vectors-crossprod-properties" component="video">
       <caption>Video presentation of <xref ref="thm_cross_prod_prop"/></caption>
-      <video youtube="QOCSD4qA_Wg"/>
+      <video youtube="QOCSD4qA_Wg" label="vid-vectors-crossprod-properties"/>
     </figure>
 
     <p>
@@ -391,7 +391,7 @@
 
     <figure xml:id="vid-vetors-crossprod-angles" component="video">
       <caption>Video presentation of <xref ref="thm_cross_product"/> and <xref ref="ex_crossp3"/></caption>
-      <video youtube="_DjAuiDG2kA"/>
+      <video youtube="_DjAuiDG2kA" label="vid-vetors-crossprod-angles"/>
     </figure>
 
     <p>
@@ -637,7 +637,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="CYboFA8zYBs" xml:id="vid-vectors-crossprod-paralleogram" component="video"/>
+          <video width="98%" youtube="CYboFA8zYBs" xml:id="vid-vectors-crossprod-paralleogram" label="vid-vectors-crossprod-paralleogram" component="video"/>
         </solution>
         <solution>
           <p>
@@ -808,7 +808,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="GuEn2qOey2U" xml:id="vid-vectors-crossprod-triangle" component="video"/>
+          <video width="98%" youtube="GuEn2qOey2U" xml:id="vid-vectors-crossprod-triangle" label="vid-vectors-crossprod-triangle" component="video"/>
         </solution>
         <solution>
           <p>
@@ -976,7 +976,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="r2_dGc1KWEc" xml:id="vid-vectors-crossprod-volume" component="video"/>
+          <video width="98%" youtube="r2_dGc1KWEc" xml:id="vid-vectors-crossprod-volume" label="vid-vectors-crossprod-volume" component="video"/>
         </solution>
         <solution>
           <p>

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -15,7 +15,7 @@
 
     <figure xml:id="vid-vvf-curv-arclength" component="video">
       <caption>Video introduction to <xref ref="sec_curvature"/></caption>
-      <video youtube="VHcu7bcQjsk"/>
+      <video youtube="VHcu7bcQjsk" label="vid-vvf-curv-arclength"/>
     </figure>
 
     <p>
@@ -155,7 +155,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="UZkbOv5zW1U" xml:id="vid-vvf-curv-arclen-eg" component="video"/>
+        <video width="98%" youtube="UZkbOv5zW1U" xml:id="vid-vvf-curv-arclen-eg" label="vid-vvf-curv-arclen-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -304,7 +304,7 @@
 
     <figure xml:id="vid-vvf-curv-arclen-thm" component="video">
       <caption>Video presentation of <xref ref="thm_arclengthparam"/></caption>
-      <video youtube="FLydDuy3r2I"/>
+      <video youtube="FLydDuy3r2I" label="vid-vvf-curv-arclen-thm"/>
     </figure>
   </subsection>
 
@@ -416,7 +416,7 @@
 
     <figure xml:id="vid-vvf-curv-curvature" component="video">
       <caption>Video presentation of <xref ref="def_curvature"/></caption>
-      <video youtube="sjz_eHxgbLg"/>
+      <video youtube="sjz_eHxgbLg" label="vid-vvf-curv-curvature"/>
     </figure>
 
     <p>
@@ -462,7 +462,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="SZigON0uhqU" xml:id="vid-vvf-curv-line" component="video"/>
+        <video width="98%" youtube="SZigON0uhqU" xml:id="vid-vvf-curv-line" label="vid-vvf-curv-line" component="video"/>
       </solution>
       <solution>
         <p>
@@ -553,7 +553,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="NgffyzJBrTc" xml:id="vid-vvf-curv-circle" component="video"/>
+        <video width="98%" youtube="NgffyzJBrTc" xml:id="vid-vvf-curv-circle" label="vid-vvf-curv-circle" component="video"/>
       </solution>
       <solution>
         <p>
@@ -675,7 +675,7 @@
 
     <figure xml:id="vid-vvf-curv-oscul" component="video">
       <caption>The osculating circle</caption>
-      <video youtube="x8TWhPo42QE"/>
+      <video youtube="x8TWhPo42QE" label="vid-vvf-curv-oscul"/>
     </figure>
 
     <p>

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -26,7 +26,7 @@
 
     <figure xml:id="vid-multint-cylindrical-intro" component="video">
       <caption>A triple integral that isn't easily performed in rectancular coordinates</caption>
-      <video youtube="Ajd8uy3U4lA"/>
+      <video youtube="Ajd8uy3U4lA" label="vid-multint-cylindrical-intro"/>
     </figure>
   </introduction>
 
@@ -136,7 +136,7 @@
 
     <figure xml:id="vid-trigint-cylindrical-definition" component="video">
       <caption>Explaining the cylindrical coordinate system</caption>
-      <video youtube="DOFhlADkGko"/>
+      <video youtube="DOFhlADkGko" label="vid-trigint-cylindrical-definition"/>
     </figure>
 
     <example xml:id="ex_cylindrical4">
@@ -371,7 +371,7 @@
 
     <figure xml:id="vid-multint-cylindrical-cone" component="video">
       <caption>Using cylindrical coordinates to find the volume of a cone</caption>
-      <video youtube="u0FYs9MaI5k"/>
+      <video youtube="u0FYs9MaI5k" label="vid-multint-cylindrical-cone"/>
     </figure>
 
     <example xml:id="ex_cylindrical2">
@@ -773,7 +773,7 @@
 
     <figure xml:id="vid-multint-spherical-intro" component="video">
       <caption>Introducing spherical coordinates</caption>
-      <video youtube="In5up-a1jMI"/>
+      <video youtube="In5up-a1jMI" label="vid-multint-spherical-intro"/>
     </figure>
 
     <aside xml:id="vidnote-aside-conventions" component="video">
@@ -1265,7 +1265,7 @@
 
     <figure xml:id="vid-multint-spherical-example1" component="video">
       <caption>Setting up an integral in spherical coorindates</caption>
-      <video youtube="wqjjslo0auI"/>
+      <video youtube="wqjjslo0auI" label="vid-multint-spherical-example1"/>
     </figure>
 
     <example xml:id="ex_spherical3">
@@ -1451,7 +1451,7 @@
 
     <figure xml:id="vid-multint-spherical-examples" component="video">
       <caption>Two more spherical coordinate examples</caption>
-      <video youtube="jwzvDiiM94o EKxY_5PlgTU"/>
+      <video youtube="jwzvDiiM94o EKxY_5PlgTU" label="vid-multint-spherical-examples"/>
     </figure>
 
     <p>

--- a/ptx/sec_cylindrical_spherical_old.ptx
+++ b/ptx/sec_cylindrical_spherical_old.ptx
@@ -12,7 +12,7 @@
 
     <figure xml:id="vid-multint-cylindrical-intro" component="video">
       <caption>A triple integral that isn't easily performed in rectancular coordinates</caption>
-      <video youtube="Ajd8uy3U4lA"/>
+      <video youtube="Ajd8uy3U4lA" label="vid-multint-cylindrical-intro"/>
     </figure>
   </introduction>
 
@@ -122,7 +122,7 @@
 
     <figure xml:id="vid-trigint-cylindrical-definition" component="video">
       <caption>Explaining the cylindrical coordinate system</caption>
-      <video youtube="DOFhlADkGko"/>
+      <video youtube="DOFhlADkGko" label="vid-trigint-cylindrical-definition"/>
     </figure>
 
     <example xml:id="ex_cylindrical4">
@@ -357,7 +357,7 @@
 
     <figure xml:id="vid-multint-cylindrical-cone" component="video">
       <caption>Using cylindrical coordinates to find the volume of a cone</caption>
-      <video youtube="u0FYs9MaI5k"/>
+      <video youtube="u0FYs9MaI5k" label="vid-multint-cylindrical-cone"/>
     </figure>
 
     <example xml:id="ex_cylindrical2">
@@ -702,7 +702,7 @@
 
     <figure xml:id="vid-multint-spherical-intro" component="video">
       <caption>Introducing spherical coordinates</caption>
-      <video youtube="In5up-a1jMI"/>
+      <video youtube="In5up-a1jMI" label="vid-multint-spherical-intro"/>
     </figure>
 
     <p>
@@ -1176,7 +1176,7 @@
 
     <figure xml:id="vid-multint-spherical-example1" component="video">
       <caption>Setting up an integral in spherical coorindates</caption>
-      <video youtube="wqjjslo0auI"/>
+      <video youtube="wqjjslo0auI" label="vid-multint-spherical-example1"/>
     </figure>
 
     <example xml:id="ex_spherical3">
@@ -1362,7 +1362,7 @@
 
     <figure xml:id="vid-multint-spherical-examples" component="video">
       <caption>Two more spherical coordinate examples</caption>
-      <video youtube="jwzvDiiM94o EKxY_5PlgTU"/>
+      <video youtube="jwzvDiiM94o EKxY_5PlgTU" label="vid-multint-spherical-examples"/>
     </figure>
 
     <p>

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -5,7 +5,7 @@
 
   <figure xml:id="vid_int_def_int_intro" component="video">
     <caption>Video introduction to <xref ref="sec_def_int"/></caption>
-    <video youtube="__Xh37Qw4UE"/>
+    <video youtube="__Xh37Qw4UE" label="vid_int_def_int_intro"/>
   </figure>
 
   <p>
@@ -176,7 +176,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="MUx3n9511e8" xml:id="vid_int_def_int_ex_vel" component="video"/>
+      <video width="98%" youtube="MUx3n9511e8" xml:id="vid_int_def_int_ex_vel" label="vid_int_def_int_ex_vel" component="video"/>
     </solution>
     <solution>
 
@@ -389,7 +389,7 @@
 
   <figure xml:id="vid_int_def_int_defn" component="video">
     <caption>Video presentation of <xref ref="def_def_int"/></caption>
-    <video youtube="1kJUMKdjumQ"/>
+    <video youtube="1kJUMKdjumQ" label="vid_int_def_int_defn"/>
   </figure>
 
 
@@ -469,7 +469,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="jrjjVT1j9uw" xml:id="vid_int_def_int_ex_1" component="video"/>
+      <video width="98%" youtube="jrjjVT1j9uw" xml:id="vid_int_def_int_ex_1" label="vid_int_def_int_ex_1" component="video"/>
     </solution>
     <solution>
 
@@ -581,7 +581,7 @@
 
   <figure xml:id="vid_int_def_int_prop" component="video">
     <caption>Video presentation of <xref ref="thm_defintprop"/></caption>
-    <video youtube="sK5vZ_QrkNk"/>
+    <video youtube="sK5vZ_QrkNk" label="vid_int_def_int_prop"/>
   </figure>
 
 
@@ -776,7 +776,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="AuGASVXd3qA" xml:id="vid_int_def_int_geo_ex" component="video"/>
+      <video width="98%" youtube="AuGASVXd3qA" xml:id="vid_int_def_int_geo_ex" label="vid_int_def_int_geo_ex" component="video"/>
     </solution>
     <solution>
 
@@ -909,7 +909,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="2zJzbg0hNXE" xml:id="vid_int_def_int_motion" component="video"/>
+      <video width="98%" youtube="2zJzbg0hNXE" xml:id="vid_int_def_int_motion" label="vid_int_def_int_motion" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -102,7 +102,7 @@
 
     <figure xml:id="vid_deriv_basic_rules" component="video">
       <caption>Video explanation of <xref ref="thm_deriv_common"/> (2 videos)</caption>
-      <video  youtube="Je10KZXLlwo fSaHMq9mNq0"/>
+      <video  youtube="Je10KZXLlwo fSaHMq9mNq0" label="vid_deriv_basic_rules"/>
     </figure>
 
 
@@ -149,7 +149,7 @@
 
     <figure xml:id="vid_deriv_basic_rules_exp_func" component="video">
       <caption>Determining the derivative of <m>f(x)=e^x</m></caption>
-      <video youtube="ipKTEdQFBjw"/>
+      <video youtube="ipKTEdQFBjw" label="vid_deriv_basic_rules_exp_func"/>
     </figure>
 
 
@@ -189,7 +189,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="lyAEJSmSr-A" xml:id="vid_deriv_basic_rules_ex" component="video"/>
+        <video width="98%" youtube="lyAEJSmSr-A" xml:id="vid_deriv_basic_rules_ex" label="vid_deriv_basic_rules_ex" component="video"/>
       </solution>
       <solution>
         <p>
@@ -308,7 +308,7 @@
 
     <figure xml:id="vid_deriv_basic_rules_const_sum_rule" component="video">
       <caption>Video presentation of <xref ref="thm_deriv_prop"/></caption>
-      <video youtube="Hr0sQcVhQ9A"/>
+      <video youtube="Hr0sQcVhQ9A" label="vid_deriv_basic_rules_const_sum_rule"/>
     </figure>
 
     <p xml:id="vidint_deriv_basic_rules_const_sum_rule" component="video">
@@ -320,7 +320,7 @@
 
     <figure xml:id="vid_deriv_basic_rules_proofs" component="video">
       <caption>Proving the sum rule</caption>
-      <video youtube="nVVpyilxZTw"/>
+      <video youtube="nVVpyilxZTw" label="vid_deriv_basic_rules_proofs"/>
     </figure>
 
 
@@ -353,7 +353,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="a0hsWtT74jM" xml:id="vid_deriv_basic_rules_examples_1" component="video"/>
+        <video width="98%" youtube="a0hsWtT74jM" xml:id="vid_deriv_basic_rules_examples_1" label="vid_deriv_basic_rules_examples_1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -551,7 +551,7 @@
 
     <figure xml:id="vid_deriv_basic_rules_higher_order_deriv" component="video">
       <caption>Video explanation of <xref ref="def_Higher_Deriv"/></caption>
-      <video youtube="usabSpUh65w"/>
+      <video youtube="usabSpUh65w" label="vid_deriv_basic_rules_higher_order_deriv"/>
     </figure>
 
     <p>
@@ -578,7 +578,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="nF2-IrvHmqc" xml:id="vid_deriv_basic_rules_examples_2" component="video"/>
+        <video width="98%" youtube="nF2-IrvHmqc" xml:id="vid_deriv_basic_rules_examples_2" label="vid_deriv_basic_rules_examples_2" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -22,7 +22,7 @@
 
   <figure xml:id="vid_deriv_chain_intro" component="video">
     <caption>Video introduction to <xref ref="sec_chainrule"/></caption>
-    <video youtube="k7wX-kxd7Kw"/>
+    <video youtube="k7wX-kxd7Kw" label="vid_deriv_chain_intro"/>
   </figure>
 
   <p>
@@ -181,7 +181,7 @@
 
   <figure xml:id="vid_deriv_chain_theorem" component="video">
     <caption>Video presentation of <xref ref="thm_chain_rule"/></caption>
-    <video youtube="1_Lp-ONIMuc"/>
+    <video youtube="1_Lp-ONIMuc" label="vid_deriv_chain_theorem"/>
   </figure>
 
   <p>
@@ -343,7 +343,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="yW1BbOeDFcM" xml:id="vid_deriv_chain_examples_1" component="video"/>
+      <video width="98%" youtube="yW1BbOeDFcM" xml:id="vid_deriv_chain_examples_1" label="vid_deriv_chain_examples_1" component="video"/>
     </solution>
     <solution>
 
@@ -523,7 +523,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="2QJLR-Y-Ht8" xml:id="vid_deriv_chain_examples_2" component="video"/>
+      <video width="98%" youtube="2QJLR-Y-Ht8" xml:id="vid_deriv_chain_examples_2" label="vid_deriv_chain_examples_2" component="video"/>
     </solution>
     <solution>
 
@@ -594,7 +594,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="JeLuSDqqFPA" xml:id="vid_deriv_chain_examples_3_func" component="video"/>
+      <video width="98%" youtube="JeLuSDqqFPA" xml:id="vid_deriv_chain_examples_3_func" label="vid_deriv_chain_examples_3_func" component="video"/>
     </solution>
     <solution>
 
@@ -756,7 +756,7 @@
 
   <figure xml:id="vid_deriv_chain_gen_power_exp" component="video">
     <caption>Derivatives of exponential and general power functions</caption>
-    <video youtube="LnmwxZ5w30w"/>
+    <video youtube="LnmwxZ5w30w" label="vid_deriv_chain_gen_power_exp"/>
   </figure>
 
   <paragraphs>

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -17,7 +17,7 @@
 
     <figure xml:id="vid_deriv_impl_intro" component="video">
       <caption>Video introduction to <xref ref="sec_imp_deriv"/></caption>
-      <video youtube="JWOOMkaNbQg A134hhXIF-0"/>
+      <video youtube="JWOOMkaNbQg A134hhXIF-0" label="vid_deriv_impl_intro"/>
     </figure>
 
 
@@ -112,7 +112,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="0baXlbhup0o" xml:id="vid_deriv_impl_ex_1" component="video"/>
+        <video width="98%" youtube="0baXlbhup0o" xml:id="vid_deriv_impl_ex_1" label="vid_deriv_impl_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -203,7 +203,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qYrcm4ObwOM" xml:id="vid_deriv_impl_tan_line_prev_ex" component="video"/>
+        <video width="98%" youtube="qYrcm4ObwOM" xml:id="vid_deriv_impl_tan_line_prev_ex" label="vid_deriv_impl_tan_line_prev_ex" component="video"/>
       </solution>
       <solution>
 
@@ -308,7 +308,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="O5OqJ7a_Ovo" xml:id="vid_deriv_impl_ex_2" component="video"/>
+        <video width="98%" youtube="O5OqJ7a_Ovo" xml:id="vid_deriv_impl_ex_2" label="vid_deriv_impl_ex_2" component="video"/>
       </solution>
       <solution>
 
@@ -405,7 +405,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="BMn-BU6VTQU" xml:id="vid_deriv_impl_ex_3" component="video"/>
+        <video width="98%" youtube="BMn-BU6VTQU" xml:id="vid_deriv_impl_ex_3" label="vid_deriv_impl_ex_3" component="video"/>
       </solution>
       <solution>
 
@@ -778,7 +778,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="V6piqsjn2mk" xml:id="vid_deriv_impl_second_deriv" component="video"/>
+        <video width="98%" youtube="V6piqsjn2mk" xml:id="vid_deriv_impl_second_deriv" label="vid_deriv_impl_second_deriv" component="video"/>
       </solution>
       <solution>
 
@@ -888,7 +888,7 @@
             In the first video, taking the log of both sides.
             In the second, using the inverse relationship <m>e^{\ln(x)}=x</m>.
           </caption>
-          <video youtube="aofx_jgKDhU w93T6AyU_aE"/>
+          <video youtube="aofx_jgKDhU w93T6AyU_aE" label="vid_deriv_implicit_logarithmic"/>
         </figure>
 
         <p>
@@ -955,7 +955,7 @@
 
     <figure xml:id="vid_deriv_impl_ex_5" component="video">
       <caption>Using logarithmic differentiation</caption>
-      <video youtube="3Cv2EgjH9ZE"/>
+      <video youtube="3Cv2EgjH9ZE" label="vid_deriv_impl_ex_5"/>
     </figure>
 
     <p>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -7,7 +7,7 @@
 
     <figure xml:id="vid_deriv_intro_introduction" component="video">
       <caption>Video introduction to <xref ref="sec_derivative"/></caption>
-      <video youtube="jRW9d25E_ls"/>
+      <video youtube="jRW9d25E_ls" label="vid_deriv_intro_introduction"/>
     </figure>
 
     <p>
@@ -330,7 +330,7 @@
 
     <figure xml:id="vid_deriv_intro_defn" component="video">
       <caption>Video presentation of <xref ref="def_derivative_at_a_point"/></caption>
-      <video youtube="JXFMh21PMx4"/>
+      <video youtube="JXFMh21PMx4" label="vid_deriv_intro_defn"/>
     </figure>
 
     <definition xml:id="def_tangent_line">
@@ -387,7 +387,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="EheTlvVDaGg q_XfRMmSEmc" xml:id="vid_deriv_intro_ex_v1" component="video"/>
+        <video width="98%" youtube="EheTlvVDaGg q_XfRMmSEmc" xml:id="vid_deriv_intro_ex_v1" label="vid_deriv_intro_ex_v1" component="video"/>
       </solution>
       <solution>
 
@@ -481,7 +481,7 @@
 
     <figure xml:id="vid_deriv_intro_diff_imp_cont" component="video">
       <caption>Showing that every differentiable function is continuous</caption>
-      <video youtube="Ev9hJVbDO1k"/>
+      <video youtube="Ev9hJVbDO1k" label="vid_deriv_intro_diff_imp_cont"/>
     </figure>
 
     <p>
@@ -809,7 +809,7 @@
 
     <figure xml:id="vid_deriv_intro_deriv_func" component="video">
       <caption>Video presentation of <xref ref="def_the_derivative"/></caption>
-      <video youtube="yPzNYlzA0Js"/>
+      <video youtube="yPzNYlzA0Js" label="vid_deriv_intro_deriv_func"/>
     </figure>
 
 
@@ -830,7 +830,7 @@
 
     <figure xml:id="vid_deriv_intro_notation" component="video">
       <caption>Explaining derivative notation</caption>
-      <video youtube="TJhJiA_w4mQ"/>
+      <video youtube="TJhJiA_w4mQ" label="vid_deriv_intro_notation"/>
     </figure>
 
 
@@ -877,7 +877,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="JKHbXYanjDs" xml:id="vid_deriv_intro_ex_1" component="video"/>
+        <video width="98%" youtube="JKHbXYanjDs" xml:id="vid_deriv_intro_ex_1" label="vid_deriv_intro_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -918,7 +918,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="vsnDopbWHXQ" xml:id="vid_deriv_intro_deriv_sin" component="video"/>
+        <video width="98%" youtube="vsnDopbWHXQ" xml:id="vid_deriv_intro_deriv_sin" label="vid_deriv_intro_deriv_sin" component="video"/>
       </solution>
       <solution>
 
@@ -972,7 +972,7 @@
 
         <figure xml:id="vid_deriv_intro_deriv_cos" component="video">
           <caption>Finding the derivative of <m>\cos(x)</m></caption>
-          <video youtube="-1lOFzhDJAo"/>
+          <video youtube="-1lOFzhDJAo" label="vid_deriv_intro_deriv_cos"/>
         </figure>
 
       </solution>
@@ -1258,7 +1258,7 @@
 
     <figure xml:id="vid_deriv_intro_ex_2" component="video">
       <caption>Determining when a piecewise-defined function is differentiable</caption>
-      <video youtube="q1ZAqRsgVPk"/>
+      <video youtube="q1ZAqRsgVPk" label="vid_deriv_intro_ex_2"/>
     </figure>
 
     <p>

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -4,7 +4,7 @@
 
   <figure xml:id="vid_deriv_inverse_intro" component="video">
     <caption>Video introduction to <xref ref="sec_deriv_inverse_function"/></caption>
-    <video youtube="rBIBiDXbWf8"/>
+    <video youtube="rBIBiDXbWf8" label="vid_deriv_inverse_intro"/>
   </figure>
 
   <p>
@@ -50,7 +50,7 @@
 
   <figure xml:id="vid_deriv_inverse_prop" component="video">
     <caption>Properties of inverse functions</caption>
-    <video youtube="1g9gAQC301Q"/>
+    <video youtube="1g9gAQC301Q" label="vid_deriv_inverse_prop"/>
   </figure>
 
   <p xml:id="vidint_derive_inverse_examples" component="video">
@@ -60,7 +60,7 @@
 
   <figure xml:id="vid_deriv_inverse_examples" component="video">
     <caption>Finding the inverse of a one-to-one function</caption>
-    <video youtube="PsJKKckGcXE"/>
+    <video youtube="PsJKKckGcXE" label="vid_deriv_inverse_examples"/>
   </figure>
 
   <p>
@@ -245,7 +245,7 @@
 
   <figure xml:id="vid_deriv_inverse_inv_func_thm" component="video">
     <caption>Video presentation of <xref ref="thm_deriv_inverse_functions"/></caption>
-    <video youtube="dOtVBJd75h8"/>
+    <video youtube="dOtVBJd75h8" label="vid_deriv_inverse_inv_func_thm"/>
   </figure>
 
   <p>
@@ -270,7 +270,7 @@
 
   <figure xml:id="vid_deriv_inverse_restrict_domain" component="video">
     <caption>Restricting the domain of <m>\sin(x)</m></caption>
-    <video youtube="lCNZPbfiono"/>
+    <video youtube="lCNZPbfiono" label="vid_deriv_inverse_restrict_domain"/>
   </figure>
 
 
@@ -284,7 +284,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="xBZqkvQRSG4" xml:id="vid_deriv_inverse_deriv_arcsin" component="video"/>
+      <video width="98%" youtube="xBZqkvQRSG4" xml:id="vid_deriv_inverse_deriv_arcsin" label="vid_deriv_inverse_deriv_arcsin" component="video"/>
     </solution>
     <solution>
 
@@ -551,7 +551,7 @@
 
   <figure xml:id="vid_deriv_inverse_seriv_arctan" component="video">
     <caption>Computing the derivative of <m>\arctan(x)</m></caption>
-    <video youtube="yO-BT5vEZ9A"/>
+    <video youtube="yO-BT5vEZ9A" label="vid_deriv_inverse_seriv_arctan"/>
   </figure>
 
 

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -17,7 +17,7 @@
 
   <figure xml:id="vid_deriv_prod_quot_prod_intro" component="video">
     <caption>Video introduction to <xref ref="sec_prod_quot_rules"/></caption>
-    <video youtube="1X3PTrkMsJ8"/>
+    <video youtube="1X3PTrkMsJ8" label="vid_deriv_prod_quot_prod_intro"/>
   </figure>
 
 
@@ -58,7 +58,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="37efDywkDyE" xml:id="vid_deriv_prod_quot_prod_ex" component="video"/>
+      <video width="98%" youtube="37efDywkDyE" xml:id="vid_deriv_prod_quot_prod_ex" label="vid_deriv_prod_quot_prod_ex" component="video"/>
     </solution>
     <solution>
 
@@ -123,7 +123,7 @@
 
   <proof>
     <title>Proof of Product Rule</title>
-    <video width="98%" youtube="i791Y97O5hI" xml:id="vid_deriv_prod_quot_proof_prod_rule" component="video"/>
+    <video width="98%" youtube="i791Y97O5hI" xml:id="vid_deriv_prod_quot_proof_prod_rule" label="vid_deriv_prod_quot_proof_prod_rule" component="video"/>
 
     <p>
       We can use the definition of the derivative to prove <xref ref="thm_ProductRule">Theorem</xref>.
@@ -191,7 +191,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="-plvLFQ21Ig" xml:id="vid_deriv_prod_quot_ex_1" component="video"/>
+      <video width="98%" youtube="-plvLFQ21Ig" xml:id="vid_deriv_prod_quot_ex_1" label="vid_deriv_prod_quot_ex_1" component="video"/>
     </solution>
     <solution>
 
@@ -233,7 +233,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="PYK64WB4JUg" xml:id="vid_deriv_prod_quot_ex_3_func" component="video"/>
+      <video width="98%" youtube="PYK64WB4JUg" xml:id="vid_deriv_prod_quot_ex_3_func" label="vid_deriv_prod_quot_ex_3_func" component="video"/>
     </solution>
     <solution>
 
@@ -280,7 +280,7 @@
   </p>
   <figure xml:id="vid_deriv_prod_quot_ex_4_func" component="video">
     <caption>Taking the derivative of a product of four functions</caption>
-    <video youtube="QdQ14efmlMg"/>
+    <video youtube="QdQ14efmlMg" label="vid_deriv_prod_quot_ex_4_func"/>
   </figure>
 
   <p>
@@ -363,7 +363,7 @@
 
   <figure xml:id="vid_deriv_prod_quot_quot_rule" component="video">
     <caption>Video presentation of <xref ref="thm_QuotientRule"/></caption>
-    <video youtube="IlsA8342GvQ"/>
+    <video youtube="IlsA8342GvQ" label="vid_deriv_prod_quot_quot_rule"/>
   </figure>
 
   <p>
@@ -399,7 +399,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="Hr4bt6yFwPg" xml:id="vid_deriv_prod_quot_example_2" component="video"/>
+      <video width="98%" youtube="Hr4bt6yFwPg" xml:id="vid_deriv_prod_quot_example_2" label="vid_deriv_prod_quot_example_2" component="video"/>
     </solution>
     <solution>
 
@@ -427,7 +427,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="wslbADxDg4c" xml:id="vid_deriv_prod_quot_tanx" component="video"/>
+      <video width="98%" youtube="wslbADxDg4c" xml:id="vid_deriv_prod_quot_tanx" label="vid_deriv_prod_quot_tanx" component="video"/>
     </solution>
     <solution>
 
@@ -577,7 +577,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="jPqqK-ObPm4" xml:id="vid_deriv_prod_quot_neg_power" component="video"/>
+      <video width="98%" youtube="jPqqK-ObPm4" xml:id="vid_deriv_prod_quot_neg_power" label="vid_deriv_prod_quot_neg_power" component="video"/>
     </solution>
     <solution>
 
@@ -681,7 +681,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="ESYjxNMNvh8" xml:id="vid_deriv_prod_quot_ex_simp_first" component="video"/>
+      <video width="98%" youtube="ESYjxNMNvh8" xml:id="vid_deriv_prod_quot_ex_simp_first" label="vid_deriv_prod_quot_ex_simp_first" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -4,7 +4,7 @@
 
   <figure xml:id="vid_deriv_apps_diff_intro" component="video">
     <caption>Video introduction to <xref ref="sec_differentials"/></caption>
-    <video youtube="YmODT2PolKY"/>
+    <video youtube="YmODT2PolKY" label="vid_deriv_apps_diff_intro"/>
   </figure>
 
   <p>
@@ -128,7 +128,7 @@
 
   <figure xml:id="vid_deriv_apps_diff_ex_1" component="video">
     <caption>Approximating the value of <m>\sin(1.1)</m></caption>
-    <video youtube="mQRelmurD-w"/>
+    <video youtube="mQRelmurD-w" label="vid_deriv_apps_diff_ex_1"/>
   </figure>
 
 
@@ -214,7 +214,7 @@
 
   <figure xml:id="vid_deriv_apps_diff_defn" component="video">
     <caption>Video presentation of <xref ref="def_differential"/></caption>
-    <video youtube="y9lTgdHD8wI"/>
+    <video youtube="y9lTgdHD8wI" label="vid_deriv_apps_diff_defn"/>
   </figure>
 
 
@@ -305,7 +305,7 @@
 
   <figure xml:id="vid_deriv_apps_diff_dx_eq_delta_x" component="video">
     <caption>Why is it that <m>dx = \Delta x</m>?</caption>
-    <video youtube="XxpcZw702nA"/>
+    <video youtube="XxpcZw702nA" label="vid_deriv_apps_diff_dx_eq_delta_x"/>
   </figure>
 
   <p>
@@ -325,7 +325,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="KCDezzvfDKA" xml:id="vid_deriv_apps_diff_ex_2" component="video"/>
+      <video width="98%" youtube="KCDezzvfDKA" xml:id="vid_deriv_apps_diff_ex_2" label="vid_deriv_apps_diff_ex_2" component="video"/>
     </solution>
     <solution>
 
@@ -412,7 +412,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="nFaq1O_wWso" xml:id="vid_deriv_apps_diff_ex_3" component="video"/>
+      <video width="98%" youtube="nFaq1O_wWso" xml:id="vid_deriv_apps_diff_ex_3" label="vid_deriv_apps_diff_ex_3" component="video"/>
     </solution>
     <solution>
 
@@ -577,7 +577,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="0_tSaBZZR1s" xml:id="vid_deriv_apps_diff_prop_error" component="video"/>
+      <video width="98%" youtube="0_tSaBZZR1s" xml:id="vid_deriv_apps_diff_prop_error" label="vid_deriv_apps_diff_prop_error" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -20,7 +20,7 @@
 
     <figure xml:id="vid-multi-directional-derivative-def" component="video">
       <caption>Introducing directional derivatives</caption>
-      <video youtube="ZQPnmL5CM6s"/>
+      <video youtube="ZQPnmL5CM6s" label="vid-multi-directional-derivative-def"/>
     </figure>
   </introduction>
 
@@ -247,7 +247,7 @@
 
     <figure xml:id="vid-multi-directional-derivative-example" component="video">
       <caption>Computing directional derivatives</caption>
-      <video youtube="aoR9ANpc334"/>
+      <video youtube="aoR9ANpc334" label="vid-multi-directional-derivative-example"/>
     </figure>
 
     <p>
@@ -945,7 +945,7 @@
 
     <figure xml:id="vid-multi-direction-derivative-interpret" component="video">
       <caption>Discussing the significance of directional derivatives</caption>
-      <video youtube="Re0amVb6QdQ"/>
+      <video youtube="Re0amVb6QdQ" label="vid-multi-direction-derivative-interpret"/>
     </figure>
   </subsection>
 

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -91,7 +91,7 @@
 
   <figure xml:id="vid-intapp-disk-intro" component="video">
     <caption>Video introduction to <xref ref="sec_disk">Section</xref></caption>
-    <video youtube="jx9XyQKDaP4"/>
+    <video youtube="jx9XyQKDaP4" label="vid-intapp-disk-intro"/>
   </figure>
 
   <p>
@@ -146,7 +146,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="JeQve79KVDE" xml:id="vid-intapp-disk-example1" component="video"/>
+      <video width="98%" youtube="JeQve79KVDE" xml:id="vid-intapp-disk-example1" label="vid-intapp-disk-example1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -449,7 +449,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="_a79nyOUVTg" xml:id="vid-intapp-disk-example2" component="video"/>
+      <video width="98%" youtube="_a79nyOUVTg" xml:id="vid-intapp-disk-example2" label="vid-intapp-disk-example2" component="video"/>
     </solution>
     <solution>
       <p>
@@ -653,7 +653,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="k9vdYxWD8xc" xml:id="vid-intapp-disk-example3" component="video"/>
+      <video width="98%" youtube="k9vdYxWD8xc" xml:id="vid-intapp-disk-example3" label="vid-intapp-disk-example3" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1191,7 +1191,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="LwJw1JwTc9E 6Xn4J5Wnkhw" xml:id="vid-intapp-washer-example1" component="video"/>
+      <video width="98%" youtube="LwJw1JwTc9E 6Xn4J5Wnkhw" xml:id="vid-intapp-washer-example1" label="vid-intapp-washer-example1" component="video"/>
     </solution>
     <solution>
 
@@ -1431,7 +1431,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="VO7B1TRcvhM" xml:id="vid-intapp-disk-example5" component="video"/>
+      <video width="98%" youtube="VO7B1TRcvhM" xml:id="vid-intapp-disk-example5" label="vid-intapp-disk-example5" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -10,7 +10,7 @@
 
     <figure xml:id="vid-vectors-dotprod-intro" component="video">
       <caption>Video introduction to <xref ref="sec_dot_product"/></caption>
-      <video youtube="I996h2jxUhw"/>
+      <video youtube="I996h2jxUhw" label="vid-vectors-dotprod-intro"/>
     </figure>
 
     <definition xml:id="def_dot_product">
@@ -80,7 +80,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="NXZz_TGvFZ0" xml:id="vid-vectors-dotprod-example" component="video"/>
+        <video width="98%" youtube="NXZz_TGvFZ0" xml:id="vid-vectors-dotprod-example" label="vid-vectors-dotprod-example" component="video"/>
       </solution>
       <solution>
         <p>
@@ -174,7 +174,7 @@
 
     <figure xml:id="vid-vectors-dotprod-properties" component="video">
       <caption>Video presentation of <xref ref="thm_dot_product_properties"/></caption>
-      <video youtube="7mZ-eK8fBCk"/>
+      <video youtube="7mZ-eK8fBCk" label="vid-vectors-dotprod-properties"/>
     </figure>
 
     <p>
@@ -304,7 +304,7 @@
 
     <figure xml:id="vid-vectors-dotprot-geometry" component="video">
       <caption>Video presentation of <xref ref="thm_dot_product"/></caption>
-      <video youtube="d8mzoznYsJo"/>
+      <video youtube="d8mzoznYsJo" label="vid-vectors-dotprot-geometry"/>
     </figure>
 
     <p>
@@ -434,7 +434,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="7bkKYObUxFo" xml:id="vid-vectors-dotprod-angles" component="video"/>
+        <video width="98%" youtube="7bkKYObUxFo" xml:id="vid-vectors-dotprod-angles" label="vid-vectors-dotprod-angles" component="video"/>
       </solution>
       <solution>
         <p>
@@ -663,7 +663,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="eXkGPeTjohM" xml:id="vid-vectors-dotprod-orthog" component="video"/>
+        <video width="98%" youtube="eXkGPeTjohM" xml:id="vid-vectors-dotprod-orthog" label="vid-vectors-dotprod-orthog" component="video"/>
       </solution>
       <solution>
         <p>
@@ -836,7 +836,7 @@
 
     <figure xml:id="vid-vectors-dotprod-orthproj" component="video">
       <caption>Video presentation of <xref ref="def_orthogonal_projection"/></caption>
-      <video youtube="h8FnrYGOpMg"/>
+      <video youtube="h8FnrYGOpMg" label="vid-vectors-dotprod-orthproj"/>
     </figure>
 
     <example xml:id="ex_dotp4">
@@ -864,7 +864,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="Pcd-bORHB7o" xml:id="vid-vectors-dotprod-proj-eg" component="video"/>
+        <video width="98%" youtube="Pcd-bORHB7o" xml:id="vid-vectors-dotprod-proj-eg" label="vid-vectors-dotprod-proj-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1223,7 +1223,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="9IxUaJ1M4Jk" xml:id="vid-vectors-dotprod-orthdecomp" component="video"/>
+        <video width="98%" youtube="9IxUaJ1M4Jk" xml:id="vid-vectors-dotprod-orthdecomp" label="vid-vectors-dotprod-orthdecomp" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1360,7 +1360,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="85RquaXgutc" xml:id="vid-vectors-dotprod-work" component="video"/>
+        <video width="98%" youtube="85RquaXgutc" xml:id="vid-vectors-dotprod-work" label="vid-vectors-dotprod-work" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -18,7 +18,7 @@
 
   <figure xml:id="vid-multint-polar-intro" component="video">
     <caption>Introducing the double integral in polar coordinates</caption>
-    <video youtube="K7hpTI0PNGo"/>
+    <video youtube="K7hpTI0PNGo" label="vid-multint-polar-intro"/>
   </figure>
 
   <p>
@@ -308,7 +308,7 @@
 
   <figure xml:id="vid-multint-polar-examples12" component="video">
     <caption>Two simple examples of double integrals in polar coordinates</caption>
-    <video youtube="Gmt0dak05Lk"/>
+    <video youtube="Gmt0dak05Lk" label="vid-multint-polar-examples12"/>
   </figure>
 
   <example xml:id="ex_doublepol2">
@@ -674,7 +674,7 @@
 
   <figure xml:id="vid-multint-polar-bounded-volume" component="video">
     <caption>Finding the volume bounded by two surfaces</caption>
-    <video youtube="47Xebo9FsKs"/>
+    <video youtube="47Xebo9FsKs" label="vid-multint-polar-bounded-volume"/>
   </figure>
 
   <example xml:id="ex_doublepol4">
@@ -857,7 +857,7 @@
 
   <figure xml:id="vid-multint-polar-rose" component="video">
     <caption>Another integral over a rose curve</caption>
-    <video youtube="x72_v_zZkI4"/>
+    <video youtube="x72_v_zZkI4" label="vid-multint-polar-rose"/>
   </figure>
 
   <p>

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -23,7 +23,7 @@
 
   <figure xml:id="vid-multint-double-intro" component="video">
     <caption>Introducing the double integral</caption>
-    <video youtube="5FpKcnG-5vY"/>
+    <video youtube="5FpKcnG-5vY" label="vid-multint-double-intro"/>
   </figure>
 
   <p>
@@ -354,7 +354,7 @@
 
   <figure xml:id="vid-multint-double-def" component="video">
     <caption>Defining the double integral</caption>
-    <video youtube="l7hGaXcsq9g"/>
+    <video youtube="l7hGaXcsq9g" label="vid-multint-double-def"/>
   </figure>
 
   <p>
@@ -552,7 +552,7 @@
 
   <figure xml:id="vid-multint-double-fubini" component="video">
     <caption>Fubini's Theorem and iterated integrals</caption>
-    <video youtube="smdRuI_ztAw"/>
+    <video youtube="smdRuI_ztAw" label="vid-multint-double-fubini"/>
   </figure>
 
   <example xml:id="ex_double1">
@@ -781,7 +781,7 @@
 
   <figure xml:id="vid-multint-double-rectangle-eg" component="video">
     <caption>Further examples of double integrals over rectangles</caption>
-    <video youtube="MMbLzFw-5Rg"/>
+    <video youtube="MMbLzFw-5Rg" label="vid-multint-double-rectangle-eg"/>
   </figure>
   <p>
     Note how in these examples that the bounds of integration depend only on <m>R</m>;
@@ -897,7 +897,7 @@
 
   <figure xml:id="vid-multint-double-general-region" component="video">
     <caption>Evaluating a double integral over a more general region</caption>
-    <video youtube="FcxnuFSNOfY"/>
+    <video youtube="FcxnuFSNOfY" label="vid-multint-double-general-region"/>
   </figure>
 
   <example xml:id="ex_double3">
@@ -1023,7 +1023,7 @@
 
   <figure xml:id="vid-multint-double-tetrahedron-volume" component="video">
     <caption>Finding the volume of a tetrahedron</caption>
-    <video youtube="m_8kBmNVxEM"/>
+    <video youtube="m_8kBmNVxEM" label="vid-multint-double-tetrahedron-volume"/>
   </figure>
   <example xml:id="ex_double4">
     <title>Evaluating a double integral</title>
@@ -1155,7 +1155,7 @@
 
   <figure xml:id="vid-multint-double-general-example" component="video">
     <caption>Evaluating a double integral over a general region</caption>
-    <video youtube="a4XiokkzyrU"/>
+    <video youtube="a4XiokkzyrU" label="vid-multint-double-general-example"/>
   </figure>
   <p>
     In the previous section we practiced changing the order of integration of a given iterated integral,
@@ -1335,7 +1335,7 @@
 
   <figure xml:id="vid-multint-double-changing-order" component="video">
     <caption>Two more examples of changing the order of integration</caption>
-    <video youtube="a4XiokkzyrU yvwwWML9PS4"/>
+    <video youtube="a4XiokkzyrU yvwwWML9PS4" label="vid-multint-double-changing-order"/>
   </figure>
 
   <p>

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -4,7 +4,7 @@
   <introduction>
     <figure xml:id="vid_graphs_concav_intro" component="video">
       <caption>Video introduction to <xref ref="sec_concavity"/></caption>
-      <video youtube="0uCjI5J4ew4"/>
+      <video youtube="0uCjI5J4ew4" label="vid_graphs_concav_intro"/>
     </figure>
 
     <p>
@@ -488,7 +488,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="n8TRVD_8sY0" xml:id="vid_graphs_concav_ex_1" component="video"/>
+        <video width="98%" youtube="n8TRVD_8sY0" xml:id="vid_graphs_concav_ex_1" label="vid_graphs_concav_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -583,7 +583,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="eC6QLbsuRVs" xml:id="vid_graphs_concav_ex_2" component="video"/>
+        <video width="98%" youtube="eC6QLbsuRVs" xml:id="vid_graphs_concav_ex_2" label="vid_graphs_concav_ex_2" component="video"/>
       </solution>
       <solution>
 
@@ -787,7 +787,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="yjcSXaGkL5Y" xml:id="vid_graphs_concav_ex_3" component="video"/>
+        <video width="98%" youtube="yjcSXaGkL5Y" xml:id="vid_graphs_concav_ex_3" label="vid_graphs_concav_ex_3" component="video"/>
       </solution>
       <solution>
 
@@ -966,7 +966,7 @@
 
     <figure xml:id="vid_graphs_concav_second_deriv_test" component="video">
       <caption>Video presentation of <xref ref="thm_second_der"/></caption>
-      <video youtube="4hWldEUoG2U"/>
+      <video youtube="4hWldEUoG2U" label="vid_graphs_concav_second_deriv_test"/>
     </figure>
 
     <p>
@@ -989,7 +989,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="_DhmPXRZfi8" xml:id="vid_graphs_concav_ex_4" component="video"/>
+        <video width="98%" youtube="_DhmPXRZfi8" xml:id="vid_graphs_concav_ex_4" label="vid_graphs_concav_ex_4" component="video"/>
       </solution>
       <solution>
 

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -67,7 +67,7 @@
 
   <figure xml:id="vid_graphs_extreme_val_abs_extrema" component="video">
     <caption>Video presentation of <xref ref="def_extreme_values"/></caption>
-    <video youtube="srE7xUmQtCQ"/>
+    <video youtube="srE7xUmQtCQ" label="vid_graphs_extreme_val_abs_extrema"/>
   </figure>
 
  <p>
@@ -174,7 +174,7 @@
 
   <figure xml:id="vid_graphs_extreme_val_EVT" component="video">
     <caption>Video presentation of <xref ref="thm_extreme_val"/></caption>
-    <video youtube="GIcjxu8dTnY"/>
+    <video youtube="GIcjxu8dTnY" label="vid_graphs_extreme_val_EVT"/>
   </figure>
 
   <p>
@@ -304,7 +304,7 @@
 
   <figure xml:id="vid_graphs_extreme_val_rel_extrema" component="video">
     <caption>Video presentation of <xref ref="def_rel_ext"/></caption>
-    <video youtube="nBZTnxn0vqQ"/>
+    <video youtube="nBZTnxn0vqQ" label="vid_graphs_extreme_val_rel_extrema"/>
   </figure>
   <p>
     We briefly practice using these definitions.
@@ -457,7 +457,7 @@
 
   <figure xml:id="vid_graphs_extreme_val_crit_pnts" component="video">
     <caption>Video presentation of <xref ref="def_criticalnum"/> and <xref ref="thm_criticalpts"/></caption>
-    <video youtube="WsBGpi006X0"/>
+    <video youtube="WsBGpi006X0" label="vid_graphs_extreme_val_crit_pnts"/>
   </figure>
 
   <p>
@@ -570,7 +570,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="LyhHlreZvhc" xml:id="vid_graphs_extreme_val_ex_1" component="video"/>
+      <video width="98%" youtube="LyhHlreZvhc" xml:id="vid_graphs_extreme_val_ex_1" label="vid_graphs_extreme_val_ex_1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -649,7 +649,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="zn--ShSSMqk" xml:id="vid_graphs_extreme_val_ex_2" component="video"/>
+      <video width="98%" youtube="zn--ShSSMqk" xml:id="vid_graphs_extreme_val_ex_2" label="vid_graphs_extreme_val_ex_2" component="video"/>
     </solution>
     <solution>
 
@@ -760,7 +760,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="sT_3kVSsbz4" xml:id="vid_graphs_extreme_val_ex_3" component="video"/>
+      <video width="98%" youtube="sT_3kVSsbz4" xml:id="vid_graphs_extreme_val_ex_3" label="vid_graphs_extreme_val_ex_3" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -80,7 +80,7 @@
 
   <figure xml:id="vid_graphs_incr_decr_defn" component="video">
     <caption>Video presentation of <xref ref="def_incr_decr"/></caption>
-    <video youtube="NtV0R-JxrmM"/>
+    <video youtube="NtV0R-JxrmM" label="vid_graphs_incr_decr_defn"/>
   </figure>
 
 
@@ -214,7 +214,7 @@
 
   <figure xml:id="vid_graphs_incr_decr_role_deriv_sign" component="video">
     <caption>Video presentation of <xref ref="thm_incr_decr"/></caption>
-    <video youtube="SjF3vslBqOA"/>
+    <video youtube="SjF3vslBqOA" label="vid_graphs_incr_decr_role_deriv_sign"/>
   </figure>
 
 
@@ -326,7 +326,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="DW6qcgE1TZ0" xml:id="vid_graphs_incr_decr_ex_1" component="video"/>
+      <video width="98%" youtube="DW6qcgE1TZ0" xml:id="vid_graphs_incr_decr_ex_1" label="vid_graphs_incr_decr_ex_1" component="video"/>
     </solution>
     <solution>
 
@@ -580,7 +580,7 @@
 
   <figure xml:id="vid_graphs_incr_decr_first_deriv_test" component="video">
     <caption>Video presentation of <xref ref="thm_first_der"/></caption>
-    <video youtube="_HjE4urOM4Y"/>
+    <video youtube="_HjE4urOM4Y" label="vid_graphs_incr_decr_first_deriv_test"/>
   </figure>
 
 
@@ -633,7 +633,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="94iCiIX07R0" xml:id="vid_graphs_incr_decr_ex_2" component="video"/>
+      <video width="98%" youtube="94iCiIX07R0" xml:id="vid_graphs_incr_decr_ex_2" label="vid_graphs_incr_decr_ex_2" component="video"/>
     </solution>
     <solution>
 
@@ -834,7 +834,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="T4RxcQnNotc" xml:id="vid_graphs_incr_decr_ex_3" component="video"/>
+      <video width="98%" youtube="T4RxcQnNotc" xml:id="vid_graphs_incr_decr_ex_3" label="vid_graphs_incr_decr_ex_3" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -29,7 +29,7 @@
 
   <figure xml:id="vid_graphs_MVT_intro" component="video">
     <caption>Video introduction to <xref ref="sec_mvt"/></caption>
-    <video youtube="GvdxKh6RpT0"/>
+    <video youtube="GvdxKh6RpT0" label="vid_graphs_MVT_intro"/>
   </figure>
 
   <p>
@@ -198,7 +198,7 @@
 
   <figure xml:id="vid_graphs_MVT_rolles_thm" component="video">
     <caption>Video presentation of <xref ref="thm_rolles"/></caption>
-    <video youtube="E05H1f8TByI"/>
+    <video youtube="E05H1f8TByI" label="vid_graphs_MVT_rolles_thm"/>
   </figure>
 
   <p>
@@ -244,7 +244,7 @@
 
   <figure xml:id="vid_graphs_MVT_ex_1" component="video">
     <caption>Using Rolle's Theorem to show a polynomial has at most one real root</caption>
-    <video youtube="le-5zsb6O7o"/>
+    <video youtube="le-5zsb6O7o" label="vid_graphs_MVT_ex_1"/>
   </figure>
 
   <p>
@@ -297,7 +297,7 @@
 
   <proof>
     <title>Proof of the Mean Value Theorem</title>
-    <video width="98%" youtube="1b9af8q5JMg" xml:id="vid_graphs_MVT_proof_MVT" component="video"/>
+    <video width="98%" youtube="1b9af8q5JMg" xml:id="vid_graphs_MVT_proof_MVT" label="vid_graphs_MVT_proof_MVT" component="video"/>
 
     <p>
       Define the function
@@ -362,7 +362,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="ON7WYLJY2tE" xml:id="vid_graphs_MVT_ex_3" component="video"/>
+      <video width="98%" youtube="ON7WYLJY2tE" xml:id="vid_graphs_MVT_ex_3" label="vid_graphs_MVT_ex_3" component="video"/>
     </solution>
     <solution>
       <p>
@@ -441,7 +441,7 @@
 
   <figure xml:id="vid_graphs_MVT_func_deriv_0_const" component="video">
     <caption>Showing that a function with zero derivative is constant</caption>
-    <video youtube="PVMLAKYehgs"/>
+    <video youtube="PVMLAKYehgs" label="vid_graphs_MVT_func_deriv_0_const"/>
   </figure>
 
   <p xml:id="vidint-MVT-applications3" component="video">
@@ -451,7 +451,7 @@
 
   <figure xml:id="vid_graphs_MVT_funcs_eq_derivs_diff_const" component="video">
     <caption>Showing that two functions with the equal derivatives differ by a constant</caption>
-    <video youtube="BzvxKeZMNtE"/>
+    <video youtube="BzvxKeZMNtE" label="vid_graphs_MVT_funcs_eq_derivs_diff_const"/>
   </figure>
 
   <p xml:id="vidint-MVT-applications4" component="video">
@@ -461,7 +461,7 @@
 
   <figure xml:id="vid_graphs_MVT_ex_2" component="video">
     <caption>Demonstrating a property of the sine function</caption>
-    <video youtube="CGBTZtM9mFY"/>
+    <video youtube="CGBTZtM9mFY" label="vid_graphs_MVT_ex_2"/>
   </figure>
 
 

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -112,7 +112,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="41XMvSHgl-Y" xml:id="vid_graphs_sketch_poly" component="video"/>
+      <video width="98%" youtube="41XMvSHgl-Y" xml:id="vid_graphs_sketch_poly" label="vid_graphs_sketch_poly" component="video"/>
     </solution>
     <solution>
 
@@ -345,7 +345,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="t3VI2oTmOiA" xml:id="vid_graphs_sketch_rational" component="video"/>
+      <video width="98%" youtube="t3VI2oTmOiA" xml:id="vid_graphs_sketch_rational" label="vid_graphs_sketch_rational" component="video"/>
     </solution>
     <solution>
 
@@ -837,17 +837,17 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
 
   <figure xml:id="vid_graphs_sketch_poly_fact" component="video">
     <caption>Sketching the polynomial <m>f(x)=x^2(5-x)^3</m></caption>
-    <video youtube="S3j-vuUZPjE"/>
+    <video youtube="S3j-vuUZPjE" label="vid_graphs_sketch_poly_fact"/>
   </figure>
 
   <figure xml:id="vid_graphs_sketch_trig" component="video">
     <caption>Sketching the graph of the trigonometric function <m>f(x)=\sin(2x)-2\sin(x)</m></caption>
-    <video youtube="fdnoec_9Yw4"/>
+    <video youtube="fdnoec_9Yw4" label="vid_graphs_sketch_trig"/>
   </figure>
 
   <figure xml:id="vid_graphs_sketch_frac_powers" component="video">
     <caption>Sketching the graph of <m>f(x)=x^{4/3}-4x^{1/3}</m></caption>
-    <video youtube="JR31YX5N3M8"/>
+    <video youtube="JR31YX5N3M8" label="vid_graphs_sketch_frac_powers"/>
   </figure>
 
   <p>

--- a/ptx/sec_greensthm.ptx
+++ b/ptx/sec_greensthm.ptx
@@ -137,7 +137,7 @@
 
     <figure xml:id="vid-veccalc-greens-curves" component="video">
       <caption>Further terminology for curves: closed, simple, positively oriented</caption>
-      <video youtube="setRFQrIgC4"/>
+      <video youtube="setRFQrIgC4" label="vid-veccalc-greens-curves"/>
     </figure>
 
     <p>
@@ -577,7 +577,7 @@
 
     <figure xml:id="vid-veccalc-greens-statement" component="video">
       <caption>Introducing Green's Theorem</caption>
-      <video youtube="JOFBkUN5Dis"/>
+      <video youtube="JOFBkUN5Dis" label="vid-veccalc-greens-statement"/>
     </figure>
     <p>
       Green's Theorem states <q>the counterclockwise circulation around a closed region <m>R</m> is equal to the sum of the curls over <m>R</m>.</q>
@@ -758,7 +758,7 @@
 
     <figure xml:id="vid-veccalc-greens-example-verify" component="video">
       <caption>Verifying Green's Theorem with an example</caption>
-      <video youtube="K2lPAvWyH4Y"/>
+      <video youtube="K2lPAvWyH4Y" label="vid-veccalc-greens-example-verify"/>
     </figure>
 
     <example xml:id="ex_green2">
@@ -882,7 +882,7 @@
 
     <figure xml:id="vid-veccalc-greens-proof" component="video">
       <caption>Sketching the proof of Green's Theorem</caption>
-      <video youtube="l9RaOCx4r1g"/>
+      <video youtube="l9RaOCx4r1g" label="vid-veccalc-greens-proof"/>
     </figure>
 
     <p>
@@ -963,12 +963,12 @@
 
     <figure xml:id="vid-veccalc-greens-cylcoid-area" component="video">
       <caption>Using Green's Theorem to find the area under a cycloid</caption>
-      <video youtube="g8iULyP0alk"/>
+      <video youtube="g8iULyP0alk" label="vid-veccalc-greens-cylcoid-area"/>
     </figure>
 
     <figure xml:id="vid-veccalc-greens-polygon" component="video">
       <caption>Using Green's Theorem to derive a polygon area formula</caption>
-      <video youtube="x1bIGtNu-0M"/>
+      <video youtube="x1bIGtNu-0M" label="vid-veccalc-greens-polygon"/>
     </figure>
 
     <p xml:id="vidint-veccalc-greens-multiply" component="video">
@@ -981,7 +981,7 @@
 
     <figure xml:id="vid-veccalc-greens-multiply" component="video">
       <caption>Green's Theorem and multiply-connected regions</caption>
-      <video youtube="PaW_ZF-js-M"/>
+      <video youtube="PaW_ZF-js-M" label="vid-veccalc-greens-multiply"/>
     </figure>
   </subsection>
 

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -28,7 +28,7 @@
 
     <figure xml:id="vid-hyperbolic-intro" component="video">
       <caption>Video introduction to <xref ref="sec_hyperbolic"/></caption>
-      <video youtube="-6y0xCwCy4s"/>
+      <video youtube="-6y0xCwCy4s" label="vid-hyperbolic-intro"/>
     </figure>
 
     <figure xml:id="fig_hfcircle">
@@ -247,7 +247,7 @@
 
     <figure xml:id="vid-hyperbolic-graphs-first-properties" component="video">
       <caption>Video presentation of graphs and basic properties of hyperbolic functions</caption>
-      <video youtube="0YP4mVrroVk"/>
+      <video youtube="0YP4mVrroVk" label="vid-hyperbolic-graphs-first-properties"/>
     </figure>
 
     <p>
@@ -362,7 +362,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="VunyFD8keVg" xml:id="vid-hyperbolic-ex-properties" component="video"/>
+        <video width="98%" youtube="VunyFD8keVg" xml:id="vid-hyperbolic-ex-properties" label="vid-hyperbolic-ex-properties" component="video"/>
       </solution>
       <solution>
         <p>
@@ -544,7 +544,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="MwYZHh9UaRo" xml:id="vid-hyperbolic-ex-deriv-int" component="video"/>
+        <video width="98%" youtube="MwYZHh9UaRo" xml:id="vid-hyperbolic-ex-deriv-int" label="vid-hyperbolic-ex-deriv-int" component="video"/>
       </solution>
       <solution>
         <p>
@@ -641,7 +641,7 @@
 
     <figure xml:id="vid-hyperbolic-inverse-sinh" component="video">
       <caption>Finding the inverse of <m>f(x)=\sinh(x)</m></caption>
-      <video youtube="znJxWgMJPw8"/>
+      <video youtube="znJxWgMJPw8" label="vid-hyperbolic-inverse-sinh"/>
     </figure>
 
     <table xml:id="fig_hfinverse2">
@@ -995,7 +995,7 @@
 
     <figure xml:id="vid-hyperbolic-int-hypsub" component="video">
       <caption>Using a hyperbolic substitution to evaluate an integral</caption>
-      <video youtube="xYG0fnGDakI"/>
+      <video youtube="xYG0fnGDakI" label="vid-hyperbolic-int-hypsub"/>
     </figure>
 
     <p>
@@ -1021,7 +1021,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="vlW6Og4hk-w" xml:id="vid-hyperbolic-ex-deriv-int2" component="video"/>
+        <video width="98%" youtube="vlW6Og4hk-w" xml:id="vid-hyperbolic-ex-deriv-int2" label="vid-hyperbolic-ex-deriv-int2" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_improper_integration.ptx
+++ b/ptx/sec_improper_integration.ptx
@@ -72,7 +72,7 @@
 
     <figure xml:id="vid-int-improper-intro" component="video">
       <caption>Video introduction to <xref ref="sec_improper_integration"/></caption>
-      <video youtube="HhBRqV7rt4I"/>
+      <video youtube="HhBRqV7rt4I" label="vid-int-improper-intro"/>
     </figure>
 
     <p>
@@ -180,7 +180,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="hXnmu7fZj-E" xml:id="vid-int-improper-ex-at-infinity" component="video"/>
+        <video width="98%" youtube="hXnmu7fZj-E" xml:id="vid-int-improper-ex-at-infinity" label="vid-int-improper-ex-at-infinity" component="video"/>
       </solution>
       <solution>
         <p>
@@ -391,7 +391,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="hKpXU3fFS6g" xml:id="vid-int-improper-ex-with-lhospital" component="video"/>
+        <video width="98%" youtube="hKpXU3fFS6g" xml:id="vid-int-improper-ex-with-lhospital" label="vid-int-improper-ex-with-lhospital" component="video"/>
       </solution>
       <solution>
         <p>
@@ -493,7 +493,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="F46oIXOBjAw" xml:id="vid-int-improper-ex-vert-asy" component="video"/>
+        <video width="98%" youtube="F46oIXOBjAw" xml:id="vid-int-improper-ex-vert-asy" label="vid-int-improper-ex-vert-asy" component="video"/>
       </solution>
       <solution>
         <p>
@@ -648,7 +648,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="-W8yESqiexA" xml:id="vid-int-improper-ex-ptest" component="video"/>
+        <video width="98%" youtube="-W8yESqiexA" xml:id="vid-int-improper-ex-ptest" label="vid-int-improper-ex-ptest" component="video"/>
       </solution>
       <solution>
         <p>
@@ -812,7 +812,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="356-QIN7fWA" xml:id="vid-int-improper-ex-compare-direct" component="video"/>
+        <video width="98%" youtube="356-QIN7fWA" xml:id="vid-int-improper-ex-compare-direct" label="vid-int-improper-ex-compare-direct" component="video"/>
       </solution>
       <solution>
         <p>
@@ -969,7 +969,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="nIr1A1Tmako" xml:id="vid-int-improper-ex-limit-compare" component="video"/>
+        <video width="98%" youtube="nIr1A1Tmako" xml:id="vid-int-improper-ex-limit-compare" label="vid-int-improper-ex-limit-compare" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -54,7 +54,7 @@
 
     <figure xml:id="vid-seqseries-intcomp-integral-test" component="video">
       <caption>Video presentation of <xref ref="thm_integral_test"/></caption>
-      <video youtube="43DIt-rRclA"/>
+      <video youtube="43DIt-rRclA" label="vid-seqseries-intcomp-integral-test"/>
     </figure>
     <p>
       We can demonstrate the truth of the Integral Test with two simple graphs.
@@ -247,7 +247,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="YuAg9zOh2Hk" xml:id="vid-seqseries-intcomp-example1" component="video"/>
+        <video width="98%" youtube="YuAg9zOh2Hk" xml:id="vid-seqseries-intcomp-example1" label="vid-seqseries-intcomp-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -343,7 +343,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="fBQkA2ntBuM" xml:id="vid-seqseries-intcomp-ptest" component="video"/>
+        <video width="98%" youtube="fBQkA2ntBuM" xml:id="vid-seqseries-intcomp-ptest" label="vid-seqseries-intcomp-ptest" component="video"/>
       </solution>
       <solution>
         <p>
@@ -482,7 +482,7 @@
 
     <figure xml:id="vid-seqseries-intcomp-comp-test" component="video">
       <caption>Video presentation of <xref ref="thm_series_direct_compare"/></caption>
-      <video youtube="KhPpyQVNR5Y"/>
+      <video youtube="KhPpyQVNR5Y" label="vid-seqseries-intcomp-comp-test"/>
     </figure>
 
     <example xml:id="ex_dct1">
@@ -494,7 +494,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="DAfdDWo948U" xml:id="vid-seqseries-intcomp-comp-example" component="video"/>
+        <video width="98%" youtube="DAfdDWo948U" xml:id="vid-seqseries-intcomp-comp-example" label="vid-seqseries-intcomp-comp-example" component="video"/>
       </solution>
       <solution>
         <p>
@@ -524,7 +524,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="G1j5JNagVmU" xml:id="vid-seqseries-intcomp-comp-example2" component="video"/>
+        <video width="98%" youtube="G1j5JNagVmU" xml:id="vid-seqseries-intcomp-comp-example2" label="vid-seqseries-intcomp-comp-example2" component="video"/>
       </solution>
       <solution>
 
@@ -573,7 +573,7 @@
 
     <figure xml:id="vid-seqseries-intcomp-motivate-limit" component="video">
       <caption>Motivating <xref ref="thm_series_limit_compare"/></caption>
-      <video youtube="bH7U2fgSWXs"/>
+      <video youtube="bH7U2fgSWXs" label="vid-seqseries-intcomp-motivate-limit"/>
     </figure>
   </subsection>
 
@@ -628,7 +628,7 @@
 
     <figure xml:id="vid-seqseries-intcomp-limit-compare" component="video">
       <caption>Video presentation of <xref ref="thm_series_limit_compare"/></caption>
-      <video youtube="zGKEPIyXvvY"/>
+      <video youtube="zGKEPIyXvvY" label="vid-seqseries-intcomp-limit-compare"/>
     </figure>
 
     <p>
@@ -646,7 +646,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="RBeu0Tgsj_c" xml:id="vid-seqseries-intcomp-limit-example1" component="video"/>
+        <video width="98%" youtube="RBeu0Tgsj_c" xml:id="vid-seqseries-intcomp-limit-example1" label="vid-seqseries-intcomp-limit-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -673,7 +673,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="1qaiCHhP3GE" xml:id="vid-seqseries-intcomp-limit-example2" component="video"/>
+        <video width="98%" youtube="1qaiCHhP3GE" xml:id="vid-seqseries-intcomp-limit-example2" label="vid-seqseries-intcomp-limit-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -721,7 +721,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="D-OsPkY8khE" xml:id="vid-seqseries-intcomp-limit-example3" component="video"/>
+        <video width="98%" youtube="D-OsPkY8khE" xml:id="vid-seqseries-intcomp-limit-example3" label="vid-seqseries-intcomp-limit-example3" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_lagrange.ptx
+++ b/ptx/sec_lagrange.ptx
@@ -90,7 +90,7 @@
 
 	<figure xml:id="vid-multi-lagrange-intro" component="video">
 	  <caption>Introducing Lagrange multipliers</caption>
-	  <video youtube="W5ykqB7261c"/>
+	  <video youtube="W5ykqB7261c" label="vid-multi-lagrange-intro"/>
 	</figure>
 
 	<p>
@@ -244,7 +244,7 @@
 
 	<figure xml:id="vid-multi-lagrange-example1" component="video">
 	  <caption>Using the method of Lagrange multipliers</caption>
-	  <video youtube="WgzwyBEDTzA"/>
+	  <video youtube="WgzwyBEDTzA" label="vid-multi-lagrange-example1"/>
 	</figure>
 
 	<p>
@@ -572,6 +572,6 @@
 
 	<figure xml:id="vid-multi-lagrange-example2" component="video">
 	  <caption>Another optimization problem using Lagrange multipliers</caption>
-	  <video youtube="uvQku50u_-0"/>
+	  <video youtube="uvQku50u_-0" label="vid-multi-lagrange-example2"/>
 	</figure>
 </section>

--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -39,7 +39,7 @@
 
     <figure xml:id="vid-lhospital-intro" component="video">
       <caption>Video introduction to <xref ref="sec_lhopitals_rule"/></caption>
-      <video youtube="_tRdRiWmFhM"/>
+      <video youtube="_tRdRiWmFhM" label="vid-lhospital-intro"/>
     </figure>
 
     <p>
@@ -126,7 +126,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="Y2O3RD9tt34" xml:id="vid-lhospital-ex-zerzer1" component="video"/>
+        <video width="98%" youtube="Y2O3RD9tt34" xml:id="vid-lhospital-ex-zerzer1" label="vid-lhospital-ex-zerzer1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -255,7 +255,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="1WIItaObKQk" xml:id="vid-lhospital-ex-infinf" component="video"/>
+        <video width="98%" youtube="1WIItaObKQk" xml:id="vid-lhospital-ex-infinf" label="vid-lhospital-ex-infinf" component="video"/>
       </solution>
       <solution>
         <p>
@@ -325,7 +325,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qQCQSB4BySw BrYTuJS8Y8M" xml:id="vid-lhospital-ex-zerinf" component="video"/>
+        <video width="98%" youtube="qQCQSB4BySw BrYTuJS8Y8M" xml:id="vid-lhospital-ex-zerinf" label="vid-lhospital-ex-zerinf" component="video"/>
       </solution>
       <solution>
 
@@ -453,7 +453,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="wHCd7Wsxzug" xml:id="vid-lhospital-ex-expforms" component="video"/>
+        <video width="98%" youtube="wHCd7Wsxzug" xml:id="vid-lhospital-ex-expforms" label="vid-lhospital-ex-expforms" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -119,7 +119,7 @@
 
   <figure xml:id="vid_limit_analytic_algebra" component="video">
     <caption>Video presentation of <xref ref="thm_limit_algebra"/> (three videos)</caption>
-    <video youtube="idVyYI9XH-A 5P2Zac-_Xhg lNbLZ2BR1gQ"/>
+    <video youtube="idVyYI9XH-A 5P2Zac-_Xhg lNbLZ2BR1gQ" label="vid_limit_analytic_algebra"/>
   </figure>
 
   <aside>
@@ -163,7 +163,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="8x42kGfu9ts" xml:id="vid_limit_analytic_using_prop" component="video"/>
+      <video width="98%" youtube="8x42kGfu9ts" xml:id="vid_limit_analytic_using_prop" label="vid_limit_analytic_using_prop" component="video"/>
     </solution>
     <solution>
       <p>
@@ -261,7 +261,7 @@
 
   <figure xml:id="vid_limit_analytic_imp_thms" component="video">
     <caption>Video presentation of <xref ref="thm_poly_rat"/> and <xref ref="thm_limit_allbut1"/></caption>
-    <video youtube="NGoUHZESPso"/>
+    <video youtube="NGoUHZESPso" label="vid_limit_analytic_imp_thms"/>
   </figure>
 
 
@@ -526,7 +526,7 @@
 
   <figure xml:id="vid_limit_analytic_squeeze_thm" component="video">
     <caption>Explaining the Squeeze Theorem</caption>
-    <video youtube="8Tv-GRQdAVA"/>
+    <video youtube="8Tv-GRQdAVA" label="vid_limit_analytic_squeeze_thm"/>
   </figure>
 
   <p>
@@ -543,7 +543,7 @@
 
   <figure xml:id="vid_limit_analytic_lim_sin_0" component="video">
     <caption>Using the Squeeze Theorem to take limits of <m>\sin(x)</m></caption>
-    <video youtube="S0VmjueQn5k L2ohy96L-F4"/>
+    <video youtube="S0VmjueQn5k L2ohy96L-F4" label="vid_limit_analytic_lim_sin_0"/>
   </figure>
 
   <p>
@@ -564,7 +564,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="pgjv3ojtXh4" xml:id="vid_limit_analytic_sinxoverx" component="video"/>
+      <video width="98%" youtube="pgjv3ojtXh4" xml:id="vid_limit_analytic_sinxoverx" label="vid_limit_analytic_sinxoverx" component="video"/>
     </solution>
     <solution>
       <p>
@@ -711,7 +711,7 @@
 
   <figure xml:id="vid_limit_analytic_trig_lim" component="video">
     <caption>Finding limits involving trigonometric functions</caption>
-    <video youtube="Wd464IIls5Y"/>
+    <video youtube="Wd464IIls5Y" label="vid_limit_analytic_trig_lim"/>
   </figure>
 
   <p>
@@ -928,7 +928,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="MSckoYqdKH4" xml:id="vid_limit_analytic_alg_ex_1" component="video"/>
+      <video width="98%" youtube="MSckoYqdKH4" xml:id="vid_limit_analytic_alg_ex_1" label="vid_limit_analytic_alg_ex_1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -969,7 +969,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="vOW92eipOu4" xml:id="vid_limit_analytic_alg_ex_2" component="video"/>
+      <video width="98%" youtube="vOW92eipOu4" xml:id="vid_limit_analytic_alg_ex_2" label="vid_limit_analytic_alg_ex_2" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -65,7 +65,7 @@
 
   <figure xml:id="vid_limit_con_defn" component="video">
     <caption>Video presentation of <xref ref="def_continuous"/></caption>
-    <video youtube="bKi6ReLchfw"/>
+    <video youtube="bKi6ReLchfw" label="vid_limit_con_defn"/>
   </figure>
 
   <p>
@@ -361,7 +361,7 @@
 
   <figure xml:id="vid_limit_con_basic_ex" component="video">
     <caption>Two continuity examples</caption>
-    <video youtube="8z07z3yeChY"/>
+    <video youtube="8z07z3yeChY" label="vid_limit_con_basic_ex"/>
   </figure>
 
   <p>
@@ -416,7 +416,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="by3ioPN6KRM" xml:id="vid_limit_con_invertals_con" component="video"/>
+      <video width="98%" youtube="by3ioPN6KRM" xml:id="vid_limit_con_invertals_con" label="vid_limit_con_invertals_con" component="video"/>
     </solution>
     <solution>
 
@@ -554,7 +554,7 @@
 
   <figure xml:id="vid_limit_con_prop" component="video">
     <caption>Video presentation of <xref ref="thm_continuity_algebra"/></caption>
-    <video youtube="GTiNiZT5ukg"/>
+    <video youtube="GTiNiZT5ukg" label="vid_limit_con_prop"/>
   </figure>
 
   <aside>
@@ -640,7 +640,7 @@
 
   <figure xml:id="vid_limit_con_using_prop" component="video">
     <caption>Continuity of compositions</caption>
-    <video youtube="ewUiuE9bQlo"/>
+    <video youtube="ewUiuE9bQlo" label="vid_limit_con_using_prop"/>
   </figure>
 
 
@@ -679,7 +679,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="6Lm-0eBi-5E" xml:id="vid_limit_con_internals_again" component="video"/>
+      <video width="98%" youtube="6Lm-0eBi-5E" xml:id="vid_limit_con_internals_again" label="vid_limit_con_internals_again" component="video"/>
     </solution>
     <solution>
 
@@ -776,7 +776,7 @@
 
     <figure xml:id="vid_limit_con_types_discon" component="video">
       <caption>Discussing classification of discontinuities</caption>
-      <video youtube="TevrD3qci0Q"/>
+      <video youtube="TevrD3qci0Q" label="vid_limit_con_types_discon"/>
     </figure>
 
     <p>
@@ -995,7 +995,7 @@
 
     <figure xml:id="vid_limit_con_IVT_stmnt" component="video">
       <caption>Video presentation of <xref ref="thm_IVT"/></caption>
-      <video youtube="Fx7Qu9tZlN4"/>
+      <video youtube="Fx7Qu9tZlN4" label="vid_limit_con_IVT_stmnt"/>
     </figure>
 
 
@@ -1061,7 +1061,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="mwq447zC9R0 dx5reJRcQD0" xml:id="vid_limit_con_IVT_bisec" component="video"/>
+        <video width="98%" youtube="mwq447zC9R0 dx5reJRcQD0" xml:id="vid_limit_con_IVT_bisec" label="vid_limit_con_IVT_bisec" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -17,7 +17,7 @@
   </aside>
   <figure xml:id="vid_limit_defn_informal" component="video">
     <caption>An informal definition of the limit</caption>
-    <video youtube="OGvDIXuWn0g"/>
+    <video youtube="OGvDIXuWn0g" label="vid_limit_defn_informal"/>
   </figure>
 
   <p>
@@ -158,7 +158,7 @@
   </definition>
   <figure xml:id="vid_limit_defn_precise" component="video">
     <caption>Video presentation of <xref ref="def_limit"/></caption>
-    <video youtube="npoSY-AFvOY"/>
+    <video youtube="npoSY-AFvOY" label="vid_limit_defn_precise"/>
   </figure>
 
 
@@ -195,7 +195,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="pdu3nRE8x1I zA_u1Hsd0Jg" xml:id="vid_limit_defn_sqrt_epsilon" component="video"/>
+      <video width="98%" youtube="pdu3nRE8x1I zA_u1Hsd0Jg" xml:id="vid_limit_defn_sqrt_epsilon" label="vid_limit_defn_sqrt_epsilon" component="video"/>
     </solution>
     <solution>
       <p>
@@ -410,7 +410,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="QGqoq-xEXyk" xml:id="vid_limit_defn_quadratic" component="video"/>
+      <video width="98%" youtube="QGqoq-xEXyk" xml:id="vid_limit_defn_quadratic" label="vid_limit_defn_quadratic" component="video"/>
     </solution>
     <solution>
 
@@ -616,7 +616,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="-&#45;_Rq2GX9IY" xml:id="vid_limit_defn_polynomial" component="video"/>
+      <video width="98%" youtube="-&#45;_Rq2GX9IY" xml:id="vid_limit_defn_polynomial" label="vid_limit_defn_polynomial" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -100,7 +100,7 @@
 
     <figure xml:id="vid_limit_inf_defn" component="video">
       <caption>Video presentation of <xref ref="def_limit_of_infinity"/></caption>
-      <video youtube="UVhqWmKqHtw"/>
+      <video youtube="UVhqWmKqHtw" label="vid_limit_inf_defn"/>
     </figure>
 
 
@@ -216,7 +216,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="S3dUAUQiKFQ" xml:id="vid_limit_inf_ex_using_defn" component="video"/>
+        <video width="98%" youtube="S3dUAUQiKFQ" xml:id="vid_limit_inf_ex_using_defn" label="vid_limit_inf_ex_using_defn" component="video"/>
       </solution>
       <solution>
 
@@ -261,7 +261,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="JP1k74FZE1I" xml:id="vid_limit_inf_ex_1overx" component="video"/>
+        <video width="98%" youtube="JP1k74FZE1I" xml:id="vid_limit_inf_ex_1overx" label="vid_limit_inf_ex_1overx" component="video"/>
       </solution>
       <solution>
 
@@ -334,7 +334,7 @@
 
     <figure xml:id="vid_limit_inf_vert_asymptotes" component="video">
       <caption>Video presentation of <xref ref="def_vertical_asymptote"/></caption>
-      <video youtube="qIrLL7jbEZw"/>
+      <video youtube="qIrLL7jbEZw" label="vid_limit_inf_vert_asymptotes"/>
     </figure>
 
     <example xml:id="ex_vertasy1">
@@ -346,7 +346,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="h-1BCF_lsHI" xml:id="vid_limit_inf_vert_asymptotes_ex" component="video"/>
+        <video width="98%" youtube="h-1BCF_lsHI" xml:id="vid_limit_inf_vert_asymptotes_ex" label="vid_limit_inf_vert_asymptotes_ex" component="video"/>
       </solution>
       <solution>
 
@@ -575,7 +575,7 @@
 
     <figure xml:id="vid_limit_at_inf_defn" component="video">
       <caption>Video presentation of <xref ref="def_limit_at_infinity"/></caption>
-      <video youtube="7PwKJHgic7U"/>
+      <video youtube="7PwKJHgic7U" label="vid_limit_at_inf_defn"/>
     </figure>
 
     <p>
@@ -678,7 +678,7 @@
 
     <figure xml:id="vid_limit_at_inf_ex_using_defn" component="video">
       <caption>Using an <m>\varepsilon</m>-<m>\delta</m> proof with <xref ref="def_limit_at_infinity"/> in <xref ref="ex_hzasy1"/></caption>
-      <video youtube="kYmfeq-qKiI"/>
+      <video youtube="kYmfeq-qKiI" label="vid_limit_at_inf_ex_using_defn"/>
     </figure>
 
     <p>
@@ -791,7 +791,7 @@
 
     <figure xml:id="vid_limit_at_inf_basic_ex" component="video">
       <caption>Basic examples involving limits at infinity</caption>
-      <video youtube="v5SrtUsdMeU"/>
+      <video youtube="v5SrtUsdMeU" label="vid_limit_at_inf_basic_ex"/>
     </figure>
 
 
@@ -909,7 +909,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="cmZ39j1YI-o" xml:id="vid_limit_at_inf_rat_func_ex" component="video"/>
+        <video width="98%" youtube="cmZ39j1YI-o" xml:id="vid_limit_at_inf_rat_func_ex" label="vid_limit_at_inf_rat_func_ex" component="video"/>
       </solution>
       <solution>
 
@@ -1115,7 +1115,7 @@
     </p>
     <figure xml:id="vid_limit_at_inf_ex_rad" component="video">
       <caption>Limits at infinity with a radical function</caption>
-      <video youtube="vD1-zrRZQTI"/>
+      <video youtube="vD1-zrRZQTI" label="vid_limit_at_inf_ex_rad"/>
     </figure>
   </subsection>
 

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -8,7 +8,7 @@
     </p>
     <figure xml:id="vid_limit_intro_limit_concept" component="video">
       <caption>The concept of a limit</caption>
-      <video youtube="rG3XVvFIZPY"/>
+      <video youtube="rG3XVvFIZPY" label="vid_limit_intro_limit_concept"/>
     </figure>
 
 
@@ -159,7 +159,7 @@
     </p>
     <figure xml:id="vid_limit_intro_sinxoverx" component="video">
       <caption>Investigating <m>\sin(x)/x</m></caption>
-      <video youtube="__qzaSg4y1I"/>
+      <video youtube="__qzaSg4y1I" label="vid_limit_intro_sinxoverx"/>
     </figure>
 
 
@@ -309,7 +309,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="eHx3LmrQZXM" xml:id="vid_limit_intro_rational_func" component="video"/>
+        <video width="98%" youtube="eHx3LmrQZXM" xml:id="vid_limit_intro_rational_func" label="vid_limit_intro_rational_func" component="video"/>
       </solution>
       <solution>
 
@@ -461,7 +461,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="7RAiKoLCpgU" xml:id="vid_limit_intro_piecewise_func" component="video"/>
+        <video width="98%" youtube="7RAiKoLCpgU" xml:id="vid_limit_intro_piecewise_func" label="vid_limit_intro_piecewise_func" component="video"/>
       </solution>
       <solution>
 
@@ -557,7 +557,7 @@
     <title>Identifying When Limits Do Not Exist</title>
     <figure xml:id="vid_limit_intro_limit_dne" component="video">
       <caption>Video introduction for <xref ref="subsec_nolimit3"/></caption>
-      <video youtube="DSIaDa_ABxo"/>
+      <video youtube="DSIaDa_ABxo" label="vid_limit_intro_limit_dne"/>
     </figure>
 
     <p>
@@ -779,7 +779,7 @@
 
     <figure xml:id="vid_limit_intro_jumps_asymptotes" component="video">
       <caption>Video presentation for <xref first="ex_no_limit1" last="ex_no_limit2">Examples</xref></caption>
-      <video youtube="NnV1A1KTbg0"/>
+      <video youtube="NnV1A1KTbg0" label="vid_limit_intro_jumps_asymptotes"/>
     </figure>
 
     <example xml:id="ex_no_limit3">
@@ -791,7 +791,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="gGvvFX5QyjE" xml:id="vid_limit_intro_limit_oscillation" component="video"/>
+        <video width="98%" youtube="gGvvFX5QyjE" xml:id="vid_limit_intro_limit_oscillation" label="vid_limit_intro_limit_oscillation" component="video"/>
       </solution>
       <solution>
 
@@ -1005,7 +1005,7 @@
     </p>
     <figure xml:id="vid_limit_intro_limit_diff_quot" component="video">
       <caption>Video introduction to <xref ref="sec_diff_quot_intro"/></caption>
-      <video youtube="2NJmd0Jrt4U"/>
+      <video youtube="2NJmd0Jrt4U" label="vid_limit_intro_limit_diff_quot"/>
     </figure>
 
 
@@ -1233,7 +1233,7 @@
     </table>
     <figure xml:id="vid_limit_intro_limit_diff_quot_ex" component="video">
       <caption>Video examples for difference quotients: once with direct computation, and then by simplifying first</caption>
-      <video  youtube="lNI90Y321b0 uUyZHfTYlBQ"/>
+      <video  youtube="lNI90Y321b0 uUyZHfTYlBQ" label="vid_limit_intro_limit_diff_quot_ex"/>
     </figure>
 
     <p>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -110,7 +110,7 @@
 
   <figure xml:id="vid_limit_one_sided_defn" component="video">
     <caption>Video presentation of <xref ref="def_onesidedlimit"/></caption>
-    <video youtube="VU8lUocFAfE"/>
+    <video youtube="VU8lUocFAfE" label="vid_limit_one_sided_defn"/>
   </figure>
 
   <p>
@@ -201,7 +201,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="NdBPwaP4Xkk" xml:id="vid_limit_one_sided_ex_1" component="video"/>
+      <video width="98%" youtube="NdBPwaP4Xkk" xml:id="vid_limit_one_sided_ex_1" label="vid_limit_one_sided_ex_1" component="video"/>
     </solution>
     <solution>
 
@@ -380,7 +380,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="vE_7FG2h_LU" xml:id="vid_limit_one_sided_ex_2" component="video"/>
+      <video width="98%" youtube="vE_7FG2h_LU" xml:id="vid_limit_one_sided_ex_2" label="vid_limit_one_sided_ex_2" component="video"/>
     </solution>
     <solution>
 
@@ -575,7 +575,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="HVFazve-Qxc" xml:id="vid_limit_one_sided_ex_4" component="video"/>
+      <video width="98%" youtube="HVFazve-Qxc" xml:id="vid_limit_one_sided_ex_4" label="vid_limit_one_sided_ex_4" component="video"/>
     </solution>
     <solution>
 
@@ -636,7 +636,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="Nn6JoJRK7nk" xml:id="vid_limit_one_sided_ex_3" component="video"/>
+      <video width="98%" youtube="Nn6JoJRK7nk" xml:id="vid_limit_one_sided_ex_3" label="vid_limit_one_sided_ex_3" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_line_int_intro.ptx
+++ b/ptx/sec_line_int_intro.ptx
@@ -13,7 +13,7 @@
     <title>Line Integrals of Functions</title>
     <figure xml:id="vid-veccalc-lineint-intro" component="video">
       <caption>Introducing the line integral</caption>
-      <video youtube="ponQzAg7V3I"/>
+      <video youtube="ponQzAg7V3I" label="vid-veccalc-lineint-intro"/>
     </figure>
     <p>
       Consider the surface and curve shown in <xref ref="fig_line_integral_intro1a_3D">Figure</xref>.
@@ -916,7 +916,7 @@
 
     <figure xml:id="vid-veccalc-line-int-scalar-example" component="video">
       <caption>Another line integral example</caption>
-      <video youtube="EN9r0JKI5uY"/>
+      <video youtube="EN9r0JKI5uY" label="vid-veccalc-line-int-scalar-example"/>
     </figure>
 
     <p>

--- a/ptx/sec_line_int_vf.ptx
+++ b/ptx/sec_line_int_vf.ptx
@@ -23,7 +23,7 @@
 
     <figure xml:id="vid-veccalc-lineint-scalar-revisit" component="video">
       <caption>Line integrals of scalar fields, revisited</caption>
-      <video youtube="ennr8HI2iFE"/>
+      <video youtube="ennr8HI2iFE" label="vid-veccalc-lineint-scalar-revisit"/>
     </figure>
 
     <p>
@@ -119,7 +119,7 @@
 
     <figure xml:id="vid-veccalc-lineint-vector-intro" component="video">
       <caption>Introducing line integrals of vector fields</caption>
-      <video youtube="fwTHe_y3T1c"/>
+      <video youtube="fwTHe_y3T1c" label="vid-veccalc-lineint-vector-intro"/>
     </figure>
 
     <insight xml:id="idea_line2">
@@ -438,7 +438,7 @@
 
     <figure xml:id="vid-veccalc-lineint-curve-terminology" component="video">
       <caption>Reivew of terminology for curves</caption>
-      <video youtube="JeEIaKjbnJo"/>
+      <video youtube="JeEIaKjbnJo" label="vid-veccalc-lineint-curve-terminology"/>
     </figure>
     <p>
       It is relatively easy to see why.
@@ -495,7 +495,7 @@
 
     <figure xml:id="vid-veccalc-lineint-vector-properties" component="video">
       <caption>Properties of line integrals</caption>
-      <video youtube="wcKzYvJ20sI"/>
+      <video youtube="wcKzYvJ20sI" label="vid-veccalc-lineint-vector-properties"/>
     </figure>
 
     <p>
@@ -643,7 +643,7 @@
 
     <figure xml:id="vid-veccalc-lineint-vector-example" component="video">
       <caption>Computing a line integral over a piecewise smooth curve</caption>
-      <video youtube="iOweAD63oCE"/>
+      <video youtube="iOweAD63oCE" label="vid-veccalc-lineint-vector-example"/>
     </figure>
 
     <example xml:id="ex_livf4">
@@ -781,7 +781,7 @@
 
     <figure xml:id="vid-veccalc-lineint-differential" component="video">
       <caption>Evaluating a line integral presented in differential form</caption>
-      <video youtube="NBkXSN614hU"/>
+      <video youtube="NBkXSN614hU" label="vid-veccalc-lineint-differential"/>
     </figure>
   </subsection>
 
@@ -797,7 +797,7 @@
 
     <figure xml:id="vid-veccalc-lineint-ftc-intro" component="video">
       <caption>Introducing the Fundamental Theorem of Line Integrals</caption>
-      <video youtube="14LOByUGRXA"/>
+      <video youtube="14LOByUGRXA" label="vid-veccalc-lineint-ftc-intro"/>
     </figure>
     <p>
       A region in the plane is <em>connected</em>
@@ -1290,7 +1290,7 @@
 
     <figure xml:id="vid-veccalc-lineint-ftc-examples" component="video">
       <caption>Further examples with the Fundamental Theorem (4 videos)</caption>
-      <video youtube="y20o-66Qdf0 oRePdTBUp0w nNpmNAeVz28 3DRi2eS_ke8"/>
+      <video youtube="y20o-66Qdf0 oRePdTBUp0w nNpmNAeVz28 3DRi2eS_ke8" label="vid-veccalc-lineint-ftc-examples"/>
     </figure>
 
     <p>
@@ -1326,7 +1326,7 @@
     </p>
     <figure xml:id="vid-veccalc-lineint-conservatve" component="video">
       <caption>Discussing conservative vector fields and path independence</caption>
-      <video youtube="I4Oaf3ArIr8"/>
+      <video youtube="I4Oaf3ArIr8" label="vid-veccalc-lineint-conservatve"/>
     </figure>
   </subsection>
 

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -20,7 +20,7 @@
 
     <figure xml:id="vid-vectors-lines-intro" component="video">
       <caption>Video introduction to <xref ref="sec_lines"/></caption>
-      <video youtube="rA3i_j9MGEM"/>
+      <video youtube="rA3i_j9MGEM" label="vid-vectors-lines-intro"/>
     </figure>
   </introduction>
 
@@ -254,7 +254,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="i307pfanflE" xml:id="vid-vectors-lines-example1" component="video"/>
+        <video width="98%" youtube="i307pfanflE" xml:id="vid-vectors-lines-example1" label="vid-vectors-lines-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -381,7 +381,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="3ROgMsmz0J0" xml:id="vid-vectors-lines-example2" component="video"/>
+        <video width="98%" youtube="3ROgMsmz0J0" xml:id="vid-vectors-lines-example2" label="vid-vectors-lines-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -538,7 +538,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="hEYfincwMX0" xml:id="vid-vectors-lines-compare" component="video"/>
+        <video width="98%" youtube="hEYfincwMX0" xml:id="vid-vectors-lines-compare" label="vid-vectors-lines-compare" component="video"/>
       </solution>
       <solution>
         <p>
@@ -851,7 +851,7 @@
 
     <figure xml:id="vid-vectors-lines-distance-point" component="video">
       <caption>Determining distance from a line to a point</caption>
-      <video youtube="ZJ_e_0s2s2M"/>
+      <video youtube="ZJ_e_0s2s2M" label="vid-vectors-lines-distance-point"/>
     </figure>
 
     <p>
@@ -977,7 +977,7 @@
 
     <figure xml:id="vid-vectors-lines-distance-skew" component="video">
       <caption>Determining distance between skew lines</caption>
-      <video youtube="h0x9SfUVGVc"/>
+      <video youtube="h0x9SfUVGVc" label="vid-vectors-lines-distance-skew"/>
     </figure>
 
     <p>
@@ -1027,7 +1027,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="xDB7li9crEs" xml:id="vid-vectors-lines-pointdist-eg" component="video"/>
+        <video width="98%" youtube="xDB7li9crEs" xml:id="vid-vectors-lines-pointdist-eg" label="vid-vectors-lines-pointdist-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1063,7 +1063,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="h0x9SfUVGVc" xml:id="vid-vectors-lines-skewdist-eg" component="video"/>
+        <video width="98%" youtube="h0x9SfUVGVc" xml:id="vid-vectors-lines-skewdist-eg" label="vid-vectors-lines-skewdist-eg" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -105,7 +105,7 @@
 
     <figure xml:id="vid-multi-chain-intro" component="video">
       <caption>Introducing the chain rule in several variables</caption>
-      <video youtube="e4uf2cA7YyA"/>
+      <video youtube="e4uf2cA7YyA" label="vid-multi-chain-intro"/>
     </figure>
   </introduction>
 
@@ -165,7 +165,7 @@
 
     <figure xml:id="vid-multi-chain-example" component="video">
       <caption>Examples involving the chain rule</caption>
-      <video youtube="bagsQndc8nw"/>
+      <video youtube="bagsQndc8nw" label="vid-multi-chain-example"/>
     </figure>
 
     <example xml:id="ex_mchain1">
@@ -525,7 +525,7 @@
 
     <!-- <figure xml:id="vid-multi-chain-general" component="video">
       <caption>Illustrating the chain rule, and interpreting as matrix multiplication (see <xref ref="sec_deriv_matrix">Section</xref>)</caption>
-      <video youtube="7jtaSujep7g"/>
+      <video youtube="7jtaSujep7g" label="vid-multi-chain-general"/>
     </figure> -->
   </subsection>
 
@@ -634,7 +634,7 @@
 
     <figure xml:id="vid-multi-implicit-differentiation" component="video">
       <caption>Examples with implicit differentiation</caption>
-      <video youtube="o9Zyg-QY8Qo"/>
+      <video youtube="o9Zyg-QY8Qo" label="vid-multi-implicit-differentiation"/>
     </figure>
 
     <p>

--- a/ptx/sec_multi_derivative_matrix.ptx
+++ b/ptx/sec_multi_derivative_matrix.ptx
@@ -69,7 +69,7 @@
 
     <figure xml:id="vid-multi-differentiability-general" component="video">
       <caption>Defining differentiability in general</caption>
-      <video youtube="Ss4wvGRb6L8"/>
+      <video youtube="Ss4wvGRb6L8" label="vid-multi-differentiability-general"/>
     </figure>
   </introduction>
 

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -5,7 +5,7 @@
     <title>Critical Points of Functions of Two Variables</title>
     <figure xml:id="vid-multi-extreme-intro" component="video">
       <caption>Introducing extreme values for functions of several variables</caption>
-      <video youtube="smAvod2dFsw"/>
+      <video youtube="smAvod2dFsw" label="vid-multi-extreme-intro"/>
     </figure>
     <p>
       Given a function <m>f(x,y)</m>,
@@ -120,7 +120,7 @@
 
     <figure xml:id="vid-multi-extreme-critical-point" component="video">
       <caption>Finding critical points</caption>
-      <video youtube="smAvod2dFsw"/>
+      <video youtube="smAvod2dFsw" label="vid-multi-extreme-critical-point"/>
     </figure>
 
     <example xml:id="ex_multi_extreme1">
@@ -545,7 +545,7 @@
 
     <figure xml:id="vid-multi-extreme-second-derivative-test" component="video">
       <caption>Presenting the second derivative test</caption>
-      <video youtube="xap1euIjzww"/>
+      <video youtube="xap1euIjzww" label="vid-multi-extreme-second-derivative-test"/>
     </figure>
 
     <p>
@@ -741,7 +741,7 @@
 
     <figure xml:id="vid-multi-classify-critical-points" component="video">
       <caption>Two more examples with classification of critical points</caption>
-      <video youtube="GP6pI3sQ9MU aVahtgOdMts"/>
+      <video youtube="GP6pI3sQ9MU aVahtgOdMts" label="vid-multi-classify-critical-points"/>
     </figure>
   </subsection>
 
@@ -1098,7 +1098,7 @@
 
     <figure xml:id="vid-multi-extreme-examples" component="video">
       <caption>Finding extreme values (two videos)</caption>
-      <video youtube="uWD5My3c5p8 W5ykqB7261c"/>
+      <video youtube="uWD5My3c5p8 W5ykqB7261c" label="vid-multi-extreme-examples"/>
     </figure>
 
     <p>

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -22,7 +22,7 @@
 
     <figure xml:id="vid-multi-function-notation" component="video">
       <caption>Video introduction to multivariable function notation</caption>
-      <video youtube="w4K2L9-OPk8"/>
+      <video youtube="w4K2L9-OPk8" label="vid-multi-function-notation"/>
     </figure>
 
     <example xml:id="ex_multi1">

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -21,7 +21,7 @@
 
     <figure xml:id="vid-multi-limits-intro" component="video">
       <caption>Introducing limits and continuity for functions of several variables</caption>
-      <video youtube="GIamhgb3Ilk"/>
+      <video youtube="GIamhgb3Ilk" label="vid-multi-limits-intro"/>
     </figure>
   </introduction>
 

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -4,7 +4,7 @@
 
   <figure xml:id="vid_deriv_apps_opt_prod_sum" component="video">
     <caption>A simple optimization problem</caption>
-    <video youtube="nlLf3CcgblI"/>
+    <video youtube="nlLf3CcgblI" label="vid_deriv_apps_opt_prod_sum"/>
   </figure>
 
 
@@ -296,7 +296,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="wIs5N5HOCrc" xml:id="vid_deriv_apps_opt_fence_river" component="video"/>
+      <video width="98%" youtube="wIs5N5HOCrc" xml:id="vid_deriv_apps_opt_fence_river" label="vid_deriv_apps_opt_fence_river" component="video"/>
     </solution>
     <solution>
 
@@ -523,7 +523,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="qDK9rqloKRs" xml:id="vid_deriv_apps_opt_power_line" component="video"/>
+      <video width="98%" youtube="qDK9rqloKRs" xml:id="vid_deriv_apps_opt_power_line" label="vid_deriv_apps_opt_power_line" component="video"/>
     </solution>
     <solution>
 
@@ -680,7 +680,7 @@
 
   <figure xml:id="vid_deriv_apps_opt_box_no_top" component="video">
     <caption>Optimizing construction of a box with no top</caption>
-    <video youtube="XJYDMZe8JUk"/>
+    <video youtube="XJYDMZe8JUk" label="vid_deriv_apps_opt_box_no_top"/>
   </figure>
 
 

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -16,7 +16,7 @@
 
     <figure xml:id="vid-planecurves-parcalc-intro" component="video">
       <caption>Video introduction to <xref ref="sec_par_calc"/></caption>
-      <video youtube="FIvX66HAaj8"/>
+      <video youtube="FIvX66HAaj8" label="vid-planecurves-parcalc-intro"/>
     </figure>
 
     <p>
@@ -133,7 +133,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="A62eUDxiOw4" xml:id="vid-planecurves-parcalc-example-tangent" component="video"/>
+        <video width="98%" youtube="A62eUDxiOw4" xml:id="vid-planecurves-parcalc-example-tangent" label="vid-planecurves-parcalc-example-tangent" component="video"/>
       </solution>
       <solution>
         <p>
@@ -259,7 +259,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="PpmsaMVJAZI" xml:id="vid-planecurves-parcalc-circle" component="video"/>
+        <video width="98%" youtube="PpmsaMVJAZI" xml:id="vid-planecurves-parcalc-circle" label="vid-planecurves-parcalc-circle" component="video"/>
       </solution>
       <solution>
         <p>
@@ -365,7 +365,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-astroid" component="video"/>
+        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-astroid" label="vid-planecurves-parcalc-astroid" component="video"/>
       </solution>
       <solution>
         <p>
@@ -474,7 +474,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-concavity" component="video"/>
+        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-concavity" label="vid-planecurves-parcalc-concavity" component="video"/>
       </solution>
       <solution>
         <p>
@@ -576,7 +576,7 @@
 
         <figure xml:id="vid-planecurves-parcalc-sketch" component="video">
           <caption>Sketching the curve in <xref ref="ex_parcalc4"/></caption>
-          <video youtube="HSBSVFSVqms"/>
+          <video youtube="HSBSVFSVqms" label="vid-planecurves-parcalc-sketch"/>
         </figure>
       </solution>
     </example>
@@ -705,7 +705,7 @@
 
     <figure xml:id="vid-planecurves-parcalc-arclength" component="video">
       <caption>Video introduction to arc length for parametric curves</caption>
-      <video youtube="57F7ZspP0lU"/>
+      <video youtube="57F7ZspP0lU" label="vid-planecurves-parcalc-arclength"/>
     </figure>
     <p>
       Recall in <xref ref="sec_arc_length">Section</xref>
@@ -785,7 +785,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="It8vHw3RHEw" xml:id="vid-planecurves-parcalc-arclength-example1" component="video"/>
+        <video width="98%" youtube="It8vHw3RHEw" xml:id="vid-planecurves-parcalc-arclength-example1" label="vid-planecurves-parcalc-arclength-example1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -844,7 +844,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="G5U9BVhB3PE" xml:id="vid-planecurves-parcalc-arclength-example2" component="video"/>
+        <video width="98%" youtube="G5U9BVhB3PE" xml:id="vid-planecurves-parcalc-arclength-example2" label="vid-planecurves-parcalc-arclength-example2" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -4,7 +4,7 @@
   <introduction>
     <figure xml:id="vid-planecurves-parameq-intro" component="video">
       <caption>Video introduction to <xref ref="sec_param_eqs"/></caption>
-      <video youtube="ktYtHfYoWi4"/>
+      <video youtube="ktYtHfYoWi4" label="vid-planecurves-parameq-intro"/>
     </figure>
     <p>
       We are familiar with sketching shapes,
@@ -116,7 +116,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="7Ytw9RTrFtM" xml:id="vid-planecurves-parameq-example-plot" component="video"/>
+        <video width="98%" youtube="7Ytw9RTrFtM" xml:id="vid-planecurves-parameq-example-plot" label="vid-planecurves-parameq-example-plot" component="video"/>
       </solution>
       <solution>
         <p>
@@ -582,7 +582,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="YsOEEcCXNb8" xml:id="vid-planecurves-parameq-find-parametrization" component="video"/>
+        <video width="98%" youtube="YsOEEcCXNb8" xml:id="vid-planecurves-parameq-find-parametrization" label="vid-planecurves-parameq-find-parametrization" component="video"/>
       </solution>
       <solution>
         <p>
@@ -700,7 +700,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="8Vgv74zCWFQ" xml:id="vid-planecurves-parameq-elim-param" component="video"/>
+        <video width="98%" youtube="8Vgv74zCWFQ" xml:id="vid-planecurves-parameq-elim-param" label="vid-planecurves-parameq-elim-param" component="video"/>
       </solution>
       <solution>
         <p>
@@ -790,7 +790,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="RYkPHhpgnas" xml:id="vid-planecurves-parameq-ellipse" component="video"/>
+        <video width="98%" youtube="RYkPHhpgnas" xml:id="vid-planecurves-parameq-ellipse" label="vid-planecurves-parameq-ellipse" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1065,7 +1065,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="rqhh0McArDM" xml:id="vid-planecurves-parameq-nonsmooth" component="video"/>
+        <video width="98%" youtube="rqhh0McArDM" xml:id="vid-planecurves-parameq-nonsmooth" label="vid-planecurves-parameq-nonsmooth" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_parametric_surfaces.ptx
+++ b/ptx/sec_parametric_surfaces.ptx
@@ -16,7 +16,7 @@
 
     <figure xml:id="vid-veccalc-parasurf-intro" component="video">
       <caption>Introducing parametrized surfaces</caption>
-      <video youtube="dPB3NGtuEhU"/>
+      <video youtube="dPB3NGtuEhU" label="vid-veccalc-parasurf-intro"/>
     </figure>
     <p>
       We are accustomed to describing surfaces as functions of two variables,
@@ -1209,7 +1209,7 @@
     <title>Surface Area</title>
     <figure xml:id="vid-veccalc-paramsurf-tangent-normal" component="video">
       <caption>Tangent and normal vectors for parametric surfaces</caption>
-      <video youtube="9TtJ6xpuadQ"/>
+      <video youtube="9TtJ6xpuadQ" label="vid-veccalc-paramsurf-tangent-normal"/>
     </figure>
     <p>
       It will become important in the following sections to be able to compute the surface area of a surface <m>\surfaceS</m> given a smooth parametrization <m>\vec r(u,v)</m>,
@@ -1567,7 +1567,7 @@
 
     <figure xml:id="vid-veccalc-paramsurf-area" component="video">
       <caption>Area of parametric surfaces</caption>
-      <video youtube="ezVITWloEfA"/>
+      <video youtube="ezVITWloEfA" label="vid-veccalc-paramsurf-area"/>
     </figure>
 
     <example xml:id="ex_parsurfarea1">
@@ -1612,7 +1612,7 @@
 
     <figure xml:id="vid-veccalc-paramsurf-area-sphere" component="video">
       <caption>Surface area of a sphere</caption>
-      <video youtube="9tIGTOpQ5WE"/>
+      <video youtube="9tIGTOpQ5WE" label="vid-veccalc-paramsurf-area-sphere"/>
     </figure>
 
     <p>

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -14,7 +14,7 @@
 
     <figure xml:id="vid-multi-partial-intro" component="video">
       <caption>Motivating the concept of the partial derivative</caption>
-      <video youtube="uApAQNSb5TQ"/>
+      <video youtube="uApAQNSb5TQ" label="vid-multi-partial-intro"/>
     </figure>
   </introduction>
 
@@ -322,7 +322,7 @@
 
     <figure xml:id="vid-multi-partial-examples" component="video">
       <caption>Additional partial derivative computation examples</caption>
-      <video youtube="R3PXGwjOmtw"/>
+      <video youtube="R3PXGwjOmtw" label="vid-multi-partial-examples"/>
     </figure>
 
     <p>
@@ -357,7 +357,7 @@
 
     <figure xml:id="vid-multi-partial-interpret" component="video">
       <caption>Interpreting partial derivatives</caption>
-      <video youtube="jvnTNe4hHL8"/>
+      <video youtube="jvnTNe4hHL8" label="vid-multi-partial-interpret"/>
     </figure>
 
     <p>
@@ -804,7 +804,7 @@
 
     <figure xml:id="vid-multi-partial-second-order" component="video">
       <caption>Second order partial derivatives and differentiability classes</caption>
-      <video youtube="H81s72zLfI8"/>
+      <video youtube="H81s72zLfI8" label="vid-multi-partial-second-order"/>
     </figure>
 
     <p>

--- a/ptx/sec_partial_fraction.ptx
+++ b/ptx/sec_partial_fraction.ptx
@@ -11,7 +11,7 @@
 
   <figure xml:id="vid-int-partfrac-intro" component="video">
     <caption>Video introduction to <xref ref="sec_partial_fraction"/></caption>
-    <video youtube="BoUWS_SVr8A"/>
+    <video youtube="BoUWS_SVr8A" label="vid-int-partfrac-intro"/>
   </figure>
 
   <p>
@@ -135,7 +135,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="9gRlWESr8lM" xml:id="vid-int-partfrac-ex-decomp1" component="video"/>
+      <video width="98%" youtube="9gRlWESr8lM" xml:id="vid-int-partfrac-ex-decomp1" label="vid-int-partfrac-ex-decomp1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -194,7 +194,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="u-avVoj3qR0" xml:id="vid-int-partfrac-ex-decomp-method1" component="video"/>
+      <video width="98%" youtube="u-avVoj3qR0" xml:id="vid-int-partfrac-ex-decomp-method1" label="vid-int-partfrac-ex-decomp-method1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -283,7 +283,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="QfEgKEhkL6o" xml:id="vid-int-partfrac-ex-decomp-method2" component="video"/>
+      <video width="98%" youtube="QfEgKEhkL6o" xml:id="vid-int-partfrac-ex-decomp-method2" label="vid-int-partfrac-ex-decomp-method2" component="video"/>
     </solution>
     <solution>
       <p>
@@ -350,7 +350,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="LqE8pvIvJco" xml:id="vid-int-partfrac-ex-rep-root1" component="video"/>
+      <video width="98%" youtube="LqE8pvIvJco" xml:id="vid-int-partfrac-ex-rep-root1" label="vid-int-partfrac-ex-rep-root1" component="video"/>
     </solution>
     <solution>
 
@@ -450,7 +450,7 @@
 
   <figure xml:id="vid-int-partfrac-ex-rep-root2" component="video">
     <caption>Alternate method for finding coefficients in <xref ref="ex_pf3"/></caption>
-    <video youtube="0yrzd4JhR3I"/>
+    <video youtube="0yrzd4JhR3I" label="vid-int-partfrac-ex-rep-root2"/>
   </figure>
 
   <example xml:id="ex_pf4">
@@ -462,7 +462,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="1cszweGfYR0" xml:id="vid-int-partfrac-ex-divide-first" component="video"/>
+      <video width="98%" youtube="1cszweGfYR0" xml:id="vid-int-partfrac-ex-divide-first" label="vid-int-partfrac-ex-divide-first" component="video"/>
     </solution>
     <solution>
       <p>
@@ -524,7 +524,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="Oa3-0K34UvM OLcNjryNC1A" xml:id="vid-int-partfrac-ex-quadroot" component="video"/>
+      <video width="98%" youtube="Oa3-0K34UvM OLcNjryNC1A" xml:id="vid-int-partfrac-ex-quadroot" label="vid-int-partfrac-ex-quadroot" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -81,7 +81,7 @@
 
     <figure xml:id="vid-vectors-planes-intro" component="video">
       <caption>Video inroduction to <xref ref="sec_planes"/></caption>
-      <video youtube="aP-fcbArvtA"/>
+      <video youtube="aP-fcbArvtA" label="vid-vectors-planes-intro"/>
     </figure>
 
     <p>
@@ -178,7 +178,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="oc77R0am1vk" xml:id="vid-vectors-planes-3points" component="video"/>
+        <video width="98%" youtube="oc77R0am1vk" xml:id="vid-vectors-planes-3points" label="vid-vectors-planes-3points" component="video"/>
       </solution>
       <solution>
         <p>
@@ -428,7 +428,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="2diP-H-QLoI" xml:id="vid-vectors-planes-given-normal" component="video"/>
+        <video width="98%" youtube="2diP-H-QLoI" xml:id="vid-vectors-planes-given-normal" label="vid-vectors-planes-given-normal" component="video"/>
       </solution>
       <solution>
         <p>
@@ -518,7 +518,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="x2HB6huEEmQ" xml:id="vid-vectors-planes-interect1" component="video"/>
+        <video width="98%" youtube="x2HB6huEEmQ" xml:id="vid-vectors-planes-interect1" label="vid-vectors-planes-interect1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -642,7 +642,7 @@
         </figure>
         <figure xml:id="vid-vectors-planes-interection2" component="video">
           <caption>An alternative method for solving <xref ref="ex_planes4"/></caption>
-          <video width="98%" youtube="tthyDV7cjR8"/>
+          <video width="98%" youtube="tthyDV7cjR8" label="vid-vectors-planes-interection2"/>
         </figure>
       </solution>
     </example>
@@ -657,7 +657,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="DjuaixH0ayo" xml:id="vid-vectors-planes-lineint" component="video"/>
+        <video width="98%" youtube="DjuaixH0ayo" xml:id="vid-vectors-planes-lineint" label="vid-vectors-planes-lineint" component="video"/>
       </solution>
       <solution>
         <p>
@@ -765,7 +765,7 @@
 
     <figure xml:id="vid-vectors-planes-distance" component="video">
       <caption>Video introduction to <xref ref="subsec_planes_distances"/></caption>
-      <video youtube="DT4JMy5Ak54"/>
+      <video youtube="DT4JMy5Ak54" label="vid-vectors-planes-distance"/>
     </figure>
 
     <p>
@@ -879,7 +879,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="SqA4OLUmoFk" xml:id="vid-vectors-planes-dist-eg" component="video"/>
+        <video width="98%" youtube="SqA4OLUmoFk" xml:id="vid-vectors-planes-dist-eg" label="vid-vectors-planes-dist-eg" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -5,7 +5,7 @@
 
     <figure xml:id="vid-planecurves-polar-intro" component="video">
       <caption>Video introduction to <xref ref="sec_polar"/></caption>
-      <video youtube="pyS8sweaJ9w"/>
+      <video youtube="pyS8sweaJ9w" label="vid-planecurves-polar-intro"/>
     </figure>
     <p>
       We are generally introduced to the idea of graphing curves by relating <m>x</m>-values to <m>y</m>-values through a function <m>f</m>.
@@ -478,7 +478,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="HTCbzFnW9KU" xml:id="vid-planecurves-polar-basic-graphs" component="video"/>
+        <video width="98%" youtube="HTCbzFnW9KU" xml:id="vid-planecurves-polar-basic-graphs" label="vid-planecurves-polar-basic-graphs" component="video"/>
       </solution>
       <solution>
         <p>
@@ -574,7 +574,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="1omaozpN7wI" xml:id="vid-planecurves-polar-cardioid" component="video"/>
+        <video width="98%" youtube="1omaozpN7wI" xml:id="vid-planecurves-polar-cardioid" label="vid-planecurves-polar-cardioid" component="video"/>
       </solution>
       <solution>
         <p>
@@ -754,7 +754,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="DSmu6HQXiS4" xml:id="vid-planecurves-polar-rose" component="video"/>
+        <video width="98%" youtube="DSmu6HQXiS4" xml:id="vid-planecurves-polar-rose" label="vid-planecurves-polar-rose" component="video"/>
       </solution>
       <solution>
         <p>
@@ -939,7 +939,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="kWnHXtXTzSw" xml:id="vid-planecurves-polar-conversions" component="video"/>
+        <video width="98%" youtube="kWnHXtXTzSw" xml:id="vid-planecurves-polar-conversions" label="vid-planecurves-polar-conversions" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1601,7 +1601,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="mI8vfQxub9g" xml:id="vid-planecurves-polar-intersection" component="video"/>
+        <video width="98%" youtube="mI8vfQxub9g" xml:id="vid-planecurves-polar-intersection" label="vid-planecurves-polar-intersection" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -4,7 +4,7 @@
   <introduction>
     <figure xml:id="vid-planecurves-polarcalc-intro" component="video">
       <caption>Video introduction to <xref ref="sec_polarcalc"/></caption>
-      <video youtube="rj1KoMXvhKw"/>
+      <video youtube="rj1KoMXvhKw" label="vid-planecurves-polarcalc-intro"/>
     </figure>
     <p>
       The previous section defined polar coordinates,
@@ -89,7 +89,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="QLsLabLb6I4" xml:id="vid-planecurves-polarcalc-example-tangent" component="video"/>
+        <video width="98%" youtube="QLsLabLb6I4" xml:id="vid-planecurves-polarcalc-example-tangent" label="vid-planecurves-polarcalc-example-tangent" component="video"/>
       </solution>
       <solution>
         <p>
@@ -247,7 +247,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="bHXRpyN37-I 2fxj1gnwvEQ" xml:id="vid-planecurves-polarcalc-polar-tangent" component="video"/>
+        <video width="98%" youtube="bHXRpyN37-I 2fxj1gnwvEQ" xml:id="vid-planecurves-polarcalc-polar-tangent" label="vid-planecurves-polarcalc-polar-tangent" component="video"/>
       </solution>
       <solution>
         <p>
@@ -474,7 +474,7 @@
 
     <figure xml:id="vid-planecurves-polarcalc-area" component="video">
       <caption>Video presentation of <xref ref="thm_polar_area"/></caption>
-      <video youtube="dYEMKbxRxpY"/>
+      <video youtube="dYEMKbxRxpY" label="vid-planecurves-polarcalc-area"/>
     </figure>
 
     <theorem xml:id="thm_polar_area">
@@ -508,7 +508,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="T_z8FNS3Whs" xml:id="vid-planecurves-polarcalc-example-area1" component="video"/>
+        <video width="98%" youtube="T_z8FNS3Whs" xml:id="vid-planecurves-polarcalc-example-area1" label="vid-planecurves-polarcalc-example-area1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -591,7 +591,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="yZpBCQnB7r8" xml:id="vid-planecurves-polarcalc-area-example2" component="video"/>
+        <video width="98%" youtube="yZpBCQnB7r8" xml:id="vid-planecurves-polarcalc-area-example2" label="vid-planecurves-polarcalc-area-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -748,7 +748,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="CM7XsZRRqSI" xml:id="vid-planecurves-polarcalc-example-area3" component="video"/>
+          <video width="98%" youtube="CM7XsZRRqSI" xml:id="vid-planecurves-polarcalc-example-area3" label="vid-planecurves-polarcalc-example-area3" component="video"/>
         </solution>
         <solution>
           <p>
@@ -817,7 +817,7 @@
         </statement>
         <solution component="video">
           <title>Video solution</title>
-          <video width="98%" youtube="5MHcrQVTjjU" xml:id="vid-planecurves-polarcalc-example-area4" component="video"/>
+          <video width="98%" youtube="5MHcrQVTjjU" xml:id="vid-planecurves-polarcalc-example-area4" label="vid-planecurves-polarcalc-example-area4" component="video"/>
         </solution>
         <solution>
           <p>
@@ -958,7 +958,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="o-cetriP4Ms" xml:id="vid-planecurves-polarcalc-arclength" component="video"/>
+        <video width="98%" youtube="o-cetriP4Ms" xml:id="vid-planecurves-polarcalc-arclength" label="vid-planecurves-polarcalc-arclength" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_power_series.ptx
+++ b/ptx/sec_power_series.ptx
@@ -14,7 +14,7 @@
 
   <figure xml:id="vid-seqseries-powerseries-intro" component="video">
     <caption>Video introduction to <xref ref="sec_power_series"/></caption>
-    <video youtube="y12Zn3QZpbE"/>
+    <video youtube="y12Zn3QZpbE" label="vid-seqseries-powerseries-intro"/>
   </figure>
 
   <definition xml:id="def_power_series">
@@ -68,7 +68,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="NK8i9T-4hSg" xml:id="vid-seqseries-powerseries-example1" component="video"/>
+      <video width="98%" youtube="NK8i9T-4hSg" xml:id="vid-seqseries-powerseries-example1" label="vid-seqseries-powerseries-example1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -168,7 +168,7 @@
 
   <figure xml:id="vid-seqseries-powerseries-radius-of-convergence" component="video">
     <caption>Video presentation of <xref ref="thm_radius_converge"/> and <xref ref="def_radius_converge"/></caption>
-    <video youtube="RRzviD89Phg"/>
+    <video youtube="RRzviD89Phg" label="vid-seqseries-powerseries-radius-of-convergence"/>
   </figure>
   <p>
     The value of <m>R</m> is important when understanding a power series,
@@ -277,7 +277,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="1YzPDWYUWO8" xml:id="vid-seqseries-powerseries-example-radius" component="video"/>
+      <video width="98%" youtube="1YzPDWYUWO8" xml:id="vid-seqseries-powerseries-example-radius" label="vid-seqseries-powerseries-example-radius" component="video"/>
     </solution>
     <solution>
       <p>
@@ -416,7 +416,7 @@
 
   <figure xml:id="vid-seqseries-powerseries-derivative" component="video">
     <caption>Video presentation of <xref ref="thm_calc_power_series"/></caption>
-    <video youtube="qErrT8xRKts"/>
+    <video youtube="qErrT8xRKts" label="vid-seqseries-powerseries-derivative"/>
   </figure>
   <p>
     A few notes about <xref ref="thm_calc_power_series">Theorem</xref>:
@@ -459,7 +459,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="XE6m9CGME5Q" xml:id="vid-seqseries-powerseries-calc-example" component="video"/>
+      <video width="98%" youtube="XE6m9CGME5Q" xml:id="vid-seqseries-powerseries-calc-example" label="vid-seqseries-powerseries-calc-example" component="video"/>
     </solution>
     <solution>
       <p>
@@ -610,7 +610,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="SQm1BC7bwEw" xml:id="vid-seqseries-powerseries-example-exponential" component="video"/>
+      <video width="98%" youtube="SQm1BC7bwEw" xml:id="vid-seqseries-powerseries-example-exponential" label="vid-seqseries-powerseries-example-exponential" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_ratio_root_tests.ptx
+++ b/ptx/sec_ratio_root_tests.ptx
@@ -68,7 +68,7 @@
 
     <figure xml:id="vid-seqseries-ratroot-ratio-test" component="video">
       <caption>Video presentation of <xref ref="thm_ratio_test"/></caption>
-      <video youtube="DlrdbRa-t84"/>
+      <video youtube="DlrdbRa-t84" label="vid-seqseries-ratroot-ratio-test"/>
     </figure>
     <p>
       The principle of the Ratio Test is this:
@@ -100,7 +100,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="Zpn9qvIGlG0" xml:id="vid-seqseries-ratroot-ratio-example" component="video"/>
+        <video width="98%" youtube="Zpn9qvIGlG0" xml:id="vid-seqseries-ratroot-ratio-example" label="vid-seqseries-ratroot-ratio-example" component="video"/>
       </solution>
       <solution>
         <p>
@@ -195,7 +195,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="JghEjy4pykA" xml:id="vid-seqseries-ratroot-ratio-example2" component="video"/>
+        <video width="98%" youtube="JghEjy4pykA" xml:id="vid-seqseries-ratroot-ratio-example2" label="vid-seqseries-ratroot-ratio-example2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -280,7 +280,7 @@
 
     <figure xml:id="vid-seqseries-ratroot-root-test" component="video">
       <caption>Video presentation of <xref ref="thm_root_test"/></caption>
-      <video youtube="foE1iRYTXpc"/>
+      <video youtube="foE1iRYTXpc" label="vid-seqseries-ratroot-root-test"/>
     </figure>
 
     <example xml:id="ex_root1">
@@ -314,7 +314,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="Y7IaFXjMLlw" xml:id="vid-seqseries-ratroot-root-example" component="video"/>
+        <video width="98%" youtube="Y7IaFXjMLlw" xml:id="vid-seqseries-ratroot-root-example" label="vid-seqseries-ratroot-root-example" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -4,7 +4,7 @@
 
   <figure xml:id="vid_deriv_apps_rel_rates_intro" component="video">
     <caption>Video introduction to <xref ref="sec_related_rates"/></caption>
-    <video youtube="TKqYEDaAidQ"/>
+    <video youtube="TKqYEDaAidQ" label="vid_deriv_apps_rel_rates_intro"/>
   </figure>
 
   <p>
@@ -62,7 +62,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="Qg3GStrQ8pY" xml:id="vid_deriv_apps_rel_rates_circumference" component="video"/>
+      <video width="98%" youtube="Qg3GStrQ8pY" xml:id="vid_deriv_apps_rel_rates_circumference" label="vid_deriv_apps_rel_rates_circumference" component="video"/>
     </solution>
     <solution>
 
@@ -105,7 +105,7 @@
 
       <figure xml:id="vid_deriv_apps_rel_rates_circ_area" component="video">
         <caption>Trying to find the rate at which area is changing for the circle in <xref ref="ex_rr1"/></caption>
-        <video width="98%" youtube="RDPxSmxqUBs"/>
+        <video width="98%" youtube="RDPxSmxqUBs" label="vid_deriv_apps_rel_rates_circ_area"/>
       </figure>
 
     </solution>
@@ -229,7 +229,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="8ctKxMoFWkU" xml:id="vid_deriv_apps_rel_rates_water_flow" component="video"/>
+      <video width="98%" youtube="8ctKxMoFWkU" xml:id="vid_deriv_apps_rel_rates_water_flow" label="vid_deriv_apps_rel_rates_water_flow" component="video"/>
     </solution>
     <solution>
 
@@ -453,7 +453,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="8fFao8XCQC0" xml:id="vid_deriv_apps_rel_rates_speed_radar" component="video"/>
+      <video width="98%" youtube="8fFao8XCQC0" xml:id="vid_deriv_apps_rel_rates_speed_radar" label="vid_deriv_apps_rel_rates_speed_radar" component="video"/>
     </solution>
     <solution>
 
@@ -590,7 +590,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="B85LlGHgVQo" xml:id="vid_deriv_apps_rel_rates_turning_camera" component="video"/>
+      <video width="98%" youtube="B85LlGHgVQo" xml:id="vid_deriv_apps_rel_rates_turning_camera" label="vid_deriv_apps_rel_rates_turning_camera" component="video"/>
     </solution>
     <solution>
 

--- a/ptx/sec_riemann.ptx
+++ b/ptx/sec_riemann.ptx
@@ -4,7 +4,7 @@
   <introduction>
     <figure xml:id="vid_int_rie_intro" component="video">
       <caption>Video introduction to <xref ref="sec_riemann"/></caption>
-      <video youtube="-4hZaGBw6EI"/>
+      <video youtube="-4hZaGBw6EI" label="vid_int_rie_intro"/>
     </figure>
 
     <p>
@@ -205,7 +205,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qn8Q1i8s5Ng" xml:id="vid_int_rie_approx" component="video"/>
+        <video width="98%" youtube="qn8Q1i8s5Ng" xml:id="vid_int_rie_approx" label="vid_int_rie_approx" component="video"/>
       </solution>
       <solution>
 
@@ -413,7 +413,7 @@
 
     <figure xml:id="vid_int_rie_sum_not" component="video">
       <caption>Explaining summation notation</caption>
-      <video youtube="d0gSFClfRdY"/>
+      <video youtube="d0gSFClfRdY" label="vid_int_rie_sum_not"/>
     </figure>
 
 
@@ -466,7 +466,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="GKaRI_a96-Q" xml:id="vid_int_rie_sum_ex" component="video"/>
+        <video width="98%" youtube="GKaRI_a96-Q" xml:id="vid_int_rie_sum_ex" label="vid_int_rie_sum_ex" component="video"/>
       </solution>
       <solution>
 
@@ -547,7 +547,7 @@
 
     <figure xml:id="vid_int_rie_sum_prop" component="video">
       <caption>Video presentation of <xref ref="thm_summation"/></caption>
-      <video youtube="w8jWl2KjOvQ"/>
+      <video youtube="w8jWl2KjOvQ" label="vid_int_rie_sum_prop"/>
     </figure>
 
 
@@ -742,7 +742,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="urkFFBmu9uQ" xml:id="vid_int_rie_ex_1" component="video"/>
+        <video width="98%" youtube="urkFFBmu9uQ" xml:id="vid_int_rie_ex_1" label="vid_int_rie_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -919,7 +919,7 @@
 
     <figure xml:id="vid_int_rie_partns" component="video">
       <caption>Video presentation of <xref ref="def_partition"/></caption>
-      <video youtube="2iw1Mh4iJ0I"/>
+      <video youtube="2iw1Mh4iJ0I" label="vid_int_rie_partns"/>
     </figure>
 
 
@@ -952,7 +952,7 @@
 
     <figure xml:id="vid_int_rie_defn" component="video">
       <caption>Video presentation of <xref ref="def_rie_sum"/></caption>
-      <video youtube="1ZxKyf4JSS4"/>
+      <video youtube="1ZxKyf4JSS4" label="vid_int_rie_defn"/>
     </figure>
 
 
@@ -1065,7 +1065,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="O6S1f6-D8Ls" xml:id="vid_int_rie_ex_2" component="video"/>
+        <video width="98%" youtube="O6S1f6-D8Ls" xml:id="vid_int_rie_ex_2" label="vid_int_rie_ex_2" component="video"/>
       </solution>
       <solution>
 
@@ -1176,7 +1176,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="LjMZOVNdRxQ" xml:id="vid_int_rie_ex_n_rect" component="video"/>
+        <video width="98%" youtube="LjMZOVNdRxQ" xml:id="vid_int_rie_ex_n_rect" label="vid_int_rie_ex_n_rect" component="video"/>
       </solution>
       <solution>
 
@@ -1283,7 +1283,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="yvWSszI0Xvc" xml:id="vid_int_rie_ex_lim" component="video"/>
+        <video width="98%" youtube="yvWSszI0Xvc" xml:id="vid_int_rie_ex_lim" label="vid_int_rie_ex_lim" component="video"/>
       </solution>
       <solution>
 
@@ -1506,7 +1506,7 @@
 
     <figure xml:id="vid_int_rie_lim_rie_sum_def_int" component="video">
       <caption>Video presentation of <xref ref="thm_riemann_sum"/></caption>
-      <video youtube="A-WLvclVMC0"/>
+      <video youtube="A-WLvclVMC0" label="vid_int_rie_lim_rie_sum_def_int"/>
     </figure>
 
 

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -11,7 +11,7 @@
 
   <figure xml:id="vid-seqseries-sequences-intro" component="video">
     <caption>Video introduction to <xref ref="sec_sequences">Section</xref></caption>
-    <video youtube="jW6PMyekBtU"/>
+    <video youtube="jW6PMyekBtU" label="vid-seqseries-sequences-intro"/>
   </figure>
 
   <p>
@@ -103,7 +103,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="j-iqXR_bANY" xml:id="vid-seqseries-sequences-example1" component="video"/>
+      <video width="98%" youtube="j-iqXR_bANY" xml:id="vid-seqseries-sequences-example1" label="vid-seqseries-sequences-example1" component="video"/>
     </solution>
     <solution>
 
@@ -287,7 +287,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="-Tu12lkQtTs" xml:id="vid-seqseries-sequences-example2" component="video"/>
+      <video width="98%" youtube="-Tu12lkQtTs" xml:id="vid-seqseries-sequences-example2" label="vid-seqseries-sequences-example2" component="video"/>
     </solution>
     <solution>
       <p>
@@ -418,7 +418,7 @@
 
   <figure xml:id="vid-seqseries-sequences-limit" component="video">
     <caption>Video presentation of <xref ref="def_seq_limit"/></caption>
-    <video youtube="kt6A8Fgg22o"/>
+    <video youtube="kt6A8Fgg22o" label="vid-seqseries-sequences-limit"/>
   </figure>
 
   <p>
@@ -536,7 +536,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="8xE6Sc8U_gU" xml:id="vid-seqseries-sequences-example3" component="video"/>
+      <video width="98%" youtube="8xE6Sc8U_gU" xml:id="vid-seqseries-sequences-example3" label="vid-seqseries-sequences-example3" component="video"/>
     </solution>
     <solution>
       <p>
@@ -874,7 +874,7 @@
 
   <figure xml:id="vid-seqseries-sequences-limit-properties" component="video">
     <caption>Video presentation of <xref ref="thm_abs_val_seq"/> and <xref ref="thm_seq_properties"/></caption>
-    <video youtube="93lWvxKvFRw"/>
+    <video youtube="93lWvxKvFRw" label="vid-seqseries-sequences-limit-properties"/>
   </figure>
 
   <example xml:id="ex_seq6">
@@ -925,7 +925,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="2PVI6iUVYcI" xml:id="vid-seqseries-sequences-example5" component="video"/>
+      <video width="98%" youtube="2PVI6iUVYcI" xml:id="vid-seqseries-sequences-example5" label="vid-seqseries-sequences-example5" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1021,7 +1021,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="d_C_rw2LXwk" xml:id="vid-seqseries-sequences-example-bounded" component="video"/>
+      <video width="98%" youtube="d_C_rw2LXwk" xml:id="vid-seqseries-sequences-example-bounded" label="vid-seqseries-sequences-example-bounded" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1159,7 +1159,7 @@
 
   <figure xml:id="vid-seqseries-sequences-convergent-bounded" component="video">
     <caption>Video presentation of <xref ref="thm_converge_bounded"/></caption>
-    <video youtube="Ljrqs5azcCI"/>
+    <video youtube="Ljrqs5azcCI" label="vid-seqseries-sequences-convergent-bounded"/>
   </figure>
 
   <p>
@@ -1239,7 +1239,7 @@
 
   <figure xml:id="vid-seqseries-sequences-monotone-bounded" component="video">
     <caption>Video presentation of <xref ref="def_monotonic"/> and <xref ref="thm_monotonic_converge"/></caption>
-    <video youtube="ZxaUovyGMBI"/>
+    <video youtube="ZxaUovyGMBI" label="vid-seqseries-sequences-monotone-bounded"/>
   </figure>
 
   <example xml:id="ex_seq7">
@@ -1279,7 +1279,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="F8mDR0ZnMCM" xml:id="vid-seqseries-sequences-monotone-example" component="video"/>
+      <video width="98%" youtube="F8mDR0ZnMCM" xml:id="vid-seqseries-sequences-monotone-example" label="vid-seqseries-sequences-monotone-example" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1561,7 +1561,7 @@
 
   <figure xml:id="vid-seqseries-sequences-monotone-limit" component="video">
     <caption>Finding the limit of a bounded, monotonic sequence</caption>
-    <video youtube="fRMKbUCIb_4"/>
+    <video youtube="fRMKbUCIb_4" label="vid-seqseries-sequences-monotone-limit"/>
   </figure>
 
   <p>

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -4,7 +4,7 @@
   <introduction>
     <figure xml:id="vid-seqseries-series-intro" component="video">
       <caption>Video introduction to <xref ref="sec_series">Section</xref></caption>
-      <video youtube="RV9LNPv20TA"/>
+      <video youtube="RV9LNPv20TA" label="vid-seqseries-series-intro"/>
     </figure>
     <p>
       Given the sequence <m>\{a_n\} = \{1/2^n\} = 1/2,\, 1/4,\, 1/8,\, \ldots</m>,
@@ -153,7 +153,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="NLXq_m8S2tw" xml:id="vid-seqseries-series-example-divergent" component="video"/>
+        <video width="98%" youtube="NLXq_m8S2tw" xml:id="vid-seqseries-series-example-divergent" label="vid-seqseries-series-example-divergent" component="video"/>
       </solution>
       <solution>
         <p>
@@ -438,7 +438,7 @@
 
     <figure xml:id="vid-seqseries-series-geometric" component="video">
       <caption>Video presentation of <xref ref="def_geom_series"/> and <xref ref="thm_geom_series"/></caption>
-      <video youtube="Js5qK6AecSM"/>
+      <video youtube="Js5qK6AecSM" label="vid-seqseries-series-geometric"/>
     </figure>
     <p>
       According to <xref ref="thm_geom_series">Theorem</xref>,
@@ -484,7 +484,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="9_AmxyiKVm8" xml:id="vid-seqseries-sequences-example-geometric" component="video"/>
+        <video width="98%" youtube="9_AmxyiKVm8" xml:id="vid-seqseries-sequences-example-geometric" label="vid-seqseries-sequences-example-geometric" component="video"/>
       </solution>
       <solution>
         <p>
@@ -770,7 +770,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="XYW0z0LMaJc" xml:id="vid-seqseries-series-pseries" component="video"/>
+        <video width="98%" youtube="XYW0z0LMaJc" xml:id="vid-seqseries-series-pseries" label="vid-seqseries-series-pseries" component="video"/>
       </solution>
       <solution>
         <p>
@@ -855,7 +855,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="ckj4xm6ZHgU" xml:id="vid-seqseries-series-telescoping1" component="video"/>
+        <video width="98%" youtube="ckj4xm6ZHgU" xml:id="vid-seqseries-series-telescoping1" label="vid-seqseries-series-telescoping1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -962,7 +962,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-telescoping2" component="video"/>
+        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-telescoping2" label="vid-seqseries-series-telescoping2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1242,7 +1242,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-using-properties" component="video"/>
+        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-using-properties" label="vid-seqseries-series-using-properties" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -18,7 +18,7 @@
 
   <figure xml:id="vid-intapp-shell-intro" component="video">
     <caption>Video introduction to <xref ref="sec_shell_method">Section</xref></caption>
-    <video youtube="YPZjBrm770g"/>
+    <video youtube="YPZjBrm770g" label="vid-intapp-shell-intro"/>
   </figure>
 
   <p>
@@ -425,7 +425,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="WQ3rUzAhgPw" xml:id="vid-intapp-shell-example1" component="video"/>
+      <video width="98%" youtube="WQ3rUzAhgPw" xml:id="vid-intapp-shell-example1" label="vid-intapp-shell-example1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -513,7 +513,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="wGVmSx1TqQI" xml:id="vid-intapp-shell-example2" component="video"/>
+      <video width="98%" youtube="wGVmSx1TqQI" xml:id="vid-intapp-shell-example2" label="vid-intapp-shell-example2" component="video"/>
     </solution>
     <solution>
       <p>
@@ -775,7 +775,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="pu80zsXPw5E" xml:id="vid-intapp-shell-example3" component="video"/>
+      <video width="98%" youtube="pu80zsXPw5E" xml:id="vid-intapp-shell-example3" label="vid-intapp-shell-example3" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1042,7 +1042,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="nd16wB-0qIQ" xml:id="vid-intapp-shell-example4" component="video"/>
+      <video width="98%" youtube="nd16wB-0qIQ" xml:id="vid-intapp-shell-example4" label="vid-intapp-shell-example4" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -20,7 +20,7 @@
 
     <figure xml:id="vid-vectors-spacecoord-intro" component="video">
       <caption>Video introduction to <xref ref="sec_space_coord"/></caption>
-      <video youtube="zqaTPul--ZU"/>
+      <video youtube="zqaTPul--ZU" label="vid-vectors-spacecoord-intro"/>
     </figure>
 
     <p>
@@ -218,7 +218,7 @@
 
     <figure xml:id="vid-vectors-spacecoord-distance" component="video">
       <caption>Video presentation of <xref ref="def_space_distance"/></caption>
-      <video youtube="zNUbi5ahC0Y"/>
+      <video youtube="zNUbi5ahC0Y" label="vid-vectors-spacecoord-distance"/>
     </figure>
 
     <example xml:id="ex_space1">
@@ -231,7 +231,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="EF-aTKoAQsU" xml:id="vid-vectors-spacecoord-linesegment" component="video"/>
+        <video width="98%" youtube="EF-aTKoAQsU" xml:id="vid-vectors-spacecoord-linesegment" label="vid-vectors-spacecoord-linesegment" component="video"/>
       </solution>
       <solution>
         <p>
@@ -348,7 +348,7 @@
 
     <figure xml:id="vid-vector-spacecoord-sphere" component="video">
       <caption>Video presentation of <xref ref="idea_sphere"/></caption>
-      <video youtube="Xzs2ita0nI0"/>
+      <video youtube="Xzs2ita0nI0" label="vid-vector-spacecoord-sphere"/>
     </figure>
 
     <example xml:id="ex_space2">
@@ -360,7 +360,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="O0VtyYNXeig" xml:id="vid-vectors-spcaecoord-sphere-eg" component="video"/>
+        <video width="98%" youtube="O0VtyYNXeig" xml:id="vid-vectors-spcaecoord-sphere-eg" label="vid-vectors-spcaecoord-sphere-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -406,7 +406,7 @@
 
     <figure xml:id="vid-vectors-spacecoord-planes" component="video">
       <caption>Video introduction to <xref ref="sec-planes-in-space"/></caption>
-      <video youtube="8yImf_yW-Ys"/>
+      <video youtube="8yImf_yW-Ys" label="vid-vectors-spacecoord-planes"/>
     </figure>
 
     <figure xml:id="fig_coordplanes">
@@ -614,7 +614,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="-9luj-GlMqA" xml:id="vid-vectors-spacecoord-planes-eg" component="video"/>
+        <video width="98%" youtube="-9luj-GlMqA" xml:id="vid-vectors-spacecoord-planes-eg" label="vid-vectors-spacecoord-planes-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -705,7 +705,7 @@
 
     <figure xml:id="vid-vectors-spacecoord-cylinders" component="video">
       <caption>Video introduction to <xref ref="subsec-space-cylinders"/></caption>
-      <video youtube="9wusVjjItyY"/>
+      <video youtube="9wusVjjItyY" label="vid-vectors-spacecoord-cylinders"/>
     </figure>
 
     <figure xml:id="fig_spacecylinder1">
@@ -871,7 +871,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="n7Yp4aWqeFc" xml:id="vid-vectors-spacecoord-cylinder-eg" component="video"/>
+        <video width="98%" youtube="n7Yp4aWqeFc" xml:id="vid-vectors-spacecoord-cylinder-eg" label="vid-vectors-spacecoord-cylinder-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1279,7 +1279,7 @@
 
     <figure xml:id="vid-vectors-spacecoord-surfrev-intro" component="video">
       <caption>Video presentation of <xref ref="subsec-space-surface-revolution"/></caption>
-      <video youtube="gxnpRE0b68U"/>
+      <video youtube="gxnpRE0b68U" label="vid-vectors-spacecoord-surfrev-intro"/>
     </figure>
 
     <p>
@@ -1456,7 +1456,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="jrJXSnHU-0o" xml:id="vid-vectors-spacecoord-surfrev-eg" component="video"/>
+        <video width="98%" youtube="jrJXSnHU-0o" xml:id="vid-vectors-spacecoord-surfrev-eg" label="vid-vectors-spacecoord-surfrev-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1742,7 +1742,7 @@
 
     <figure xml:id="vid-vectors-spacecoord-quadric" component="video">
       <caption>Video introduction to <xref ref="subsec-space-quadric"/></caption>
-      <video youtube="Ax_QfsRTwrc"/>
+      <video youtube="Ax_QfsRTwrc" label="vid-vectors-spacecoord-quadric"/>
     </figure>
 
     <definition xml:id="def_quadric">
@@ -3072,7 +3072,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="7BPClg70Lmg" xml:id="vid-vectors-spacecoord-quadric-eg" component="video"/>
+        <video width="98%" youtube="7BPClg70Lmg" xml:id="vid-vectors-spacecoord-quadric-eg" label="vid-vectors-spacecoord-quadric-eg" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -24,7 +24,7 @@
 
     <figure xml:id="vid-veccalc-stokesdiv-divthm" component="video">
       <caption>Introducing the Divergenge Theorem</caption>
-      <video youtube="Ra6bxrTj5xU"/>
+      <video youtube="Ra6bxrTj5xU" label="vid-veccalc-stokesdiv-divthm"/>
     </figure>
 
     <theorem xml:id="thm_divergence2">
@@ -596,7 +596,7 @@
 
     <figure xml:id="vid-veccalc-stokesdiv-gauss" component="video">
       <caption>Exploring Gauss's Law</caption>
-      <video youtube="Zc_OAF_CRIQ"/>
+      <video youtube="Zc_OAF_CRIQ" label="vid-veccalc-stokesdiv-gauss"/>
     </figure>
 
     <p>
@@ -657,7 +657,7 @@
 
     <figure xml:id="vid-veccalc-stokesdiv-stokes-thm" component="video">
       <caption>Introducing Stokes' Theorem</caption>
-      <video youtube="WzrQbtC7ZiU"/>
+      <video youtube="WzrQbtC7ZiU" label="vid-veccalc-stokesdiv-stokes-thm"/>
     </figure>
 
     <p>
@@ -820,7 +820,7 @@
 
     <figure xml:id="vid-veccalc-stokesdiv-stokes-eg1" component="video">
       <caption>An example with Stokes' Theorem</caption>
-      <video youtube="IxDa_2_Eric"/>
+      <video youtube="IxDa_2_Eric" label="vid-veccalc-stokesdiv-stokes-eg1"/>
     </figure>
     <p>
       One of the interesting results of Stokes' Theorem is that if two surfaces <m>\surfaceS_1</m> and
@@ -1013,7 +1013,7 @@
 
     <figure xml:id="vid-veccalc-stokesdiv-stokes-eg2" component="video">
       <caption>Another example with Stokes' Theorem</caption>
-      <video youtube="sIqNIkmYPiE"/>
+      <video youtube="sIqNIkmYPiE" label="vid-veccalc-stokesdiv-stokes-eg2"/>
     </figure>
   </subsection>
 

--- a/ptx/sec_substitution.ptx
+++ b/ptx/sec_substitution.ptx
@@ -5,7 +5,7 @@
 
     <figure xml:id="vid_int_sub_intro" component="video">
       <caption>Video introduction to <xref ref="sec_substitution"/></caption>
-      <video youtube="mElhuqXsPhQ"/>
+      <video youtube="mElhuqXsPhQ" label="vid_int_sub_intro"/>
     </figure>
 
     <p>
@@ -292,7 +292,7 @@
 
     <figure xml:id="vid_int_sub_examples_1" component="video">
       <caption>Video presentation of <xref first="ex_sub1" last="ex_sub3">Examples</xref></caption>
-      <video youtube="-6CFSvtMCDU"/>
+      <video youtube="-6CFSvtMCDU" label="vid_int_sub_examples_1"/>
     </figure>
 
 
@@ -311,7 +311,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="UdGVU8H5w3M" xml:id="vid_int_sub_ex_1" component="video"/>
+        <video width="98%" youtube="UdGVU8H5w3M" xml:id="vid_int_sub_ex_1" label="vid_int_sub_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -437,7 +437,7 @@
 
     <figure xml:id="vid_int_sub_examples_2" component="video">
       <caption>Video presentation of <xref first="ex_sub4" last="ex_sub5">Examples</xref></caption>
-      <video youtube="Qzj4UJX_69c"/>
+      <video youtube="Qzj4UJX_69c" label="vid_int_sub_examples_2"/>
     </figure>
 
   </introduction>
@@ -467,7 +467,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="sJryXwwdqM4" xml:id="vid-int-sub-ex-tan" component="video"/>
+        <video width="98%" youtube="sJryXwwdqM4" xml:id="vid-int-sub-ex-tan" label="vid-int-sub-ex-tan" component="video"/>
       </solution>
       <solution>
 
@@ -520,7 +520,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="ivQ5GFSvEGg" xml:id="vid-int-sub-ex-sec" component="video"/>
+        <video width="98%" youtube="ivQ5GFSvEGg" xml:id="vid-int-sub-ex-sec" label="vid-int-sub-ex-sec" component="video"/>
       </solution>
       <solution>
         <p>
@@ -550,7 +550,7 @@
 
     <!-- <figure xml:id="vid_int_sub_trig_ex" component="video">
       <caption>Video presentation of <xref first="ex_sub6" last="ex_sub7">Examples</xref></caption>
-      <video youtube="OX7WRbWGrts"/>
+      <video youtube="OX7WRbWGrts" label="vid_int_sub_trig_ex"/>
     </figure> -->
 
 
@@ -646,7 +646,7 @@
 
     <figure xml:id="vid-int-sub-ex-trig" component="video">
       <caption>Video presentation of <xref ref="ex_sub8"/> and two other trigonometric examples</caption>
-      <video youtube="XB_PG1Z_n1M"/>
+      <video youtube="XB_PG1Z_n1M" label="vid-int-sub-ex-trig"/>
     </figure>
   </subsection>
 
@@ -671,7 +671,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="kuHKfsyaOAI" xml:id="vid-int-sub-with-longdiv" component="video"/>
+        <video width="98%" youtube="kuHKfsyaOAI" xml:id="vid-int-sub-with-longdiv" label="vid-int-sub-with-longdiv" component="video"/>
       </solution>
       <solution>
         <p>
@@ -809,7 +809,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="skYWHK8feRs" xml:id="vid-int-sub-ex-arctan" component="video"/>
+        <video width="98%" youtube="skYWHK8feRs" xml:id="vid-int-sub-ex-arctan" label="vid-int-sub-ex-arctan" component="video"/>
       </solution>
       <solution>
         <p>
@@ -930,7 +930,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="wSrXvtTvUjI" xml:id="vid-int-sub-ex-complet-square" component="video"/>
+        <video width="98%" youtube="wSrXvtTvUjI" xml:id="vid-int-sub-ex-complet-square" label="vid-int-sub-ex-complet-square" component="video"/>
       </solution>
       <solution>
         <p>
@@ -989,7 +989,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="tEPUnupFCfs" xml:id="vid-int-sub-ex-two-methods" component="video"/>
+        <video width="98%" youtube="tEPUnupFCfs" xml:id="vid-int-sub-ex-two-methods" label="vid-int-sub-ex-two-methods" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1038,7 +1038,7 @@
     <title>Substitution and Definite Integration</title>
     <figure xml:id="vid_int_sub_def_int" component="video">
       <caption>Video introduction to <xref ref="sec-sub-def-int"/></caption>
-      <video youtube="JGD5OtxoKoI"/>
+      <video youtube="JGD5OtxoKoI" label="vid_int_sub_def_int"/>
     </figure>
 
     <p>
@@ -1231,7 +1231,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="U3B47kxjidk" xml:id="vid_int_sub_def_int_ex" component="video"/>
+        <video width="98%" youtube="U3B47kxjidk" xml:id="vid_int_sub_def_int_ex" label="vid_int_sub_def_int_ex" component="video"/>
       </solution>
       <solution>
 

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -57,7 +57,7 @@
 
     <figure xml:id="vid-veccalc-surfint-scalar-intro" component="video">
       <caption>The surface integral of a scalar field (function)</caption>
-      <video youtube="-1NgI5Xts6E"/>
+      <video youtube="-1NgI5Xts6E" label="vid-veccalc-surfint-scalar-intro"/>
     </figure>
 
     <definition xml:id="def_surface_integral">
@@ -220,7 +220,7 @@
 
     <figure xml:id="vid-veccalc-surfint-vector-intro" component="video">
       <caption>Introducing surface integrals of vector fields</caption>
-      <video youtube="ISowVEDVEzM"/>
+      <video youtube="ISowVEDVEzM" label="vid-veccalc-surfint-vector-intro"/>
     </figure>
 
     <p>
@@ -478,7 +478,7 @@
 
     <figure xml:id="vid-veccalc-surfint-example1" component="video">
       <caption>Computing a surface integral over part of a paraboloid</caption>
-      <video youtube="5XEt-DZedNM"/>
+      <video youtube="5XEt-DZedNM" label="vid-veccalc-surfint-example1"/>
     </figure>
 
     <example xml:id="ex_surfflux2">
@@ -726,12 +726,12 @@
 
     <figure xml:id="vid-veccalc-surfint-flux-cube" component="video">
       <caption>Computing flux across a cube</caption>
-      <video youtube="u59S_E8VCM8"/>
+      <video youtube="u59S_E8VCM8" label="vid-veccalc-surfint-flux-cube"/>
     </figure>
 
     <figure xml:id="vid-veccalc-surfint-flux-sphere" component="video">
       <caption>Some surface integrals over spheres</caption>
-      <video youtube="xdtbrzLRtBY"/>
+      <video youtube="xdtbrzLRtBY" label="vid-veccalc-surfint-flux-sphere"/>
     </figure>
   </subsection>
 

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -31,7 +31,7 @@
 
     <figure xml:id="vid-vvf-tannorm-tangent" component="video">
       <caption>Video presentation of <xref ref="def_unit_tangent"/></caption>
-      <video youtube="tmKmAKUdSZ8"/>
+      <video youtube="tmKmAKUdSZ8" label="vid-vvf-tannorm-tangent"/>
     </figure>
 
     <example xml:id="ex_tannorm1">
@@ -45,7 +45,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="aGEMbQrBpPI" xml:id="vid-vvf-tannorm-tangent-eg1" component="video"/>
+        <video width="98%" youtube="aGEMbQrBpPI" xml:id="vid-vvf-tannorm-tangent-eg1" label="vid-vvf-tannorm-tangent-eg1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -154,7 +154,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="zdfMTWdXzJs" xml:id="vid-vvf-tannorm-tangent-eg2" component="video"/>
+        <video width="98%" youtube="zdfMTWdXzJs" xml:id="vid-vvf-tannorm-tangent-eg2" label="vid-vvf-tannorm-tangent-eg2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -310,7 +310,7 @@
 
     <figure xml:id="vid-vvf-tannorm-normal" component="video">
       <caption>Video presentation of <xref ref="def_unit_normal"/></caption>
-      <video youtube="HWX5uPUCFJs"/>
+      <video youtube="HWX5uPUCFJs" label="vid-vvf-tannorm-normal"/>
     </figure>
 
     <example xml:id="ex_tannorm3">
@@ -324,7 +324,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="cZkvyF0t5P4" xml:id="vid-vvf-tannorm-normal-eg1" component="video"/>
+        <video width="98%" youtube="cZkvyF0t5P4" xml:id="vid-vvf-tannorm-normal-eg1" label="vid-vvf-tannorm-normal-eg1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -437,7 +437,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="VExazWvgGlQ" xml:id="vid-vvf-tannorm-normal-eg2" component="video"/>
+        <video width="98%" youtube="VExazWvgGlQ" xml:id="vid-vvf-tannorm-normal-eg2" label="vid-vvf-tannorm-normal-eg2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -668,7 +668,7 @@
 
     <figure xml:id="vid-vvf-tannorm-accel" component="video">
       <caption>Video presentation of <xref ref="thm_acc_plane"/></caption>
-      <video youtube="mRKDo_rot7Y"/>
+      <video youtube="mRKDo_rot7Y" label="vid-vvf-tannorm-accel"/>
     </figure>
 
     <example xml:id="ex_tannorm5">
@@ -682,7 +682,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qA776vEHYM0" xml:id="vid-vvf-tannorm-accel-eg1" component="video"/>
+        <video width="98%" youtube="qA776vEHYM0" xml:id="vid-vvf-tannorm-accel-eg1" label="vid-vvf-tannorm-accel-eg1" component="video"/>
       </solution>
       <solution>
         <p>
@@ -725,7 +725,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="8LTqjQPvh-A" xml:id="vid-vvf-tannorm-accel-eg2" component="video"/>
+        <video width="98%" youtube="8LTqjQPvh-A" xml:id="vid-vvf-tannorm-accel-eg2" label="vid-vvf-tannorm-accel-eg2" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -5,7 +5,7 @@
 
     <figure xml:id="vid_deriv_apps_taylor_poly_intro" component="video">
       <caption>Video introduction to <xref ref="sec_taylor_poly"/></caption>
-      <video youtube="SYJ2uGJCQdY"/>
+      <video youtube="SYJ2uGJCQdY" label="vid_deriv_apps_taylor_poly_intro"/>
     </figure>
 
     <p>
@@ -255,7 +255,7 @@
 
     <figure xml:id="vid_deriv_apps_taylor_poly_determ_coeffs" component="video">
       <caption>Determining the coefficients of a Taylor polynomial</caption>
-      <video youtube="v8mPY7fu1e0"/>
+      <video youtube="v8mPY7fu1e0" label="vid_deriv_apps_taylor_poly_determ_coeffs"/>
     </figure>
 
     <p>
@@ -378,7 +378,7 @@
 
     <figure xml:id="vid_deriv_apps_taylor_poly_defn" component="video">
       <caption>Video presentation of <xref ref="def_taypoly"/></caption>
-      <video youtube="J-5vVJIGQp4"/>
+      <video youtube="J-5vVJIGQp4" label="vid_deriv_apps_taylor_poly_defn"/>
     </figure>
 
 
@@ -408,7 +408,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="ENf-Z2pLrJg" xml:id="vid_deriv_apps_taylor_poly_ex_1" component="video"/>
+        <video width="98%" youtube="ENf-Z2pLrJg" xml:id="vid_deriv_apps_taylor_poly_ex_1" label="vid_deriv_apps_taylor_poly_ex_1" component="video"/>
       </solution>
       <solution>
 
@@ -540,7 +540,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="6BeNQe0hl3k" xml:id="vid_deriv_apps_taylor_poly_ex_2" component="video"/>
+        <video width="98%" youtube="6BeNQe0hl3k" xml:id="vid_deriv_apps_taylor_poly_ex_2" label="vid_deriv_apps_taylor_poly_ex_2" component="video"/>
       </solution>
       <solution>
 
@@ -869,7 +869,7 @@
 
     <figure xml:id="vid_deriv_apps_taylor_poly_taylors_thm" component="video">
       <caption>Video presentation of <xref ref="thm_taylorthm"/></caption>
-      <video youtube="2IHECY8dFN0"/>
+      <video youtube="2IHECY8dFN0" label="vid_deriv_apps_taylor_poly_taylors_thm"/>
     </figure>
 
 
@@ -905,7 +905,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="TBV4-X7HoHk" xml:id="vid_deriv_apps_taylor_poly_err_est_ex" component="video"/>
+        <video width="98%" youtube="TBV4-X7HoHk" xml:id="vid_deriv_apps_taylor_poly_err_est_ex" label="vid_deriv_apps_taylor_poly_err_est_ex" component="video"/>
       </solution>
       <solution>
 
@@ -1003,7 +1003,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="zg1W9miUCB4" xml:id="vid_deriv_apps_taylor_poly_ex_4" component="video"/>
+        <video width="98%" youtube="zg1W9miUCB4" xml:id="vid_deriv_apps_taylor_poly_ex_4" label="vid_deriv_apps_taylor_poly_ex_4" component="video"/>
       </solution>
       <solution>
 

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -14,7 +14,7 @@
 
   <figure xml:id="vid-seqseries-taylorseries-intro" component="video">
     <caption>Video introduction to <xref ref="sec_taylor_series"/></caption>
-    <video youtube="4RC4SLmEjro"/>
+    <video youtube="4RC4SLmEjro" label="vid-seqseries-taylorseries-intro"/>
   </figure>
 
   <definition xml:id="def_taylor_series">
@@ -87,7 +87,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="97x6p1616z0" xml:id="vid-seqseries-taylorseries-maclaurin-cos" component="video"/>
+      <video width="98%" youtube="97x6p1616z0" xml:id="vid-seqseries-taylorseries-maclaurin-cos" label="vid-seqseries-taylorseries-maclaurin-cos" component="video"/>
     </solution>
     <solution>
       <p>
@@ -211,7 +211,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="Bdk4lGCkz7o" xml:id="vid-seqseries-taylorseries-natural-log" component="video"/>
+      <video width="98%" youtube="Bdk4lGCkz7o" xml:id="vid-seqseries-taylorseries-natural-log" label="vid-seqseries-taylorseries-natural-log" component="video"/>
     </solution>
     <solution>
       <p>
@@ -374,7 +374,7 @@
 
   <figure xml:id="vid-seqseries-taylorseries-equality-with-function" component="video">
     <caption>Video presentation of <xref ref="thm_function_series_equality"/></caption>
-    <video youtube="FF3m792UGiA"/>
+    <video youtube="FF3m792UGiA" label="vid-seqseries-taylorseries-equality-with-function"/>
   </figure>
 
   <p>
@@ -472,7 +472,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="ABhiG2xZmWY GMY1-7f9fu0 Odvm-etYS0Y" xml:id="vid-seqseries-taylorseries-binomial" component="video"/>
+      <video width="98%" youtube="ABhiG2xZmWY GMY1-7f9fu0 Odvm-etYS0Y" xml:id="vid-seqseries-taylorseries-binomial" label="vid-seqseries-taylorseries-binomial" component="video"/>
     </solution>
     <solution>
       <p>
@@ -710,7 +710,7 @@
 
   <figure xml:id="vid-seqseries-taylorseries-arctan" component="video">
     <caption>Deriving the Taylor series for <m>\arctan(x)</m> in <xref ref="idea_common_taylor">Key Idea</xref></caption>
-    <video youtube="v-y5IH796gY"/>
+    <video youtube="v-y5IH796gY" label="vid-seqseries-taylorseries-arctan"/>
   </figure>
 
   <example xml:id="ex_ts5">
@@ -724,7 +724,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="rUBF6BC201g" xml:id="vid-seqseries-taylorseries-product" component="video"/>
+      <video width="98%" youtube="rUBF6BC201g" xml:id="vid-seqseries-taylorseries-product" label="vid-seqseries-taylorseries-product" component="video"/>
     </solution>
     <solution>
       <p>
@@ -774,7 +774,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="j3eHOO9taNQ" xml:id="vid-seqseries-taylorseries-composition" component="video"/>
+      <video width="98%" youtube="j3eHOO9taNQ" xml:id="vid-seqseries-taylorseries-composition" label="vid-seqseries-taylorseries-composition" component="video"/>
     </solution>
     <solution>
       <p>
@@ -961,7 +961,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="WhpEci26gUA" xml:id="vid-seqseries-taylorseries-integration" component="video"/>
+      <video width="98%" youtube="WhpEci26gUA" xml:id="vid-seqseries-taylorseries-integration" label="vid-seqseries-taylorseries-integration" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1026,7 +1026,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="ojjEGO5H8qQ" xml:id="vid-seqseries-taylorseries-ivp" component="video"/>
+      <video width="98%" youtube="ojjEGO5H8qQ" xml:id="vid-seqseries-taylorseries-ivp" label="vid-seqseries-taylorseries-ivp" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_total_differential.ptx
+++ b/ptx/sec_total_differential.ptx
@@ -159,7 +159,7 @@
 
     <figure xml:id="vid-multi-differentiability" component="video">
       <caption>Another approach to defining differentiability</caption>
-      <video youtube="hJaLxYbPgdM"/>
+      <video youtube="hJaLxYbPgdM" label="vid-multi-differentiability"/>
     </figure>
 
     <example xml:id="ex_totaldiff1">
@@ -209,7 +209,7 @@
 
     <figure xml:id="vid-multi-differentiability-example" component="video">
       <caption>Establishing differentiability using the definition in <xref ref="vid-multi-differentiability"/></caption>
-      <video youtube="rYvDghlxlUA"/>
+      <video youtube="rYvDghlxlUA" label="vid-multi-differentiability-example"/>
     </figure>
 
     <p>

--- a/ptx/sec_transformations.ptx
+++ b/ptx/sec_transformations.ptx
@@ -56,7 +56,7 @@
 
 		<figure xml:id="vid-multint-transformations-intro" component="video">
 		  <caption>Introducing the change of variables formula</caption>
-		  <video youtube="G1YTunRt6g0"/>
+		  <video youtube="G1YTunRt6g0" label="vid-multint-transformations-intro"/>
 		</figure>
 	</introduction>
 
@@ -1153,7 +1153,7 @@
 
 		<figure xml:id="vid-transformation-spherical" component="video">
 			<caption>Computing the spherical coordinate Jacobian</caption>
-			<video youtube="r1FX1DkDRb0"/>
+			<video youtube="r1FX1DkDRb0" label="vid-transformation-spherical"/>
 		</figure>
 
 	</subsection>
@@ -1277,7 +1277,7 @@
 
 		<figure xml:id="vid-multint-transformations-parallelogram" component="video">
 		  <caption>Using a transformation to compute an integral over a parallelogram</caption>
-		  <video youtube="Yf-0g8afcb4"/>
+		  <video youtube="Yf-0g8afcb4" label="vid-multint-transformations-parallelogram"/>
 		</figure>
 
 		<p>
@@ -1701,7 +1701,7 @@
 
 		<figure xml:id="vid-multint-tranformations-inverse" component="video">
 		  <caption>Working with the inverse of a transformation</caption>
-		  <video youtube="-kHCIjBbcoA"/>
+		  <video youtube="-kHCIjBbcoA" label="vid-multint-tranformations-inverse"/>
 		</figure>
 
 		<p>
@@ -2038,7 +2038,7 @@
 
 		<figure xml:id="vid-multint-transformations-example" component="video">
 		  <caption>A video presentation of <xref ref="ex_int_trans2">Example</xref>, with slightly different numbers</caption>
-		  <video youtube="hSDH3FnD97w"/>
+		  <video youtube="hSDH3FnD97w" label="vid-multint-transformations-example"/>
 		</figure>
 	</subsection>
 

--- a/ptx/sec_transformations_old.ptx
+++ b/ptx/sec_transformations_old.ptx
@@ -56,7 +56,7 @@
 
 		<figure xml:id="vid-multint-transformations-intro" component="video">
 		  <caption>Introducing the change of variables formula</caption>
-		  <video youtube="G1YTunRt6g0"/>
+		  <video youtube="G1YTunRt6g0" label="vid-multint-transformations-intro"/>
 		</figure>
 	</introduction>
 
@@ -1157,7 +1157,7 @@
 
 		<figure xml:id="vid-transformation-spherical" component="video">
 			<caption>Computing the spherical coordinate Jacobian</caption>
-			<video youtube="r1FX1DkDRb0"/>
+			<video youtube="r1FX1DkDRb0" label="vid-transformation-spherical"/>
 		</figure>
 
 	</subsection>
@@ -1281,7 +1281,7 @@
 
 		<figure xml:id="vid-multint-transformations-parallelogram" component="video">
 		  <caption>Using a transformation to compute an integral over a parallelogram</caption>
-		  <video youtube="Yf-0g8afcb4"/>
+		  <video youtube="Yf-0g8afcb4" label="vid-multint-transformations-parallelogram"/>
 		</figure>
 
 		<p>
@@ -1705,7 +1705,7 @@
 
 		<figure xml:id="vid-multint-tranformations-inverse" component="video">
 		  <caption>Working with the inverse of a transformation</caption>
-		  <video youtube="-kHCIjBbcoA"/>
+		  <video youtube="-kHCIjBbcoA" label="vid-multint-tranformations-inverse"/>
 		</figure>
 
 		<p>
@@ -2042,7 +2042,7 @@
 
 		<figure xml:id="vid-multint-transformations-example" component="video">
 		  <caption>A video presentation of <xref ref="ex_int_trans2">Example</xref>, with slightly different numbers</caption>
-		  <video youtube="hSDH3FnD97w"/>
+		  <video youtube="hSDH3FnD97w" label="vid-multint-transformations-example"/>
 		</figure>
 	</subsection>
 

--- a/ptx/sec_trig_sub.ptx
+++ b/ptx/sec_trig_sub.ptx
@@ -32,7 +32,7 @@
 
   <figure xml:id="vid-int-trigsub-intro" component="video">
     <caption>Video introduction to <xref ref="sec_trig_sub"/></caption>
-    <video youtube="l3gtQyPLr-E"/>
+    <video youtube="l3gtQyPLr-E" label="vid-int-trigsub-intro"/>
   </figure>
 
   <p>
@@ -50,7 +50,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="5CKWeQvnGAU" xml:id="vid-int-trigsub-ex-def-sine" component="video"/>
+      <video width="98%" youtube="5CKWeQvnGAU" xml:id="vid-int-trigsub-ex-def-sine" label="vid-int-trigsub-ex-def-sine" component="video"/>
     </solution>
     <solution>
       <p>
@@ -260,7 +260,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="2a9Oks-FCg0" xml:id="vid-int-trigsub-ex-tan1" component="video"/>
+      <video width="98%" youtube="2a9Oks-FCg0" xml:id="vid-int-trigsub-ex-tan1" label="vid-int-trigsub-ex-tan1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -325,7 +325,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="0oCjVzIa_t8" xml:id="vid-int-trigsub-ex-sec1" component="video"/>
+      <video width="98%" youtube="0oCjVzIa_t8" xml:id="vid-int-trigsub-ex-sec1" label="vid-int-trigsub-ex-sec1" component="video"/>
     </solution>
     <solution>
       <p>
@@ -411,7 +411,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="E37-2LvYSsg" xml:id="vid-int-trigsub-ex-sin2" component="video"/>
+      <video width="98%" youtube="E37-2LvYSsg" xml:id="vid-int-trigsub-ex-sin2" label="vid-int-trigsub-ex-sin2" component="video"/>
     </solution>
     <solution>
       <p>
@@ -493,7 +493,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="5JAXeV1-vCo" xml:id="vid-int-trigsub-ex-complete-square" component="video"/>
+      <video width="98%" youtube="5JAXeV1-vCo" xml:id="vid-int-trigsub-ex-complete-square" label="vid-int-trigsub-ex-complete-square" component="video"/>
     </solution>
     <solution>
       <p>
@@ -560,7 +560,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="Pz56QfleHX4" xml:id="vid-int-trigsub-ex-tan-def" component="video"/>
+      <video width="98%" youtube="Pz56QfleHX4" xml:id="vid-int-trigsub-ex-tan-def" label="vid-int-trigsub-ex-tan-def" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_trigint.ptx
+++ b/ptx/sec_trigint.ptx
@@ -38,7 +38,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="soXjOeFRrsk" xml:id="vid-int-trig-ex-sin3cos" component="video"/>
+        <video width="98%" youtube="soXjOeFRrsk" xml:id="vid-int-trig-ex-sin3cos" label="vid-int-trig-ex-sin3cos" component="video"/>
       </solution>
       <solution>
         <p>
@@ -161,7 +161,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="CAV4gSbw1GU" xml:id="vid-int-trig-ex-sin5cos8" component="video"/>
+        <video width="98%" youtube="CAV4gSbw1GU" xml:id="vid-int-trig-ex-sin5cos8" label="vid-int-trig-ex-sin5cos8" component="video"/>
       </solution>
       <solution>
         <p>
@@ -318,7 +318,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="EXODR17otIw" xml:id="vid-int-trig-ex-cos4sin2" component="video"/>
+        <video width="98%" youtube="EXODR17otIw" xml:id="vid-int-trig-ex-cos4sin2" label="vid-int-trig-ex-cos4sin2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -409,7 +409,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="KbW-xwlTuyI" xml:id="vid-int-trig-ex-sin5xcos2x" component="video"/>
+        <video width="98%" youtube="KbW-xwlTuyI" xml:id="vid-int-trig-ex-sin5xcos2x" label="vid-int-trig-ex-sin5xcos2x" component="video"/>
       </solution>
       <solution>
         <p>
@@ -564,7 +564,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="yYbn6R20qTk" xml:id="vid-int-trig-ex-tan2sec6" component="video"/>
+        <video width="98%" youtube="yYbn6R20qTk" xml:id="vid-int-trig-ex-tan2sec6" label="vid-int-trig-ex-tan2sec6" component="video"/>
       </solution>
       <solution>
         <p>
@@ -592,7 +592,7 @@
 
     <figure xml:id="vid-int-trig-ex-tan3sec3" component="video">
       <caption>An integral with odd powers of <m>\tan(x)</m> and <m>\sec(x)</m></caption>
-      <video youtube="QsdKxEr3jG8"/>
+      <video youtube="QsdKxEr3jG8" label="vid-int-trig-ex-tan3sec3"/>
     </figure>
 
     <example xml:id="ex_trigint6">
@@ -604,7 +604,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="mPuR46ztxZQ" xml:id="vid-int-trig-ex-sec3" component="video"/>
+        <video width="98%" youtube="mPuR46ztxZQ" xml:id="vid-int-trig-ex-sec3" label="vid-int-trig-ex-sec3" component="video"/>
       </solution>
       <solution>
         <p>
@@ -670,7 +670,7 @@
 
     <figure xml:id="vid-int-trig-ex-secant-power-reduction" component="video">
       <caption>Deriving a power reduction formula for secant integrals</caption>
-      <video youtube="Om0iOgV9IwA"/>
+      <video youtube="Om0iOgV9IwA" label="vid-int-trig-ex-secant-power-reduction"/>
     </figure>
 
     <p>
@@ -687,7 +687,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="MUDKKDz3_C8" xml:id="vid-int-trig-ex-tan6" component="video"/>
+        <video width="98%" youtube="MUDKKDz3_C8" xml:id="vid-int-trig-ex-tan6" label="vid-int-trig-ex-tan6" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_triple_int.ptx
+++ b/ptx/sec_triple_int.ptx
@@ -449,7 +449,7 @@
 
     <figure xml:id="vid-multint-triple-intro" component="video">
       <caption>Introducing the triple integral</caption>
-      <video youtube="EEWiIQfJktI"/>
+      <video youtube="EEWiIQfJktI" label="vid-multint-triple-intro"/>
     </figure>
 
     <p>
@@ -540,7 +540,7 @@
 
     <figure xml:id="vid-multint-triple-tetrahedron" component="video">
       <caption>Finding the volume of a tetrahedron</caption>
-      <video youtube="lswNoU6cAmA"/>
+      <video youtube="lswNoU6cAmA" label="vid-multint-triple-tetrahedron"/>
     </figure>
 
     <example xml:id="ex_trip2">
@@ -1190,7 +1190,7 @@
 
     <figure xml:id="vid-multint-triple-changing-order" component="video">
       <caption>Changing the order of integration in a triple integral</caption>
-      <video youtube="PA9fkl8bLaI"/>
+      <video youtube="PA9fkl8bLaI" label="vid-multint-triple-changing-order"/>
     </figure>
 
     <example xml:id="ex_trip3">

--- a/ptx/sec_vector_fields.ptx
+++ b/ptx/sec_vector_fields.ptx
@@ -24,7 +24,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-intro" component="video">
       <caption>Introducing vector fields</caption>
-      <video youtube="hnQqjC0cwKY"/>
+      <video youtube="hnQqjC0cwKY" label="vid-veccalc-vectorfield-intro"/>
     </figure>
 
     <p>
@@ -528,7 +528,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-del" component="video">
       <caption>Introducing the del operator</caption>
-      <video youtube="L7AEW0NsyHA"/>
+      <video youtube="L7AEW0NsyHA" label="vid-veccalc-vectorfield-del"/>
     </figure>
 
     <p>
@@ -554,7 +554,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-gradient" component="video">
       <caption>Del and the gradient</caption>
-      <video youtube="QbkbxwicFRI"/>
+      <video youtube="QbkbxwicFRI" label="vid-veccalc-vectorfield-gradient"/>
     </figure>
 
     <p>
@@ -594,7 +594,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-divergence" component="video">
       <caption>Introducing the divergence</caption>
-      <video youtube="10Yh8JUGRYU"/>
+      <video youtube="10Yh8JUGRYU" label="vid-veccalc-vectorfield-divergence"/>
     </figure>
 
     <p>
@@ -652,7 +652,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-curl" component="video">
       <caption>Introducing the curl</caption>
-      <video youtube="PMZXQDhcA2I"/>
+      <video youtube="PMZXQDhcA2I" label="vid-veccalc-vectorfield-curl"/>
     </figure>
 
     <p>
@@ -721,7 +721,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-curl-interpret" component="video">
       <caption>Interpreting the curl of a vector field</caption>
-      <video youtube="PXMWLny21CI"/>
+      <video youtube="PXMWLny21CI" label="vid-veccalc-vectorfield-curl-interpret"/>
     </figure>
 
     <p>
@@ -1176,7 +1176,7 @@
 
     <figure xml:id="vid-veccalc-vectorfield-divergence-example" component="video">
       <caption>Further examples with divergence</caption>
-      <video youtube="_QPgbwG_SHw"/>
+      <video youtube="_QPgbwG_SHw" label="vid-veccalc-vectorfield-divergence-example"/>
     </figure>
 
     <example xml:id="ex_vectorfield3">

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -17,7 +17,7 @@
 
   <figure xml:id="vid-vectors-intro-intro" component="video">
     <caption>Video introduction to <xref ref="sec_vector_intro"/></caption>
-    <video youtube="_1mYILsTF2U"/>
+    <video youtube="_1mYILsTF2U" label="vid-vectors-intro-intro"/>
   </figure>
 
   <p>
@@ -245,7 +245,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="w1MzWJzoyGg" xml:id="vid-vectors-intro-sketch" component="video"/>
+      <video width="98%" youtube="w1MzWJzoyGg" xml:id="vid-vectors-intro-sketch" label="vid-vectors-intro-sketch" component="video"/>
     </solution>
     <solution>
       <p>
@@ -472,7 +472,7 @@
 
   <figure xml:id="vid-vectors-intro-algebra" component="video">
     <caption>Video presentation of <xref ref="def_vector_algebra"/> (2 videos)</caption>
-    <video youtube="F3Y0srvt9lk eWCNYGeDYVA"/>
+    <video youtube="F3Y0srvt9lk eWCNYGeDYVA" label="vid-vectors-intro-algebra"/>
   </figure>
 
   <example xml:id="ex_vect2">
@@ -486,7 +486,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="3MSwQJq_3s0" xml:id="vid-vectors-intro-addition" component="video"/>
+      <video width="98%" youtube="3MSwQJq_3s0" xml:id="vid-vectors-intro-addition" label="vid-vectors-intro-addition" component="video"/>
     </solution>
     <solution>
       <p>
@@ -636,7 +636,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="a_qRwTkQXYQ" xml:id="vid-vectors-intro-subtraction" component="video"/>
+      <video width="98%" youtube="a_qRwTkQXYQ" xml:id="vid-vectors-intro-subtraction" label="vid-vectors-intro-subtraction" component="video"/>
     </solution>
     <solution>
       <p>
@@ -713,7 +713,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="-zvqs7hveXc" xml:id="vid-vectors-intro-scalarmult" component="video"/>
+      <video width="98%" youtube="-zvqs7hveXc" xml:id="vid-vectors-intro-scalarmult" label="vid-vectors-intro-scalarmult" component="video"/>
     </solution>
     <solution>
       <p>
@@ -873,7 +873,7 @@
 
   <figure xml:id="vid-vectors-intro-normprop" component="video">
     <caption>Video presentation of <xref ref="thm_zero_norm" text="custom">Part</xref> of <xref ref="thm_vector_properties"/></caption>
-    <video youtube="oixzQ2EGYPM"/>
+    <video youtube="oixzQ2EGYPM" label="vid-vectors-intro-normprop"/>
   </figure>
 
   <p>
@@ -901,7 +901,7 @@
 
   <figure xml:id="vid-vectors-intro-unitvec" component="video">
     <caption>Video presentation of <xref ref="def_unit_vector"/></caption>
-    <video youtube="6kKUB3OSurs"/>
+    <video youtube="6kKUB3OSurs" label="vid-vectors-intro-unitvec"/>
   </figure>
 
   <p>
@@ -961,7 +961,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="B9OV0Dja6IY" xml:id="vid-vectors-intro-unitvec-eg" component="video"/>
+      <video width="98%" youtube="B9OV0Dja6IY" xml:id="vid-vectors-intro-unitvec-eg" label="vid-vectors-intro-unitvec-eg" component="video"/>
     </solution>
     <solution>
       <p>
@@ -1081,7 +1081,7 @@
 
   <figure xml:id="vid-vectors-intro-parallel" component="video">
     <caption>Video presentation of <xref ref="def_parallel_vectors"/></caption>
-    <video youtube="TZxf7vV1iuk"/>
+    <video youtube="TZxf7vV1iuk" label="vid-vectors-intro-parallel"/>
   </figure>
 
   <p>
@@ -1217,7 +1217,7 @@
     </statement>
     <solution component="video">
       <title>Video solution</title>
-      <video width="98%" youtube="XxSQSU4Nvig" xml:id="vid-vectors-intro-weightchain" component="video"/>
+      <video width="98%" youtube="XxSQSU4Nvig" xml:id="vid-vectors-intro-weightchain" label="vid-vectors-intro-weightchain" component="video"/>
     </solution>
     <solution>
       <p>

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -11,7 +11,7 @@
 
     <figure xml:id="vid-vvf-vvfintro-intro" component="video">
       <caption>Video introduction to <xref ref="sec_vvf"/></caption>
-      <video youtube="MJBP_8ZxiwM"/>
+      <video youtube="MJBP_8ZxiwM" label="vid-vvf-vvfintro-intro"/>
     </figure>
 
     <definition xml:id="def_vvf">
@@ -137,7 +137,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="wXzQo0ce3Us" xml:id="vid-vvf-vvfintro-graph" component="video"/>
+        <video width="98%" youtube="wXzQo0ce3Us" xml:id="vid-vvf-vvfintro-graph" label="vid-vvf-vvfintro-graph" component="video"/>
       </solution>
       <solution>
         <p>
@@ -240,7 +240,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="N1qqqHWR6yw" xml:id="vid-vvf-vvfintro-graph3d" component="video"/>
+        <video width="98%" youtube="N1qqqHWR6yw" xml:id="vid-vvf-vvfintro-graph3d" label="vid-vvf-vvfintro-graph3d" component="video"/>
       </solution>
       <solution>
         <p>
@@ -350,7 +350,7 @@
 
     <figure xml:id="vid-vvf-vvfintro-algebra" component="video">
       <caption>Video presentation of <xref ref="def_vvf_algebra"/></caption>
-      <video youtube="5jygsmDFjZw"/>
+      <video youtube="5jygsmDFjZw" label="vid-vvf-vvfintro-algebra"/>
     </figure>
 
     <example xml:id="ex_vvf3">
@@ -365,7 +365,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="6A3op7KYppw" xml:id="vid-vvf-vvfintro-algebra-eg" component="video"/>
+        <video width="98%" youtube="6A3op7KYppw" xml:id="vid-vvf-vvfintro-algebra-eg" label="vid-vvf-vvfintro-algebra-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -531,7 +531,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="BH9FZMTdgQw" xml:id="vid-vvf-vvfintro-cycloid" component="video"/>
+        <video width="98%" youtube="BH9FZMTdgQw" xml:id="vid-vvf-vvfintro-cycloid" label="vid-vvf-vvfintro-cycloid" component="video"/>
       </solution>
       <solution>
         <p>
@@ -631,7 +631,7 @@
 
     <figure xml:id="vid-vvf-vvfintro-displacement" component="video">
       <caption>Video presentation of <xref ref="def_displacement"/></caption>
-      <video youtube="LfOpC91t7H8"/>
+      <video youtube="LfOpC91t7H8" label="vid-vvf-vvfintro-displacement"/>
     </figure>
 
     <p>
@@ -651,7 +651,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="eGsIv3hYlak" xml:id="vid-vvf-vvfintro-displacement-eg" component="video"/>
+        <video width="98%" youtube="eGsIv3hYlak" xml:id="vid-vvf-vvfintro-displacement-eg" label="vid-vvf-vvfintro-displacement-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -741,7 +741,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="REA-v1g68bo" xml:id="vid-vvf-vvfintro-average" component="video"/>
+        <video width="98%" youtube="REA-v1g68bo" xml:id="vid-vvf-vvfintro-average" label="vid-vvf-vvfintro-average" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -98,7 +98,7 @@
 
     <figure xml:id="vid-vvf-calc-intro" component="video">
       <caption>Video presentation of <xref ref="def_vvf_limit"/> and <xref ref="thm_vvf_limit"/></caption>
-      <video youtube="MS6iGW1AQ2c"/>
+      <video youtube="MS6iGW1AQ2c" label="vid-vvf-calc-intro"/>
     </figure>
 
     <example xml:id="ex_vvflimit1">
@@ -111,7 +111,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="FCFNyv2V8yk" xml:id="vid-vvf-calc-limit-eg" component="video"/>
+        <video width="98%" youtube="FCFNyv2V8yk" xml:id="vid-vvf-calc-limit-eg" label="vid-vvf-calc-limit-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -179,7 +179,7 @@
 
     <figure xml:id="vid-vvf-calc-continuity" component="video">
       <caption>Video presentation of <xref ref="subsec_vvf_continuity"/></caption>
-      <video youtube="5sX-TKcgnA0"/>
+      <video youtube="5sX-TKcgnA0" label="vid-vvf-calc-continuity"/>
     </figure>
 
     <example xml:id="ex_vvflimit2">
@@ -381,7 +381,7 @@
 
     <figure xml:id="vid-vvf-calc-derivative" component="video">
       <caption>Video presentation of <xref ref="def_vvf_derivative"/> and <xref ref="thm_vvf_deriv"/></caption>
-      <video youtube="-o7FIEjwkQs"/>
+      <video youtube="-o7FIEjwkQs" label="vid-vvf-calc-derivative"/>
     </figure>
 
     <example xml:id="ex_vvflimit3">
@@ -409,7 +409,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="vcTn9uy2Fi8" xml:id="vid-vvf-calc-deriv-eg" component="video"/>
+        <video width="98%" youtube="vcTn9uy2Fi8" xml:id="vid-vvf-calc-deriv-eg" label="vid-vvf-calc-deriv-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -631,7 +631,7 @@
 
     <figure xml:id="vid-vvf-calc-tangent" component="video">
       <caption>Video presentation of <xref ref="def_vector_tangent"/></caption>
-      <video youtube="WwKvTWkgetI"/>
+      <video youtube="WwKvTWkgetI" label="vid-vvf-calc-tangent"/>
     </figure>
 
     <example xml:id="ex_vvfderiv1">
@@ -644,7 +644,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="mG-r7_uCzSk" xml:id="vid-vvf-calc-tangent-eg" component="video"/>
+        <video width="98%" youtube="mG-r7_uCzSk" xml:id="vid-vvf-calc-tangent-eg" label="vid-vvf-calc-tangent-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -727,7 +727,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="czvJ5AtLpa4" xml:id="vid-vvf-calc-tangent-eg2" component="video"/>
+        <video width="98%" youtube="czvJ5AtLpa4" xml:id="vid-vvf-calc-tangent-eg2" label="vid-vvf-calc-tangent-eg2" component="video"/>
       </solution>
       <solution>
         <p>
@@ -813,7 +813,7 @@
 
     <figure xml:id="vid-vvf-calc-smooth" component="video">
       <caption>Video presentation of <xref ref="def_vector_smooth"/></caption>
-      <video youtube="sSPWKKcGno4"/>
+      <video youtube="sSPWKKcGno4" label="vid-vvf-calc-smooth"/>
     </figure>
 
     <p>
@@ -879,7 +879,7 @@
 
     <figure xml:id="vid-vvf-calc-deriv-prop" component="video">
       <caption>Video presentation of <xref ref="thm_vvf_deriv_prop"/></caption>
-      <video youtube="8ulgeUUc0rY"/>
+      <video youtube="8ulgeUUc0rY" label="vid-vvf-calc-deriv-prop"/>
     </figure>
 
     <example xml:id="ex_vvfderiv2">
@@ -911,7 +911,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="sD1mgVOWQFo" xml:id="vid-vvf-calc-deriv-prop-eg" component="video"/>
+        <video width="98%" youtube="sD1mgVOWQFo" xml:id="vid-vvf-calc-deriv-prop-eg" label="vid-vvf-calc-deriv-prop-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1185,7 +1185,7 @@
 
     <figure xml:id="vid-vvf-calc-integration" component="video">
       <caption>Video presentation of <xref ref="def_vvf_integral"/> and <xref ref="thm_vvf_integration"/></caption>
-      <video youtube="GQTMVNKQusc"/>
+      <video youtube="GQTMVNKQusc" label="vid-vvf-calc-integration"/>
     </figure>
 
     <example xml:id="ex_vvfint1">
@@ -1198,7 +1198,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="57pkOzkF7TE" xml:id="vid-vvf-calc-integration-eg" component="video"/>
+        <video width="98%" youtube="57pkOzkF7TE" xml:id="vid-vvf-calc-integration-eg" label="vid-vvf-calc-integration-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1240,7 +1240,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="0-1B6C9jj9k" xml:id="vid-vvf-calc-ivp-eg" component="video"/>
+        <video width="98%" youtube="0-1B6C9jj9k" xml:id="vid-vvf-calc-ivp-eg" label="vid-vvf-calc-ivp-eg" component="video"/>
       </solution>
       <solution>
         <p>

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -11,7 +11,7 @@
 
     <figure xml:id="vid-vvf-motion-intro" component="video">
       <caption>Video introduction to <xref ref="sec_vvf_motion"/></caption>
-      <video youtube="UAGqV-r6jBI"/>
+      <video youtube="UAGqV-r6jBI" label="vid-vvf-motion-intro"/>
     </figure>
 
     <definition xml:id="def_vvf_motion">
@@ -90,7 +90,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qpQidOR7TQQ" xml:id="vid-vvf-motion-example-velacc" component="video"/>
+        <video width="98%" youtube="qpQidOR7TQQ" xml:id="vid-vvf-motion-example-velacc" label="vid-vvf-motion-example-velacc" component="video"/>
       </solution>
       <solution>
         <p>
@@ -491,7 +491,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="qrNYh5hmyLE" xml:id="vid-vvf-motion-example-ball" component="video"/>
+        <video width="98%" youtube="qrNYh5hmyLE" xml:id="vid-vvf-motion-example-ball" label="vid-vvf-motion-example-ball" component="video"/>
       </solution>
       <solution>
         <p>
@@ -741,7 +741,7 @@
 
     <figure xml:id="vid-vvf-motion-projectile" component="video">
       <caption>Video presentation of <xref ref="subsec_vvf_projectile"/></caption>
-      <video youtube="-n1VJ3ngrTw"/>
+      <video youtube="-n1VJ3ngrTw" label="vid-vvf-motion-projectile"/>
     </figure>
 
     <p>
@@ -837,7 +837,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="9_Ev_uu0Y74" xml:id="vid-vvf-motion-projectile-eg" component="video"/>
+        <video width="98%" youtube="9_Ev_uu0Y74" xml:id="vid-vvf-motion-projectile-eg" label="vid-vvf-motion-projectile-eg" component="video"/>
       </solution>
       <solution>
         <p>
@@ -1009,7 +1009,7 @@
 
     <figure xml:id="vid-vvf-motion-distance" component="video">
       <caption>Video presentation of <xref ref="thm_distance_traveled"/></caption>
-      <video youtube="vTtjBp2SC1I"/>
+      <video youtube="vTtjBp2SC1I" label="vid-vvf-motion-distance"/>
     </figure>
 
     <example xml:id="ex_motion6">
@@ -1045,7 +1045,7 @@
       </statement>
       <solution component="video">
         <title>Video solution</title>
-        <video width="98%" youtube="vLSocZ7XLQM" xml:id="vid-vvf-motion-distance-eg" component="video"/>
+        <video width="98%" youtube="vLSocZ7XLQM" xml:id="vid-vvf-motion-distance-eg" label="vid-vvf-motion-distance-eg" component="video"/>
       </solution>
       <solution>
         <p>


### PR DESCRIPTION
YouTube videos currently don't work in the Runestone build because labels are missing.
This adds labels to all YouTube videos.