### PR TITLE
Revert tables to figures

### DIFF
--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -438,8 +438,8 @@
           This integral <em>cannot</em> be evaluated in terms of elementary functions so we will approximate it with Simpson's Method with <m>n=4</m>.
         </p>
 
-        <table xml:id="fig_arc3">
-          <title>A table of values of <m>y=\sqrt{1+\cos^2(x) }</m> to evaluate a definite integral in <xref ref="ex_arc3">Example</xref></title>
+        <figure xml:id="fig_arc3">
+          <caption>A table of values of <m>y=\sqrt{1+\cos^2(x) }</m> to evaluate a definite integral in <xref ref="ex_arc3">Example</xref></caption>
           <tabular>
             <row bottom="minor">
               <cell><m>x</m></cell><cell><m>\sqrt{1+\cos^2(x) }</m></cell>
@@ -460,10 +460,10 @@
               <cell><m>\pi</m></cell><cell><m>\sqrt{2}</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
-          <xref ref="fig_arc3">Figure</xref>
+          <xref ref="fig_arc3"/>
           gives <m>\sqrt{1+\cos^2(x) }</m> evaluated at 5 evenly spaced points in <m>[0,\pi]</m>.
           Simpson's Rule then states that
           <md>

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -972,7 +972,7 @@
       <statement>
         <p>
           The minimum radius of the curve in a highway cloverleaf is determined by the operating speed,
-          as given in the table in <xref ref="fig_curvature5">Figure</xref>.
+          as given in the table in <xref ref="fig_curvature5"/>.
           For each curve and speed, compute <m>a_\text{N}</m>.
         </p>
       </statement>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -120,13 +120,13 @@
     </p>
 
     <p>
-      We can approximate the value of this limit numerically with small values of <m>h</m> as seen in <xref ref="table_falling">Table</xref>.
+      We can approximate the value of this limit numerically with small values of <m>h</m> as seen in <xref ref="table_falling"/>.
       It looks as though the velocity is approaching
       <quantity><mag>-64</mag><unit base="foot"/><per base="second"/></quantity>.
     </p>
 
-    <table xml:id="table_falling">
-      <title>Approximating the instantaneous velocity with average velocities over a small time period <m>h</m></title>
+    <figure xml:id="table_falling">
+      <caption>Approximating the instantaneous velocity with average velocities over a small time period <m>h</m></caption>
       <tabular>
         <row bottom="medium">
           <cell><m>h</m></cell>
@@ -153,7 +153,7 @@
           <cell><m>\phantom{Average}{-64.016}</m></cell>
         </row>
       </tabular>
-    </table>
+    </figure>
 
     <p>
       Computing the limit directly gives

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -162,7 +162,7 @@
   </figure>
 
   <p>
-    The information from these two graphs is summarized in <xref ref="table_fandfinv"> Table </xref> below:
+    The information from these two graphs is summarized in <xref ref="table_fandfinv"/> below:
   </p>
 
   <table xml:id="table_fandfinv">
@@ -438,7 +438,7 @@
   <p>
     Using similar techniques,
     we can find the derivatives of all the inverse trigonometric functions.
-    In <xref ref="tab_domain_trig">Table</xref>
+    In <xref ref="tab_domain_trig"/>
     we show the restrictions of the domains of the standard trigonometric functions that allow them to be invertible.
   </p>
 

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -592,15 +592,15 @@
       </p>
 
       <p>
-        <xref ref="table_ext4">Figure</xref>
+        <xref ref="table_ext4"/>
         gives <m>f</m> evaluated at the <q>important</q>
         <m>x</m> values in <m>[0,3]</m>.
         We can easily see the maximum and minimum values of <m>f</m>:
         the maximum value is <m>45</m> and the minimum value is <m>-7</m>.
       </p>
 
-      <table xml:id="table_ext4">
-        <title>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in <xref ref="ex_extval4">Example</xref></title>
+      <figure xml:id="table_ext4">
+        <caption>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in <xref ref="ex_extval4">Example</xref></caption>
         <tabular>
           <row bottom="medium">
             <cell><m>x</m></cell>
@@ -619,7 +619,7 @@
             <cell><m>45</m></cell>
           </row>
         </tabular>
-      </table>
+      </figure>
 
     </solution>
   </example>
@@ -695,17 +695,17 @@
         So we have three important <m>x</m>-values to consider:
         <m>x= -4, 2</m> and <m>0</m>.
         Evaluating <m>f</m> at each gives, respectively, <m>25</m>,
-        <m>3</m> and <m>1</m>, shown in <xref ref="table_ext5">Figure</xref>.
+        <m>3</m> and <m>1</m>, shown in <xref ref="table_ext5"/>.
 
         Thus the absolute minimum of <m>f</m> is 1,
         the absolute maximum of <m>f</m> is <m>25</m>.
-        Our answer is confirmed by the graph of <m>f</m> in <xref ref="fig_extval5">Figure</xref>.
+        Our answer is confirmed by the graph of <m>f</m> in <xref ref="fig_extval5"/>.
       </p>
 
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
-        <table xml:id="table_ext5">
-          <title>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref></title>
+        <figure xml:id="table_ext5">
+          <caption>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -724,7 +724,7 @@
               <cell><m>3</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <figure xml:id="fig_extval5">
           <caption>A graph of <m>f(x)</m> on <m>[-4,2]</m> as in <xref ref="ex_extval5">Example</xref></caption>
@@ -787,18 +787,18 @@
       </p>
 
       <p>
-        We again construct a table of important values in <xref ref="table_ext6">Figure</xref>.
+        We again construct a table of important values in <xref ref="table_ext6"/>.
         In this example we have five values to consider:
         <m>x= 0, \pm 2, \pm\sqrt{\pi}</m>.
         From the table it is clear that the maximum value of <m>f</m> on <m>[-2,2]</m> is <m>1</m>;
         the minimum value is <m>-1</m>.
-        The graph in <xref ref="fig_extval6">Figure</xref> confirms our results.
+        The graph in <xref ref="fig_extval6"/> confirms our results.
       </p>
 
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
-        <table xml:id="table_ext6">
-          <title>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref></title>
+        <figure xml:id="table_ext6">
+          <caption>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -825,7 +825,7 @@
               <cell><m>-0.65</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <figure xml:id="fig_extval6">
           <caption>A graph of <m>f(x)=\cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m> as in <xref ref="ex_extval6">Example</xref></caption>
@@ -859,7 +859,7 @@
     <statement>
       <p>
         Find the extreme values of <m>f(x) = \sqrt{1-x^2}</m>,
-        graphed in <xref ref="fig_extval7">Figure</xref>(a).
+        graphed in <xref ref="fig_extval7"/>.
       </p>
     </statement>
     <solution>
@@ -893,8 +893,8 @@
             <!-- figures/fig_extval7.tex END -->
         </figure>
 
-        <table xml:id="table_ext7">
-          <title>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref></title>
+        <figure xml:id="table_ext7">
+          <caption>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -913,7 +913,7 @@
               <cell><m>0</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
       </sidebyside>
 

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -754,8 +754,7 @@
     <title>Finding extreme values</title>
     <statement>
       <p>
-        Find the extrema of <m>f(x) = \cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m>,
-          graphed in <xref ref="fig_extval6">Figure</xref>.
+        Find the extrema of <m>f(x) = \cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m>.
       </p>
     </statement>
     <solution component="video">
@@ -858,8 +857,7 @@
     <title>Finding extreme values</title>
     <statement>
       <p>
-        Find the extreme values of <m>f(x) = \sqrt{1-x^2}</m>,
-        graphed in <xref ref="fig_extval7"/>.
+        Find the extreme values of <m>f(x) = \sqrt{1-x^2}</m>.
       </p>
     </statement>
     <solution>
@@ -926,7 +924,7 @@
         and <m>\fp</m> is undefined when <m>x=\pm 1</m>,
         the endpoints of the interval
         (which <em>are</em> in the domain of <m>f</m>.)
-        The table of important values is given in <xref ref="table_ext7">Figure</xref>.
+        The table of important values is given in <xref ref="table_ext7"/>.
         The maximum value is <m>1</m>,
         and the minimum value is <m>0</m>.
       </p>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1117,7 +1117,7 @@
                 So replace <m>0.8</m> with <m>0.75</m> and repeat.
                 Note that we don't need to continue to check the endpoints,
                 just the midpoint.
-                Thus we put the rest of the iterations in <xref ref="table_rootfinding">Table</xref>.
+                Thus we put the rest of the iterations in <xref ref="table_rootfinding"/>.
               </p>
             </li>
           </dl>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -602,8 +602,8 @@
         </p>
 
         <p>
-          <xref ref="fig_hzasy1a">Figure</xref> shows a sketch of <m>f</m>,
-          and the table in <xref ref="fig_hzasy1b">Figure</xref>
+          <xref ref="fig_hzasy1a"/> shows a sketch of <m>f</m>,
+          and the table in <xref ref="fig_hzasy1b"/>
           gives values of <m>f(x)</m> for large magnitude values of <m>x</m>.
           It seems reasonable to conclude from both of these sources that <m>f</m> has a horizontal asymptote at <m>y=1</m>.
         </p>
@@ -631,7 +631,7 @@
               <!-- figures/fig_hzasy1.tex END -->
             </figure>
 
-            <table xml:id="fig_hzasy1b"><title/>
+            <figure xml:id="fig_hzasy1b"><caption/>
               <tabular>
                 <row bottom="minor">
                   <cell><m>x</m></cell>
@@ -662,7 +662,7 @@
                   <cell><m>0.999996</m></cell>
                 </row>
               </tabular>
-            </table>
+            </figure>
           </sidebyside>
         </figure>
 

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -180,7 +180,7 @@
       Consider again <m>\lim_{x\to 1}\frac{\sin(x)}{x}</m>.
       To approximate this limit numerically,
       we can create a table of <m>x</m> and <m>f(x)</m> values where <m>x</m> is <q>near</q> <m>1</m>.
-      This is done in <xref ref="table_sinx_1">Figure</xref>.
+      This is done in <xref ref="table_sinx_1"/>.
     </p>
 
     <p>
@@ -192,8 +192,8 @@
       we are only concerned with the values of the function when <m>x</m> is <em>near</em> 1.
     </p>
 
-    <table xml:id="table_sinx_1">
-      <title>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>1</m></title>
+    <figure xml:id="table_sinx_1">
+      <caption>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>1</m></caption>
       <tabular>
         <row bottom="medium">
           <cell><m>x</m></cell>
@@ -228,13 +228,13 @@
           <cell>0.810189</cell>
         </row>
       </tabular>
-    </table>
+    </figure>
 
     <p>
       Now approximate <m>\lim_{x\to 0} \frac{\sin(x)}{x}</m> numerically.
       We already approximated the value of this limit as <m>1</m> graphically in
-      <xref ref="fig_sinx_over_x">Figure</xref>.
-      <xref ref="table_sinx_2">Figure</xref>
+      <xref ref="fig_sinx_over_x"/>.
+      <xref ref="table_sinx_2"/>
       shows the value of <m>\sin(x)/x</m> for values of <m>x</m> near <m>0</m>.
       Ten places after the decimal point are shown to highlight how close to <m>1</m> the value of
       <m>\sin(x)/x</m> gets as <m>x</m> takes on values very near <m>0</m>.
@@ -242,8 +242,8 @@
       only on the behavior of the function <em>near</em> <m>0</m>.
     </p>
 
-    <table xml:id="table_sinx_2">
-      <title>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>0</m></title>
+    <figure xml:id="table_sinx_2">
+      <caption>Values of <m>\sin(x)/x</m> with <m>x</m> near <m>0</m></caption>
       <tabular>
         <row bottom="medium">
           <cell><m>x</m></cell>
@@ -278,7 +278,7 @@
           <cell>0.9983341665</cell>
         </row>
       </tabular>
-    </table>
+    </figure>
 
     <p>
       This numerical method gives confidence to say that <m>1</m> is a good approximation of
@@ -321,8 +321,8 @@
           on a small interval that contains <m>3</m>.
           To numerically approximate the limit,
           create a table of values where the <m>x</m> values are near <m>3</m>.
-          This is done in <xref ref="fig_limit1">Figure</xref>
-          and <xref ref="table_limit1">Figure</xref>, respectively.
+          This is done in <xref ref="fig_limit1"/>
+          and <xref ref="table_limit1"/>, respectively.
         </p>
 
         <sidebyside widths="47% 47%" margins="0%" valign="bottom">
@@ -351,8 +351,8 @@
             <!-- figures/fig_limit1.tex END -->
           </figure>
 
-          <table xml:id="table_limit1">
-            <title>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref></title>
+          <figure xml:id="table_limit1">
+            <caption>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -387,7 +387,7 @@
                 <cell><m>0.289773</m></cell>
               </row>
             </tabular>
-          </table>
+          </figure>
         </sidebyside>
 
         <p>
@@ -500,8 +500,8 @@
             <!-- figures/fig_limit2.tex END -->
           </figure>
 
-          <table xml:id="table_limit2">
-            <title>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref></title>
+          <figure xml:id="table_limit2">
+            <caption>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -532,7 +532,7 @@
                 <cell><m>0.99</m></cell>
               </row>
             </tabular>
-          </table>
+          </figure>
         </sidebyside>
 
         <p>
@@ -647,8 +647,8 @@
             <!-- figures/fig_nolimit1.tex END -->
           </figure>
 
-          <table xml:id="table_nolimit1">
-            <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref></title>
+          <figure xml:id="table_nolimit1">
+            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -679,7 +679,7 @@
                 <cell><m>1.1</m></cell>
               </row>
             </tabular>
-          </table>
+          </figure>
         </sidebyside>
       </solution>
     </example>
@@ -694,8 +694,8 @@
       <solution>
         <p>
           A graph and table of <m>f(x) = \frac{1}{(x-1)^2}</m> are given in
-          <xref ref="fig_nolimit2">Figure</xref>
-          and <xref ref="table_nolimit2">Figure</xref>, respectively.
+          <xref ref="fig_nolimit2"/>
+          and <xref ref="table_nolimit2"/>, respectively.
           Both show that as <m>x</m> approaches <m>1</m>,
           <m>f(x)</m> grows larger and larger.
         </p>
@@ -723,8 +723,8 @@
             <!-- figures/fig_nolimit2.tex END -->
           </figure>
 
-          <table xml:id="table_nolimit2">
-            <title>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref></title>
+          <figure xml:id="table_nolimit2">
+            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -755,7 +755,7 @@
                 <cell><m>100</m>.</cell>
               </row>
             </tabular>
-          </table>
+          </figure>
         </sidebyside>
 
         <p>
@@ -797,16 +797,16 @@
 
         <p>
           Two graphs of <m>f(x) = \sin(1/x)</m> are given in <xref ref="fig_nolimit3">Figure</xref>.
-          <xref ref="fig_nolimit3a">Figure</xref>
+          <xref ref="fig_nolimit3a"/>
           shows <m>f(x)</m> on the interval <m>[-1,1]</m>;
           notice how <m>f(x)</m> seems to oscillate near <m>x=0</m>.
           One might think that despite the oscillation,
           as <m>x</m> approaches <m>0</m>,
           <m>f(x)</m> approaches <m>0</m>.
-          However, <xref ref="fig_nolimit3b">Figure</xref> zooms in on <m>\sin(1/x)</m>,
+          However, <xref ref="fig_nolimit3b"/> zooms in on <m>\sin(1/x)</m>,
           on the interval <m>[-0.1,0.1]</m>.
           Here the oscillation is even more pronounced.
-          Finally, in <xref ref="table_nolimit3c">Figure</xref>,
+          Finally, in <xref ref="table_nolimit3c"/>,
           we see <m>\sin(1/x)</m> evaluated for values of <m>x</m> near <m>0</m>.
           As <m>x</m> approaches <m>0</m>,
           <m>f(x)</m> does not appear to approach any value.
@@ -945,8 +945,8 @@
           </sidebyside>
         </figure>
 
-        <table xml:id="table_nolimit3c">
-          <title>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref></title>
+        <figure xml:id="table_nolimit3c">
+          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -981,7 +981,7 @@
               <cell><m>0.420548</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           It can be shown that in reality,
@@ -1198,8 +1198,8 @@
       The table gives us reason to assume the value of the limit is about <m>8.5</m>.
     </p>
 
-    <table xml:id="table_diff_quot_smallh">
-      <title>The difference quotient evaluated at values of <m>h</m> near <m>0</m></title>
+    <figure xml:id="table_diff_quot_smallh">
+      <caption>The difference quotient evaluated at values of <m>h</m> near <m>0</m></caption>
       <tabular>
         <row bottom="medium">
           <cell><m>h</m></cell>
@@ -1230,7 +1230,7 @@
           <cell><m>7.75</m></cell>
         </row>
       </tabular>
-    </table>
+    </figure>
     <figure xml:id="vid_limit_intro_limit_diff_quot_ex" component="video">
       <caption>Video examples for difference quotients: once with direct computation, and then by simplifying first</caption>
       <video  youtube="lNI90Y321b0 uUyZHfTYlBQ" label="vid_limit_intro_limit_diff_quot_ex"/>

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -780,8 +780,8 @@
           <m>1/\sqrt{c}</m>, centered at the origin.
         </p>
 
-        <table xml:id="fig_multi4">
-          <title>A table of <m>c</m> values and the corresponding radius <m>r</m> of the spheres of constant value in <xref ref="ex_multi4">Example</xref></title>
+        <figure xml:id="fig_multi4">
+          <caption>A table of <m>c</m> values and the corresponding radius <m>r</m> of the spheres of constant value in <xref ref="ex_multi4">Example</xref></caption>
           <tabular>
             <row>
               <cell><m>c</m></cell>
@@ -792,24 +792,24 @@
               <cell></cell>
             </row>
             <row>
-              <cell>16.</cell>
+              <cell>16</cell>
               <cell>0.25</cell>
             </row>
             <row>
-              <cell>8.</cell>
+              <cell>8</cell>
               <cell>0.35</cell>
             </row>
             <row>
-              <cell>4.</cell>
+              <cell>4</cell>
               <cell>0.5</cell>
             </row>
             <row>
-              <cell>2.</cell>
+              <cell>2</cell>
               <cell>0.71</cell>
             </row>
             <row>
-              <cell>1.</cell>
-              <cell>1.</cell>
+              <cell>1</cell>
+              <cell>1</cell>
             </row>
             <row>
               <cell>0.5</cell>
@@ -817,7 +817,7 @@
             </row>
             <row>
               <cell>0.25</cell>
-              <cell>2.</cell>
+              <cell>2</cell>
             </row>
             <row>
               <cell>0.125</cell>
@@ -825,13 +825,13 @@
             </row>
             <row>
               <cell>0.0625</cell>
-              <cell>4.</cell>
+              <cell>4</cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
-          <xref ref="fig_multi4">Figure</xref>
+          <xref ref="fig_multi4"/>
           gives a table of the radii of the spheres for given <m>c</m> values.
           Normally one would use equally spaced <m>c</m> values,
           but these values have been chosen purposefully.

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -333,8 +333,8 @@
           <m>\sin(x^3)</m> evaluated at these points.
         </p>
 
-        <table xml:id="fig_num2a">
-          <title>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2">Example</xref></title>
+        <figure xml:id="fig_num2a">
+          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2">Example</xref></caption>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -415,7 +415,7 @@
               <cell><m>-0.6700</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           Once this table is created,
@@ -632,12 +632,12 @@
       </statement>
       <solution>
         <p>
-          To compute the areas of the 5 trapezoids in <xref ref="fig_num3a">Figure</xref>,
+          To compute the areas of the 5 trapezoids in <xref ref="fig_num3a"/>,
           it will again be useful to create a table of values as shown in <xref ref="fig_num3b"/>.
         </p>
 
-        <table xml:id="fig_num3b">
-          <title>A table of values of <m>e^{-x^2}</m></title>
+        <figure xml:id="fig_num3b">
+          <caption>A table of values of <m>e^{-x^2}</m></caption>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -672,7 +672,7 @@
               <cell><m>0.3679</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           The leftmost trapezoid has legs of length <m>1</m> and <m>0.9607</m> and a height of 0.2.
@@ -815,8 +815,7 @@
       </statement>
       <solution>
         <p>
-          We cannot use the same table
-          (<xref ref="fig_num3b">Table</xref>)
+          We cannot use the table in <xref ref="fig_num3b"/>
           that we used for the Trapezoidal, Right and Left Hand Rules when using the Midpoint Rule.
           The Trapezoidal rule averages the <em>outputs</em>
           of the function to obtain a more accurate estimate of the definite integral.
@@ -826,14 +825,14 @@
         </p>
 
         <p>
-          So we will create a new table of values as shown in <xref ref="fig_num3_2b">Table</xref>.
+          So we will create a new table of values as shown in <xref ref="fig_num3_2b"/>.
           We have <m>\dx=(1-0)/5=0.2</m>.
           The midpoint of the first subinteval is at
           <m>0+0.2(1/2)=0.1</m> and each successive midpoint is <m>0.2</m> from the last.
         </p>
 
-        <table xml:id="fig_num3_2b">
-          <title>A table of values of <m>e^{-x^2}</m></title>
+        <figure xml:id="fig_num3_2b">
+          <caption>A table of values of <m>e^{-x^2}</m></caption>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -864,7 +863,7 @@
               <cell><m>0.4449</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           So we have
@@ -899,8 +898,8 @@
           So we have:
         </p>
 
-        <table xml:id="fig_num4_2">
-          <title>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num4_2 ">Example</xref></title>
+        <figure xml:id="fig_num4_2">
+          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num4_2 ">Example</xref></caption>
           <tabular>
             <row>
               <cell><m>\overline{x_i}</m></cell>
@@ -979,7 +978,7 @@
             </row>
           </tabular>
 
-        </table>
+        </figure>
 
         <p>
           Thus we have:
@@ -1227,7 +1226,7 @@
           <caption>A table of values to approximate <m>\int_0^1e^{-x^2}\, dx</m>, along with a graph of the function</caption>
           <sidebyside widths="40% 54%">
 
-          <table xml:id="fig_num5a"><title/>
+          <figure xml:id="fig_num5a"><caption/>
             <tabular>
               <row>
                 <cell><m>x_i</m></cell>
@@ -1261,7 +1260,7 @@
                 <cell></cell>
               </row>
             </tabular>
-          </table>
+          </figure>
 
           <figure xml:id="fig_num5b">
           <!-- START figures/fig_num5b.tex -->
@@ -1346,8 +1345,8 @@
           Again, <m>\dx = (\pi/2+\pi/4)/10 \approx 0.236</m>.
         </p>
 
-        <table xml:id="fig_num6a">
-          <title>Table of values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6">Example</xref></title>
+        <figure xml:id="fig_num6a">
+          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6">Example</xref></caption>
           <tabular>
             <row bottom="minor">
               <cell><m>x_i</m></cell>
@@ -1398,7 +1397,7 @@
               <cell><m>-0.6700</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           Simpson's Rule states that
@@ -1863,8 +1862,8 @@
           The data is given in <xref ref="fig_num8"/>.
           Approximate the distance they traveled.
         </p>
-        <table xml:id="fig_num8">
-          <title>Speed data collected at 30 second intervals for <xref ref="ex_num8">Example</xref></title>
+        <figure xml:id="fig_num8">
+          <caption>Speed data collected at 30 second intervals for <xref ref="ex_num8">Example</xref></caption>
           <tabular>
             <row>
               <cell>Time</cell><cell>Speed</cell>
@@ -1973,7 +1972,7 @@
               <cell><m>0</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
       </statement>
       <solution>
         <p>

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -124,7 +124,7 @@
           we make a table of values, plot points,
           then connect these points with a
           <q>reasonable</q> looking curve.
-          <xref ref="fig_pareq1a">Figure</xref> shows such a table of values;
+          <xref ref="fig_pareq1a"/> shows such a table of values;
           note how we have 3 columns.
         </p>
 
@@ -140,7 +140,7 @@
         <figure xml:id="fig_pareq1">
           <caption>A table of values of the parametric equations in <xref ref="ex_pareq1">Example</xref> along with a sketch of their graph</caption>
           <sidebyside valign="bottom" widths="47% 47%">
-            <table xml:id="fig_pareq1a"><title/>
+            <figure xml:id="fig_pareq1a"><caption/>
               <tabular>
                 <row>
                   <cell><m>t</m></cell>
@@ -178,7 +178,7 @@
                   <cell><m>3</m></cell>
                 </row>
               </tabular>
-            </table>
+            </figure>
             <figure xml:id="fig_pareq1b">
               <caption/>
               <!-- START figures/fig_pareq1.tex -->
@@ -235,14 +235,14 @@
       </statement>
       <solution>
         <p>
-          We again start by making a table of values in <xref ref="fig_pareq2a">Figure</xref>,
-          then plot the points <m>(x,y)</m> on the Cartesian plane in <xref ref="fig_pareq2b">Figure</xref>.
+          We again start by making a table of values in <xref ref="fig_pareq2a"/>,
+          then plot the points <m>(x,y)</m> on the Cartesian plane in <xref ref="fig_pareq2b"/>.
         </p>
 
         <figure xml:id="fig_pareq2">
           <caption>A table of values of the parametric equations in <xref ref="ex_pareq2">Example</xref> along with a sketch of their graph</caption>
           <sidebyside valign="bottom" widths="47% 47%">
-            <table xml:id="fig_pareq2a"><title/>
+            <figure xml:id="fig_pareq2a"><caption/>
               <tabular>
                 <row>
                   <cell><m>t</m></cell>
@@ -280,7 +280,7 @@
                   <cell><m>0</m></cell>
                 </row>
               </tabular>
-            </table>
+            </figure>
             <figure xml:id="fig_pareq2b">
               <caption/>
               <!-- START figures/fig_pareq2.tex -->

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -607,7 +607,7 @@
         <figure xml:id="fig_polar4">
           <caption>Graphing a polar function in <xref ref="ex_polar4">Example</xref> by plotting points</caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
-            <table xml:id="fig_polar4a"><title/>
+            <figure xml:id="fig_polar4a"><caption/>
               <tabular halign="center">
                 <row bottom="minor">
                   <cell><m>\theta</m></cell><cell><m>r=1+\cos(\theta)</m></cell>
@@ -628,7 +628,7 @@
                   <cell><m>7 \pi/4</m></cell><cell><m>1.70711</m></cell>
                 </row>
               </tabular>
-            </table>
+            </figure>
 
             <figure xml:id="fig_polar4b">
               <!-- START figures/fig_polar4.tex -->
@@ -760,7 +760,7 @@
         <p>
           We start by making a table of
           <m>\cos(2\theta)</m> evaluated at common angles <m>\theta</m>,
-          as shown in <xref ref="fig_polar5table">Figure</xref>.
+          as shown in <xref ref="fig_polar5table"/>.
           These points are then plotted in <xref ref="fig_polar5a">Figure</xref>.
           This particular graph <q>moves</q>
           around quite a bit and one can easily forget which points should be connected to each other.
@@ -768,8 +768,8 @@
           we numbered each point in the table and on the graph.
         </p>
 
-        <table xml:id="fig_polar5table">
-          <title>Table of points for plotting a polar curve in <xref ref="ex_polar5"/></title>
+        <figure xml:id="fig_polar5table">
+          <caption>Table of points for plotting a polar curve in <xref ref="ex_polar5"/></caption>
           <tabular halign="center">
             <row bottom="minor"><cell>Pt.</cell><cell><m>\theta</m></cell><cell><m>\cos(2\theta)</m></cell></row>
             <row><cell><m>1</m></cell><cell><m>0</m></cell><cell><m>1</m></cell></row>
@@ -790,7 +790,7 @@
             <row><cell><m>16</m></cell><cell><m>11\pi/6</m></cell><cell><m>0.5</m></cell></row>
             <row><cell><m>17</m></cell><cell><m>2\pi</m></cell><cell><m>1</m></cell></row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           Using more points

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -881,7 +881,7 @@
         </p>
 
         <p>
-          <xref ref="fig_tannorm7a">Figure</xref>
+          <xref ref="fig_tannorm7a"/>
           gives a table of values of
           <m>a_\text{T}</m> and <m>a_\text{N}</m>.
           When <m>t=0</m>, we see the ball's speed is decreasing;
@@ -897,8 +897,8 @@
           and not in changing its direction.
         </p>
 
-        <table xml:id="fig_tannorm7a">
-          <title>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7">Example</xref></title>
+        <figure xml:id="fig_tannorm7a">
+          <caption>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7">Example</xref></caption>
           <tabular>
             <row>
               <cell><m>t</m></cell>
@@ -941,7 +941,7 @@
               <cell><m>12.7</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
       </solution>
     </example>
 

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -22,7 +22,7 @@
     <p>
       In <xref ref="fig_taypolyintroa_1">Figure</xref>,
       we see a function <m>y=f(x)</m> graphed.
-      The table in <xref ref="fig_taypolyintroa_2">Table</xref>
+      The table in <xref ref="fig_taypolyintroa_2"/>
       shows that <m>f(0)=2</m> and <m>\fp(0) = 1</m>;
       therefore, the tangent line to <m>f</m> at <m>x=0</m> is
       <m>p_1(x) = 1(x-0)+2 = x+2</m>.
@@ -64,8 +64,8 @@
 
       </figure>
       <!-- figures/fig_taypolyintroa.tex END -->
-      <table xml:id="fig_taypolyintroa_2">
-        <title>Derivatives of <m>f</m> evaluated at <m>0</m></title>
+      <figure xml:id="fig_taypolyintroa_2">
+        <caption>Derivatives of <m>f</m> evaluated at <m>0</m></caption>
         <tabular>
           <row>
             <cell><m>f(0) = 2</m></cell>
@@ -83,7 +83,7 @@
             <cell><m>f^{(5)}(0)=-19</m></cell>
           </row>
         </tabular>
-      </table>
+      </figure>
     </sidebyside>
 
     <p>
@@ -92,7 +92,7 @@
       it does not, for instance, match the concavity of <m>f</m>.
       We can find a polynomial, <m>p_2(x)</m>,
       that does match the concavity near <m>0</m> without much difficulty, though.
-      The table in <xref ref="fig_taypolyintroa_2">Table</xref>
+      The table in <xref ref="fig_taypolyintroa_2"/>
       gives the following information:
       <me>
         f(0) = 2 \qquad \fp(0) = 1\qquad \fp'(0) = 2
@@ -156,7 +156,7 @@
       first <m>n</m> derivatives of <m>f</m>.
       <xref ref="fig_taypolyintrob">Figure</xref>
       shows <m>p_4(x)= -x^4/2-x^3/6+x^2+x+2</m>,
-      whose first four derivatives at 0 match those of <m>f</m>. (Using the table in <xref ref="fig_taypolyintroa_2">Table</xref>,
+      whose first four derivatives at 0 match those of <m>f</m>. (Using the table in <xref ref="fig_taypolyintroa_2"/>,
       start with <m>p_4^{(4)}(x)=-12</m> and solve the related initial-value problem.)
     </p>
 
@@ -419,11 +419,11 @@
                 We start with creating a table of the derivatives of <m>e^x</m>
                 evaluated at <m>x=0</m>.
                 In this particular case, this is relatively simple,
-                as shown in <xref ref="fig_taypoly1a">Table</xref>.
+                as shown in <xref ref="fig_taypoly1a"/>.
               </p>
 
-              <table xml:id="fig_taypoly1a">
-                <title>The derivatives of <m>f(x)=e^x</m> evaluated at <m>x=0</m></title>
+              <figure xml:id="fig_taypoly1a">
+                <caption>The derivatives of <m>f(x)=e^x</m> evaluated at <m>x=0</m></caption>
                 <tabular>
                   <row>
                     <cell><m>f(x) = e^x</m></cell>
@@ -451,7 +451,7 @@
                     <cell><m>f\,^{(n)}(0) = 1</m></cell>
                   </row>
                 </tabular>
-              </table>
+              </figure>
 
               <p>
                 By the definition of the Maclaurin polynomial, we have
@@ -552,7 +552,7 @@
                 evaluated at <m>x=1</m>.
                 While this is not as straightforward as it was in the previous
                 example, a pattern does emerge (for <m>n\ge 1</m>),
-                as shown in <xref ref="fig_taypoly2a">Table</xref>.
+                as shown in <xref ref="fig_taypoly2a"/>.
 
                 Notice in the table below that each time we take a derivative
                 (starting at the second derivative),
@@ -562,8 +562,8 @@
                 <m>1\cdot 2\cdot 3=3!</m>.
               </p>
 
-              <table xml:id="fig_taypoly2a">
-                <title>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></title>
+              <figure xml:id="fig_taypoly2a">
+                <caption>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></caption>
                 <tabular>
                   <row>
                     <cell><m>f(x) = \ln(x)</m></cell>
@@ -606,7 +606,7 @@
                     <cell><m>\!\!(-1)^{n+1}(n-1)!</m></cell>
                   </row>
                 </tabular>
-              </table>
+              </figure>
 
               <p>
                 Notice that the coefficients alternate in sign starting at <m>n=1</m>.
@@ -1038,11 +1038,11 @@
           We now set out to compute <m>p_9(x)</m>.
           We again need a table of the derivatives of
           <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m>.
-          A table of these values is given in <xref ref="fig_taypoly4a">Table</xref>.
+          A table of these values is given in <xref ref="fig_taypoly4a"/>.
         </p>
 
-        <table xml:id="fig_taypoly4a">
-          <title>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></title>
+        <figure xml:id="fig_taypoly4a">
+          <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></caption>
           <tabular>
             <row>
               <cell><m>f(x) = \cos(x)</m></cell>
@@ -1095,7 +1095,7 @@
               <cell><m>f^{(9)}(0) = 0</m></cell>
             </row>
           </tabular>
-        </table>
+        </figure>
 
         <p>
           Notice how the derivatives, evaluated at <m>x=0</m>, follow a certain
@@ -1207,11 +1207,11 @@
             <li>
               <p>
                 We begin by evaluating the derivatives of <m>f</m> at <m>x=4</m>.
-                This is done in <xref ref="fig_taypoly5a">Table</xref>.
+                This is done in <xref ref="fig_taypoly5a"/>.
               </p>
 
-              <table xml:id="fig_taypoly5a">
-                <title>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></title>
+              <figure xml:id="fig_taypoly5a">
+                <caption>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></caption>
                 <tabular>
                   <row>
                     <cell><m>f(x) = \sqrt{x}</m></cell>
@@ -1239,7 +1239,7 @@
                     <cell><m>\ds f^{(4)}(4) = \frac{-15}{2048}</m></cell>
                   </row>
                 </tabular>
-              </table>
+              </figure>
 
               <p>
                 These values allow us to form the Taylor polynomial <m>p_4(x)</m>:

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -94,11 +94,11 @@
         In <xref ref="ex_taypoly4">Example</xref>
         we found the <m>8</m>th degree Maclaurin polynomial of <m>\cos(x)</m>.
         In doing so,
-        we created the table shown in <xref ref="fig_ts1">Table</xref>.
+        we created the table shown in <xref ref="fig_ts1"/>.
       </p>
 
-      <table xml:id="fig_ts1">
-        <title>A table of the derivatives of <m>f(x)=\cos (x)</m> evaluated at <m>x=0</m></title>
+      <figure xml:id="fig_ts1">
+        <caption>Derivatives of <m>f(x)=\cos (x)</m> evaluated at <m>x=0</m></caption>
         <tabular>
           <row>
             <cell><m>f(x) = \cos(x)</m></cell>
@@ -151,7 +151,7 @@
             <cell><m>f^{(9)}(0) = 0</m></cell>
           </row>
         </tabular>
-      </table>
+      </figure>
 
       <p>
         Notice how <m>f^{(n)}(0)=0</m> when <m>n</m> is odd,
@@ -215,7 +215,7 @@
     </solution>
     <solution>
       <p>
-        <xref ref="fig_ts2">Figure</xref>
+        <xref ref="fig_ts2"/>
         shows the <m>n</m>th derivative of <m>\ln(x)</m> evaluated at <m>x=1</m> for <m>n=0,\ldots,5</m>,
         along with an expression for the <m>n</m>th term:
         <me>
@@ -229,8 +229,8 @@
         not just finding a finite set of coefficients for a polynomial.
       </p>
 
-      <table xml:id="fig_ts2">
-        <title>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></title>
+      <figure xml:id="fig_ts2">
+        <caption>Derivatives of <m>\ln(x)</m> evaluated at <m>x=1</m></caption>
         <tabular>
           <row>
             <cell><m>f(x) = \ln(x)</m></cell>
@@ -278,7 +278,7 @@
             <cell><m>(-1)^{n+1}(n-1)!</m></cell>
           </row>
         </tabular>
-      </table>
+      </figure>
 
       <p>
         Since <m>f(1) = \ln(1) = 0</m>,

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -142,9 +142,9 @@
       <solution>
         <p>
           We start by making a table of <m>t</m>,
-          <m>x</m> and <m>y</m> values as shown in <xref ref="fig_vvf1a">Figure</xref>.
+          <m>x</m> and <m>y</m> values as shown in <xref ref="fig_vvf1a"/>.
           Plotting these points gives an indication of what the graph looks like.
-          In <xref ref="fig_vvf1b">Figure</xref>,
+          In <xref ref="fig_vvf1b"/>,
           we indicate these points and sketch the full graph.
           We also highlight <m>\vec r(-1)</m> and <m>\vec r(2)</m> on the graph.
         </p>
@@ -152,8 +152,8 @@
         <figure xml:id="fig_vvf1">
           <caption>Sketching the vector-valued function of <xref ref="ex_vvf1">Example</xref></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
-            <table xml:id="fig_vvf1a">
-              <title/>
+            <figure xml:id="fig_vvf1a">
+              <caption/>
               <tabular>
                 <row>
                   <cell><m>t</m></cell>
@@ -191,7 +191,7 @@
                   <cell>1/5</cell>
                 </row>
               </tabular>
-            </table>
+            </figure>
 
             <figure xml:id="fig_vvf1b">
               <caption/>


### PR DESCRIPTION
This pull request puts most `tabular` environments back into figures, rather than tables.

A small number of cases were actually tables in the Chicago Style sense, so I left them alone.

At the moment, this is working fine: HTML builds normally, with no errors or warnings, despite the fact that `figure/tabular` is no longer in the schema. It's possible that at some point Rob will insist that these `tabular` environments inside of figures are named in some other way, but for now I think we can do this.

I also noticed one case where a figure was referred to in the statement of an example, but the figure itself was hidden in the solution knowl. The xref wasn't really necessary to understand the question, so I removed it.