### PR TITLE
Ensure all exercise groups use two columns

### DIFF
--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -1270,7 +1270,7 @@
         </exercise>
       </exercisegroup>
 
-      <exercisegroup cols="3">
+      <exercisegroup cols="2">
         <introduction>
           <p>
             Compute the derivative of the given function in two ways:
@@ -1334,7 +1334,11 @@
                 <ol>
                   <li>
                     <p>
-                      <m>f(x) = x</m>, so <m>\fp(x) = 1</m>.
+                      Recall that the inverse tangent function is defined to have range <m>(-\pi/2, \pi/2)</m>.
+                      If <m>-\pi/2 \lt x\lt \pi/2</m>, then <m>f(x) = x</m>.
+                      If <m>x</m> is in the interval <m>(-\pi/2+k\pi,\pi/2+k\pi)</m> for some integer <m>k</m>,
+                      then <m>f(x)=x-k\pi</m>. On any interval where <m>f(x)</m> is defined,
+                      <m>f(x)=x+C</m> for some constant <m>C</m>,  so <m>\fp(x) = 1</m>.
                     </p>
                   </li>
                   <li>
@@ -1369,6 +1373,46 @@
                   <li>
                     <p>
                       <m>\fp(x) = \cos(\cos^{-1}(x) ) \frac{1}{\sqrt{1-x^2}} =\frac{-x}{\sqrt{1-x^2}}</m>.
+                    </p>
+                  </li>
+                </ol>
+              </p>
+            </solution>
+          </webwork>
+        </exercise>
+
+        <exercise>
+          <webwork>
+            <statement>
+              <p>
+                <m>f(x)=\sin(2\sin^{-1}(x))</m>
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                <ol>
+                  <li>
+                    <p>
+                      <m>f(x) = 2\sin(\sin^{-1}(x))\cos(\sin^{-1}(x))=2x\sqrt{1-x^2}</m>, 
+                      so <m>\fp(x) = 2\sqrt{1-x^2} -\frac{2x^2}{\sqrt{1-x^2}}</m>.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      <m>\fp(x) = \cos(2\sin^{-1}(x) ) \frac{2}{\sqrt{1-x^2}}</m>,
+                      but to compare, we need to simplify <m>\cos(2\sin^{-1}(x))</m>.
+                      Using <m>\cos(2\theta)=1-2\sin^2(\theta)</m>, 
+                      we get <m>\fp(x) = (1-2x^2)\frac{2}{\sqrt{1-x^2}}</m>.
+                    </p>
+                    <p>
+                      This is the same as the first answer, since
+                      <md>
+                        <mrow>2\sqrt{1-x^2} -\frac{2x^2}{\sqrt{1-x^2}} \amp = \frac{2(1-x^2)-2x^2}{\sqrt{1-x^2}}</mrow>
+                        <mrow> \amp =\frac{2(1-2x^2)}{\sqrt{1-x^2}}</mrow>
+                      </md>.                      
                     </p>
                   </li>
                 </ol>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -2064,7 +2064,7 @@
 
     <subexercises>
       <title>Review</title>
-      <exercisegroup cols="3">
+      <exercisegroup cols="2">
         <introduction>
           <p>
             Evaluate the limit.
@@ -2098,7 +2098,7 @@
           </webwork>
         </exercise>
 
-        <exercise>
+        <!-- <exercise>
           <webwork>
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
@@ -2123,7 +2123,7 @@
               </p>
             </statement>
           </webwork>
-        </exercise>
+        </exercise> -->
 
         <exercise>
           <webwork>


### PR DESCRIPTION
In a discussion with @davidfarmer about HTML styling for exercise groups with columns, he requested that we ensure all exercise groups use two columns. There were two cases where three columns were used; in each case, this is because there were three exercises in total.

In one case, I added a new exercise to get two columns with two exercises each.

In the other, I noticed that the source for two of the three problems was identical, so the problems only differed through randomization. I removed one of these, since students can re-randomize if they want to see another question of that type.