### PR TITLE
Remove redundant instructions from exercise group.

### DIFF
--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -707,7 +707,7 @@
 
         <introduction>
           <p>
-            In the following exercises, evaluate the given limit.
+            Evaluate the given limit using l'Hospital's rule.
           </p>
         </introduction>
   <!-- Exercise 8 -->
@@ -729,7 +729,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <m>\lim\limits_{x\to 1} \frac{<var name="$fu"/> }{<var name="$fl"/>}</m>
                 </p>
 
@@ -758,7 +757,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 2} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -788,7 +786,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \pi} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -818,7 +815,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \pi/4} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -848,7 +844,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -871,7 +866,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -901,7 +895,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -933,7 +926,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -962,7 +954,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -992,7 +983,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -1022,7 +1012,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} \frac{<var name="$fu"/> }{<var name="$fl"/>}</me>
                 </p>
 
@@ -1045,7 +1034,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1066,7 +1054,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1087,7 +1074,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to\infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
               </statement>
@@ -1104,7 +1090,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1125,7 +1110,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1146,7 +1130,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1175,7 +1158,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 3} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1205,7 +1187,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to -2} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1227,7 +1208,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1251,7 +1231,6 @@
               <!--   <m>\lim\limits_{x\to \infty} \frac{\ln(x^2)}{x}</m></p> -->
               <!-- When placed from above ln(x^2) squishes the n( too closely -->
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1275,7 +1254,6 @@
               <!--   <m>\lim\limits_{x\to \infty} \frac{\Big(\ln(x) \Big)^2}{x}</m></p> -->
               <!-- Format is different when fn's placed from above. Bad? -->
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1297,7 +1275,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} <var name="$f1"/>\cdot <var name="$f2"/></me>
                 </p>
 
@@ -1318,7 +1295,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} <var name="$f1"/>\cdot <var name="$f2"/></me>
                 </p>
 
@@ -1341,7 +1317,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} <var name="$f1"/> \cdot <var name="$f2"/></me>
                 </p>
 
@@ -1362,7 +1337,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} <var name="$f1"/>-<var name="$f2"/></me>
                 </p>
 
@@ -1384,7 +1358,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} <var name="$f1"/>-<var name="$f2"/></me>
                 </p>
 
@@ -1405,7 +1378,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to -\infty} <var name="$f1"/> \cdot <var name="$f2"/></me>
                 </p>
 
@@ -1426,7 +1398,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} <var name="$f1"/> \cdot <var name="$f2"/></me>
                 </p>
 
@@ -1447,7 +1418,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} (<var name="$fb"/>)^<var name="$fp"/></me>
                 </p>
 
@@ -1468,7 +1438,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1489,7 +1458,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1510,7 +1478,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 0^+} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                   Hint: use the Squeeze Theorem.
                 </p>
@@ -1532,7 +1499,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 1^-} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1553,7 +1519,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1574,7 +1539,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1595,7 +1559,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 1^+} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1616,7 +1579,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1637,7 +1599,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} (<var name="$fb"/>)^{<var name="$fp"/>}</me>
                 </p>
 
@@ -1658,7 +1619,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \pi/2} <var name="$f1"/> <var name="$f2"/></me>
                 </p>
 
@@ -1679,7 +1639,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \pi/2} <var name="$f1"/> <var name="$f2"/></me>
                 </p>
 
@@ -1700,7 +1659,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 1^+} <var name="$f1"/> - <var name="$f2"/></me>
                 </p>
 
@@ -1721,7 +1679,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 3^+} <var name="$f1"/> - <var name="$f2"/></me>
                 </p>
 
@@ -1742,7 +1699,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} <var name="$f1"/> <var name="$f2"/></me>
                 </p>
 
@@ -1763,7 +1719,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to \infty} \frac{<var name="$fu"/>}{<var name="$fl"/>}</me>
                 </p>
 
@@ -1792,7 +1747,6 @@
               </pg-code>
               <statement>
                 <p>
-                  Use l'Hospital's Rule to evaluate the limit:
                   <me>\lim\limits_{x\to 1} \frac{<var name="$fu"/>}{<var name="$fl"/> }</me>
                 </p>
 


### PR DESCRIPTION
This section escaped earlier efforts to move instructions from individual execises to the exercise group introduction.