### PR TITLE
Update language: function vs surface

### DIFF
--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -757,7 +757,7 @@
       <title>The flow of water downhill</title>
       <statement>
         <p>
-          Consider the surface given by <m>f(x,y)= 20-x^2-2y^2</m>.
+          Consider the surface given by the graph of <m>f(x,y)= 20-x^2-2y^2</m>.
           Water is poured on the surface at <m>(1,1/4)</m>.
           What path does it take as it flows downhill?
         </p>
@@ -832,7 +832,7 @@
         </p>
 
         <figure xml:id="fig_direct3">
-          <caption>A graph of the surface described in <xref ref="ex_direct3">Example</xref> along with the path in the <m>xy</m>-plane with the level curves</caption>
+          <caption>A sketch of the surface described in <xref ref="ex_direct3">Example</xref> along with the path in the <m>xy</m>-plane with the level curves</caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_direct3a_3D">
               <caption/>

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -510,7 +510,7 @@
     <title>Evaluating a double integral with polar coordinates</title>
     <statement>
       <p>
-        Find the volume under the surface
+        Find the volume under the surface given by the graph of
         <m>\ds f(x,y) =\frac1{x^2+y^2+1}</m> over the sector of the circle with radius <m>a</m> centered at the origin in the first quadrant,
         as shown in <xref ref="fig_doublepol5">Figure</xref>.
       </p>
@@ -1190,8 +1190,8 @@
                     <li>
                       <p>
                         Take the limit of your answer from (b), as <m>a\to\infty</m>.
-                        What does this imply about the volume under the surface of
-                        <m>\ds e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane?
+                        What does this imply about the volume under the surface
+                        <m>z= e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane?
                       </p>
                     </li>
                   </ol>
@@ -1217,7 +1217,7 @@
                       <p>
                         <m>\lim\limits_{a\to\infty} \pi(1-e^{-a^2})=\pi</m>.
                         This implies that there is a finite volume under the surface
-                        <m>e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane.
+                        <m>z=e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane.
                       </p>
                     </li>
                   </ol>

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -30,7 +30,7 @@
     Let <m>R</m> be a closed,
     bounded region in the <m>xy</m>-plane and let
     <m>z=f(x,y)</m> be a continuous function defined on <m>R</m>.
-    We wish to find the signed volume under the surface of <m>f</m> over <m>R</m>.
+    We wish to find the signed volume under the graph of <m>f</m> over <m>R</m>.
     (We use the term <q>signed volume</q>
     to denote that space above the <m>xy</m>-plane,
     under <m>f</m>, will have a positive volume;
@@ -795,7 +795,7 @@
     <p>
       When evaluating <m>\iint_R f(x,y)\, dA</m> using an iterated integral,
       the bounds of integration depend only on <m>R</m>.
-      The surface <m>f</m> does not determine the bounds of integration.
+      The function <m>f</m> does not determine the bounds of integration.
     </p>
   </insight>
 
@@ -1148,7 +1148,7 @@
       </p>
 
       <p>
-        The signed volume under the surface <m>f</m> is about 11.7 cubic units.
+        The signed volume under the surface <m>z=f(x,y)</m> is about 11.7 cubic units.
       </p>
     </solution>
   </example>
@@ -1263,7 +1263,7 @@
       </p>
 
       <figure xml:id="fig_double6b">
-        <caption>Showing the surface <m>f</m> defined in <xref ref="ex_double6">Example</xref> over its region <m>R</m></caption>
+        <caption>Showing the surface <m>z=f(x,y)</m> defined in <xref ref="ex_double6">Example</xref> over its region <m>R</m></caption>
 
         <!-- START figures/figdouble6b_3D.asy -->
         <image xml:id="img_double6b" width="47%">

--- a/ptx/sec_line_int_intro.ptx
+++ b/ptx/sec_line_int_intro.ptx
@@ -27,7 +27,7 @@
       The question we want to answer is this:
       what is the area that lies below the curve drawn with the solid line?
       In other words,
-      what is the area of the region above <m>C</m> and under the the surface <m>f</m>?
+      what is the area of the region above <m>C</m> and under the the surface <m>z=f(x,y)</m>?
       This region is shown in <xref ref="fig_line_integral_intro1b_3D">Figure</xref>.
     </p>
 
@@ -636,7 +636,7 @@
       <title>Evaluating a line integral: area under a surface over a curve</title>
       <statement>
         <p>
-          Find the area over the unit circle in the <m>xy</m>-plane and under the surface <m>f(x,y) = x^2-y^2+3</m>,
+          Find the area over the unit circle in the <m>xy</m>-plane and under the graph of <m>f(x,y) = x^2-y^2+3</m>,
           shown in <xref ref="fig_linescalarfield3">Figure</xref>.
         </p>
         <figure xml:id="fig_linescalarfield3">
@@ -1306,7 +1306,7 @@
         </statement>
         <answer>
           <p>
-            When <m>C</m> is a curve in the plane and <m>f</m> is a surface defined over <m>C</m>,
+            When <m>C</m> is a curve in the plane and <m>f</m> is a function defined over <m>C</m>,
             then <m>\int_C f(s)\, ds</m> describes the area under the spatial curve that lies on <m>f</m>,
             over <m>C</m>.
           </p>
@@ -1366,7 +1366,7 @@
         <introduction>
           <p>
             In the following exercises,
-            a planar curve <m>C</m> is given along with a surface <m>f</m> that is defined over <m>C</m>.
+            a planar curve <m>C</m> is given along with a function <m>f</m> that is defined over <m>C</m>.
             Evaluate the line integral <m>\ds \int_Cf(s)\, ds</m>.
           </p>
         </introduction>
@@ -1375,7 +1375,7 @@
           <statement>
             <p>
               <m>C</m> is the line segment joining the points <m>(-2,-1)</m> and <m>(1,2)</m>;
-              the surface is <m>f(x,y)=x^2+y^2+2</m>.
+              the function is <m>f(x,y)=x^2+y^2+2</m>.
             </p>
           </statement>
           <answer>
@@ -1389,7 +1389,7 @@
           <statement>
             <p>
               <m>C</m> is the segment of <m>y=3x+2</m> on <m>[1,2]</m>;
-              the surface is <m>f(x,y)=5x+2y</m>.
+              the function is <m>f(x,y)=5x+2y</m>.
             </p>
           </statement>
           <answer>
@@ -1403,7 +1403,7 @@
           <statement>
             <p>
               <m>C</m> is the circle with radius 2 centered at the point <m>(4,2)</m>;
-              the surface is <m>f(x,y)=3x-y</m>.
+              the function is <m>f(x,y)=3x-y</m>.
             </p>
           </statement>
           <answer>
@@ -1417,7 +1417,7 @@
           <statement>
             <p>
               <m>C</m> is the curve given by <m>\vec r(t) = \langle \cos t+t\sin t, \sin t-t\cos t\rangle</m> on <m>[0,2\pi]</m>;
-              the surface is <m>f(x,y)=5</m>.
+              the function is <m>f(x,y)=5</m>.
             </p>
           </statement>
           <answer>
@@ -1432,7 +1432,7 @@
             <p>
               <m>C</m> is the piecewise curve composed of the line segments that connect <m>(0,1)</m> to <m>(1,1)</m>,
               then connect <m>(1,1)</m> to <m>(1,0)</m>;
-              the surface is <m>f(x,y)=x+y^2</m>.
+              the function is <m>f(x,y)=x+y^2</m>.
             </p>
           </statement>
           <answer>
@@ -1451,7 +1451,7 @@
               <m>C</m> is the piecewise curve composed of the line segment joining the points <m>(0,0)</m> and <m>(1,1)</m>,
               along with the quarter-circle parametrized by <m>\langle \cos t,-\sin t+1\rangle</m> on
               <m>[0,\pi/2]</m>(which starts at the point <m>(1,1)</m> and ends at <m>(0,0)</m>;
-              the surface is <m>f(x,y)=x^2+y^2</m>.
+              the function is <m>f(x,y)=x^2+y^2</m>.
             </p>
           </statement>
           <answer>
@@ -1469,7 +1469,7 @@
         <introduction>
           <p>
             In the following exercises,
-            a planar curve <m>C</m> is given along with a surface <m>f</m> that is defined over <m>C</m>.
+            a planar curve <m>C</m> is given along with a function <m>f</m> that is defined over <m>C</m>.
             Set up the line integral <m>\ds \int_Cf(s)\, ds</m>,
             then approximate its value using technology.
           </p>
@@ -1479,7 +1479,7 @@
           <statement>
             <p>
               <m>C</m> is the portion of the parabola <m>y=2x^2+x+1</m> on <m>[0,1]</m>;
-              the surface is <m>f(x,y)=x^2+2y</m>.
+              the function is <m>f(x,y)=x^2+2y</m>.
             </p>
           </statement>
           <answer>
@@ -1493,7 +1493,7 @@
           <statement>
             <p>
               <m>C</m> is the portion of the curve <m>y=\sin x</m> on <m>[0,\pi]</m>;
-              the surface is <m>f(x,y)=x</m>.
+              the function is <m>f(x,y)=x</m>.
             </p>
           </statement>
           <answer>
@@ -1507,7 +1507,7 @@
           <statement>
             <p>
               <m>C</m> is the ellipse given by <m>\vec r(t) = \langle 2\cos t,\sin t\rangle</m> on <m>[0,2\pi]</m>;
-              the surface is <m>f(x,y)=10-x^2-y^2</m>.
+              the function is <m>f(x,y)=10-x^2-y^2</m>.
             </p>
           </statement>
           <answer>
@@ -1521,7 +1521,7 @@
           <statement>
             <p>
               <m>C</m> is the portion of <m>y=x^3</m> on <m>[-1,1]</m>;
-              the surface is <m>f(x,y)=2x+3y+5</m>.
+              the function is <m>f(x,y)=2x+3y+5</m>.
             </p>
           </statement>
           <answer>

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -64,8 +64,8 @@
     </definition>
 
     <p>
-      If <m>f</m> has a relative or absolute maximum at <m>P=(x_0,y_0)</m>,
-      it means every curve on the surface of <m>f</m> through <m>P</m> will also have a relative or absolute maximum at <m>P</m>.
+      If <m>f</m> has a relative or absolute maximum at <m>(x_0,y_0)</m>,
+      it means every curve on the graph of <m>f</m> through <m>(x_0,y_0,f(x_0,y_0))</m> will also have a relative or absolute maximum at <m>P</m>.
       Recalling what we learned in <xref ref="sec_extreme_values">Section</xref>,
       the slopes of the tangent lines to these curves at <m>P</m> must be 0 or undefined.
       Since directional derivatives are computed using <m>f_x</m> and <m>f_y</m>,
@@ -291,7 +291,7 @@
         </figure>
 
         <p>
-          The surface of <m>f</m> is graphed in <xref ref="fig_multi_extreme2">Figure</xref>
+          The graph of <m>f</m> is plotted in <xref ref="fig_multi_extreme2">Figure</xref>
           along with the point <m>(0,0,2)</m>.
           The graph shows that this point is the absolute maximum of <m>f</m>.
         </p>
@@ -794,13 +794,13 @@
         <p>
           It can help to see a graph of <m>f</m> along with the set <m>S</m>.
           In <xref ref="fig_conopt1a_3D">Figure</xref> the triangle defining <m>S</m> is shown in the <m>xy</m>-plane in a dashed line.
-          Above it is the surface of <m>f</m>;
-          we are only concerned with the portion of <m>f</m> enclosed by the
-          <q>triangle</q> on its surface.
+          Above it is the graph of <m>f</m>;
+          we are only concerned with the portion of the surface <m>z=f(x,y)</m> enclosed by the
+          <q>triangle</q>.
         </p>
 
         <figure xml:id="fig_conopt1">
-          <caption>Plotting the surface of <m>f</m> along with the restricted domain <m>S</m> in <xref ref="ex_conopt1">Example</xref></caption>
+          <caption>Plotting the graph of <m>f</m> along with the restricted domain <m>S</m> in <xref ref="ex_conopt1">Example</xref></caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
             <figure xml:id="fig_conopt1a_3D">
               <caption/>
@@ -1002,7 +1002,7 @@
         </p>
 
         <figure xml:id="fig_conopt1bX">
-          <caption>The surface of <m>f</m> along with important points along the boundary of <m>S</m> and the interior  in <xref ref="ex_conopt1">Example</xref></caption>
+          <caption>The graph of <m>f</m> along with important points along the boundary of <m>S</m> and the interior  in <xref ref="ex_conopt1">Example</xref></caption>
           <!-- START figures/figconopt1c_3D.asy -->
           <image xml:id="img_conopt1bX" width="47%">
             <description></description>
@@ -1233,7 +1233,7 @@
           The volume function <m>V(w,\ell)</m> is shown in <xref ref="fig_conopt2">Figure</xref>
           along with the constraint <m>\ell = 130-4w</m>.
           As done previously,
-          the constraint is drawn dashed in the <m>xy</m>-plane and also along the surface of the function.
+          the constraint is drawn dashed in the <m>xy</m>-plane and also along the graph of the function.
           The point where the volume is maximized is indicated.
         </p>
       </solution>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -543,7 +543,7 @@
     </definition>
 
     <p>
-      Thus the parametric equations of the normal line to a surface <m>f</m> at <m>\big(x_0,y_0,f(x_0,y_0)\big)</m> is:
+      Thus the parametric equations of the normal line to a surface <m>z=f(x,y)</m> at <m>\big(x_0,y_0,f(x_0,y_0)\big)</m> is:
       <me>
         \ell_{n}(t) = \left\{\begin{array}{l} x= x_0+at\\ y = y_0 + bt \\ z = f(x_0,y_0) - t
         \end{array} \right.
@@ -662,7 +662,7 @@
       <m>\overline{PQ}</m> over all points <m>P</m> on the surface.
       This, in turn,
       implies that <m>\overrightarrow{PQ}</m> will be orthogonal to the surface at <m>P</m>.
-      Therefore we can measure the distance from <m>Q</m> to the surface <m>f</m> by finding a point <m>P</m> on the surface such that <m>\overrightarrow{PQ}</m> is parallel to the normal line to <m>f</m> at <m>P</m>.
+      Therefore we can measure the distance from <m>Q</m> to the surface <m>z=f(x,y)</m> by finding a point <m>P</m> on the surface such that <m>\overrightarrow{PQ}</m> is parallel to the normal line to <m>f</m> at <m>P</m>.
     </p>
 
     <example xml:id="ex_tpl4">
@@ -717,7 +717,7 @@
           which is not difficult to solve with a numeric solver.
           We find that <m>x= 0.689</m>,
           hence <m>P = (0.689,0.689, 1.051)</m>.
-          We find the distance from <m>Q</m> to the surface of <m>f</m> is
+          We find the distance from <m>Q</m> to the graph of <m>f</m> is
           <me>
             \norm{\overrightarrow{PQ}} = \sqrt{(2-0.689)^2 +(2-0.689)^2+(2-1.051)^2} = 2.083
           </me>.
@@ -735,7 +735,7 @@
         <p>
           Let <m>f(x,y) = x-y^2+3</m>.
           Let <m>P = \big(2,1,f(2,1)\big) = (2,1,4)</m>.
-          Find points <m>Q</m> in space that are 4 units from the surface of <m>f</m> at <m>P</m>.
+          Find points <m>Q</m> in space that are 4 units from the graph of <m>f</m> at <m>P</m>.
           That is, find <m>Q</m> such that
           <m>\norm{\overrightarrow{PQ}}=4</m> and <m>\overrightarrow{PQ}</m> is orthogonal to <m>f</m> at <m>P</m>.
         </p>
@@ -980,7 +980,7 @@
       <title>Using the tangent plane to approximate function values</title>
       <statement>
         <p>
-          The point <m>(3,-1,4)</m> lies on the surface of an unknown differentiable function <m>f</m> where
+          The point <m>(3,-1,4)</m> lies on the graph of an unknown differentiable function <m>f</m> where
           <m>f_x(3,-1) = 2</m> and <m>f_y(3,-1) = -1/2</m>.
           Find the equation of the tangent plane to <m>f</m> at <m>P</m>,
           and use this to approximate the value of <m>f(2.9,-0.8)</m>.

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -31,7 +31,7 @@
     </p>
 
     <figure xml:id="fig_partialintro">
-      <caption>By fixing <m>y=2</m>, the surface <m>f(x,y) = x^2+2y^2</m> is a curve in space</caption>
+      <caption>By fixing <m>y=2</m>, the surface <m>z=f(x,y) = x^2+2y^2</m> is a curve in space</caption>
       <sidebyside widths="47% 47%" margins="0%">
         <figure xml:id="fig_partialintroa_3D">
           <caption/>

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -842,7 +842,7 @@
         </p>
 
         <figure xml:id="fig_stokes2">
-          <caption>As given in <xref ref="ex_stokes2">Example</xref>, the surface \surfaceS<nbsp/>is the portion of the plane bounded by the curve</caption>
+          <caption>As given in <xref ref="ex_stokes2">Example</xref>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_stokes2a_3D">
               <caption/>
@@ -972,7 +972,7 @@
           We begin by demonstrating that <m>C</m> lies on the surface <m>z=6-x^2-y^2</m>.
           We can parametrize the <m>x</m> and <m>y</m> components of <m>C</m> with <m>x=\cos t+1</m>,
           <m>y=\sin t+1</m> as before.
-          Lifting these components to the surface <m>f</m> gives the <m>z</m> component as <m>z = 6-x^2-y^2 = 6-(\cos t+1)^2-(\sin t+1)^2 = 3-2\cos t-2\sin t</m>,
+          Lifting these components to the surface <m>z=6-x^2-y^2</m> gives the <m>z</m> component as <m>z = 6-x^2-y^2 = 6-(\cos t+1)^2-(\sin t+1)^2 = 3-2\cos t-2\sin t</m>,
           which is the same <m>z</m> component as found in <xref ref="ex_stokes1">Example</xref>.
           Thus the curve <m>C</m> lies on the surface <m>z=6-x^2-y^2</m>,
           as illustrated in <xref ref="fig_stokes2">Figure</xref>.

--- a/ptx/sec_surface_area.ptx
+++ b/ptx/sec_surface_area.ptx
@@ -818,8 +818,8 @@
             </pg-code> -->
             <statement>
               <p>
-                Let <m>f(x,y)</m> and <m>g(x,y)=2f(x,y)</m>.
-                Why is the surface area of <m>z=g(x,y)</m> over a region <m>R</m> not twice the surface area of <m>z=f(x,y)</m> over <m>R</m>?
+                Let <m>f(x,y)</m> be a function defined over a region <m>R</m> and let <m>g(x,y)=2f(x,y)</m>.
+                Why is the surface area of <m>z=g(x,y)</m> over <m>R</m> not twice the surface area of <m>z=f(x,y)</m> over <m>R</m>?
               </p>
             </statement>
             <solution>

--- a/ptx/sec_surface_area.ptx
+++ b/ptx/sec_surface_area.ptx
@@ -818,8 +818,8 @@
             </pg-code> -->
             <statement>
               <p>
-                Let <m>z=f(x,y)</m> and <m>z=g(x,y)=2f(x,y)</m>.
-                Why is the surface area of <m>g</m> over a region <m>R</m> not twice the surface area of <m>f</m> over <m>R</m>?
+                Let <m>f(x,y)</m> and <m>g(x,y)=2f(x,y)</m>.
+                Why is the surface area of <m>z=g(x,y)</m> over a region <m>R</m> not twice the surface area of <m>z=f(x,y)</m> over <m>R</m>?
               </p>
             </statement>
             <solution>
@@ -840,7 +840,7 @@
         <introduction>
           <p>
             In the following exercises,
-            <em>set up</em> the iterated integral that computes the surface area of the given surface over the region <m>R</m>.
+            <em>set up</em> the iterated integral that computes the surface area of the graph of the given function over the region <m>R</m>.
           </p>
         </introduction>
 
@@ -1154,7 +1154,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 3x-7y+2</m>;
+                  <m>z = 3x-7y+2</m>;
                   <m>R</m> is the rectangle with opposite corners <m>(-1,0)</m> and <m>(1,3)</m>.
                 </p>
               </statement>
@@ -1172,7 +1172,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 2x+2y+2</m>;
+                  <m>z = 2x+2y+2</m>;
                   <m>R</m> is the triangle with corners <m>(0,0)</m>,
                   <m>(1,0)</m> and <m>(0,1)</m>.
                 </p>
@@ -1191,7 +1191,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = x^2+y^2+10</m>; <m>R</m> is bounded by the circle <m>x^2+y^2=16</m>.
+                  <m>z = x^2+y^2+10</m>; <m>R</m> is bounded by the circle <m>x^2+y^2=16</m>.
                 </p>
               </statement>
               <solution>
@@ -1213,7 +1213,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = -2x+4y^2+7</m> over <m>R</m>,
+                  <m>z = -2x+4y^2+7</m> over <m>R</m>,
                   the triangle bounded by <m>y=-x</m>,
                   <m>y=x</m>, <m>0\leq y\leq 1</m>.
                 </p>
@@ -1236,7 +1236,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = x^2+y</m> over <m>R</m>,
+                  <m>z = x^2+y</m> over <m>R</m>,
                   the triangle bounded by <m>y=2x</m>,
                   <m>y=0</m> and <m>x=2</m>.
                 </p>
@@ -1259,7 +1259,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = \frac23x^{3/2}+2y^{3/2}</m> over <m>R</m>,
+                  <m>z = \frac23x^{3/2}+2y^{3/2}</m> over <m>R</m>,
                   the rectangle with opposite corners <m>(0,0)</m> and <m>(1,1)</m>.
                 </p>
               </statement>
@@ -1281,7 +1281,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 10-2\sqrt{x^2+y^2}</m> over the region <m>R</m>
+                  <m>z = 10-2\sqrt{x^2+y^2}</m> over the region <m>R</m>
                   bounded by the circle <m>x^2+y^2=25</m>.
                   (This is the cone with height 10 and base radius 5;
                   be sure to compare your result with the known formula.)

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -812,7 +812,7 @@
           <statement>
             <p>
               <m>\surfaceS</m> is the plane
-              <m>f(x,y)=x+y</m> on <m>-2\leq x\leq 2</m>,
+              <m>z=x+y</m> on <m>-2\leq x\leq 2</m>,
               <m>-3\leq y\leq 3</m>, with <m>\delta(x,y,z) = z+10</m>.
             </p>
           </statement>
@@ -853,7 +853,7 @@
         <exercise label="ex-surface-integral-flux-1">
           <statement>
             <p>
-              <m>\surfaceS</m> is the plane <m>f(x,y) = 3x+y</m> on
+              <m>\surfaceS</m> is the plane <m>z = 3x+y</m> on
               <m>0\leq x\leq 1</m>, <m>1\leq y\leq 4</m>;
               <m>\vec F = \langle x^2,-z,2y\rangle</m>.
             </p>
@@ -869,7 +869,7 @@
           <statement>
             <p>
               <m>\surfaceS</m> is the plane
-              <m>f(x,y) = 8-x-y</m> over the triangle with vertices at <m>(0,0)</m>,
+              <m>z = 8-x-y</m> over the triangle with vertices at <m>(0,0)</m>,
               <m>(1,0)</m> and <m>(1,5)</m>;
               <m>\vec F = \langle 3,1,2\rangle</m>.
             </p>
@@ -884,7 +884,7 @@
         <exercise label="ex-surface-integral-flux-3">
           <statement>
             <p>
-              <m>\surfaceS</m> is the paraboloid <m>f(x,y) = x^2+y^2</m> over the unit disk;
+              <m>\surfaceS</m> is the paraboloid <m>z = x^2+y^2</m> over the unit disk;
               <m>\vec F = \langle 1,0,0\rangle</m>.
             </p>
           </statement>

--- a/ptx/sec_triple_int.ptx
+++ b/ptx/sec_triple_int.ptx
@@ -3137,10 +3137,11 @@
 
         <introduction>
           <p>
-            Two surfaces <m>f_1(x,y)</m> and
+            Two functions <m>f_1(x,y)</m> and
             <m>f_2(x,y)</m> and a region <m>R</m> in the <m>x</m>,
             <m>y</m> plane are given.
-            Set up and evaluate the double integral that finds the volume between these surfaces over <m>R</m>.
+            Set up and evaluate the double integral that finds the volume 
+            between the surfaces given by the graphs of these two functions over <m>R</m>.
           </p>
         </introduction>
 
@@ -3217,7 +3218,7 @@
 
               <statement>
                 <p>
-                  <m>z=f_1(x,y) = 2x^2+2y^2+3</m> and <m>z=f_2(x,y) = 6-x^2-y^2</m>;
+                  <m>f_1(x,y) = 2x^2+2y^2+3</m> and <m>f_2(x,y) = 6-x^2-y^2</m>;
                 </p>
 
                 <p>


### PR DESCRIPTION
This should address the language issues identified in #241, but across the whole book.
(I basically searched the whole book for "surface" and patrolled for cases where a function was referred to as a surface.)

@APEXCalculus please review to see if the changes seem reasonable, and let me know if there are any issues or mistakes.

In a few places the phrase "graph of" was being used as synonymous with "sketch of" or "plot of". I changed a couple of these but probably missed others. (Maybe this is picky, but to me, "graph of f" refers to a set of points, not the illustration of that set.)