### PR TITLE
Modify webwork ids to be different from exercise labels

### DIFF
--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -702,7 +702,7 @@
     <subexercises xml:id="TaC-area-between">
       <title>Terms and Concepts</title>
       <exercise label="ex-area-between-TaC-1">
-        <webwork xml:id="ex-area-between-TaC-1">
+        <webwork xml:id="webwork-ex-area-between-TaC-1">
             <pg-code>
               $true = PopUp(['?','True','False'],1);
             </pg-code>
@@ -715,7 +715,7 @@
       </exercise>
 <!-- Exercise 2 -->
       <exercise label="ex-area-between-TaC-2">
-        <webwork xml:id="ex-area-between-TaC-2">
+        <webwork xml:id="webwork-ex-area-between-TaC-2">
             <pg-code>
               $true = PopUp(['?','True','False'],1);
             </pg-code>
@@ -728,7 +728,7 @@
       </exercise>
 <!-- Exercise 3 -->
       <exercise label="ex-area-between-TaC-3">
-        <webwork xml:id="ex-area-between-TaC-3">
+        <webwork xml:id="webwork-ex-area-between-TaC-3">
             <pg-code>
             </pg-code>
             <statement>
@@ -745,7 +745,7 @@
       </exercise>
 
       <exercise label="ex-area-between-TaC-4">
-        <webwork xml:id="ex-area-between-TaC-4">
+        <webwork xml:id="webwork-ex-area-between-TaC-4">
           <pg-code>
           </pg-code>
           <statement>
@@ -786,7 +786,7 @@
 
   <!-- Exercise 4 -->
         <exercise label="ex-area-between-graph-1">
-          <!-- <webwork xml:id="ex-area-between-graph-1">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-1">
               <pg-code>
                 $x0 = 0;
                 $x1 = Compute("2*pi");
@@ -846,7 +846,7 @@
         </exercise>
   <!-- Exercise 5 -->
         <exercise label="ex-area-between-graph-2">
-          <!-- <webwork xml:id="ex-area-between-graph-2">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-2">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("1");
@@ -905,7 +905,7 @@
         </exercise>
   <!-- Exercise 6 -->
         <exercise label="ex-area-between-graph-3">
-          <!-- <webwork xml:id="ex-area-between-graph-3">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-3">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi");
@@ -965,7 +965,7 @@
         </exercise>
   <!-- Exercise 7 -->
         <exercise label="ex-area-between-graph-4">
-          <!-- <webwork xml:id="ex-area-between-graph-4">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-4">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi");
@@ -1026,7 +1026,7 @@
         </exercise>
   <!-- Exercise 8 -->
         <exercise label="ex-area-between-graph-5">
-          <!-- <webwork xml:id="ex-area-between-graph-5">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-5">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi/4");
@@ -1088,7 +1088,7 @@
         </exercise>
   <!-- Exercise 9 -->
         <exercise label="ex-area-between-graph-6">
-          <!-- <webwork xml:id="ex-area-between-graph-6">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-6">
               <pg-code>
                 $x0 = Compute("pi/4");
                 $x1 = Compute("5*pi/4");
@@ -1148,7 +1148,7 @@
         </exercise>
   <!-- Exercise 10 -->
         <exercise label="ex-area-between-graph-7">
-          <!-- <webwork xml:id="ex-area-between-graph-7">
+          <!-- <webwork xml:id="webwork-ex-area-between-graph-7">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
@@ -1257,7 +1257,7 @@
         </introduction>
   <!-- Exercise 11 -->
         <exercise label="ex-area-between-bounded-1">
-          <webwork xml:id="ex-area-between-bounded-1">
+          <webwork xml:id="webwork-ex-area-between-bounded-1">
               <pg-code>
                 $x0 = Compute("-2");
                 $x1 = Compute("1");
@@ -1282,7 +1282,7 @@
         </exercise>
   <!-- Exercise 12 -->
         <exercise label="ex-area-between-bounded-2">
-          <webwork xml:id="ex-area-between-bounded-2">
+          <webwork xml:id="webwork-ex-area-between-bounded-2">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("1");
@@ -1307,7 +1307,7 @@
         </exercise>
   <!-- Exercise 13 -->
         <exercise label="ex-area-between-bounded-3">
-          <webwork xml:id="ex-area-between-bounded-3">
+          <webwork xml:id="webwork-ex-area-between-bounded-3">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi/2");
@@ -1333,7 +1333,7 @@
         </exercise>
   <!-- Exercise 14 -->
         <exercise label="ex-area-between-bounded-4">
-          <webwork xml:id="ex-area-between-bounded-4">
+          <webwork xml:id="webwork-ex-area-between-bounded-4">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("1");
@@ -1363,7 +1363,7 @@
         </exercise>
   <!-- Exercise 15 -->
         <exercise label="ex-area-between-bounded-5">
-          <webwork xml:id="ex-area-between-bounded-5">
+          <webwork xml:id="webwork-ex-area-between-bounded-5">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
@@ -1388,7 +1388,7 @@
         </exercise>
   <!-- Exercise 16 -->
         <exercise label="ex-area-between-bounded-6">
-          <webwork xml:id="ex-area-between-bounded-6">
+          <webwork xml:id="webwork-ex-area-between-bounded-6">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("1");
@@ -1439,7 +1439,7 @@
 
   <!-- Exercise 17 -->
       <exercise label="ex-area-between-bounded-8">
-        <webwork xml:id="ex-area-between-bounded-8">
+        <webwork xml:id="webwork-ex-area-between-bounded-8">
             <pg-code>
               $x0 = Compute("pi/6");
               $x1 = Compute("5*pi/6");
@@ -1503,7 +1503,7 @@
         </introduction>
   <!-- Exercise 18 -->
         <exercise label="ex-area-between-two-ways-1">
-          <!-- <webwork xml:id="ex-area-between-two-ways-1">
+          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-1">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
@@ -1567,7 +1567,7 @@
         </exercise>
   <!-- Exercise 19 -->
         <exercise label="ex-area-between-two-ways-2">
-          <!-- <webwork xml:id="ex-area-between-two-ways-2">
+          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-2">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
@@ -1631,7 +1631,7 @@
         </exercise>
   <!-- Exercise 20 -->
         <exercise label="ex-area-between-two-ways-3">
-          <!-- <webwork xml:id="ex-area-between-two-ways-3">
+          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-3">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("2");
@@ -1687,7 +1687,7 @@
         </exercise>
   <!-- Exercise 21 -->
         <exercise label="ex-area-between-two-ways-4">
-          <!--<webwork xml:id="ex-area-between-two-ways-4">
+          <!--<webwork xml:id="webwork-ex-area-between-two-ways-4">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1/2");
@@ -1750,7 +1750,7 @@
         </exercise>
   <!-- Exercise 22 -->
         <exercise label="ex-area-between-two-ways-5">
-          <!-- <webwork xml:id="ex-area-between-two-ways-5">
+          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-5">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1/2");
@@ -1865,7 +1865,7 @@
         </introduction>
   <!-- Exercise 23 -->
         <exercise label="ex-area-between-triangle-1">
-          <webwork xml:id="ex-area-between-triangle-1">
+          <webwork xml:id="webwork-ex-area-between-triangle-1">
               <pg-code>
                 @p1 = (1,1);
                 @p2 = (2,3);
@@ -1890,7 +1890,7 @@
         </exercise>
   <!-- Exercise 24 -->
         <exercise label="ex-area-between-triangle-2">
-          <webwork xml:id="ex-area-between-triangle-2">
+          <webwork xml:id="webwork-ex-area-between-triangle-2">
               <pg-code>
                 @p1 = (-1,1);
                 @p2 = (1,3);
@@ -1915,7 +1915,7 @@
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-area-between-triangle-3">
-          <webwork xml:id="ex-area-between-triangle-3">
+          <webwork xml:id="webwork-ex-area-between-triangle-3">
               <pg-code>
                 @p1 = (1,1);
                 @p2 = (3,3);
@@ -1940,7 +1940,7 @@
         </exercise>
   <!-- Exercise 26 -->
         <exercise label="ex-area-between-triangle-4">
-          <webwork xml:id="ex-area-between-triangle-4">
+          <webwork xml:id="webwork-ex-area-between-triangle-4">
               <pg-code>
                 @p1 = (0,0);
                 @p2 = (2,5);
@@ -1967,7 +1967,7 @@
       </exercisegroup>
   <!-- Exercise 27 -->
       <exercise xml:id="x07_01_ex_29" label="ex-area-between-trapezoidal-1">
-        <!-- <webwork xml:id="ex-area-between-trapezoidal-1">
+        <!-- <webwork xml:id="webwork-ex-area-between-trapezoidal-1">
             <pg-code> -->
             <!-- Trapezoidal Rule, n = 6 -->
               <!-- $a = 0;
@@ -2029,7 +2029,7 @@
       </exercise>
 <!-- Exercise 28 -->
       <exercise xml:id="x07_01_ex_30" label="ex-area-between-trapezoidal-2">
-        <!-- <webwork xml:id="ex-area-between-trapezoidal-2">
+        <!-- <webwork xml:id="webwork-ex-area-between-trapezoidal-2">
             <pg-code> -->
             <!-- Simpson's Rule, n = 6 -->
               <!-- $a = 0;

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -1474,7 +1474,7 @@
     <subexercises xml:id="TaC-FTC">
       <title>Terms and Concepts</title>
       <exercise label="TaC-FTC-1">
-        <webwork xml:id="TaC-FTC-1">
+        <webwork xml:id="webwork-TaC-FTC-1">
           <statement>
             <p>
               How are definite and indefinite integrals related?
@@ -1487,7 +1487,7 @@
       </exercise>
       <!-- Exercise 2 -->
       <exercise label="TaC-FTC-2">
-        <webwork xml:id="TaC-FTC-2">
+        <webwork xml:id="webwork-TaC-FTC-2">
           <statement>
             <p>
               What constant of integration is most commonly used when evaluating definite integrals?
@@ -1500,7 +1500,7 @@
       </exercise>
       <!-- Exercise 3 -->
       <exercise label="TaC-FTC-3">
-        <webwork xml:id="TaC-FTC-3">
+        <webwork xml:id="webwork-TaC-FTC-3">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1515,7 +1515,7 @@
       </exercise>
       <!-- Exercise 4 -->
       <exercise label="TaC-FTC-4">
-        <webwork xml:id="TaC-FTC-4">
+        <webwork xml:id="webwork-TaC-FTC-4">
           <statement>
             <p>
               The definite integral can be used to find
@@ -1540,7 +1540,7 @@
         </introduction>
         <!-- Exercise 5 -->
         <exercise label="ex-FTC-defint-evaluate-1">
-          <webwork xml:id="ex-FTC-defint-evaluate-1">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-1">
             <pg-code>
               $b = list_random(-1,1);
               $c = non_zero_random(-9,9,1);
@@ -1564,7 +1564,7 @@
         </exercise>
         <!-- Exercise 6 -->
         <exercise label="ex-FTC-defint-evaluate-2">
-          <webwork xml:id="ex-FTC-defint-evaluate-2">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-2">
             <pg-code>
               $c = non_zero_random(-9,9,1);
               $low = 0;
@@ -1588,7 +1588,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-FTC-defint-evaluate-3">
-          <webwork xml:id="ex-FTC-defint-evaluate-3">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-3">
             <pg-code>
               $b = list_random(-1,1);
               $low = random(-4,-1,1);
@@ -1613,7 +1613,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-FTC-defint-evaluate-4">
-          <webwork xml:id="ex-FTC-defint-evaluate-4">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-4">
             <pg-code>
               $trig = list_random('sin','cos');
               $lh = list_random(['0','pi/2'],['0','pi'],['pi/2','pi']);
@@ -1636,7 +1636,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-FTC-defint-evaluate-5">
-          <webwork xml:id="ex-FTC-defint-evaluate-5">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-5">
             <pg-code>
               $trig = list_random('tan','sec');
               $lh = list_random(['0','pi/4'],['0','pi/3'],['pi/4','pi/3']);
@@ -1665,7 +1665,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-FTC-defint-evaluate-6">
-          <webwork xml:id="ex-FTC-defint-evaluate-6">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-6">
             <pg-code>
               $n = random(1,9,1);
               if($envir{problemSeed}==1){$n=1;};
@@ -1687,7 +1687,7 @@
         </exercise>
         <!-- Exercise 11 -->
         <exercise label="ex-FTC-defint-evaluate-7">
-          <webwork xml:id="ex-FTC-defint-evaluate-7">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-7">
             <pg-code>
               $b = random(2,9,1);
               $low = random(-3,-1,1);
@@ -1710,7 +1710,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-FTC-defint-evaluate-8">
-          <webwork xml:id="ex-FTC-defint-evaluate-8">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-8">
             <pg-code>
               ($low,$high) = num_sort((-4..-1)[NchooseK(4,2)]);
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -1732,7 +1732,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise label="ex-FTC-defint-evaluate-9">
-          <webwork xml:id="ex-FTC-defint-evaluate-9">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-9">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$a=2;$b=-2;};
@@ -1751,7 +1751,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-FTC-defint-evaluate-10">
-          <webwork xml:id="ex-FTC-defint-evaluate-10">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-10">
             <pg-code>
               ($low,$high) = num_sort((1..4)[NchooseK(4,2)]);
               if($envir{problemSeed}==1){$low=1;$high=4;};
@@ -1770,7 +1770,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-FTC-defint-evaluate-11">
-          <webwork xml:id="ex-FTC-defint-evaluate-11">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-11">
             <pg-code>
               ($low,$high) = num_sort((0,1,4,9,16,25)[NchooseK(6,2)]);
               if($envir{problemSeed}==1){$low=0;$high=4;};
@@ -1791,7 +1791,7 @@
         </exercise>
         <!-- Exercise 16 -->
         <exercise label="ex-FTC-defint-evaluate-12">
-          <webwork xml:id="ex-FTC-defint-evaluate-12">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-12">
             <pg-code>
               ($low,$high) = num_sort((1,4,9,16,25)[NchooseK(5,2)]);
               if($envir{problemSeed}==1){$low=9;$high=25;};
@@ -1812,7 +1812,7 @@
         </exercise>
         <!-- Exercise 17 -->
         <exercise label="ex-FTC-defint-evaluate-13">
-          <webwork xml:id="ex-FTC-defint-evaluate-13">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-13">
             <pg-code>
               $n = random(3,5,1);
               ($low,$high) = num_sort((0**$n,1**$n,2**$n,3**$n,4**$n)[NchooseK(5,2)]);
@@ -1834,7 +1834,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-FTC-defint-evaluate-14">
-          <webwork xml:id="ex-FTC-defint-evaluate-14">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-14">
             <pg-code>
               $low = 1;
               $high = random(2,9,1);
@@ -1855,7 +1855,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-FTC-defint-evaluate-15">
-          <webwork xml:id="ex-FTC-defint-evaluate-15">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-15">
             <pg-code>
               $low = 1;
               $high = random(2,9,1);
@@ -1876,7 +1876,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-FTC-defint-evaluate-16">
-          <webwork xml:id="ex-FTC-defint-evaluate-16">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-16">
             <pg-code>
               $n = random(3,6,1);
               $low = 1;
@@ -1898,7 +1898,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-FTC-defint-evaluate-17">
-          <webwork xml:id="ex-FTC-defint-evaluate-17">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-17">
             <pg-code>
               $low = 0;
               $high = 1;
@@ -1918,7 +1918,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-FTC-defint-evaluate-18">
-          <webwork xml:id="ex-FTC-defint-evaluate-18">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-18">
             <pg-code>
               $low = 0;
               $high = 1;
@@ -1938,7 +1938,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-FTC-defint-evaluate-19">
-          <webwork xml:id="ex-FTC-defint-evaluate-19">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-19">
             <pg-code>
               $low = 0;
               $high = 1;
@@ -1958,7 +1958,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-FTC-defint-evaluate-20">
-          <webwork xml:id="ex-FTC-defint-evaluate-20">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-20">
             <pg-code>
               $n = random(80,120,1);
               if($envir{problemSeed}==1){$n=100;};
@@ -1980,7 +1980,7 @@
         </exercise>
         <!-- Exercise 25 -->
         <exercise label="ex-FTC-defint-evaluate-21">
-          <webwork xml:id="ex-FTC-defint-evaluate-21">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-21">
             <pg-code>
               $low = random(-9,-2,1);
               if($envir{problemSeed}==1){$low=-4;};
@@ -1999,7 +1999,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-FTC-defint-evaluate-22">
-          <webwork xml:id="ex-FTC-defint-evaluate-22">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-22">
             <pg-code>
               ($low,$high) = num_sort((-9..-1)[NchooseK(9,2)]);
               $c = random(2,9,1);
@@ -2019,7 +2019,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <exercise label="ex-FTC-defint-evaluate-23">
-          <webwork xml:id="ex-FTC-defint-evaluate-23">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-23">
             <pg-code>
               $low = random(-9,-2,1);
               if($envir{problemSeed}==1){$low=-2;};
@@ -2039,7 +2039,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-FTC-defint-evaluate-24">
-          <webwork xml:id="ex-FTC-defint-evaluate-24">
+          <webwork xml:id="webwork-ex-FTC-defint-evaluate-24">
             <pg-code>
               $trig = list_random('-cot','-csc');
               $lh = list_random(['pi/6','pi/4'],['pi/6','pi/3'],['pi/6','pi/2'],['pi/4','pi/3'],['pi/4','pi/2'],['pi/3','pi/2']);
@@ -2076,7 +2076,7 @@
 
       <!-- Exercise 29 -->
       <exercise label="ex-FTC-even-odd-explain">
-        <webwork xml:id="ex-FTC-even-odd-explain">
+        <webwork xml:id="webwork-ex-FTC-even-odd-explain">
           <statement>
             <p>
               Explain why:
@@ -2103,7 +2103,7 @@
       </exercise>
       <!-- Exercise 30 -->
       <exercise label="ex-FTC-sin-period-explain">
-        <webwork xml:id="ex-FTC-sin-period-explain">
+        <webwork xml:id="webwork-ex-FTC-sin-period-explain">
           <statement>
             <p>
               Explain why <m>\ds\int_{a}^{a+2\pi} \sin t\, dt = 0</m> for all values of <m>a</m>.
@@ -2124,7 +2124,7 @@
         </introduction>
         <!-- Exercise 31 -->
         <exercise label="ex-FTC-MVT-1">
-          <webwork xml:id="ex-FTC-MVT-1">
+          <webwork xml:id="webwork-ex-FTC-MVT-1">
             <pg-code>
               $low = 0;
               $high = random(2,4,1);
@@ -2148,7 +2148,7 @@
         </exercise>
         <!-- Exercise 32 -->
         <exercise label="ex-FTC-MVT-2">
-          <webwork xml:id="ex-FTC-MVT-2">
+          <webwork xml:id="webwork-ex-FTC-MVT-2">
             <pg-code>
               $low = random(-9,-1,1);
               if($envir{problemSeed}==1){$low=-2;};
@@ -2173,7 +2173,7 @@
         </exercise>
         <!-- Exercise 33 -->
         <exercise label="ex-FTC-MVT-3">
-          <webwork xml:id="ex-FTC-MVT-3">
+          <webwork xml:id="webwork-ex-FTC-MVT-3">
             <pg-code>
               $low = 0;
               $high = 1;
@@ -2197,7 +2197,7 @@
         </exercise>
         <!-- Exercise 34 -->
         <exercise label="ex-FTC-MVT-4">
-          <webwork xml:id="ex-FTC-MVT-4">
+          <webwork xml:id="webwork-ex-FTC-MVT-4">
             <pg-code>
               $low = 0;
               $high = list_random(1,4,9,16,25,36,49);
@@ -2230,7 +2230,7 @@
         </introduction>
         <!-- Exercise 35 -->
         <exercise label="ex-FTC-average-1">
-          <webwork xml:id="ex-FTC-average-1">
+          <webwork xml:id="webwork-ex-FTC-average-1">
             <pg-code>
               $trig = list_random('sin','cos');
               $lh = list_random(['0','pi/2'],['0','pi'],['pi/2','pi']);
@@ -2256,7 +2256,7 @@
         </exercise>
         <!-- Exercise 36 -->
         <exercise label="ex-FTC-average-2">
-          <webwork xml:id="ex-FTC-average-2">
+          <webwork xml:id="webwork-ex-FTC-average-2">
             <pg-code>
               $trig = list_random('sin','cos');
               $lh = list_random(['0','pi/2'],['0','pi'],['pi/2','pi']);
@@ -2282,7 +2282,7 @@
         </exercise>
         <!-- Exercise 37 -->
         <exercise label="ex-FTC-average-3">
-          <webwork xml:id="ex-FTC-average-3">
+          <webwork xml:id="webwork-ex-FTC-average-3">
             <pg-code>
               $low = 0;
               $high = random(1,9,1);
@@ -2305,7 +2305,7 @@
         </exercise>
         <!-- Exercise 38 -->
         <exercise label="ex-FTC-average-4">
-          <webwork xml:id="ex-FTC-average-4">
+          <webwork xml:id="webwork-ex-FTC-average-4">
             <pg-code>
               $low = 0;
               $high = random(1,9,1);
@@ -2328,7 +2328,7 @@
         </exercise>
         <!-- Exercise 39 -->
         <exercise label="ex-FTC-average-5">
-          <webwork xml:id="ex-FTC-average-5">
+          <webwork xml:id="webwork-ex-FTC-average-5">
             <pg-code>
               $low = 0;
               $high = random(1,9,1);
@@ -2351,7 +2351,7 @@
         </exercise>
         <!-- Exercise 40 -->
         <exercise label="ex-FTC-average-6">
-          <webwork xml:id="ex-FTC-average-6">
+          <webwork xml:id="webwork-ex-FTC-average-6">
             <pg-code>
               $low = 1;
               $m = random(1,9,1);
@@ -2385,7 +2385,7 @@
         </introduction>
         <!-- Exercise 41 -->
         <exercise label="ex-FTC-displacement-1">
-          <webwork xml:id="ex-FTC-displacement-1">
+          <webwork xml:id="webwork-ex-FTC-displacement-1">
             <pg-code>
               $low = 0;
               $high = random(4,8,1);
@@ -2410,7 +2410,7 @@
         </exercise>
         <!-- Exercise 42 -->
         <exercise label="ex-FTC-displacement-2">
-          <webwork xml:id="ex-FTC-displacement-2">
+          <webwork xml:id="webwork-ex-FTC-displacement-2">
             <pg-code>
               $low = 0;
               $high = random(7,15,1);
@@ -2435,7 +2435,7 @@
         </exercise>
         <!-- Exercise 43 -->
         <exercise label="ex-FTC-displacement-3">
-          <webwork xml:id="ex-FTC-displacement-3">
+          <webwork xml:id="webwork-ex-FTC-displacement-3">
             <pg-code>
               $low = 0;
               $high = random(2,9,1);
@@ -2459,7 +2459,7 @@
         </exercise>
         <!-- Exercise 44 -->
         <exercise label="ex-FTC-displacement-4">
-          <webwork xml:id="ex-FTC-displacement-4">
+          <webwork xml:id="webwork-ex-FTC-displacement-4">
             <pg-code>
               $low = random(-3,-1,1);
               $high = random(1,3,1);
@@ -2482,7 +2482,7 @@
         </exercise>
         <!-- Exercise 45 -->
         <exercise label="ex-FTC-displacement-5">
-          <webwork xml:id="ex-FTC-displacement-5">
+          <webwork xml:id="webwork-ex-FTC-displacement-5">
             <pg-code>
               $trig = list_random('sin','cos');
               $lh = list_random(['0','pi/2'],['0','pi'],['0','3*pi/2'],['pi/2','pi'],['pi/2','3*pi/2'],['pi','3*pi/2']);
@@ -2506,7 +2506,7 @@
         </exercise>
         <!-- Exercise 46 -->
         <exercise label="ex-FTC-displacement-6">
-          <webwork xml:id="ex-FTC-displacement-6">
+          <webwork xml:id="webwork-ex-FTC-displacement-6">
             <pg-code>
               $low = 0;
               $n = random(3,5,1);
@@ -2540,7 +2540,7 @@
         </introduction>
         <!-- Exercise 47 -->
         <exercise label="ex-FTC-velocity-1">
-          <webwork xml:id="ex-FTC-velocity-1">
+          <webwork xml:id="webwork-ex-FTC-velocity-1">
             <pg-code>
               $low = 0;
               $high = random(1,9,1);
@@ -2564,7 +2564,7 @@
         </exercise>
         <!-- Exercise 48 -->
         <exercise label="ex-FTC-velocity-2">
-          <webwork xml:id="ex-FTC-velocity-2">
+          <webwork xml:id="webwork-ex-FTC-velocity-2">
             <pg-code>
               $low = 0;
               $high = random(1,9,1);
@@ -2588,7 +2588,7 @@
         </exercise>
         <!-- Exercise 49 -->
         <exercise label="ex-FTC-velocity-3">
-          <webwork xml:id="ex-FTC-velocity-3">
+          <webwork xml:id="webwork-ex-FTC-velocity-3">
             <pg-code>
               $low = 0;
               $high = random(1,9,1);
@@ -2611,7 +2611,7 @@
         </exercise>
         <!-- Exercise 50 -->
         <exercise label="ex-FTC-velocity-4">
-          <webwork xml:id="ex-FTC-velocity-4">
+          <webwork xml:id="webwork-ex-FTC-velocity-4">
             <pg-code>
               $trig = list_random('sin','cos');
               $lh = list_random(['0','pi/2'],['0','pi'],['0','3*pi/2'],['pi/2','pi'],['pi/2','3*pi/2'],['pi','3*pi/2']);
@@ -2684,7 +2684,7 @@
         </introduction>
         <!-- Exercise 55 -->
         <exercise label="ex-FTC-part1-1">
-          <webwork xml:id="ex-FTC-part1-1">
+          <webwork xml:id="webwork-ex-FTC-part1-1">
             <pg-code>
               $m = random(3,5,1);
               $b = non_zero_random(-9,9,1);
@@ -2707,7 +2707,7 @@
         </exercise>
         <!-- Exercise 56 -->
         <exercise label="ex-FTC-part1-2">
-          <webwork xml:id="ex-FTC-part1-2">
+          <webwork xml:id="webwork-ex-FTC-part1-2">
             <pg-code>
               $m = random(2,5,1);
               $high = random(-9,9,1);
@@ -2729,7 +2729,7 @@
         </exercise>
         <!-- Exercise 57 -->
         <exercise label="ex-FTC-part1-3">
-          <webwork xml:id="ex-FTC-part1-3">
+          <webwork xml:id="webwork-ex-FTC-part1-3">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               $m = random(2,4,1);
@@ -2752,7 +2752,7 @@
         </exercise>
         <!-- Exercise 58 -->
         <exercise label="ex-FTC-part1-4">
-          <webwork xml:id="ex-FTC-part1-4">
+          <webwork xml:id="webwork-ex-FTC-part1-4">
             <pg-code>
               ($low,$high,$f) = ('e^','ln','sin','cos','sqrt')[NchooseK(5,3)];
               if($envir{problemSeed}==1){$low='ln';$high='e^';$f='sin';};

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -795,7 +795,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-int-by-parts-1">
-        <webwork xml:id="TaC-int-by-parts-1">
+        <webwork xml:id="webwork-TaC-int-by-parts-1">
           <pg-code>
             $false = PopUp(['?','True','False'],2);
             $true = PopUp(['?','True','False'],1);
@@ -810,7 +810,7 @@
       </exercise>
       <!-- Exercise 2 -->
       <exercise label="TaC-int-by-parts-2">
-        <webwork xml:id="TaC-int-by-parts-2">
+        <webwork xml:id="webwork-TaC-int-by-parts-2">
           <pg-code>
             $false = PopUp(['?','True','False'],2);
             $true = PopUp(['?','True','False'],1);
@@ -826,7 +826,7 @@
       </exercise>
       <!-- Exercise 3 -->
       <exercise label="TaC-int-by-parts-3">
-        <webwork xml:id="TaC-int-by-parts-3">
+        <webwork xml:id="webwork-TaC-int-by-parts-3">
           <statement>
             <p>
               For what is <q><acro>LIATE</acro></q> useful?
@@ -845,7 +845,7 @@
       </exercise>
       <!-- New in V4 -->
       <exercise label="TaC-int-by-parts-4">
-        <webwork xml:id="TaC-int-by-parts-4">
+        <webwork xml:id="webwork-TaC-int-by-parts-4">
           <pg-code>
             $false = PopUp(['?','True','False'],2);
             $true = PopUp(['?','True','False'],1);
@@ -877,7 +877,7 @@
         </introduction>
         <!-- Exercise 5 -->
         <exercise xml:id="ibp_prob_5" label="ex-int-by-parts-evaluate-1">
-          <webwork xml:id="ex-int-by-parts-evaluate-1">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-1">
             <pg-code>
               $F = FormulaUpToConstant("sin(x)-x*cos(x)");
             </pg-code>
@@ -898,7 +898,7 @@
         </exercise>
         <!-- Exercise 6 -->
         <exercise label="ex-int-by-parts-evaluate-2">
-          <webwork xml:id="ex-int-by-parts-evaluate-2">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-2">
             <pg-code>
               $F = FormulaUpToConstant("-e^(-x)*(x+1)");
             </pg-code>
@@ -914,7 +914,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-int-by-parts-evaluate-3">
-          <webwork xml:id="ex-int-by-parts-evaluate-3">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-3">
             <pg-code>
               $F = FormulaUpToConstant("-x^2*cos(x)+2x*sin(x)+2*cos(x)");
             </pg-code>
@@ -930,7 +930,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-int-by-parts-evaluate-4">
-          <webwork xml:id="ex-int-by-parts-evaluate-4">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-4">
             <pg-code>
               $F = FormulaUpToConstant("-x^3*cos(x)+3x^2*sin(x)+6x*cos(x)-6*sin(x)");
             </pg-code>
@@ -946,7 +946,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-int-by-parts-evaluate-5">
-          <webwork xml:id="ex-int-by-parts-evaluate-5">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-5">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("1/2*e^(x^2)");
@@ -963,7 +963,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-int-by-parts-evaluate-6">
-          <webwork xml:id="ex-int-by-parts-evaluate-6">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-6">
             <pg-code>
               $F = FormulaUpToConstant("e^x*(x^3-3x^2+6x-6)");
             </pg-code>
@@ -979,7 +979,7 @@
         </exercise>
         <!-- Exercise 11 -->
         <exercise label="ex-int-by-parts-evaluate-7">
-          <webwork xml:id="ex-int-by-parts-evaluate-7">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-7">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("-1/2*x*e^(-2x)-e^(-2x)/4");
@@ -996,7 +996,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-int-by-parts-evaluate-8">
-          <webwork xml:id="ex-int-by-parts-evaluate-8">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-8">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("1/2*e^x*(sin(x)-cos(x))");
@@ -1013,7 +1013,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise xml:id="ibp_prob_13" label="ex-int-by-parts-evaluate-9">
-          <webwork xml:id="ex-int-by-parts-evaluate-9">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-9">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("1/5*e^(2x)*(sin(x)+2*cos(x))");
@@ -1030,7 +1030,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-int-by-parts-evaluate-10">
-          <webwork xml:id="ex-int-by-parts-evaluate-10">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-10">
             <pg-code>
               ($m,$n) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$m=2;$n=3};
@@ -1054,7 +1054,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-int-by-parts-evaluate-11">
-          <webwork xml:id="ex-int-by-parts-evaluate-11">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-11">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=5;};
@@ -1075,7 +1075,7 @@
         </exercise>
         <!-- Exercise 16 -->
         <exercise label="ex-int-by-parts-evaluate-12">
-          <webwork xml:id="ex-int-by-parts-evaluate-12">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-12">
             <pg-code>
               $F = FormulaUpToConstant("1/2*sin(x)^2");
             </pg-code>
@@ -1091,7 +1091,7 @@
         </exercise>
         <!-- Exercise 17 -->
         <exercise label="ex-int-by-parts-evaluate-13">
-          <webwork xml:id="ex-int-by-parts-evaluate-13">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-13">
             <pg-code>
               $f = Formula("sin^-1(x)");
               $F = FormulaUpToConstant("sqrt(1-x^2)+x*asin(x)");
@@ -1108,7 +1108,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-int-by-parts-evaluate-14">
-          <webwork xml:id="ex-int-by-parts-evaluate-14">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-14">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m = 2;};
@@ -1127,7 +1127,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-int-by-parts-evaluate-15">
-          <webwork xml:id="ex-int-by-parts-evaluate-15">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-15">
             <pg-code>
               $F = FormulaUpToConstant("1/2*x^2*atan(x)-x/2+1/2*atan(x)");
             </pg-code>
@@ -1143,7 +1143,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-int-by-parts-evaluate-16">
-          <webwork xml:id="ex-int-by-parts-evaluate-16">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-16">
             <pg-code>
               $f = Formula("cos^-1(x)");
               $F = FormulaUpToConstant("-sqrt(1-x^2)+x*acos(x)");
@@ -1160,7 +1160,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-int-by-parts-evaluate-17">
-          <webwork xml:id="ex-int-by-parts-evaluate-17">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-17">
             <pg-code>
               Context()->variables->set(x=>{limits=>[0,4]});
               $F = FormulaUpToConstant("1/2*x^2*ln(x)-x^2/4");
@@ -1177,7 +1177,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-int-by-parts-evaluate-18">
-          <webwork xml:id="ex-int-by-parts-evaluate-18">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-18">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b = -2;};
@@ -1198,7 +1198,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-int-by-parts-evaluate-19">
-          <webwork xml:id="ex-int-by-parts-evaluate-19">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-19">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b = 1;};
@@ -1220,7 +1220,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-int-by-parts-evaluate-20">
-          <webwork xml:id="ex-int-by-parts-evaluate-20">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-20">
             <pg-code>
               $F = FormulaUpToConstant("1/2*x^2*ln(x^2) - x^2/2");
             </pg-code>
@@ -1236,7 +1236,7 @@
         </exercise>
         <!-- Exercise 25 -->
         <exercise label="ex-int-by-parts-evaluate-21">
-          <webwork xml:id="ex-int-by-parts-evaluate-21">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-21">
             <pg-code>
               Context()->variables->set(x => {limits => [0,4]});
               $F = FormulaUpToConstant("1/3*x^3*ln(x) - x^3/9");
@@ -1253,7 +1253,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-int-by-parts-evaluate-22">
-          <webwork xml:id="ex-int-by-parts-evaluate-22">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-22">
             <pg-code>
               $F = FormulaUpToConstant("2x+x*(ln(x))^2-2x*ln(x)");
               $F->{limits} = [1,5];
@@ -1270,7 +1270,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <exercise label="ex-int-by-parts-evaluate-23">
-          <webwork xml:id="ex-int-by-parts-evaluate-23">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-23">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b = 1;};
@@ -1292,7 +1292,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-int-by-parts-evaluate-24">
-          <webwork xml:id="ex-int-by-parts-evaluate-24">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-24">
             <pg-code>
               $F = FormulaUpToConstant("x*tan(x)+ln(abs(cos(x)))");
               $F->{test_at} = [[pi/4],[3*pi/4],[5*pi/4],[7*pi/4]];
@@ -1309,7 +1309,7 @@
         </exercise>
         <!-- Exercise 29 -->
         <exercise label="ex-int-by-parts-evaluate-25">
-          <webwork xml:id="ex-int-by-parts-evaluate-25">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-25">
             <pg-code>
               $F = FormulaUpToConstant("ln(abs(sin(x)))-x*cot(x)");
               $F->{test_at} = [[pi/4],[3*pi/4],[5*pi/4],[7*pi/4]];
@@ -1326,7 +1326,7 @@
         </exercise>
         <!-- Exercise 30 -->
         <exercise label="ex-int-by-parts-evaluate-26">
-          <webwork xml:id="ex-int-by-parts-evaluate-26">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-26">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b = -2;};
@@ -1348,7 +1348,7 @@
         </exercise>
         <!-- Exercise 31 -->
         <exercise label="ex-int-by-parts-evaluate-27">
-          <webwork xml:id="ex-int-by-parts-evaluate-27">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-27">
             <pg-code>
               $b = non_zero_random(2,9,1);
               if($envir{problemSeed}==1){$b = 2;};
@@ -1369,7 +1369,7 @@
         </exercise>
         <!-- Exercise 32 -->
         <exercise label="ex-int-by-parts-evaluate-28">
-          <webwork xml:id="ex-int-by-parts-evaluate-28">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-28">
             <pg-code>
               $F = FormulaUpToConstant("sec(x)");
             </pg-code>
@@ -1385,7 +1385,7 @@
         </exercise>
         <!-- Exercise 33 -->
         <exercise label="ex-int-by-parts-evaluate-29">
-          <webwork xml:id="ex-int-by-parts-evaluate-29">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-29">
             <pg-code>
               $F = FormulaUpToConstant("x*sec(x)-ln(abs(sec(x)+tan(x)))");
             </pg-code>
@@ -1401,7 +1401,7 @@
         </exercise>
         <!-- Exercise 34 -->
         <exercise label="ex-int-by-parts-evaluate-30">
-          <webwork xml:id="ex-int-by-parts-evaluate-30">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-30">
             <pg-code>
               $F = FormulaUpToConstant("-x*csc(x)-ln(abs(csc(x)+cot(x)))");
             </pg-code>
@@ -1425,7 +1425,7 @@
         </introduction>
         <!-- Exercise 35 -->
         <exercise label="ex-int-by-parts-sub-first-1">
-          <webwork xml:id="ex-int-by-parts-sub-first-1">
+          <webwork xml:id="webwork-ex-int-by-parts-sub-first-1">
             <pg-code>
               $trig = list_random('sin','cos');
               if($envir{problemSeed}==1){$trig = 'sin';};
@@ -1446,7 +1446,7 @@
         </exercise>
         <!-- Exercise 36 -->
         <exercise label="ex-int-by-parts-sub-first-2">
-          <webwork xml:id="ex-int-by-parts-sub-first-2">
+          <webwork xml:id="webwork-ex-int-by-parts-sub-first-2">
             <pg-code>
               $trig = list_random('sin','cos');
               if($envir{problemSeed}==1){$trig = 'cos';};
@@ -1466,7 +1466,7 @@
         </exercise>
         <!-- Exercise 37 -->
         <exercise label="ex-int-by-parts-sub-first-3">
-          <webwork xml:id="ex-int-by-parts-sub-first-3">
+          <webwork xml:id="webwork-ex-int-by-parts-sub-first-3">
             <pg-code>
               $trig = list_random('sin','cos');
               if($envir{problemSeed}==1){$trig = 'sin';};
@@ -1487,7 +1487,7 @@
         </exercise>
         <!-- Exercise 38 -->
         <exercise label="ex-int-by-parts-sub-first-4">
-          <webwork xml:id="ex-int-by-parts-sub-first-4">
+          <webwork xml:id="webwork-ex-int-by-parts-sub-first-4">
             <pg-code>
               $F = FormulaUpToConstant("x ln(sqrt(x)) - x/2");
               Context()->variables->set(x=>{limits=>[0,4]});
@@ -1504,7 +1504,7 @@
         </exercise>
         <!-- Exercise 39 -->
         <exercise label="ex-int-by-parts-sub-first-5">
-          <webwork xml:id="ex-int-by-parts-sub-first-5">
+          <webwork xml:id="webwork-ex-int-by-parts-sub-first-5">
             <pg-code>
               $F = FormulaUpToConstant("2*sqrt(x)*e^sqrt(x)-2*e^sqrt(x)");
               Context()->variables->set(x=>{limits=>[0,4]});
@@ -1521,7 +1521,7 @@
         </exercise>
         <!-- Exercise 40 -->
         <exercise label="ex-int-by-parts-sub-first-6">
-          <webwork xml:id="ex-int-by-parts-sub-first-6">
+          <webwork xml:id="webwork-ex-int-by-parts-sub-first-6">
               <pg-code>
                 $F = FormulaUpToConstant("x^2/2");
                 Context()->variables->set(x=>{limits=>[0,4]});
@@ -1548,7 +1548,7 @@
         </introduction>
         <!-- Exercise 41 -->
         <exercise label="ex-int-by-parts-definite-1">
-          <webwork xml:id="ex-int-by-parts-definite-1">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-1">
             <pg-code>
               $b = list_random('\pi/2','\pi','3\pi/2','2\pi');
               if($envir{problemSeed}==1){$b = '\pi';};
@@ -1568,7 +1568,7 @@
         </exercise>
         <!-- Exercise 42 -->
         <exercise label="ex-int-by-parts-definite-2">
-          <webwork xml:id="ex-int-by-parts-definite-2">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-2">
             <pg-code>
               ($a,$b) = num_sort((-2,-1,1,2)[NchooseK(4,2)]);
               if($envir{problemSeed}==1){$a=-1;$b=1;};
@@ -1588,7 +1588,7 @@
         </exercise>
         <!-- Exercise 43 -->
         <exercise label="ex-int-by-parts-definite-3">
-          <webwork xml:id="ex-int-by-parts-definite-3">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-3">
             <pg-code>
               $b = list_random('\pi/6','\pi/4','\pi/3','\pi/2');
               if($envir{problemSeed}==1){$b='\pi/4';};
@@ -1609,7 +1609,7 @@
         </exercise>
         <!-- Exercise 44 -->
         <exercise label="ex-int-by-parts-definite-4">
-          <webwork xml:id="ex-int-by-parts-definite-4">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-4">
             <pg-code>
               $b = list_random('\pi/6','\pi/4','\pi/3','\pi/2');
               if($envir{problemSeed}==1){$b='\pi/2';};
@@ -1633,7 +1633,7 @@
         </exercise>
         <!-- Exercise 45 -->
         <exercise label="ex-int-by-parts-definite-5">
-          <webwork xml:id="ex-int-by-parts-definite-5">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-5">
             <pg-code>
               $c = random(2,9,1);
               if($envir{problemSeed}==1){$c=2;};
@@ -1657,7 +1657,7 @@
         </exercise>
         <!-- Exercise 46 -->
         <exercise label="ex-int-by-parts-definite-6">
-          <webwork xml:id="ex-int-by-parts-definite-6">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-6">
             <pg-code>
               $a = 0;
               $b = 1;
@@ -1676,7 +1676,7 @@
         </exercise>
         <!-- Exercise 47 -->
         <exercise label="ex-int-by-parts-definite-7">
-          <webwork xml:id="ex-int-by-parts-definite-7">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-7">
             <pg-code>
               ($a,$b) = num_sort((1..4)[NchooseK(4,2)]);
               if($envir{problemSeed}==1){$a=1;$b=2};
@@ -1701,7 +1701,7 @@
         </exercise>
         <!-- Exercise 48 -->
         <exercise label="ex-int-by-parts-definite-8">
-          <webwork xml:id="ex-int-by-parts-definite-8">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-8">
             <pg-code>
               $b = list_random('\pi/2','\pi','3\pi/2','2\pi');
               if($envir{problemSeed}==1){$b='\pi'};
@@ -1725,7 +1725,7 @@
         </exercise>
         <!-- Exercise 49 -->
         <exercise label="ex-int-by-parts-definite-9">
-          <webwork xml:id="ex-int-by-parts-definite-9">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-9">
             <pg-code>
               $b = list_random('\pi/2','\pi','3\pi/2','2\pi');
               if($envir{problemSeed}==1){$b='\pi/2'};

--- a/ptx/sec_alt_series.ptx
+++ b/ptx/sec_alt_series.ptx
@@ -770,7 +770,7 @@
     <subexercises xml:id="TaC-alternating-series">
       <title>Terms and Concepts</title>
       <exercise label="TaC-alternating-series-1">
-        <!--<webwork xml:id="TaC-alternating-series-1">
+        <!--<webwork xml:id="webwork-TaC-alternating-series-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -789,7 +789,7 @@
       </exercise>
 
       <exercise label="TaC-alternating-series-2">
-        <!--<webwork xml:id="TaC-alternating-series-2">
+        <!--<webwork xml:id="webwork-TaC-alternating-series-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -806,7 +806,7 @@
       </exercise>
 
       <exercise label="TaC-alternating-series-3">
-        <!--<webwork xml:id="TaC-alternating-series-3">
+        <!--<webwork xml:id="webwork-TaC-alternating-series-3">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -824,7 +824,7 @@
       </exercise>
 
       <exercise label="TaC-alternating-series-4">
-        <!--<webwork xml:id="TaC-alternating-series-4">
+        <!--<webwork xml:id="webwork-TaC-alternating-series-4">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -875,7 +875,7 @@
         </introduction>
 
         <exercise label="ex-alternating-series-conditional-1">
-          <!--<webwork xml:id="ex-alternating-series-conditional-1">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -910,7 +910,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-2">
-          <!--<webwork xml:id="ex-alternating-series-conditional-2">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -945,7 +945,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-3">
-          <!--<webwork xml:id="ex-alternating-series-conditional-3">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -980,7 +980,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-4">
-          <!--<webwork xml:id="ex-alternating-series-conditional-4">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1015,7 +1015,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-5">
-          <!--<webwork xml:id="ex-alternating-series-conditional-5">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1050,7 +1050,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-6">
-          <!--<webwork xml:id="ex-alternating-series-conditional-6">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1085,7 +1085,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-7"> 
-          <!--<webwork xml:id="ex-alternating-series-conditional-7">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1120,7 +1120,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-8">
-          <!--<webwork xml:id="ex-alternating-series-conditional-8">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1155,7 +1155,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-9">
-          <!--<webwork xml:id="ex-alternating-series-conditional-9">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1190,7 +1190,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-10">
-          <!--<webwork xml:id="ex-alternating-series-conditional-10">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1225,7 +1225,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-11">
-          <!--<webwork xml:id="ex-alternating-series-conditional-11">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-11">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1260,7 +1260,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-12">
-          <!--<webwork xml:id="ex-alternating-series-conditional-12">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-12">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1295,7 +1295,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-13">
-          <!--<webwork xml:id="ex-alternating-series-conditional-13">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-13">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1330,7 +1330,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-14">
-          <!--<webwork xml:id="ex-alternating-series-conditional-14">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-14">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1365,7 +1365,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-15">
-          <!--<webwork xml:id="ex-alternating-series-conditional-15">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-15">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1400,7 +1400,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-conditional-16">
-          <!--<webwork xml:id="ex-alternating-series-conditional-16">
+          <!--<webwork xml:id="webwork-ex-alternating-series-conditional-16">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1446,7 +1446,7 @@
         </introduction>
 
         <exercise label="ex-alternating-series-bound-sum-1">
-          <!--<webwork xml:id="ex-alternating-series-bound-sum-1">
+          <!--<webwork xml:id="webwork-ex-alternating-series-bound-sum-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1467,7 +1467,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-bound-sum-2">
-          <!--<webwork xml:id="ex-alternating-series-bound-sum-2">
+          <!--<webwork xml:id="webwork-ex-alternating-series-bound-sum-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1488,7 +1488,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-bound-sum-3">
-          <!--<webwork xml:id="ex-alternating-series-bound-sum-3">
+          <!--<webwork xml:id="webwork-ex-alternating-series-bound-sum-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1509,7 +1509,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-bound-sum-4">
-          <!--<webwork xml:id="ex-alternating-series-bound-sum-4">
+          <!--<webwork xml:id="webwork-ex-alternating-series-bound-sum-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1544,7 +1544,7 @@
         </introduction>
 
         <exercise label="ex-alternating-series-approx-1">
-          <!--<webwork xml:id="ex-alternating-series-approx-1">
+          <!--<webwork xml:id="webwork-ex-alternating-series-approx-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1562,7 +1562,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-approx-2">
-          <!--<webwork xml:id="ex-alternating-series-approx-2">
+          <!--<webwork xml:id="webwork-ex-alternating-series-approx-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1580,7 +1580,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-approx-3">
-          <!--<webwork xml:id="ex-alternating-series-approx-3">
+          <!--<webwork xml:id="webwork-ex-alternating-series-approx-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1601,7 +1601,7 @@
         </exercise>
 
         <exercise label="ex-alternating-series-approx-4">
-          <!--<webwork xml:id="ex-alternating-series-approx-4">
+          <!--<webwork xml:id="webwork-ex-alternating-series-approx-4">
               <pg-code>
               </pg-code>-->
               <statement>

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -686,7 +686,7 @@
     <subexercises xml:id="TaC-antiderivatives">
       <title>Terms and Concepts</title>
       <exercise label="TaC-antiderivatives-1">
-        <webwork xml:id="TaC-antiderivatives-1">
+        <webwork xml:id="webwork-TaC-antiderivatives-1">
           <statement>
             <p>
               Define the term <q>antiderivative</q> in your own words.
@@ -699,7 +699,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-2">
-        <webwork xml:id="TaC-antiderivatives-2">
+        <webwork xml:id="webwork-TaC-antiderivatives-2">
           <pg-code>
             Context()->strings->add('the antiderivative'=>{});
             Context()->strings->add('the'=>{alias=>'the antiderivative'});
@@ -720,7 +720,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-3">
-        <webwork xml:id="TaC-antiderivatives-3">
+        <webwork xml:id="webwork-TaC-antiderivatives-3">
           <statement>
             <p>
               Use your own words to define the indefinite integral of <m>f(x)</m>.
@@ -733,7 +733,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-4">
-        <webwork xml:id="TaC-antiderivatives-4">
+        <webwork xml:id="webwork-TaC-antiderivatives-4">
           <pg-code>
             Context()->strings->add('opposite'=>{});
             Context()->strings->add('reverse'=>{alias=>'opposite'});
@@ -749,7 +749,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-5">
-        <webwork xml:id="TaC-antiderivatives-5">
+        <webwork xml:id="webwork-TaC-antiderivatives-5">
           <statement>
             <p>
               What is an <q>initial value problem</q>?
@@ -762,7 +762,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-6">
-        <webwork xml:id="TaC-antiderivatives-6">
+        <webwork xml:id="webwork-TaC-antiderivatives-6">
           <pg-code>
             Context()->strings->add('velocity'=>{});
             Context()->strings->add('acceleration'=>{});
@@ -777,7 +777,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-7">
-        <webwork xml:id="TaC-antiderivatives-7">
+        <webwork xml:id="webwork-TaC-antiderivatives-7">
           <pg-code>
             Context()->strings->add('velocity'=>{});
             Context()->strings->add('position'=>{});
@@ -793,7 +793,7 @@
       </exercise>
 
       <exercise label="TaC-antiderivatives-8">
-        <webwork xml:id="TaC-antiderivatives-8">
+        <webwork xml:id="webwork-TaC-antiderivatives-8">
           <pg-code>
             parserFunction("F" => "exp(x)*sin(x)/sqrt(abs(x))");
             parserFunction("G" => "ln(abs(x))*cos(x)*sqrt(abs(x))");
@@ -825,7 +825,7 @@
         </introduction>
         <!-- Exercise 9 -->
         <exercise label="ex-antiderivatives-evaluate-1">
-          <webwork xml:id="ex-antiderivatives-evaluate-1">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-1">
             <pg-code>
               $a = random(2,9,1);
               $n = random(2,9,1);
@@ -847,7 +847,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-2">
-          <webwork xml:id="ex-antiderivatives-evaluate-2">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-2">
             <pg-code>
               $n = random(2,9,1);
               if($envir{problemSeed}==1){$n=9};
@@ -867,7 +867,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-3">
-          <webwork xml:id="ex-antiderivatives-evaluate-3">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-3">
             <pg-code>
               $a = random(5,15,1);
               $n = random(2,9,1);
@@ -890,7 +890,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-antiderivatives-evaluate-4">
-          <webwork xml:id="ex-antiderivatives-evaluate-4">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-4">
             <pg-code>
               Context()->variables->are(t=>"Real");
               $F = FormulaUpToConstant("t");
@@ -907,7 +907,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-5">
-          <webwork xml:id="ex-antiderivatives-evaluate-5">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-5">
             <pg-code>
               Context()->variables->are(s=>"Real");
               $F = FormulaUpToConstant("s");
@@ -924,7 +924,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-6">
-          <webwork xml:id="ex-antiderivatives-evaluate-6">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-6">
             <pg-code>
               ($a,$n) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$a=3;$n=2};
@@ -945,7 +945,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-antiderivatives-evaluate-7">
-          <webwork xml:id="ex-antiderivatives-evaluate-7">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-7">
             <pg-code>
               ($a,$n) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$a=3;$n=2};
@@ -967,7 +967,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-8">
-          <webwork xml:id="ex-antiderivatives-evaluate-8">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-8">
             <pg-code>
               $F = FormulaUpToConstant("2*sqrt(x)");
             </pg-code>
@@ -983,7 +983,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-9">
-          <webwork xml:id="ex-antiderivatives-evaluate-9">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-9">
             <pg-code>
               $F = list_random('tan','cot','sec','csc');
               if($envir{problemSeed}==1){$F='tan';};
@@ -1007,7 +1007,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-antiderivatives-evaluate-10">
-          <webwork xml:id="ex-antiderivatives-evaluate-10">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-10">
             <pg-code>
               $F = list_random('-sin','-cos');
               if($envir{problemSeed}==1){$F='-cos';};
@@ -1031,7 +1031,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-11">
-          <webwork xml:id="ex-antiderivatives-evaluate-11">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-11">
             <pg-code>
               ($G,$H) = ('sec','csc','tan','cot');
               $c = list_random(-1,1);
@@ -1052,7 +1052,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-12">
-          <webwork xml:id="ex-antiderivatives-evaluate-12">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-12">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=5;};
@@ -1076,7 +1076,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-antiderivatives-evaluate-13">
-          <webwork xml:id="ex-antiderivatives-evaluate-13">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-13">
             <pg-code>
               $b = random(2,9,1);
               if($envir{problemSeed}==1){$b=3;};
@@ -1097,7 +1097,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-14">
-          <webwork xml:id="ex-antiderivatives-evaluate-14">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-14">
             <pg-code>
               ($b,$c) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$b=5;$c=2};
@@ -1118,7 +1118,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-15">
-          <webwork xml:id="ex-antiderivatives-evaluate-15">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-15">
             <pg-code>
               $a = random(2,9,1);
               $b = non_zero_random(-9,9,1);
@@ -1144,7 +1144,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-antiderivatives-evaluate-16">
-          <webwork xml:id="ex-antiderivatives-evaluate-16">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-16">
             <pg-code>
               $m = random(2,5,1);
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -1169,7 +1169,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-17">
-          <webwork xml:id="ex-antiderivatives-evaluate-17">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-17">
             <pg-code>
               ($m,$n) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$m=2;$n=3};
@@ -1188,7 +1188,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-evaluate-18">
-          <webwork xml:id="ex-antiderivatives-evaluate-18">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-18">
             <pg-code>
               ($b,$p) = ('pi','e','sqrt(2)')[NchooseK(3,2)];
               if($envir{problemSeed}==1){$b='e';$p='pi'};
@@ -1208,7 +1208,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <exercise label="ex-antiderivatives-evaluate-19">
-          <webwork xml:id="ex-antiderivatives-evaluate-19">
+          <webwork xml:id="webwork-ex-antiderivatives-evaluate-19">
             <pg-code>
               $c = list_random('a'..'d','k','m','n','p'..'s');
               if($envir{problemSeed}==1){$c='a'};
@@ -1278,7 +1278,7 @@
       </exercise>
 
       <exercise label="ex-antiderivatives-log-abs">
-        <webwork xml:id="ex-antiderivatives-log-abs">
+        <webwork xml:id="webwork-ex-antiderivatives-log-abs">
           <statement>
             <p>
               This problem investigates why <xref ref="thm_indef_alg">Theorem</xref>
@@ -1330,7 +1330,7 @@
         </introduction>
         <!-- Exercise 29 -->
         <exercise label="ex-antiderivatives-ivp-1">
-          <webwork xml:id="ex-antiderivatives-ivp-1">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-1">
             <pg-code>
               $trig = list_random('-sin','-cos');
               $f0 = list_random(-9..-1,2..9);
@@ -1353,7 +1353,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-ivp-2">
-          <webwork xml:id="ex-antiderivatives-ivp-2">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-2">
             <pg-code>
               $a = random(2,9,1);
               $b = random(2,9,1);
@@ -1374,7 +1374,7 @@
         </exercise>
         <!-- Exercise 31 -->
         <exercise label="ex-antiderivatives-ivp-3">
-          <webwork xml:id="ex-antiderivatives-ivp-3">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-3">
             <pg-code>
               $a = random(2,9,1);
               $b = non_zero_random(-9,9,1);
@@ -1402,7 +1402,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-ivp-4">
-          <webwork xml:id="ex-antiderivatives-ivp-4">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-4">
             <pg-code>
               $trig = list_random(['tan','pi/4'],['sec','pi/3'],['cot','pi/4'],['csc','pi/6']);
               $f0 = non_zero_random(-9,9,1);
@@ -1428,7 +1428,7 @@
         </exercise>
         <!-- Exercise 33 -->
         <exercise label="ex-antiderivatives-ivp-5">
-          <webwork xml:id="ex-antiderivatives-ivp-5">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-5">
             <pg-code>
               $b = random(2,9,1);
               $f0 = random(1,9,1);
@@ -1449,7 +1449,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-ivp-6">
-          <webwork xml:id="ex-antiderivatives-ivp-6">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-6">
             <pg-code>
               ($fpp,$fp0,$f0) = (2..9)[NchooseK(8,3)];
               if($envir{problemSeed}==1){$fpp=5;$fp0=7;$f0=3;};
@@ -1469,7 +1469,7 @@
         </exercise>
         <!-- Exercise 35 -->
         <exercise label="ex-antiderivatives-ivp-7">
-          <webwork xml:id="ex-antiderivatives-ivp-7">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-7">
             <pg-code>
               ($fpp,$fp0,$f0) = (-10..-2,2..10)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$fpp=7;$fp0=-1;$f0=10;};
@@ -1490,7 +1490,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-ivp-8">
-          <webwork xml:id="ex-antiderivatives-ivp-8">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-8">
             <pg-code>
               $fpp = random(2,9,1);
               ($fp0,$f0) = (-10..-2,2..10)[NchooseK(18,2)];
@@ -1510,7 +1510,7 @@
         </exercise>
         <!-- Exercise 37 -->
         <exercise label="ex-antiderivatives-ivp-9">
-          <webwork xml:id="ex-antiderivatives-ivp-9">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-9">
             <pg-code>
               $trig = list_random('sin','cos');
               $x0 = list_random(0,'pi/2','pi');
@@ -1538,7 +1538,7 @@
         </exercise>
 
         <exercise label="ex-antiderivatives-ivp-10">
-          <webwork xml:id="ex-antiderivatives-ivp-10">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-10">
             <pg-code>
               $a = random(10,30,1);
               $m = random(2,4,1);
@@ -1567,7 +1567,7 @@
         </exercise>
         <!-- Exercise 39 -->
         <exercise label="ex-antiderivatives-ivp-11">
-          <webwork xml:id="ex-antiderivatives-ivp-11">
+          <webwork xml:id="webwork-ex-antiderivatives-ivp-11">
             <pg-code>
               $x0 = non_zero_random(-5,5,1);
               ($fp0,$f0) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -1598,7 +1598,7 @@
       </exercise>
 
       <exercise label="review-antiderivatives-2">
-        <webwork xml:id="review-antiderivatives-2">
+        <webwork xml:id="webwork-review-antiderivatives-2">
           <pg-code>
             $m = random(2,5,1);
             $trig = list_random('sin','cos');

--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -1146,7 +1146,7 @@
     <subexercises xml:id="TaC-arc-length">
       <title>Terms and Concepts</title>
       <exercise label="TaC-arc-length-1">
-        <webwork xml:id="TaC-arc-length-1">
+        <webwork xml:id="webwork-TaC-arc-length-1">
             <pg-code>
             </pg-code>
             <statement>
@@ -1163,7 +1163,7 @@
       </exercise>
 
       <exercise label="TaC-arc-length-2">
-        <webwork xml:id="TaC-arc-length-2">
+        <webwork xml:id="webwork-TaC-arc-length-2">
             <pg-code>
             </pg-code>
             <statement>
@@ -1192,7 +1192,7 @@
         </introduction>
 
         <exercise label="ex-arc-length-compute-1">
-          <webwork xml:id="ex-arc-length-compute-1">
+          <webwork xml:id="webwork-ex-arc-length-compute-1">
               <pg-code>
               </pg-code>
               <statement>
@@ -1209,7 +1209,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-2">
-          <webwork xml:id="ex-arc-length-compute-2">
+          <webwork xml:id="webwork-ex-arc-length-compute-2">
               <pg-code>
               </pg-code>
               <statement>
@@ -1226,7 +1226,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-3">
-          <webwork xml:id="ex-arc-length-compute-3">
+          <webwork xml:id="webwork-ex-arc-length-compute-3">
               <pg-code>
               </pg-code>
               <statement>
@@ -1243,7 +1243,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-4">
-          <webwork xml:id="ex-arc-length-compute-4">
+          <webwork xml:id="webwork-ex-arc-length-compute-4">
               <pg-code>
               </pg-code>
               <statement>
@@ -1260,7 +1260,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-5">
-          <webwork xml:id="ex-arc-length-compute-5">
+          <webwork xml:id="webwork-ex-arc-length-compute-5">
               <pg-code>
               </pg-code>
               <statement>
@@ -1277,7 +1277,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-6">
-          <webwork xml:id="ex-arc-length-compute-6">
+          <webwork xml:id="webwork-ex-arc-length-compute-6">
               <pg-code>
               </pg-code>
               <statement>
@@ -1294,7 +1294,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-7">
-          <webwork xml:id="ex-arc-length-compute-7">
+          <webwork xml:id="webwork-ex-arc-length-compute-7">
               <pg-code>
               </pg-code>
               <statement>
@@ -1311,7 +1311,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-8">
-          <webwork xml:id="ex-arc-length-compute-8">
+          <webwork xml:id="webwork-ex-arc-length-compute-8">
               <pg-code>
               </pg-code>
               <statement>
@@ -1328,7 +1328,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-9">
-          <webwork xml:id="ex-arc-length-compute-9">
+          <webwork xml:id="webwork-ex-arc-length-compute-9">
               <pg-code>
               </pg-code>
               <statement>
@@ -1345,7 +1345,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-compute-10">
-          <webwork xml:id="ex-arc-length-compute-10">
+          <webwork xml:id="webwork-ex-arc-length-compute-10">
               <pg-code>
               </pg-code>
               <statement>
@@ -1373,7 +1373,7 @@
         </introduction>
 
         <exercise xml:id="ex_07_04_ex_13" label="ex-arclength-setup-1">
-          <webwork xml:id="ex-arclength-setup-1">
+          <webwork xml:id="webwork-ex-arclength-setup-1">
               <pg-code>
               </pg-code>
               <statement>
@@ -1390,7 +1390,7 @@
         </exercise>
 
         <exercise label="ex-arclength-setup-2">
-          <webwork xml:id="ex-arclength-setup-2">
+          <webwork xml:id="webwork-ex-arclength-setup-2">
               <pg-code>
               </pg-code>
               <statement>
@@ -1407,7 +1407,7 @@
         </exercise>
 
         <exercise label="ex-arclength-setup-3">
-          <webwork xml:id="ex-arclength-setup-3">
+          <webwork xml:id="webwork-ex-arclength-setup-3">
               <pg-code>
               </pg-code>
               <statement>
@@ -1424,7 +1424,7 @@
         </exercise>
 
         <exercise label="ex-arclength-setup-4">
-          <webwork xml:id="ex-arclength-setup-4">
+          <webwork xml:id="webwork-ex-arclength-setup-4">
               <pg-code>
               </pg-code>
               <statement>
@@ -1441,7 +1441,7 @@
         </exercise>
 
         <exercise label="ex-arclength-setup-5">
-          <webwork xml:id="ex-arclength-setup-5">
+          <webwork xml:id="webwork-ex-arclength-setup-5">
               <pg-code>
               </pg-code>
               <statement>
@@ -1459,7 +1459,7 @@
         </exercise>
 
         <exercise label="ex-arclength-setup-6">
-          <webwork xml:id="ex-arclength-setup-6">
+          <webwork xml:id="webwork-ex-arclength-setup-6">
               <pg-code>
               </pg-code>
               <statement>
@@ -1477,7 +1477,7 @@
         </exercise>
 
         <exercise label="ex-arclength-setup-7">
-          <webwork xml:id="ex-arclength-setup-7">
+          <webwork xml:id="webwork-ex-arclength-setup-7">
               <pg-code>
               </pg-code>
               <statement>
@@ -1494,7 +1494,7 @@
         </exercise>
 
         <exercise xml:id="ex_07_04_ex_20" label="ex-arclength-setup-8">
-          <webwork xml:id="ex-arclength-setup-8">
+          <webwork xml:id="webwork-ex-arclength-setup-8">
               <pg-code>
               </pg-code>
               <statement>
@@ -1522,7 +1522,7 @@
         </introduction>
 
         <exercise label="ex-arc-length-simpsons-1">
-          <webwork xml:id="ex-arc-length-simpsons-1">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-1">
               <pg-code>
               </pg-code>
               <statement>
@@ -1539,7 +1539,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-2">
-          <webwork xml:id="ex-arc-length-simpsons-2">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-2">
               <pg-code>
               </pg-code>
               <statement>
@@ -1556,7 +1556,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-3">
-          <webwork xml:id="ex-arc-length-simpsons-3">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-3">
               <pg-code>
               </pg-code>
               <statement>
@@ -1575,7 +1575,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-4">
-          <webwork xml:id="ex-arc-length-simpsons-4">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-4">
               <pg-code>
               </pg-code>
               <statement>
@@ -1592,7 +1592,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-5">
-          <webwork xml:id="ex-arc-length-simpsons-5">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-5">
               <pg-code>
               </pg-code>
               <statement>
@@ -1610,7 +1610,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-6">
-          <webwork xml:id="ex-arc-length-simpsons-6">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-6">
               <pg-code>
               </pg-code>
               <statement>
@@ -1628,7 +1628,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-7">
-          <webwork xml:id="ex-arc-length-simpsons-7">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-7">
               <pg-code>
               </pg-code>
               <statement>
@@ -1645,7 +1645,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-simpsons-8">
-          <webwork xml:id="ex-arc-length-simpsons-8">
+          <webwork xml:id="webwork-ex-arc-length-simpsons-8">
               <pg-code>
               </pg-code>
               <statement>
@@ -1672,7 +1672,7 @@
         </introduction>
 
         <exercise label="ex-arc-length-surfarea-1">
-          <webwork xml:id="ex-arc-length-surfarea-1">
+          <webwork xml:id="webwork-ex-arc-length-surfarea-1">
               <pg-code>
               </pg-code>
               <statement>
@@ -1689,7 +1689,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-surfarea-2">
-          <webwork xml:id="ex-arc-length-surfarea-2">
+          <webwork xml:id="webwork-ex-arc-length-surfarea-2">
               <pg-code>
               </pg-code>
               <statement>
@@ -1706,7 +1706,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-surfarea-3">
-          <webwork xml:id="ex-arc-length-surfarea-3">
+          <webwork xml:id="webwork-ex-arc-length-surfarea-3">
               <pg-code>
               </pg-code>
               <statement>
@@ -1723,7 +1723,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-surfarea-4">
-          <webwork xml:id="ex-arc-length-surfarea-4">
+          <webwork xml:id="webwork-ex-arc-length-surfarea-4">
               <pg-code>
               </pg-code>
               <statement>
@@ -1741,7 +1741,7 @@
         </exercise>
 
         <exercise label="ex-arc-length-surfarea-5">
-          <webwork xml:id="ex-arc-length-surfarea-5">
+          <webwork xml:id="webwork-ex-arc-length-surfarea-5">
               <pg-code>
               </pg-code>
               <statement>

--- a/ptx/sec_center_of_mass.ptx
+++ b/ptx/sec_center_of_mass.ptx
@@ -1206,7 +1206,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-center-mass-1">
-        <!--<webwork xml:id="TaC-center-mass-1">
+        <!--<webwork xml:id="webwork-TaC-center-mass-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1225,7 +1225,7 @@
       </exercise>
 
       <exercise label="TaC-center-mass-2">
-        <!--<webwork xml:id="TaC-center-mass-2">
+        <!--<webwork xml:id="webwork-TaC-center-mass-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1243,7 +1243,7 @@
       </exercise>
 
       <exercise label="TaC-center-mass-3">
-        <!--<webwork xml:id="TaC-center-mass-3">
+        <!--<webwork xml:id="webwork-TaC-center-mass-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1261,7 +1261,7 @@
       </exercise>
 
       <exercise label="TaC-center-mass-4">
-        <!--<webwork xml:id="TaC-center-mass-4">
+        <!--<webwork xml:id="webwork-TaC-center-mass-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1280,7 +1280,7 @@
       </exercise>
 
       <exercise label="TaC-center-mass-5">
-        <!--<webwork xml:id="TaC-center-mass-5">
+        <!--<webwork xml:id="webwork-TaC-center-mass-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1300,7 +1300,7 @@
       </exercise>
 
       <exercise label="TaC-center-mass-6">
-        <!--<webwork xml:id="TaC-center-mass-6">
+        <!--<webwork xml:id="webwork-TaC-center-mass-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1333,7 +1333,7 @@
         </introduction>
 
         <exercise label="ex-center-mass-point-1">
-          <!--<webwork xml:id="ex-center-mass-point-1">
+          <!--<webwork xml:id="webwork-ex-center-mass-point-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1351,7 +1351,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-point-2">
-          <!--<webwork xml:id="ex-center-mass-point-2">
+          <!--<webwork xml:id="webwork-ex-center-mass-point-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1373,7 +1373,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-point-3">
-          <!--<webwork xml:id="ex-center-mass-point-3">
+          <!--<webwork xml:id="webwork-ex-center-mass-point-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1395,7 +1395,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-point-4">
-          <!--<webwork xml:id="ex-center-mass-point-4">
+          <!--<webwork xml:id="webwork-ex-center-mass-point-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1427,7 +1427,7 @@
         </introduction>
 
         <exercise xml:id="x13_04_ex_11" label="ex-center-mass-lamina-mass-1">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-1">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1446,7 +1446,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-mass-2">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-2">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1465,7 +1465,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-mass-3">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-3">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1484,7 +1484,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-mass-4">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-4">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1503,7 +1503,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-mass-5">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-5">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1521,7 +1521,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-mass-6">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-6">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1540,7 +1540,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-mass-7">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-7">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1559,7 +1559,7 @@
         </exercise>
 
         <exercise xml:id="x13_04_ex_18" label="ex-center-mass-lamina-mass-8">
-          <!--<webwork xml:id="ex-center-mass-lamina-mass-8">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-mass-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1593,7 +1593,7 @@
         </introduction>
 
         <exercise xml:id="ex_13_04_ex_11" label="ex-center-mass-lamina-cm-1">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-1">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1613,7 +1613,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-2">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-2">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1633,7 +1633,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-3">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-3">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1653,7 +1653,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-4">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-4">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1673,7 +1673,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-5">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-5">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1693,7 +1693,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-6">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-6">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1714,7 +1714,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-7">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-7">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1735,7 +1735,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-lamina-cm-8">
-          <!--<webwork xml:id="ex-center-mass-lamina-cm-8">
+          <!--<webwork xml:id="webwork-ex-center-mass-lamina-cm-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1787,7 +1787,7 @@
         </introduction>
 
         <exercise label="ex-center-mass-inertia-1">
-          <!--<webwork xml:id="ex-center-mass-inertia-1">
+          <!--<webwork xml:id="webwork-ex-center-mass-inertia-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1804,7 +1804,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-inertia-2">
-          <!--<webwork xml:id="ex-center-mass-inertia-2">
+          <!--<webwork xml:id="webwork-ex-center-mass-inertia-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1821,7 +1821,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-inertia-3">
-          <!--<webwork xml:id="ex-center-mass-inertia-3">
+          <!--<webwork xml:id="webwork-ex-center-mass-inertia-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1838,7 +1838,7 @@
         </exercise>
 
         <exercise label="ex-center-mass-inertia-4">
-          <!--<webwork xml:id="ex-center-mass-inertia-4">
+          <!--<webwork xml:id="webwork-ex-center-mass-inertia-4">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -1889,7 +1889,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-conic-1">
-        <!-- <webwork xml:id="TaC-conic-1">
+        <!-- <webwork xml:id="webwork-TaC-conic-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1909,7 +1909,7 @@
       </exercise>
 
       <exercise label="TaC-conic-2">
-        <!-- <webwork xml:id="TaC-conic-2">
+        <!-- <webwork xml:id="webwork-TaC-conic-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1926,7 +1926,7 @@
       </exercise>
 
       <exercise label="TaC-conic-3">
-        <!-- <webwork xml:id="TaC-conic-3">
+        <!-- <webwork xml:id="webwork-TaC-conic-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1944,7 +1944,7 @@
       </exercise>
 
       <exercise label="TaC-conic-4">
-        <!-- <webwork xml:id="TaC-conic-4">
+        <!-- <webwork xml:id="webwork-TaC-conic-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1967,7 +1967,7 @@
       </exercise>
 
       <exercise label="TaC-conic-5">
-        <!-- <webwork xml:id="TaC-conic-5">
+        <!-- <webwork xml:id="webwork-TaC-conic-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2014,7 +2014,7 @@
         </introduction>
 
         <exercise label="ex-conic-parabola-eqn-1">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-1">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2031,7 +2031,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-eqn-2">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-2">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2048,7 +2048,7 @@
         </exercise>
 
         <exercise  label="ex-conic-parabola-eqn-3">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-3">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2065,7 +2065,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-eqn-4">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-4">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2082,7 +2082,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-eqn-5">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-5">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2099,7 +2099,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-eqn-6">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-6">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2116,7 +2116,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-eqn-7">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-7">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2133,7 +2133,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-eqn-8">
-          <!-- <webwork xml:id="ex-conic-parabola-eqn-8">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-eqn-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2162,7 +2162,7 @@
         </introduction>
 
         <exercise label="ex-conic-parabola-focus-1">
-          <!-- <webwork xml:id="ex-conic-parabola-focus-1">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-focus-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2180,7 +2180,7 @@
         </exercise>
 
         <exercise label="ex-conic-parabola-focus-2">
-          <!-- <webwork xml:id="ex-conic-parabola-focus-2">
+          <!-- <webwork xml:id="webwork-ex-conic-parabola-focus-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2208,7 +2208,7 @@
         </introduction>
 
         <exercise label="ex-conic-ellipse-sketch-1">
-          <!-- <webwork xml:id="ex-conic-ellipse-sketch-1">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-sketch-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2223,7 +2223,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-sketch-2">
-          <!-- <webwork xml:id="ex-conic-ellipse-sketch-2">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-sketch-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2249,7 +2249,7 @@
         </introduction>
 
         <exercise label="ex-conic-ellipse-eqn-1">
-          <!-- <webwork xml:id="ex-conic-ellipse-eqn-1">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-eqn-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2288,7 +2288,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-eqn-2">
-          <!-- <webwork xml:id="ex-conic-ellipse-eqn-2">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-eqn-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2339,7 +2339,7 @@
         </introduction>
 
         <exercise label="ex-conic-ellipse-data-1">
-          <!-- <webwork xml:id="ex-conic-ellipse-data-1">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-data-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2356,7 +2356,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-data-2">
-          <!-- <webwork xml:id="ex-conic-ellipse-data-2">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-data-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2374,7 +2374,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-data-3">
-          <!-- <webwork xml:id="ex-conic-ellipse-data-3">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-data-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2391,7 +2391,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-data-4">
-          <!-- <webwork xml:id="ex-conic-ellipse-data-4">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-data-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2419,7 +2419,7 @@
         </introduction>
 
         <exercise label="ex-conic-ellipse-eqn-std-1">
-          <!-- <webwork xml:id="ex-conic-ellipse-eqn-std-1">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-eqn-std-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2436,7 +2436,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-eqn-std-2">
-          <!-- <webwork xml:id="ex-conic-ellipse-eqn-std-2">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-eqn-std-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2453,7 +2453,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-eqn-std-3">
-          <!-- <webwork xml:id="ex-conic-ellipse-eqn-std-3">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-eqn-std-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2470,7 +2470,7 @@
         </exercise>
 
         <exercise label="ex-conic-ellipse-eqn-std-4">
-          <!-- <webwork xml:id="ex-conic-ellipse-eqn-std-4">
+          <!-- <webwork xml:id="webwork-ex-conic-ellipse-eqn-std-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2497,7 +2497,7 @@
         </introduction>
 
         <exercise label="ex-conic-hyperbola-eqn-1">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-1">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2540,7 +2540,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-eqn-2">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-2">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2584,7 +2584,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-eqn-3">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-3">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2631,7 +2631,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-eqn-4">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-4">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2688,7 +2688,7 @@
         </introduction>
 
         <exercise label="ex-conic-hyperbola-sketch-1">
-          <!-- <webwork xml:id="ex-conic-hyperbola-sketch-1">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-sketch-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2703,7 +2703,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-sketch-2">
-          <!-- <webwork xml:id="ex-conic-hyperbola-sketch-2">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-sketch-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2729,7 +2729,7 @@
         </introduction>
 
         <exercise label="ex-conic-hyperbola-data-1">
-          <!-- <webwork xml:id="ex-conic-hyperbola-data-1">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-data-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2746,7 +2746,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-data-2">
-          <webwork xml:id="ex-conic-hyperbola-data-2">
+          <webwork xml:id="webwork-ex-conic-hyperbola-data-2">
               <pg-code>
               </pg-code>
               <statement>
@@ -2763,7 +2763,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-data-3">
-          <!-- <webwork xml:id="ex-conic-hyperbola-data-3">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-data-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2781,7 +2781,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-data-4">
-          <!-- <webwork xml:id="ex-conic-hyperbola-data-4">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-data-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2809,7 +2809,7 @@
         </introduction>
 
         <exercise label="ex-conic-hyperbola-eqn-std-1">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-std-1">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-std-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2826,7 +2826,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-eqn-std-2">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-std-2">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-std-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2843,7 +2843,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-eqn-std-3">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-std-3">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-std-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2860,7 +2860,7 @@
         </exercise>
 
         <exercise label="ex-conic-hyperbola-eqn-std-4">
-          <!-- <webwork xml:id="ex-conic-hyperbola-eqn-std-4">
+          <!-- <webwork xml:id="webwork-ex-conic-hyperbola-eqn-std-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2878,7 +2878,7 @@
       </exercisegroup>
 
       <exercise label="ex-conic-ellipse-foci">
-        <!-- <webwork xml:id="ex-conic-ellipse-foci">
+        <!-- <webwork xml:id="webwork-ex-conic-ellipse-foci">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2924,7 +2924,7 @@
       </exercise>
 
       <exercise label="ex-conic-ellipse-kepler">
-        <!-- <webwork xml:id="ex-conic-ellipse-kepler">
+        <!-- <webwork xml:id="webwork-ex-conic-ellipse-kepler">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3026,7 +3026,7 @@
       </exercise>
 
       <exercise label="ex-conic-sound">
-        <!-- <webwork xml:id="ex-conic-sound">
+        <!-- <webwork xml:id="webwork-ex-conic-sound">
             <pg-code>
             </pg-code> -->
             <statement>

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -1250,7 +1250,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-cross-product-1">
-        <!--<webwork xml:id="TaC-cross-product-1">
+        <!--<webwork xml:id="webwork-TaC-cross-product-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1267,7 +1267,7 @@
       </exercise>
 
       <exercise label="TaC-cross-product-2">
-        <!--<webwork xml:id="TaC-cross-product-2">
+        <!--<webwork xml:id="webwork-TaC-cross-product-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1288,7 +1288,7 @@
       </exercise>
 
       <exercise label="TaC-cross-product-3">
-        <!--<webwork xml:id="TaC-cross-product-3">
+        <!--<webwork xml:id="webwork-TaC-cross-product-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1305,7 +1305,7 @@
       </exercise>
 
       <exercise label="TaC-cross-product-4">
-        <webwork xml:id="TaC-cross-product-4">
+        <webwork xml:id="webwork-TaC-cross-product-4">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1324,7 +1324,7 @@
       </exercise>
 
       <exercise label="TaC-cross-product-5">
-        <!--<webwork xml:id="TaC-cross-product-5">
+        <!--<webwork xml:id="webwork-TaC-cross-product-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1367,7 +1367,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-compute-1">
-          <webwork xml:id="ex-cross-product-compute-1">
+          <webwork xml:id="webwork-ex-cross-product-compute-1">
               <pg-code>
                 Context("Vector");
                 $cp=Vector("&lt;12, -15, 3>");
@@ -1391,7 +1391,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-2">
-          <webwork xml:id="ex-cross-product-compute-2">
+          <webwork xml:id="webwork-ex-cross-product-compute-2">
               <pg-code>
                 Context("Vector");
                 $cp=Vector("&lt;11, 1, -17>");
@@ -1415,7 +1415,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-3">
-          <webwork xml:id="ex-cross-product-compute-3">
+          <webwork xml:id="webwork-ex-cross-product-compute-3">
               <pg-code>
                 Context("Vector");
                 $cp=Vector("&lt;-5, -31, 27>");
@@ -1439,7 +1439,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-4">
-          <webwork xml:id="ex-cross-product-compute-4">
+          <webwork xml:id="webwork-ex-cross-product-compute-4">
               <pg-code>
                 Context("Vector");
                 $cp=Vector("&lt;47, -36, -44>");
@@ -1463,7 +1463,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-5">
-          <webwork xml:id="ex-cross-product-compute-5">
+          <webwork xml:id="webwork-ex-cross-product-compute-5">
               <pg-code>
                 Context("Vector");
                 $cp=Vector("&lt;0, -2, 0>");
@@ -1487,7 +1487,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-6">
-          <webwork xml:id="ex-cross-product-compute-6">
+          <webwork xml:id="webwork-ex-cross-product-compute-6">
               <pg-code>
                 Context("Vector");
                 $cp=Vector("&lt;0, 0, 0>");
@@ -1526,7 +1526,7 @@
 
 
         <exercise label="ex-cross-product-compute-8">
-          <webwork xml:id="ex-cross-product-compute-8">
+          <webwork xml:id="webwork-ex-cross-product-compute-8">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(ijk=>1);
@@ -1551,7 +1551,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-9">
-          <webwork xml:id="ex-cross-product-compute-9">
+          <webwork xml:id="webwork-ex-cross-product-compute-9">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(ijk=>1);
@@ -1575,7 +1575,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-compute-10">
-          <webwork xml:id="ex-cross-product-compute-10">
+          <webwork xml:id="webwork-ex-cross-product-compute-10">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(ijk=>1);
@@ -1601,7 +1601,7 @@
       </exercisegroup>
 
       <exercise label="ex-cross-product-dist-prop">
-        <!--<webwork xml:id="ex-cross-product-dist-prop">
+        <!--<webwork xml:id="webwork-ex-cross-product-dist-prop">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1620,7 +1620,7 @@
       </exercise>
 
       <exercise label="ex-cross-product-triple-prop">
-        <!--<webwork xml:id="ex-cross-product-triple-prop">
+        <!--<webwork xml:id="webwork-ex-cross-product-triple-prop">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1650,7 +1650,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-angle-mag-1">
-          <webwork xml:id="ex-cross-product-angle-mag-1">
+          <webwork xml:id="webwork-ex-cross-product-angle-mag-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $normucv=Formula("5");
@@ -1667,7 +1667,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-angle-mag-2">
-          <webwork xml:id="ex-cross-product-angle-mag-2">
+          <webwork xml:id="webwork-ex-cross-product-angle-mag-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $normucv=Formula("21");
@@ -1684,7 +1684,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-angle-mag-3">
-          <webwork xml:id="ex-cross-product-angle-mag-3">
+          <webwork xml:id="webwork-ex-cross-product-angle-mag-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $normucv=Formula("0");
@@ -1701,7 +1701,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-angle-mag-4">
-          <webwork xml:id="ex-cross-product-angle-mag-4">
+          <webwork xml:id="webwork-ex-cross-product-angle-mag-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $normucv=Formula("5");
@@ -1728,7 +1728,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-parallelogram-1">
-          <webwork xml:id="ex-cross-product-parallelogram-1">
+          <webwork xml:id="webwork-ex-cross-product-parallelogram-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("sqrt(14)");
@@ -1748,7 +1748,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-parallelogram-2">
-          <webwork xml:id="ex-cross-product-parallelogram-2">
+          <webwork xml:id="webwork-ex-cross-product-parallelogram-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("sqrt(230)");
@@ -1768,7 +1768,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-parallelogram-3">
-          <webwork xml:id="ex-cross-product-parallelogram-3">
+          <webwork xml:id="webwork-ex-cross-product-parallelogram-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("3");
@@ -1788,7 +1788,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-parallelogram-4">
-          <webwork xml:id="ex-cross-product-parallelogram-4">
+          <webwork xml:id="webwork-ex-cross-product-parallelogram-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("6");
@@ -1818,7 +1818,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-triangle-1">
-          <webwork xml:id="ex-cross-product-triangle-1">
+          <webwork xml:id="webwork-ex-cross-product-triangle-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("5sqrt(2)/2");
@@ -1838,7 +1838,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-triangle-2">
-          <webwork xml:id="ex-cross-product-triangle-2">
+          <webwork xml:id="webwork-ex-cross-product-triangle-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("3sqrt(30)");
@@ -1858,7 +1858,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-triangle-3">
-          <webwork xml:id="ex-cross-product-triangle-3">
+          <webwork xml:id="webwork-ex-cross-product-triangle-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("1");
@@ -1878,7 +1878,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-triangle-4">
-          <webwork xml:id="ex-cross-product-triangle-4">
+          <webwork xml:id="webwork-ex-cross-product-triangle-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("5/2");
@@ -1909,7 +1909,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-quadrilateral-1">
-          <webwork xml:id="ex-cross-product-quadrilateral-1">
+          <webwork xml:id="webwork-ex-cross-product-quadrilateral-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("7");
@@ -1935,7 +1935,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-quadrilateral-2">
-          <webwork xml:id="ex-cross-product-quadrilateral-2">
+          <webwork xml:id="webwork-ex-cross-product-quadrilateral-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
                 $area=Formula("4sqrt(14)");
@@ -1970,7 +1970,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-parallelepiped-1">
-          <webwork xml:id="ex-cross-product-parallelepiped-1">
+          <webwork xml:id="webwork-ex-cross-product-parallelepiped-1">
               <pg-code>
                 $volume=Compute("2");
               </pg-code>
@@ -1989,7 +1989,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-parallelepiped-2">
-          <webwork xml:id="ex-cross-product-parallelepiped-2">
+          <webwork xml:id="webwork-ex-cross-product-parallelepiped-2">
               <pg-code>
                 $volume=Compute("15");
               </pg-code>
@@ -2018,7 +2018,7 @@
         </introduction>
 
         <exercise label="ex-cross-product-unit-ortho-1">
-          <webwork xml:id="ex-cross-product-unit-ortho-1">
+          <webwork xml:id="webwork-ex-cross-product-unit-ortho-1">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
@@ -2040,7 +2040,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-unit-ortho-2">
-          <webwork xml:id="ex-cross-product-unit-ortho-2">
+          <webwork xml:id="webwork-ex-cross-product-unit-ortho-2">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
@@ -2062,7 +2062,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-unit-ortho-3">
-          <webwork xml:id="ex-cross-product-unit-ortho-3">
+          <webwork xml:id="webwork-ex-cross-product-unit-ortho-3">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
@@ -2084,7 +2084,7 @@
         </exercise>
 
         <exercise label="ex-cross-product-unit-ortho-4">
-          <webwork xml:id="ex-cross-product-unit-ortho-4">
+          <webwork xml:id="webwork-ex-cross-product-unit-ortho-4">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0, reduceConstantFunctions=>0);
@@ -2119,7 +2119,7 @@
       </exercisegroup>
 
       <exercise label="ex-cross-product-torque-1">
-        <!--<webwork xml:id="ex-cross-product-torque-1">
+        <!--<webwork xml:id="webwork-ex-cross-product-torque-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2138,7 +2138,7 @@
       </exercise>
 
       <exercise label="ex-cross-product-torque-2">
-        <!--<webwork xml:id="ex-cross-product-torque-2">
+        <!--<webwork xml:id="webwork-ex-cross-product-torque-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2158,7 +2158,7 @@
       </exercise>
 
       <exercise label="ex-cross-product-torque-3">
-        <!--<webwork xml:id="ex-cross-product-torque-3">
+        <!--<webwork xml:id="webwork-ex-cross-product-torque-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2176,7 +2176,7 @@
       </exercise>
 
       <exercise label="ex-cross-product-torque-4">
-        <!--<webwork xml:id="ex-cross-product-torque-4">
+        <!--<webwork xml:id="webwork-ex-cross-product-torque-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2196,7 +2196,7 @@
       </exercise>
 
       <exercise label="ex-cross-product-ortho-proof">
-        <!--<webwork xml:id="ex-cross-product-ortho-proof">
+        <!--<webwork xml:id="webwork-ex-cross-product-ortho-proof">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2220,7 +2220,7 @@
       </exercise>
 
       <exercise label="ex-cross-product-self-zero">
-        <!--<webwork xml:id="ex-cross-product-self-zero">
+        <!--<webwork xml:id="webwork-ex-cross-product-self-zero">
             <pg-code>
             </pg-code> -->
             <statement>

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -1060,7 +1060,7 @@
     <subexercises xml:id="TaC-curvature">
       <title>Terms and Concepts</title>
       <exercise label="TaC-curvature-1">
-        <!--<webwork xml:id="TaC-curvature-1">
+        <!--<webwork xml:id="webwork-TaC-curvature-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1077,7 +1077,7 @@
       </exercise>
 
       <exercise label="TaC-curvature-2">
-        <!--<webwork xml:id="TaC-curvature-2">
+        <!--<webwork xml:id="webwork-TaC-curvature-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1095,7 +1095,7 @@
       </exercise>
 
       <exercise label="TaC-curvature-3">
-        <!--<webwork xml:id="TaC-curvature-3">
+        <!--<webwork xml:id="webwork-TaC-curvature-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1112,7 +1112,7 @@
       </exercise>
 
       <exercise label="TaC-curvature-4">
-        <!--<webwork xml:id="TaC-curvature-4">
+        <!--<webwork xml:id="webwork-TaC-curvature-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1131,7 +1131,7 @@
       </exercise>
 
       <exercise label="TaC-curvature-5">
-        <!--<webwork xml:id="TaC-curvature-5">
+        <!--<webwork xml:id="webwork-TaC-curvature-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1148,7 +1148,7 @@
       </exercise>
 
       <exercise label="TaC-curvature-6">
-        <!--<webwork xml:id="TaC-curvature-6">
+        <!--<webwork xml:id="webwork-TaC-curvature-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1182,7 +1182,7 @@
         </introduction>
 
         <exercise label="ex-curvature-arc-param-1">
-          <!--<webwork xml:id="ex-curvature-arc-param-1">
+          <!--<webwork xml:id="webwork-ex-curvature-arc-param-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1199,7 +1199,7 @@
         </exercise>
 
         <exercise label="ex-curvature-arc-param-2">
-          <webwork xml:id="ex-curvature-arc-param-2">
+          <webwork xml:id="webwork-ex-curvature-arc-param-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(s=>'Real',t=>'Real');
@@ -1229,7 +1229,7 @@
         </exercise>
 
         <exercise label="ex-curvature-arc-param-3">
-          <!--<webwork xml:id="ex-curvature-arc-param-3">
+          <!--<webwork xml:id="webwork-ex-curvature-arc-param-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1247,7 +1247,7 @@
         </exercise>
 
         <exercise label="ex-curvature-arc-param-4">
-          <webwork xml:id="ex-curvature-arc-param-4">
+          <webwork xml:id="webwork-ex-curvature-arc-param-4">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(s=>'Real',t=>'Real');
@@ -1306,7 +1306,7 @@
         </introduction>
 
         <exercise label="ex-curvature-compare-1">
-          <!--<webwork xml:id="ex-curvature-compare-1">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1329,7 +1329,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-2">
-          <webwork xml:id="ex-curvature-compare-2">
+          <webwork xml:id="webwork-ex-curvature-compare-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $comp=PopUp(['?','greater than', 'equal to', 'less than'],1);
@@ -1375,7 +1375,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-3">
-          <!--<webwork xml:id="ex-curvature-compare-3">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1397,7 +1397,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-4">
-          <!--<webwork xml:id="ex-curvature-compare-4">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1419,7 +1419,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-5">
-          <webwork xml:id="ex-curvature-compare-5">
+          <webwork xml:id="webwork-ex-curvature-compare-5">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 Context()->variables->are(t=>'Real');
@@ -1466,7 +1466,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-6">
-          <!--<webwork xml:id="ex-curvature-compare-6">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1488,7 +1488,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-7">
-          <!--<webwork xml:id="ex-curvature-compare-7">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1511,7 +1511,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-8">
-          <webwork xml:id="ex-curvature-compare-8">
+          <webwork xml:id="webwork-ex-curvature-compare-8">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 Context()->variables->are(t=>'Real');
@@ -1558,7 +1558,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-9">
-          <!--<webwork xml:id="ex-curvature-compare-9">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-9">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1580,7 +1580,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-10">
-          <webwork xml:id="ex-curvature-compare-10">
+          <webwork xml:id="webwork-ex-curvature-compare-10">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 Context()->variables->are(t=>'Real');
@@ -1627,7 +1627,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-11">
-          <!--<webwork xml:id="ex-curvature-compare-11">
+          <!--<webwork xml:id="webwork-ex-curvature-compare-11">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1649,7 +1649,7 @@
         </exercise>
 
         <exercise label="ex-curvature-compare-12">
-          <webwork xml:id="ex-curvature-compare-12">
+          <webwork xml:id="webwork-ex-curvature-compare-12">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 Context()->variables->are(t=>'Real');
@@ -1704,7 +1704,7 @@
         </introduction>
 
         <exercise label="ex-curvature-maximum-1">
-          <webwork xml:id="ex-curvature-maximum-1">
+          <webwork xml:id="webwork-ex-curvature-maximum-1">
               <!-- <pg-macros><macro-file>parserRoot.pl</macro-file></pg-macros> -->
               <pg-code>
                 parser::Root->Enable;
@@ -1725,7 +1725,7 @@
         </exercise>
 
         <exercise label="ex-curvature-maximum-2">
-          <!--<webwork xml:id="ex-curvature-maximum-2">
+          <!--<webwork xml:id="webwork-ex-curvature-maximum-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1742,7 +1742,7 @@
         </exercise>
 
         <exercise label="ex-curvature-maximum-3">
-          <webwork xml:id="ex-curvature-maximum-3">
+          <webwork xml:id="webwork-ex-curvature-maximum-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $max=Formula("1/4");
@@ -1761,7 +1761,7 @@
         </exercise>
 
         <exercise label="ex-curvature-maximum-4">
-          <webwork xml:id="ex-curvature-maximum-4">
+          <webwork xml:id="webwork-ex-curvature-maximum-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $max=List(Formula("sqrt(5)"),Formula("-sqrt(5)"));
@@ -1789,7 +1789,7 @@
         </introduction>
 
         <exercise label="ex-curvature-radius-1">
-          <!--<webwork xml:id="ex-curvature-radius-1">
+          <!--<webwork xml:id="webwork-ex-curvature-radius-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1806,7 +1806,7 @@
         </exercise>
 
         <exercise label="ex-curvature-radius-2">
-          <webwork xml:id="ex-curvature-radius-2">
+          <webwork xml:id="webwork-ex-curvature-radius-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $radius=Formula("5sqrt(10)");
@@ -1825,7 +1825,7 @@
         </exercise>
 
         <exercise label="ex-curvature-radius-3">
-          <!--<webwork xml:id="ex-curvature-radius-3">
+          <!--<webwork xml:id="webwork-ex-curvature-radius-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1842,7 +1842,7 @@
         </exercise>
 
         <exercise label="ex-curvature-radius-4">
-          <webwork xml:id="ex-curvature-radius-4">
+          <webwork xml:id="webwork-ex-curvature-radius-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $radius=Formula("1/45");
@@ -1870,7 +1870,7 @@
         </introduction>
 
         <exercise label="ex-curvature-osculating-1">
-          <!--<webwork xml:id="ex-curvature-osculating-1">
+          <!--<webwork xml:id="webwork-ex-curvature-osculating-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1888,7 +1888,7 @@
         </exercise>
 
         <exercise label="ex-curvature-osculating-2">
-          <webwork xml:id="ex-curvature-osculating-2">
+          <webwork xml:id="webwork-ex-curvature-osculating-2">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->set(x=>{limits=>[2,4]});
@@ -1910,7 +1910,7 @@
         </exercise>
 
         <exercise label="ex-curvature-osculating-3">
-          <!--<webwork xml:id="ex-curvature-osculating-3">
+          <!--<webwork xml:id="webwork-ex-curvature-osculating-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1928,7 +1928,7 @@
         </exercise>
 
         <exercise label="ex-curvature-osculating-4">
-          <webwork xml:id="ex-curvature-osculating-4">
+          <webwork xml:id="webwork-ex-curvature-osculating-4">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->set(x=>{limits=>[-1,2]});

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -974,7 +974,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="ex-TaC-definite-integral-1">
-        <webwork xml:id="ex-TaC-definite-integral-1">
+        <webwork xml:id="webwork-ex-TaC-definite-integral-1">
           <statement>
             <p>
               What is <q>total signed area</q>?
@@ -987,7 +987,7 @@
       </exercise>
 
       <exercise label="ex-TaC-definite-integral-2">
-        <webwork xml:id="ex-TaC-definite-integral-2">
+        <webwork xml:id="webwork-ex-TaC-definite-integral-2">
           <statement>
             <p>
               What is <q>displacement</q>?
@@ -1000,7 +1000,7 @@
       </exercise>
 
       <exercise label="ex-TaC-definite-integral-3">
-        <webwork xml:id="ex-TaC-definite-integral-3">
+        <webwork xml:id="webwork-ex-TaC-definite-integral-3">
           <statement>
             <p>
               What is <m>\ds \int_3^3 \sin(x) \, dx</m>?
@@ -1039,7 +1039,7 @@
         </introduction>
         <!-- Exercise 5 -->
         <exercise label="ex-definite-integral-geometry-1">
-          <webwork xml:id="ex-definite-integral-geometry-1">
+          <webwork xml:id="webwork-ex-definite-integral-geometry-1">
             <pg-code>
               $gr = init_graph(-1,-5,5,5,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "-2x+4 for x in &lt;0,4>" . " using color:blue and weight:1");
@@ -1131,7 +1131,7 @@
         </exercise>
         <!-- Exercise 6       -->
         <exercise label="ex-definite-integral-geometry-2">
-          <webwork xml:id="ex-definite-integral-geometry-2">
+          <webwork xml:id="webwork-ex-definite-integral-geometry-2">
             <pg-code>
               $gr = init_graph(-1,-3,6,3,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "-2 for x in &lt;0,2>" . " using color:blue and weight:1",
@@ -1228,7 +1228,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-definite-integral-geometry-3">
-          <webwork xml:id="ex-definite-integral-geometry-3">
+          <webwork xml:id="webwork-ex-definite-integral-geometry-3">
             <pg-code>
               $gr = init_graph(-1,-1,5,5,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "4x for x in &lt;0,1>" . " using color:blue and weight:1",
@@ -1325,7 +1325,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-definite-integral-geometry-4">
-          <webwork xml:id="ex-definite-integral-geometry-4">
+          <webwork xml:id="webwork-ex-definite-integral-geometry-4">
             <pg-code>
               $gr = init_graph(-1,-2,5,4,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "x-1 for x in &lt;0,4>" . " using color:blue and weight:1");
@@ -1420,7 +1420,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-definite-integral-geometry-5">
-          <webwork xml:id="ex-definite-integral-geometry-5">
+          <webwork xml:id="webwork-ex-definite-integral-geometry-5">
             <pg-code>
               $gr = init_graph(-1,-0.5,5,3.1,axes=>[0,0],size=>[240,144]);
               $xfunc = sub { my $t = shift();
@@ -1505,7 +1505,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-definite-integral-geometry-6">
-          <webwork xml:id="ex-definite-integral-geometry-6">
+          <webwork xml:id="webwork-ex-definite-integral-geometry-6">
             <pg-code>
               $gr = init_graph(-1,-1,11,4,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "3 for x in &lt;0,10>" . " using color:blue and weight:1");
@@ -1594,7 +1594,7 @@
         </introduction>
         <!-- Exercise 11 -->
         <exercise label="ex-definite-integral-area-1">
-          <webwork xml:id="ex-definite-integral-area-1">
+          <webwork xml:id="webwork-ex-definite-integral-area-1">
             <pg-code>
               $gr = init_graph(-1,-125,3.5,75,axes=>[0,0],size=>[240,144]);
               $gr->new_color("lightblue", 191,191,255);
@@ -1686,7 +1686,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-definite-integral-area-2">
-          <webwork xml:id="ex-definite-integral-area-2">
+          <webwork xml:id="webwork-ex-definite-integral-area-2">
             <pg-code>
               $gr = init_graph(-1,-2,4.5,2,axes=>[0,0],size=>[240,144]);
               $gr->new_color("lightblue", 191,191,255);
@@ -1775,7 +1775,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise label="ex-definite-integral-area-3">
-          <webwork xml:id="ex-definite-integral-area-3">
+          <webwork xml:id="webwork-ex-definite-integral-area-3">
             <pg-code>
               $gr = init_graph(-2.5,-6,2.5,12,axes=>[0,0],size=>[240,144]);
               $gr->new_color("lightblue", 191,191,255);
@@ -1875,7 +1875,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-definite-integral-area-4">
-          <webwork xml:id="ex-definite-integral-area-4">
+          <webwork xml:id="webwork-ex-definite-integral-area-4">
             <pg-code>
               $gr = init_graph(-0.2,-1,2.1,5,axes=>[0,0],size=>[240,144]);
               $gr->new_color("lightblue", 191,191,255);
@@ -1982,7 +1982,7 @@
         </introduction>
         <!-- Exercise 15 -->
         <exercise label="ex-definite-integral-velocity-1">
-          <webwork xml:id="ex-definite-integral-velocity-1">
+          <webwork xml:id="webwork-ex-definite-integral-velocity-1">
             <pg-code>
               $gr = init_graph(-0.2,-1.1,3.1,2.5,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "-x+2 for x in &lt;0,3>" . " using color:blue and weight:1");
@@ -2053,7 +2053,7 @@
         </exercise>
         <!-- Exercise 16 -->
         <exercise label="ex-definite-integral-velocity-2">
-          <webwork xml:id="ex-definite-integral-velocity-2">
+          <webwork xml:id="webwork-ex-definite-integral-velocity-2">
             <pg-code>
               $gr = init_graph(-0.2,-0.5,5.2,3.5,axes=>[0,0],size=>[240,144]);
               add_functions($gr, "3 for x in &lt;0,1>" . " using color:blue and weight:1",
@@ -2132,7 +2132,7 @@
       </exercisegroup>
       <!-- Exercise 17 -->
       <exercise label="ex-definite-integral-velocity-3">
-        <webwork xml:id="ex-definite-integral-velocity-3">
+        <webwork xml:id="webwork-ex-definite-integral-velocity-3">
           <pg-code>
             $mv = NumberWithUnits("64 ft/s");
             $md = NumberWithUnits("64 ft");
@@ -2185,7 +2185,7 @@
       </exercise>
       <!-- Exercise 18 -->
       <exercise label="ex-definite-integral-velocity-4">
-        <webwork xml:id="ex-definite-integral-velocity-4">
+        <webwork xml:id="webwork-ex-definite-integral-velocity-4">
           <pg-code>
             $v0 = NumberWithUnits("96 ft/s");
             $d = NumberWithUnits("6 s");
@@ -2248,7 +2248,7 @@
         </introduction>
         <!-- Exercise 19-->
         <exercise label="ex-definite-integral-properties-1">
-          <webwork xml:id="ex-definite-integral-properties-1">
+          <webwork xml:id="webwork-ex-definite-integral-properties-1">
             <statement>
               <p>
                 <m>\int_0^2 \big(f(x)+g(x)\big) \, dx</m>
@@ -2261,7 +2261,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-definite-integral-properties-2">
-          <webwork xml:id="ex-definite-integral-properties-2">
+          <webwork xml:id="webwork-ex-definite-integral-properties-2">
             <statement>
               <p>
                 <m>\int_0^3 \big(f(x)-g(x)\big) \, dx</m>
@@ -2274,7 +2274,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-definite-integral-properties-3">
-          <webwork xml:id="ex-definite-integral-properties-3">
+          <webwork xml:id="webwork-ex-definite-integral-properties-3">
             <statement>
               <p>
                 <m>\int_2^3 \big(3f(x)+2g(x)\big) \, dx</m>
@@ -2287,7 +2287,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-definite-integral-properties-4">
-          <webwork xml:id="ex-definite-integral-properties-4">
+          <webwork xml:id="webwork-ex-definite-integral-properties-4">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(a=>"Real",b=>"Real");
@@ -2317,7 +2317,7 @@
         </introduction>
         <!-- Exercise 23 -->
         <exercise label="ex-definite-integral-properties-5">
-          <webwork xml:id="ex-definite-integral-properties-5">
+          <webwork xml:id="webwork-ex-definite-integral-properties-5">
             <statement>
               <p>
                 <m>\int_0^3 \big(s(t) + r(t)\big)\, dt</m>
@@ -2330,7 +2330,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-definite-integral-properties-6">
-          <webwork xml:id="ex-definite-integral-properties-6">
+          <webwork xml:id="webwork-ex-definite-integral-properties-6">
             <statement>
               <p>
                 <m>\int_5^0 \big(s(t) - r(t)\big)\, dt</m>
@@ -2343,7 +2343,7 @@
         </exercise>
         <!-- Exercise 25 -->
         <exercise label="ex-definite-integral-properties-7">
-          <webwork xml:id="ex-definite-integral-properties-7">
+          <webwork xml:id="webwork-ex-definite-integral-properties-7">
             <statement>
               <p>
                 <m>\int_3^3 \big(\pi s(t) - 7r(t)\big)\, dt</m>
@@ -2356,7 +2356,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-definite-integral-properties-8">
-          <webwork xml:id="ex-definite-integral-properties-8">
+          <webwork xml:id="webwork-ex-definite-integral-properties-8">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(a=>"Real",b=>"Real");
@@ -2387,7 +2387,7 @@
         </introduction>
         <!-- Exercise 27 -->
         <exercise label="ex-definite-integral-review-1">
-          <webwork xml:id="ex-definite-integral-review-1">
+          <webwork xml:id="webwork-ex-definite-integral-review-1">
             <pg-code>
               ($b,$c,$d) = (-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$b=-2;$c=7;$d=-9;};
@@ -2411,7 +2411,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-definite-integral-review-2">
-          <webwork xml:id="ex-definite-integral-review-2">
+          <webwork xml:id="webwork-ex-definite-integral-review-2">
             <pg-code>
               ($s,$t,$u) = ('sin','cos','tan','sec','cot','csc')[NchooseK(6,3)];
               $a = list_random(-1,1);
@@ -2436,7 +2436,7 @@
         </exercise>
         <!-- Exercise 29 -->
         <exercise label="ex-definite-integral-review-3">
-          <webwork xml:id="ex-definite-integral-review-3">
+          <webwork xml:id="webwork-ex-definite-integral-review-3">
             <pg-code>
               $m = random(3,6,1);
               $n = random(2,8,1);
@@ -2463,7 +2463,7 @@
         </exercise>
         <!-- Exercise 30 -->
         <exercise label="ex-definite-integral-review-4">
-          <webwork xml:id="ex-definite-integral-review-4">
+          <webwork xml:id="webwork-ex-definite-integral-review-4">
             <pg-code>
               $t = list_random('sec','csc','cot','tan');
               if($envir{problemSeed}==1){$t='csc';};

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -690,7 +690,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-deriv-basic-1">
-        <webwork xml:id="TaC-deriv-basic-1">
+        <webwork xml:id="webwork-TaC-deriv-basic-1">
           <pg-code>
             Context()->strings->add('the power rule'=>{});
             Context()->strings->add(
@@ -712,7 +712,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-2">
-        <webwork xml:id="TaC-deriv-basic-2">
+        <webwork xml:id="webwork-TaC-deriv-basic-2">
           <pg-code>
             $ans=Formula("1/x");
           </pg-code>
@@ -728,7 +728,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-3">
-        <webwork xml:id="TaC-deriv-basic-3">
+        <webwork xml:id="webwork-TaC-deriv-basic-3">
           <pg-code>
             $ans=Compute("e^x");
             $ev=$ans->cmp(checker=>sub{
@@ -758,7 +758,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-4">
-        <webwork xml:id="TaC-deriv-basic-4">
+        <webwork xml:id="webwork-TaC-deriv-basic-4">
           <pg-code>
             $ans=Formula("10");
             $ev=$ans->cmp(checker=>sub{my($correct,$student,$self)=@_;
@@ -787,7 +787,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-5">
-        <webwork xml:id="TaC-deriv-basic-5">
+        <webwork xml:id="webwork-TaC-deriv-basic-5">
           <pg-code>
             $options = CheckboxList(
               [[
@@ -812,7 +812,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-6">
-        <webwork xml:id="TaC-deriv-basic-6">
+        <webwork xml:id="webwork-TaC-deriv-basic-6">
           <statement>
             <p>
               Explain in your own words how to find the third derivative of a function <m>f(x)</m>.
@@ -825,7 +825,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-7">
-        <webwork xml:id="TaC-deriv-basic-7">
+        <webwork xml:id="webwork-TaC-deriv-basic-7">
           <pg-code>
             $ans=Compute("17x-205");
             $ev=$ans->cmp(checker=>sub{my($correct,$student,$self )=@_;
@@ -856,7 +856,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-8">
-        <webwork xml:id="TaC-deriv-basic-8">
+        <webwork xml:id="webwork-TaC-deriv-basic-8">
           <statement>
             <p>
               Explain in your own words what the second derivative <q>means</q>.
@@ -869,7 +869,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-9">
-        <webwork xml:id="TaC-deriv-basic-9">
+        <webwork xml:id="webwork-TaC-deriv-basic-9">
           <pg-code>
             Context()->strings->add('a velocity function'=>{});
             Context()->strings->add(
@@ -913,7 +913,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-basic-10">
-        <webwork xml:id="TaC-deriv-basic-10">
+        <webwork xml:id="webwork-TaC-deriv-basic-10">
           <pg-code>
             Context()->strings->add('pound per foot squared'=>{});
             Context()->strings->add(
@@ -1004,7 +1004,7 @@
         </introduction>
 
         <exercise label="ex-deriv-basic-compute-1">
-          <webwork xml:id="ex-deriv-basic-compute-1">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-1">
             <pg-code>
               $a=list_random(-9..-2,2..9);
               $b=list_random(-9..-2,2..9);
@@ -1025,7 +1025,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-2">
-          <webwork xml:id="ex-deriv-basic-compute-2">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-2">
             <pg-code>
               $a=list_random(-29..-2,2..29);
               $b=list_random(-29..-2,2..29);
@@ -1047,7 +1047,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-3">
-          <webwork xml:id="ex-deriv-basic-compute-3">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-3">
             <pg-code>
               $a=list_random(-9..-2,2..9);
               $b=list_random(-8,-7,-5,-4,-2,2,4,5,6,8);
@@ -1071,7 +1071,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-4">
-          <webwork xml:id="ex-deriv-basic-compute-4">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-4">
             <pg-code>
               $a=list_random(-19..-2,2..19);
               $b=list_random(-19..-2,2..19);
@@ -1095,7 +1095,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-5">
-          <webwork xml:id="ex-deriv-basic-compute-5">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-5">
             <pg-code>
               $a=list_random(-9..-2,2..9);
               if($envir{problemSeed}==1){$a=6;};
@@ -1115,7 +1115,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-6">
-          <webwork xml:id="ex-deriv-basic-compute-6">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-6">
             <pg-code>
               $a=non_zero_random(-19,19,1);
               $n=random(2,5,1);
@@ -1138,7 +1138,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-7">
-          <webwork xml:id="ex-deriv-basic-compute-7">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-7">
             <pg-code>
               $a=non_zero_random(-9,9,1);
               $b=non_zero_random(-9,9,1);
@@ -1158,7 +1158,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-8">
-          <webwork xml:id="ex-deriv-basic-compute-8">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-8">
             <pg-code>
               Context("Fraction");
               Context()->variables->are(s=>'Real');
@@ -1177,7 +1177,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-9">
-          <webwork xml:id="ex-deriv-basic-compute-9">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-9">
             <pg-code>
               $a=non_zero_random(-1,1,2);
               $b=non_zero_random(-1,1,2);
@@ -1199,7 +1199,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-10">
-          <webwork xml:id="ex-deriv-basic-compute-10">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-10">
             <pg-code>
               $a=non_zero_random(2,9,1);
               $b=non_zero_random(2,9,2);
@@ -1219,7 +1219,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-11">
-          <webwork xml:id="ex-deriv-basic-compute-11">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-11">
             <pg-code>
               $a=random(2,20,1);
               $b=random(2,9,1);
@@ -1244,7 +1244,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-12">
-          <webwork xml:id="ex-deriv-basic-compute-12">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-12">
             <pg-code>
               $a=random(1,9,1);
               $b=random(1,9,1);
@@ -1265,7 +1265,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-13">
-          <webwork xml:id="ex-deriv-basic-compute-13">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-13">
             <pg-code>
               $a=random(1,4,1);
               $b=non_zero_random(-4,4,1);
@@ -1285,7 +1285,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-14">
-          <webwork xml:id="ex-deriv-basic-compute-14">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-14">
             <pg-code>
               $a=random(1,4,1);
               $b=non_zero_random(-4,4,1);
@@ -1305,7 +1305,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-compute-15">
-          <webwork xml:id="ex-deriv-basic-compute-15">
+          <webwork xml:id="webwork-ex-deriv-basic-compute-15">
             <pg-code>
               $a=random(1,9,1);
               $b=non_zero_random(1,9,1);
@@ -1326,7 +1326,7 @@
       </exercisegroup>
 
       <exercise label="ex-deriv-basic-log-prop">
-        <webwork xml:id="ex-deriv-basic-log-prop">
+        <webwork xml:id="webwork-ex-deriv-basic-log-prop">
           <statement>
             <p>
               A property of logarithms is that <m>\log_a(x) = \frac{\log_b(x)}{\log_b(a)}</m>,
@@ -1365,7 +1365,7 @@
         </introduction>
 
         <exercise label="ex-deriv-basic-higher-1">
-          <webwork xml:id="ex-deriv-basic-higher-1">
+          <webwork xml:id="webwork-ex-deriv-basic-higher-1">
             <pg-code>
               $n=random(5,10,1);
               if($envir{problemSeed}==1){$n=6;};
@@ -1408,7 +1408,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-higher-2">
-          <webwork xml:id="ex-deriv-basic-higher-2">
+          <webwork xml:id="webwork-ex-deriv-basic-higher-2">
             <pg-code>
               $a=non_zero_random(-9,9,1);
               $b=list_random('sin','cos');
@@ -1452,7 +1452,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-higher-3">
-          <webwork xml:id="ex-deriv-basic-higher-3">
+          <webwork xml:id="webwork-ex-deriv-basic-higher-3">
             <pg-code>
               $a=non_zero_random(-4,4,1);
               $b=random(-4,4,1);
@@ -1498,7 +1498,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-higher-4">
-          <webwork xml:id="ex-deriv-basic-higher-4">
+          <webwork xml:id="webwork-ex-deriv-basic-higher-4">
             <pg-code>
               ($a,$b)=(2..9)[NchooseK(8,2)];
               $c=random(-1,1,2);
@@ -1548,7 +1548,7 @@
         </exercise>
 
       <exercise label="ex-deriv-basic-higher-5">
-          <webwork xml:id="ex-deriv-basic-higher-5">
+          <webwork xml:id="webwork-ex-deriv-basic-higher-5">
             <pg-code>
               $a=random(-1,1,2);
               $b=random(-1,1,2);
@@ -1597,7 +1597,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-higher-6">
-          <webwork xml:id="ex-deriv-basic-higher-6">
+          <webwork xml:id="webwork-ex-deriv-basic-higher-6">
             <pg-code>
               $a=random(1,2000,1);
               if($envir{problemSeed}==1){$a=1100};
@@ -1648,7 +1648,7 @@
         </introduction>
 
         <exercise label="ex-deriv-basic-tangent-1">
-          <webwork xml:id="ex-deriv-basic-tangent-1">
+          <webwork xml:id="webwork-ex-deriv-basic-tangent-1">
             <pg-code>
               $a=non_zero_random(-3,3,1);
               do {$b=non_zero_random(-9,9,1)} until ($b != -3*$a**2);
@@ -1684,7 +1684,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-tangent-2">
-          <webwork xml:id="ex-deriv-basic-tangent-2">
+          <webwork xml:id="webwork-ex-deriv-basic-tangent-2">
             <pg-code>
               $a=random(-3,3,1);
               $b=non_zero_random(-9,9,1);
@@ -1722,7 +1722,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-tangent-3">
-          <webwork xml:id="ex-deriv-basic-tangent-3">
+          <webwork xml:id="webwork-ex-deriv-basic-tangent-3">
             <pg-code>
               Context()->flags->set(reduceConstants=>0);
               Context()->variables->are(y=>'Real',x=>'Real');
@@ -1751,7 +1751,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-tangent-4">
-          <webwork xml:id="ex-deriv-basic-tangent-4">
+          <webwork xml:id="webwork-ex-deriv-basic-tangent-4">
             <pg-code>
               $a=list_random(2,3,4,6);
               $b=non_zero_random(-9,9,1);
@@ -1830,7 +1830,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-tangent-5">
-          <webwork xml:id="ex-deriv-basic-tangent-5">
+          <webwork xml:id="webwork-ex-deriv-basic-tangent-5">
             <pg-code>
               $a=list_random(2,3,4,6);
               $b=non_zero_random(-9,9,1);
@@ -1909,7 +1909,7 @@
         </exercise>
 
         <exercise label="ex-deriv-basic-tangent-6">
-          <webwork xml:id="ex-deriv-basic-tangent-6">
+          <webwork xml:id="webwork-ex-deriv-basic-tangent-6">
             <pg-code>
               $a=random(-9,9,1);
               $b=non_zero_random(-9,9,1);
@@ -1950,7 +1950,7 @@
       <title>Review</title>
 
       <exercise label="ex-deriv-basic-review-1">
-        <webwork xml:id="ex-deriv-basic-review-1">
+        <webwork xml:id="webwork-ex-deriv-basic-review-1">
           <pg-code>
             $ans=1.1;
           </pg-code>
@@ -1973,7 +1973,7 @@
       </exercise>
 
       <exercise label="ex-deriv-basic-review-2">
-        <webwork xml:id="ex-deriv-basic-review-2">
+        <webwork xml:id="webwork-ex-deriv-basic-review-2">
           <pg-code>
             ($n,$x0) = (3,4,5)[NchooseK(3,2)];
             $dx = 0.1;

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -924,7 +924,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-deriv-chain-1">
-        <webwork xml:id="TaC-deriv-chain-1">
+        <webwork xml:id="webwork-TaC-deriv-chain-1">
           <pg-code>
             $tf=PopUp(['?','True','False'],1);
           </pg-code>
@@ -938,7 +938,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-chain-2">
-        <webwork xml:id="TaC-deriv-chain-2">
+        <webwork xml:id="webwork-TaC-deriv-chain-2">
           <pg-code>
             $tf=PopUp(['?','True','False'],2);
           </pg-code>
@@ -952,7 +952,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-chain-3">
-        <webwork xml:id="TaC-deriv-chain-3">
+        <webwork xml:id="webwork-TaC-deriv-chain-3">
           <pg-code>
             $tf=PopUp(['?','True','False'],2);
           </pg-code>
@@ -966,7 +966,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-chain-4">
-        <webwork xml:id="TaC-deriv-chain-4">
+        <webwork xml:id="webwork-TaC-deriv-chain-4">
           <pg-code>
             $tf=PopUp(['?','True','False'],1);
           </pg-code>
@@ -980,7 +980,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-chain-5">
-        <webwork xml:id="TaC-deriv-chain-5">
+        <webwork xml:id="webwork-TaC-deriv-chain-5">
           <pg-code>
             $tf=PopUp(['?','True','False'],1);
           </pg-code>
@@ -994,7 +994,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-chain-6">
-        <webwork xml:id="TaC-deriv-chain-6">
+        <webwork xml:id="webwork-TaC-deriv-chain-6">
           <pg-code>
             $tf=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1020,7 +1020,7 @@
 
         <exercise xml:id="exer_02_05_06" label="ex-deriv-chain-compute-1">
           <!-- Intentionally not randomized because function used again later. -->
-          <webwork xml:id="ex-deriv-chain-compute-1">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-1">
             <pg-code>
               $fp=Formula("10(4x^3-x)^9(12x^2-1)");
             </pg-code>
@@ -1037,7 +1037,7 @@
 
         <exercise label="ex-deriv-chain-compute-2">
           <!-- Intentionally not randomized because function used again later. -->
-          <webwork xml:id="ex-deriv-chain-compute-2">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-2">
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("15(3t-2)^4");
@@ -1055,7 +1055,7 @@
 
         <exercise label="ex-deriv-chain-compute-3">
           <!-- Intentionally not randomized because function used again later. -->
-          <webwork xml:id="ex-deriv-chain-compute-3">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-3">
             <pg-code>
               Context()->variables->are(theta=>['Real',TeX=>'\theta']);
               $fp=Formula("3(sin(theta)+cos(theta))^2(cos(theta)-sin(theta))");
@@ -1076,7 +1076,7 @@
 
         <exercise xml:id="exer_02_05_09"  label="ex-deriv-chain-compute-4">
           <!-- Intentionally not randomized because function used again later. -->
-          <webwork xml:id="ex-deriv-chain-compute-4">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-4">
             <pg-code>
               Context()->variables->are(t=>'Real');
               $fp=Formula("(6t+1)e^(3t^2+t-1)");
@@ -1093,7 +1093,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-5">
-          <webwork xml:id="ex-deriv-chain-compute-5">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-5">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1117,7 +1117,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-6">
-          <webwork xml:id="ex-deriv-chain-compute-6">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-6">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1141,7 +1141,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-7">
-          <webwork xml:id="ex-deriv-chain-compute-7">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-7">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1164,7 +1164,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-8">
-          <webwork xml:id="ex-deriv-chain-compute-8">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-8">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1187,7 +1187,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-9">
-          <webwork xml:id="ex-deriv-chain-compute-9">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-9">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1210,7 +1210,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-10">
-          <webwork xml:id="ex-deriv-chain-compute-10">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-10">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $trig= list_random('sin','cos','tan','cot');
@@ -1235,7 +1235,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-11">
-          <webwork xml:id="ex-deriv-chain-compute-11">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-11">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1259,7 +1259,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-12">
-          <webwork xml:id="ex-deriv-chain-compute-12">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-12">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1283,7 +1283,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-13">
-          <webwork xml:id="ex-deriv-chain-compute-13">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-13">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1307,7 +1307,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-14">
-          <webwork xml:id="ex-deriv-chain-compute-14">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-14">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1329,7 +1329,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-15">
-          <webwork xml:id="ex-deriv-chain-compute-15">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-15">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1351,7 +1351,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-16">
-          <webwork xml:id="ex-deriv-chain-compute-16">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-16">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1373,7 +1373,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-17">
-          <webwork xml:id="ex-deriv-chain-compute-17">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-17">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1396,7 +1396,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-18">
-          <webwork xml:id="ex-deriv-chain-compute-18">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-18">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1420,7 +1420,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-19">
-          <webwork xml:id="ex-deriv-chain-compute-19">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-19">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1443,7 +1443,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-20">
-          <webwork xml:id="ex-deriv-chain-compute-20">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-20">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1466,7 +1466,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-21">
-          <webwork xml:id="ex-deriv-chain-compute-21">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-21">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1489,7 +1489,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-22">
-          <webwork xml:id="ex-deriv-chain-compute-22">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-22">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1513,7 +1513,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-23">
-          <webwork xml:id="ex-deriv-chain-compute-23">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-23">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1537,7 +1537,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-24">
-          <webwork xml:id="ex-deriv-chain-compute-24">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-24">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1561,7 +1561,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-25">
-          <webwork xml:id="ex-deriv-chain-compute-25">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-25">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1584,7 +1584,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-26">
-          <webwork xml:id="ex-deriv-chain-compute-26">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-26">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1610,7 +1610,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-27">
-          <webwork xml:id="ex-deriv-chain-compute-27">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-27">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1635,7 +1635,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-28">
-          <webwork xml:id="ex-deriv-chain-compute-28">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-28">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1659,7 +1659,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-29">
-          <webwork xml:id="ex-deriv-chain-compute-29">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-29">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1685,7 +1685,7 @@
         </exercise>
 
         <exercise label="ex-deriv-chain-compute-30">
-          <webwork xml:id="ex-deriv-chain-compute-30">
+          <webwork xml:id="webwork-ex-deriv-chain-compute-30">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1720,7 +1720,7 @@
 
         <exercise label="ex-deriv-chain-tangent-1">
           <!-- Intentionally not randomized because function used from earlier. -->
-          <webwork xml:id="ex-deriv-chain-tangent-1">
+          <webwork xml:id="webwork-ex-deriv-chain-tangent-1">
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1749,7 +1749,7 @@
 
         <exercise label="ex-deriv-chain-tangent-2">
           <!-- Intentionally not randomized because function used from earlier. -->
-          <webwork xml:id="ex-deriv-chain-tangent-2">
+          <webwork xml:id="webwork-ex-deriv-chain-tangent-2">
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1779,7 +1779,7 @@
 
         <exercise label="ex-deriv-chain-tangent-3">
           <!-- Intentionally not randomized because function used from earlier. -->
-          <webwork xml:id="ex-deriv-chain-tangent-3">
+          <webwork xml:id="webwork-ex-deriv-chain-tangent-3">
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1809,7 +1809,7 @@
 
         <exercise label="ex-deriv-chain-tangent-4">
           <!-- Intentionally not randomized because function used from earlier. -->
-          <webwork xml:id="ex-deriv-chain-tangent-4">
+          <webwork xml:id="webwork-ex-deriv-chain-tangent-4">
             <pg-code>
               Context("Numeric")->variables->add(y=>'Real');
               parser::Assignment->Allow;
@@ -1839,7 +1839,7 @@
       </exercisegroup>
 
       <exercise label="ex-deriv-chain-tangent-5">
-        <webwork xml:id="ex-deriv-chain-tangent-5">
+        <webwork xml:id="webwork-ex-deriv-chain-tangent-5">
           <pg-code>
             Context()->variables->add(k=>'Real');
             $f = Formula("ln(k x)");
@@ -1868,7 +1868,7 @@
       </exercise>
 
       <exercise label="ex-deriv-chain-tangent-6">
-        <webwork xml:id="ex-deriv-chain-tangent-6">
+        <webwork xml:id="webwork-ex-deriv-chain-tangent-6">
           <pg-code>
             Context()->variables->add(k=>'Real');
             $f = Formula("ln(x^k)");
@@ -1902,7 +1902,7 @@
       <title>Review</title>
 
       <exercise label="ex-deriv-chain-review-1">
-        <webwork xml:id="ex-deriv-chain-review-1">
+        <webwork xml:id="webwork-ex-deriv-chain-review-1">
           <pg-code>
             $sign=PopUp(['?','positive','negative'],2);
           </pg-code>
@@ -1956,7 +1956,7 @@
       </exercise>
 
       <exercise label="ex-deriv-chain-review-2">
-        <webwork xml:id="ex-deriv-chain-review-2">
+        <webwork xml:id="webwork-ex-deriv-chain-review-2">
           <pg-code>
             Context()->flags->set(reduceConstants=>0);
             $a=random(1,9,1);

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -974,7 +974,7 @@
     <subexercises xml:id="TaC-deriv-implicit">
       <title>Terms and Concepts</title>
       <exercise label="TaC-deriv-implicit-1">
-        <webwork xml:id="TaC-deriv-implicit-1">
+        <webwork xml:id="webwork-TaC-deriv-implicit-1">
           <statement>
             <p>
               In your own words,
@@ -988,7 +988,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-implicit-2">
-        <webwork xml:id="TaC-deriv-implicit-2">
+        <webwork xml:id="webwork-TaC-deriv-implicit-2">
           <pg-code>
             Context()->strings->add('the chain rule'=>{});
             Context()->strings->add(
@@ -1009,7 +1009,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-implicit-3">
-        <webwork xml:id="TaC-deriv-implicit-3">
+        <webwork xml:id="webwork-TaC-deriv-implicit-3">
           <pg-code>
             $tf=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1023,7 +1023,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-implicit-4">
-        <webwork xml:id="TaC-deriv-implicit-4">
+        <webwork xml:id="webwork-TaC-deriv-implicit-4">
           <pg-code>
             $tf=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1047,7 +1047,7 @@
         </introduction>
 
         <exercise label="ex-deriv-implicit-power-1">
-          <webwork xml:id="ex-deriv-implicit-power-1">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-1">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1073,7 +1073,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-2">
-          <webwork xml:id="ex-deriv-implicit-power-2">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-2">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1103,7 +1103,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-3">
-          <webwork xml:id="ex-deriv-implicit-power-3">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-3">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1131,7 +1131,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-4">
-          <webwork xml:id="ex-deriv-implicit-power-4">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-4">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1157,7 +1157,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-5">
-          <webwork xml:id="ex-deriv-implicit-power-5">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-5">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1181,7 +1181,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-6">
-          <webwork xml:id="ex-deriv-implicit-power-6">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-6">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1206,7 +1206,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-7">
-          <webwork xml:id="ex-deriv-implicit-power-7">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-7">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1232,7 +1232,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-power-8">
-          <webwork xml:id="ex-deriv-implicit-power-8">
+          <webwork xml:id="webwork-ex-deriv-implicit-power-8">
             <pg-code>
               Context("Fraction");
               $fname = list_random('f','g','h','j','k','p','m');
@@ -1269,7 +1269,7 @@
           </p>
         </introduction>
         <exercise xml:id="exer_02_06_ex_09" label="ex-deriv-implicit-compute-1">
-          <webwork xml:id="ex-deriv-implicit-compute-1">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-1">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-4x^3/(2y+1)");
@@ -1294,7 +1294,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-2">
-          <webwork xml:id="ex-deriv-implicit-compute-2">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-2">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-y^(3/5)/x^(3/5)");
@@ -1319,7 +1319,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-3">
-          <webwork xml:id="ex-deriv-implicit-compute-3">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-3">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("sin(x)sec(y)");
@@ -1344,7 +1344,7 @@
         </exercise>
 
         <exercise xml:id="exer_02_06_ex_12" label="ex-deriv-implicit-compute-4">
-          <webwork xml:id="ex-deriv-implicit-compute-4">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-4">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("y/x");
@@ -1369,7 +1369,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-5">
-          <webwork xml:id="ex-deriv-implicit-compute-5">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-5">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("y/x");
@@ -1397,7 +1397,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-6">
-          <webwork xml:id="ex-deriv-implicit-compute-6">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-6">
             <pg-code>
               Context()->variables->add(y=>'Real');
               Context()->flags->set(reduceConstantFunctions=>0);
@@ -1428,7 +1428,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-7">
-          <webwork xml:id="ex-deriv-implicit-compute-7">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-7">
             <pg-code>
               Context()->variables->add(y=>'Real');
               #$m = random(2,9,1);
@@ -1470,7 +1470,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-8">
-          <webwork xml:id="ex-deriv-implicit-compute-8">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-8">
             <pg-code>
               Context("Fraction");
               parser::Root->Enable;
@@ -1510,7 +1510,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-9">
-          <webwork xml:id="ex-deriv-implicit-compute-9">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-9">
             <pg-code>
               Context("Fraction");
               parser::Root->Enable;
@@ -1546,7 +1546,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-10">
-          <webwork xml:id="ex-deriv-implicit-compute-10">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-10">
             <pg-code>
               Context("Fraction");
               Context()->variables->add(y=>'Real');
@@ -1600,7 +1600,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-11">
-          <webwork xml:id="ex-deriv-implicit-compute-11">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-11">
             <pg-code>
               Context()->variables->add(y=>'Real');
               #($triga,$trigb) = ('sin','cos')[NchooseK(2,2)];
@@ -1650,7 +1650,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-12">
-          <webwork xml:id="ex-deriv-implicit-compute-12">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-12">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-x/y");
@@ -1676,7 +1676,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-compute-13">
-          <webwork xml:id="ex-deriv-implicit-compute-13">
+          <webwork xml:id="webwork-ex-deriv-implicit-compute-13">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $dydx=Formula("-(2x+y)/(2y+x)");
@@ -1705,7 +1705,7 @@
       </exercisegroup>
 
       <exercise label="ex-deriv-implicit-compute-14">
-        <webwork xml:id="ex-deriv-implicit-compute-14">
+        <webwork xml:id="webwork-ex-deriv-implicit-compute-14">
           <statement>
             <p>
               Show that <m>\lz{y}{x}</m> is the same for each of the following implicitly defined functions.
@@ -1760,7 +1760,7 @@
         </introduction>
 
         <exercise label="ex-deriv-implicit-tangent-1">
-          <webwork xml:id="ex-deriv-implicit-tangent-1">
+          <webwork xml:id="webwork-ex-deriv-implicit-tangent-1">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->add(y=>'Real');
@@ -1814,7 +1814,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-tangent-2">
-          <webwork xml:id="ex-deriv-implicit-tangent-2">
+          <webwork xml:id="webwork-ex-deriv-implicit-tangent-2">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->add(y=>'Real');
@@ -1875,7 +1875,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-tangent-3">
-          <webwork xml:id="ex-deriv-implicit-tangent-3">
+          <webwork xml:id="webwork-ex-deriv-implicit-tangent-3">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->add(y=>'Real');
@@ -1928,7 +1928,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-tangent-4">
-          <webwork xml:id="ex-deriv-implicit-tangent-4">
+          <webwork xml:id="webwork-ex-deriv-implicit-tangent-4">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->add(y=>'Real');
@@ -1981,7 +1981,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-tangent-5">
-          <webwork xml:id="ex-deriv-implicit-tangent-5">
+          <webwork xml:id="webwork-ex-deriv-implicit-tangent-5">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->add(y=>'Real');
@@ -2036,7 +2036,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-tangent-6">
-          <webwork xml:id="ex-deriv-implicit-tangent-6">
+          <webwork xml:id="webwork-ex-deriv-implicit-tangent-6">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               Context()->variables->add(y=>'Real');
@@ -2110,7 +2110,7 @@
           </p>
         </introduction>
         <exercise label="ex-deriv-implicit-second-1">
-          <webwork xml:id="ex-deriv-implicit-second-1">
+          <webwork xml:id="webwork-ex-deriv-implicit-second-1">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("-((2y+1)(12x^2)-4x^3(2*-(4x^3)/(2y+1)))/(2y+1)^2");
@@ -2131,7 +2131,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-second-2">
-          <webwork xml:id="ex-deriv-implicit-second-2">
+          <webwork xml:id="webwork-ex-deriv-implicit-second-2">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("-(x^(3/5)*3/5y^(-2/5)(-y^(3/5)/x^(3/5))-y^(3/5)*3/5x^(-2/5))/x^(6/5)");
@@ -2152,7 +2152,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-second-3">
-          <webwork xml:id="ex-deriv-implicit-second-3">
+          <webwork xml:id="webwork-ex-deriv-implicit-second-3">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("sin^2(x)sec^2(y)tan(y)+cos(x)sec(y)");
@@ -2173,7 +2173,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-second-4">
-          <webwork xml:id="ex-deriv-implicit-second-4">
+          <webwork xml:id="webwork-ex-deriv-implicit-second-4">
             <pg-code>
               Context()->variables->add(y=>'Real');
               $ddyddx=Formula("0");
@@ -2202,7 +2202,7 @@
           </p>
         </introduction>
         <exercise label="ex-deriv-implicit-log-1">
-          <webwork xml:id="ex-deriv-implicit-log-1">
+          <webwork xml:id="webwork-ex-deriv-implicit-log-1">
             <pg-code>
               Context()->variables->set(x=>{limits=>[-0.9,4]});
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2238,7 +2238,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-log-2">
-          <webwork xml:id="ex-deriv-implicit-log-2">
+          <webwork xml:id="webwork-ex-deriv-implicit-log-2">
             <pg-code>
               Context()->variables->set(x=>{limits=>[0.01,4]});
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2274,7 +2274,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-log-3">
-          <webwork xml:id="ex-deriv-implicit-log-3">
+          <webwork xml:id="webwork-ex-deriv-implicit-log-3">
             <pg-code>
               Context()->variables->set(x=>{limits=>[0.01,4]});
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2310,7 +2310,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-log-4">
-          <webwork xml:id="ex-deriv-implicit-log-4">
+          <webwork xml:id="webwork-ex-deriv-implicit-log-4">
             <pg-code>
               Context()->variables->set(x=>{limits=>[0.01,4]});
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2346,7 +2346,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-log-5">
-          <webwork xml:id="ex-deriv-implicit-log-5">
+          <webwork xml:id="webwork-ex-deriv-implicit-log-5">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("(x+1)/(x+2)(1/(x+1)-1/(x+2))");
@@ -2381,7 +2381,7 @@
         </exercise>
 
         <exercise label="ex-deriv-implicit-log-6">
-          <webwork xml:id="ex-deriv-implicit-log-6">
+          <webwork xml:id="webwork-ex-deriv-implicit-log-6">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $dydx=Formula("((x+1)(x+2))/((x+3)(x+4))(1/(x+1)+1/(x+2)-1/(x+3)-1/(x+4))");

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -666,7 +666,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-deriv-interpret-1">
-        <webwork xml:id="TaC-deriv-interpret-1">
+        <webwork xml:id="webwork-TaC-deriv-interpret-1">
           <pg-code>
             Context()->strings->add('velocity'=>{});
             $velocity = Compute("velocity");
@@ -683,7 +683,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-interpret-2">
-        <webwork xml:id="TaC-deriv-interpret-2">
+        <webwork xml:id="webwork-TaC-deriv-interpret-2">
           <statement>
             <p>
               Given a function <m>y=f(x)</m>,
@@ -697,7 +697,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-interpret-3">
-        <webwork xml:id="TaC-deriv-interpret-3">
+        <webwork xml:id="webwork-TaC-deriv-interpret-3">
           <pg-code>
             Context()->strings->add('linear functions'=>{});
             Context()->strings->add(
@@ -725,7 +725,7 @@
       <title>Problems</title>
 
       <exercise label="ex-deriv-interpret-1">
-        <webwork xml:id="ex-deriv-interpret-1">
+        <webwork xml:id="webwork-ex-deriv-interpret-1">
           <pg-code>
             $a=random(1,9,1);
             $fa=random(10,20,1);
@@ -746,7 +746,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-2">
-        <webwork xml:id="ex-deriv-interpret-2">
+        <webwork xml:id="webwork-ex-deriv-interpret-2">
           <pg-code>
             $a=random(50,150,10);
             $fa=non_zero_random(-99,99,1);
@@ -767,7 +767,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-3">
-        <webwork xml:id="ex-deriv-interpret-3">
+        <webwork xml:id="webwork-ex-deriv-interpret-3">
           <pg-code>
             $a=random(10,95,5);
             $fa=random(101,199,1);
@@ -788,7 +788,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-4">
-        <webwork xml:id="ex-deriv-interpret-4">
+        <webwork xml:id="webwork-ex-deriv-interpret-4">
           <pg-code>
             $popup = PopUp(['?','f(10.1)','f(11)','f(20)'],1);
             $showwork = '[@ explanation_box(message => "Explain your reasoning.") @]*';
@@ -813,7 +813,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-5">
-        <webwork xml:id="ex-deriv-interpret-5">
+        <webwork xml:id="webwork-ex-deriv-interpret-5">
           <pg-code>
             $a=random(1,9,1);
             $fa=random(11,99,1);
@@ -835,7 +835,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-6">
-        <webwork xml:id="ex-deriv-interpret-6">
+        <webwork xml:id="webwork-ex-deriv-interpret-6">
           <pg-code>
             $a=random(-5,5,1);
             $fa=random(11,99,1);
@@ -857,7 +857,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-7">
-        <webwork xml:id="ex-deriv-interpret-7">
+        <webwork xml:id="webwork-ex-deriv-interpret-7">
           <pg-code>
             Context()->strings->add('decibels per customer'=>{});
             Context()->strings->add(
@@ -886,7 +886,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-8">
-        <webwork xml:id="ex-deriv-interpret-8">
+        <webwork xml:id="webwork-ex-deriv-interpret-8">
           <pg-code>
             Context()->strings->add('foot per second squared'=>{});
             Context()->strings->add(
@@ -950,7 +950,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-9">
-        <webwork xml:id="ex-deriv-interpret-9">
+        <webwork xml:id="webwork-ex-deriv-interpret-9">
           <pg-code>
             Context()->strings->add('foot per hour'=>{});
             Context()->strings->add(
@@ -997,7 +997,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-10">
-        <webwork xml:id="ex-deriv-interpret-10">
+        <webwork xml:id="webwork-ex-deriv-interpret-10">
           <statement>
             <p>
               <m>P</m> is the profit, in thousands of dollars,
@@ -1045,7 +1045,7 @@
       </exercise>
 
       <exercise label="ex-deriv-interpret-11">
-        <webwork xml:id="ex-deriv-interpret-11">
+        <webwork xml:id="webwork-ex-deriv-interpret-11">
           <statement>
             <p>
               <m>T</m> is the temperature in degrees Fahrenheit,
@@ -1117,7 +1117,7 @@
         </introduction>
 
         <exercise label="ex-deriv-interpret-graph-1">
-          <webwork xml:id="ex-deriv-interpret-graph-1">
+          <webwork xml:id="webwork-ex-deriv-interpret-graph-1">
             <pg-code>
               $h=non_zero_random(-2,2,1);
               $k=non_zero_random(-2,2,1);
@@ -1177,7 +1177,7 @@
         </exercise>
 
         <exercise label="ex-deriv-interpret-graph-2">
-          <webwork xml:id="ex-deriv-interpret-graph-2">
+          <webwork xml:id="webwork-ex-deriv-interpret-graph-2">
             <pg-code>
               ($r,$s,$t)=num_sort((-3..3)[NchooseK(7,3)]);
               $a=non_zero_random(-1,1,0.05);
@@ -1237,7 +1237,7 @@
         </exercise>
 
         <exercise label="ex-deriv-interpret-graph-3">
-          <webwork xml:id="ex-deriv-interpret-graph-3">
+          <webwork xml:id="webwork-ex-deriv-interpret-graph-3">
             <pg-code>
               $gr=init_graph(-5,-5,5,5,axes=>[0,0],size=>[400,240],grid=>[10,10]);
               $gr->lb('reset');
@@ -1266,7 +1266,7 @@
         </exercise>
 
         <exercise label="ex-deriv-interpret-graph-4">
-          <webwork xml:id="ex-deriv-interpret-graph-4">
+          <webwork xml:id="webwork-ex-deriv-interpret-graph-4">
             <pg-code>
               $h=random(-2,2,1);
               $p=random(2,4,1);
@@ -1320,7 +1320,7 @@
         </introduction>
 
         <exercise label="ex-deriv-interpret-review-1">
-          <webwork xml:id="ex-deriv-interpret-review-1">
+          <webwork xml:id="webwork-ex-deriv-interpret-review-1">
             <pg-code>
               $answer = Formula("10x");
               $showwork = '[@ explanation_box(message => "Show your work using the definition of the derivative.") @]*';
@@ -1340,7 +1340,7 @@
         </exercise>
 
         <exercise label="ex-deriv-interpret-review-2">
-          <webwork xml:id="ex-deriv-interpret-review-2">
+          <webwork xml:id="webwork-ex-deriv-interpret-review-2">
             <pg-code>
               $answer = Formula("3(x-2)^2");
               $showwork = '[@ explanation_box(message => "Show your work using the definition of the derivative.") @]*';
@@ -1367,7 +1367,7 @@
           </p>
         </introduction>
         <exercise label="ex-deriv-interpret-review-3">
-          <webwork xml:id="ex-deriv-interpret-review-3">
+          <webwork xml:id="webwork-ex-deriv-interpret-review-3">
             <pg-code>
               $ans=0;
             </pg-code>
@@ -1383,7 +1383,7 @@
         </exercise>
 
         <exercise label="ex-deriv-interpret-review-4">
-          <webwork xml:id="ex-deriv-interpret-review-4">
+          <webwork xml:id="webwork-ex-deriv-interpret-review-4">
             <pg-code>
               $r=list_random([2,2],[3,2],[4,2],[5,2],[6,2],[7,2],[8,2],[9,2],[2,3],[3,3],[4,3],[2,5],[2,6]);
               if($envir{problemSeed}==1){$r=[3,2];};

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -1460,7 +1460,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-deriv-intro-1">
-        <webwork xml:id="TaC-deriv-intro-1">
+        <webwork xml:id="webwork-TaC-deriv-intro-1">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -1476,7 +1476,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-intro-2">
-        <webwork xml:id="TaC-deriv-intro-2">
+        <webwork xml:id="webwork-TaC-deriv-intro-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -1491,7 +1491,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-intro-3">
-        <webwork xml:id="TaC-deriv-intro-3">
+        <webwork xml:id="webwork-TaC-deriv-intro-3">
           <statement>
             <p>
               In your own words,
@@ -1505,7 +1505,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-intro-4">
-        <webwork xml:id="TaC-deriv-intro-4">
+        <webwork xml:id="webwork-TaC-deriv-intro-4">
           <statement>
             <p>
               In your own words,
@@ -1520,7 +1520,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-intro-5">
-        <webwork xml:id="TaC-deriv-intro-5">
+        <webwork xml:id="webwork-TaC-deriv-intro-5">
           <statement>
             <p>
               Let <m>y=f(x)</m>.
@@ -1534,7 +1534,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-intro-6">
-        <webwork xml:id="TaC-deriv-intro-6">
+        <webwork xml:id="webwork-TaC-deriv-intro-6">
           <statement>
             <p>
               If two lines are perpendicular,
@@ -1565,7 +1565,7 @@
         </introduction>
 
         <exercise xml:id="exer_derivative_definition_constant" label="ex-deriv-intro-definition-constant">
-          <webwork xml:id="ex-deriv-intro-definition-constant">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-constant">
             <pg-code>
               $d = Formula('0');
               $showwork = '[@ explanation_box(message => "Show your work.") @]*';
@@ -1585,7 +1585,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-definition-linear">
-          <webwork xml:id="ex-deriv-intro-definition-linear">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-linear">
             <pg-code>
               $d = Formula('2');
               $showwork = '[@ explanation_box(message => "Show your work.") @]*';
@@ -1605,7 +1605,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-definition-linear-2">
-          <webwork xml:id="ex-deriv-intro-definition-linear-2">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-linear-2">
             <pg-code>
               Context()->variables->are(t=>'Real');
               $d = Formula('-3');
@@ -1626,7 +1626,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-definition-square">
-          <webwork xml:id="ex-deriv-intro-definition-square">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-square">
             <pg-code>
               $d = Formula('2x');
               $showwork = '[@ explanation_box(message => "Show your work.") @]*';
@@ -1646,7 +1646,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-definition-cube">
-          <webwork xml:id="ex-deriv-intro-definition-cube">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-cube">
             <pg-code>
               $d = Formula('3x^2');
               $showwork = '[@ explanation_box(message => "Show your work.") @]*';
@@ -1666,7 +1666,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-definition-quadratic">
-          <webwork xml:id="ex-deriv-intro-definition-quadratic">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-quadratic">
             <pg-code>
               $d = Formula('6x-1');
               $showwork = '[@ explanation_box(message => "Show your work.") @]*';
@@ -1686,7 +1686,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-definition-reciprocal">
-          <webwork xml:id="ex-deriv-intro-definition-reciprocal">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-reciprocal">
             <pg-code>
               $d = Formula('-1/x^2');
               $showwork = '[@ explanation_box(message => "Show your work.") @]*';
@@ -1706,7 +1706,7 @@
         </exercise>
 
         <exercise xml:id="exer_derivative_definition_fractional_linear" label="ex-deriv-intro-definition-frac-linear">
-          <webwork xml:id="ex-deriv-intro-definition-frac-linear">
+          <webwork xml:id="webwork-ex-deriv-intro-definition-frac-linear">
             <pg-code>
               Context()->variables->are(s=>'Real');
               $d = Formula('-1/(s-2)^2');
@@ -1738,7 +1738,7 @@
         </introduction>
 
         <exercise label="ex-deriv-intro-def-tangent-1">
-          <webwork xml:id="ex-deriv-intro-def-tangent-1">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-1">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1766,7 +1766,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-2">
-          <webwork xml:id="ex-deriv-intro-def-tangent-2">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-2">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1794,7 +1794,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-3">
-          <webwork xml:id="ex-deriv-intro-def-tangent-3">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-3">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1822,7 +1822,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-4">
-          <webwork xml:id="ex-deriv-intro-def-tangent-4">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-4">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1850,7 +1850,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-5">
-          <webwork xml:id="ex-deriv-intro-def-tangent-5">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-5">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1878,7 +1878,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-6">
-          <webwork xml:id="ex-deriv-intro-def-tangent-6">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-6">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1906,7 +1906,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-7">
-          <webwork xml:id="ex-deriv-intro-def-tangent-7">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-7">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1934,7 +1934,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-def-tangent-8">
-          <webwork xml:id="ex-deriv-intro-def-tangent-8">
+          <webwork xml:id="webwork-ex-deriv-intro-def-tangent-8">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -1972,7 +1972,7 @@
         </introduction>
 
         <exercise label="ex-deriv-intro-approx-1">
-          <webwork xml:id="ex-deriv-intro-approx-1">
+          <webwork xml:id="webwork-ex-deriv-intro-approx-1">
             <pg-code>
               $b=non_zero_random(-5,5,1);
               $c=non_zero_random(-9,9,1);
@@ -1998,7 +1998,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-approx-2">
-          <webwork xml:id="ex-deriv-intro-approx-2">
+          <webwork xml:id="webwork-ex-deriv-intro-approx-2">
             <pg-code>
               $b=non_zero_random(-10,10,1);
               $c=non_zero_random(-9,9,1);
@@ -2024,7 +2024,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-approx-3">
-          <webwork xml:id="ex-deriv-intro-approx-3">
+          <webwork xml:id="webwork-ex-deriv-intro-approx-3">
             <pg-code>
               $a=non_zero_random(-5,5,1);
               if($envir{problemSeed}==1){$a=2;};
@@ -2048,7 +2048,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-approx-4">
-          <webwork xml:id="ex-deriv-intro-approx-4">
+          <webwork xml:id="webwork-ex-deriv-intro-approx-4">
             <pg-code>
               Context("ImplicitPlane");
               Context()->variables->are(x=>'Real',y=>'Real');
@@ -2067,7 +2067,7 @@
       </exercisegroup>
 
       <exercise label="ex-deriv-intro-graph-approx-1">
-        <webwork xml:id="ex-deriv-intro-graph-approx-1">
+        <webwork xml:id="webwork-ex-deriv-intro-graph-approx-1">
           <pg-code>
             $gr = init_graph(-3,-2,3,4,axes=>[0,0],grid=>[6,6],size=>[400,240]);
             $gr->lb('reset');
@@ -2146,7 +2146,7 @@
       </exercise>
 
       <exercise label="ex-deriv-intro-graph-approx-2">
-        <webwork xml:id="ex-deriv-intro-graph-approx-2">
+        <webwork xml:id="webwork-ex-deriv-intro-graph-approx-2">
           <pg-code>
             $gr = init_graph(-1,-1,3,6,axes=>[0,0],grid=>[4,7],size=>[400,240]);
             $gr->lb('reset');
@@ -2317,7 +2317,7 @@
           </p>
         </introduction>
         <exercise label="ex-deriv-intro-graph-interpret-1">
-          <webwork xml:id="ex-deriv-intro-graph-interpret-1">
+          <webwork xml:id="webwork-ex-deriv-intro-graph-interpret-1">
             <pg-code>
               $gr = init_graph(-3,-5,3,5,axes=>[0,0],size=>[400,240]);
               add_functions($gr, "-3*(x+1)^2+3 for x in &lt;-2.75,-1> using color:blue and weight:2");
@@ -2399,7 +2399,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-graph-interpret-2">
-          <webwork xml:id="ex-deriv-intro-graph-interpret-2">
+          <webwork xml:id="webwork-ex-deriv-intro-graph-interpret-2">
             <pg-code>
               $gr = init_graph(-3,-10,3,5,axes=>[0,0],grid=>[6,15],size=>[400,240]);
               add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2> using color:blue and weight:2");
@@ -2487,7 +2487,7 @@
         </introduction>
 
         <exercise label="ex-deriv-intro-domain-1">
-          <webwork xml:id="ex-deriv-intro-domain-1">
+          <webwork xml:id="webwork-ex-deriv-intro-domain-1">
             <pg-code>
               $isisnot = PopUp(['?','yes','no'],2);
             </pg-code>
@@ -2520,7 +2520,7 @@
         </exercise>
 
         <exercise label="ex-deriv-intro-domain-2">
-          <webwork xml:id="ex-deriv-intro-domain-2">
+          <webwork xml:id="webwork-ex-deriv-intro-domain-2">
             <pg-code>
               $isisnot = PopUp(['?','yes','no'],1);
             </pg-code>
@@ -2554,7 +2554,7 @@
       <title>Review</title>
 
       <exercise label="ex-deriv-intro-review-1">
-        <webwork xml:id="ex-deriv-intro-review-1">
+        <webwork xml:id="webwork-ex-deriv-intro-review-1">
           <pg-code>
             ($r,$s,$t) = (-9..-1,1..9)[NchooseK(18,3)];
             $t += non_zero_random(-0.5,0.5,0.1);
@@ -2583,7 +2583,7 @@
       </exercise>
 
       <exercise label="ex-deriv-intro-review-2">
-        <webwork xml:id="ex-deriv-intro-review-2">
+        <webwork xml:id="webwork-ex-deriv-intro-review-2">
           <pg-code>
             $a=non_zero_random(-4,4,1);
             $low = int(($a)**2/3)+1;
@@ -2623,7 +2623,7 @@
       </exercise>
 
       <exercise label="ex-deriv-intro-review-3">
-        <webwork xml:id="ex-deriv-intro-review-3">
+        <webwork xml:id="webwork-ex-deriv-intro-review-3">
           <pg-code>
             $a=random(1,9,1);
             $b=list_random(2,3,5,6,7,11,13);
@@ -2689,7 +2689,7 @@
       </exercise>
 
       <exercise label="ex-deriv-intro-review-4">
-        <webwork xml:id="ex-deriv-intro-review-4">
+        <webwork xml:id="webwork-ex-deriv-intro-review-4">
           <pg-code>
             $gr = init_graph(-5,-1,1,4,axes=>[0,0],grid=>[6,5],size=>[400,240]);
             add_functions($gr, "(x+3)^2 +1 for x in &lt;-5,-3) using color:blue and weight:2");

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -662,7 +662,7 @@
     <subexercises xml:id="TaC-deriv-inverse">
       <title>Terms and Concepts</title>
       <exercise label="TaC-deriv-inverse-1">
-        <webwork xml:id="TaC-deriv-inverse-1">
+        <webwork xml:id="webwork-TaC-deriv-inverse-1">
           <pg-code>
             $tf=PopUp(['?','True','False'],2);
           </pg-code>
@@ -676,7 +676,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-inverse-2">
-        <webwork xml:id="TaC-deriv-inverse-2">
+        <webwork xml:id="webwork-TaC-deriv-inverse-2">
           <statement>
             <p>
               In your own words explain what it means for a function to be <q>one-to-one.</q>
@@ -689,7 +689,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-inverse-3">
-        <webwork xml:id="TaC-deriv-inverse-3">
+        <webwork xml:id="webwork-TaC-deriv-inverse-3">
           <statement>
             <p>
               If <m>(1,10)</m> lies on the graph of <m>y=f(x)</m>,
@@ -709,7 +709,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-inverse-4">
-        <webwork xml:id="TaC-deriv-inverse-4">
+        <webwork xml:id="webwork-TaC-deriv-inverse-4">
           <statement>
             <p>
               If <m>(1,10)</m> lies on the graph of <m>y=f(x)</m> and <m>\fp(1) = 5</m>,
@@ -740,7 +740,7 @@
         </introduction>
 
         <exercise label="ex-deriv-inverse-verify-1">
-          <webwork xml:id="ex-deriv-inverse-verify-1">
+          <webwork xml:id="webwork-ex-deriv-inverse-verify-1">
             <statement>
               <p>
                 <m>f(x) = 2x+6</m> and
@@ -759,7 +759,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-verify-2">
-          <webwork xml:id="ex-deriv-inverse-verify-2">
+          <webwork xml:id="webwork-ex-deriv-inverse-verify-2">
             <statement>
               <p>
                 <m>f(x) = x^2+6x+11</m>, <m>x\geq 3</m> and
@@ -778,7 +778,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-verify-3">
-          <webwork xml:id="ex-deriv-inverse-verify-3">
+          <webwork xml:id="webwork-ex-deriv-inverse-verify-3">
             <statement>
               <p>
                 <m>f(x) = \frac{3}{x-5}</m>, <m>x\neq 5</m> and
@@ -797,7 +797,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-verify-4">
-          <webwork xml:id="ex-deriv-inverse-verify-4">
+          <webwork xml:id="webwork-ex-deriv-inverse-verify-4">
             <statement>
               <p>
                 <m>f(x) = \frac{x+1}{x-1}</m>, <m>x\neq 1</m> and
@@ -826,7 +826,7 @@
         </introduction>
 
         <exercise label="ex-deriv-inverse-evaluate-1">
-          <webwork xml:id="ex-deriv-inverse-evaluate-1">
+          <webwork xml:id="webwork-ex-deriv-inverse-evaluate-1">
             <pg-code>
               Context("Fraction");
               ($m,$b,$x0) = (2..10)[NchooseK(9,3)];
@@ -849,7 +849,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-evaluate-2">
-          <webwork xml:id="ex-deriv-inverse-evaluate-2">
+          <webwork xml:id="webwork-ex-deriv-inverse-evaluate-2">
             <pg-code>
               Context("Fraction");
               ($h,$c,$x0) = (-9..-1,1..9)[NchooseK(18,3)];
@@ -874,7 +874,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-evaluate-3">
-          <webwork xml:id="ex-deriv-inverse-evaluate-3">
+          <webwork xml:id="webwork-ex-deriv-inverse-evaluate-3">
             <pg-code>
               Context("Fraction")->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $n = random(2,4,1);
@@ -926,7 +926,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-evaluate-4">
-          <webwork xml:id="ex-deriv-inverse-evaluate-4">
+          <webwork xml:id="webwork-ex-deriv-inverse-evaluate-4">
             <pg-code>
               Context("Fraction");
               ($h,$k,$c) = (-9..-1,1..9)[NchooseK(18,3)];
@@ -952,7 +952,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-evaluate-5">
-          <webwork xml:id="ex-deriv-inverse-evaluate-5">
+          <webwork xml:id="webwork-ex-deriv-inverse-evaluate-5">
             <pg-code>
               Context("Fraction");
               $n = random(2,5,1);
@@ -978,7 +978,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-evaluate-6">
-          <webwork xml:id="ex-deriv-inverse-evaluate-6">
+          <webwork xml:id="webwork-ex-deriv-inverse-evaluate-6">
             <pg-code>
               Context("Fraction");
               ($a,$k) = (2..9)[NchooseK(8,2)];
@@ -1012,7 +1012,7 @@
         </introduction>
 
         <exercise label="ex-deriv-inverse-compute-1">
-          <webwork xml:id="ex-deriv-inverse-compute-1">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-1">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1038,7 +1038,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-2">
-          <webwork xml:id="ex-deriv-inverse-compute-2">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-2">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1064,7 +1064,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-3">
-          <webwork xml:id="ex-deriv-inverse-compute-3">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-3">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1089,7 +1089,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-4">
-          <webwork xml:id="ex-deriv-inverse-compute-4">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-4">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1114,7 +1114,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-5">
-          <webwork xml:id="ex-deriv-inverse-compute-5">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-5">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1139,7 +1139,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-6">
-          <webwork xml:id="ex-deriv-inverse-compute-6">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-6">
             <pg-code>
               Context()->variables->are(t=>'Real');
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1158,7 +1158,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-7">
-          <webwork xml:id="ex-deriv-inverse-compute-7">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-7">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1183,7 +1183,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-8">
-          <webwork xml:id="ex-deriv-inverse-compute-8">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-8">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1215,7 +1215,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-9">
-          <webwork xml:id="ex-deriv-inverse-compute-9">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-9">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1241,7 +1241,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-compute-10">
-          <webwork xml:id="ex-deriv-inverse-compute-10">
+          <webwork xml:id="webwork-ex-deriv-inverse-compute-10">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p','m');
               $x = list_random('q','r','t','x','y','z','w');
@@ -1291,7 +1291,7 @@
         </introduction>
 
         <exercise label="ex-deriv-inverse-two-ways-1">
-          <webwork xml:id="ex-deriv-inverse-two-ways-1">
+          <webwork xml:id="webwork-ex-deriv-inverse-two-ways-1">
             <statement>
               <p>
                 <m>f(x)=\sin(\sin^{-1}(x))</m>
@@ -1320,7 +1320,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-two-ways-2">
-          <webwork xml:id="ex-deriv-inverse-two-ways-2">
+          <webwork xml:id="webwork-ex-deriv-inverse-two-ways-2">
             <statement>
               <p>
                 <m>f(x)=\tan^{-1}(\tan(x))</m>
@@ -1353,7 +1353,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-two-ways-3">
-          <webwork xml:id="ex-deriv-inverse-two-ways-3">
+          <webwork xml:id="webwork-ex-deriv-inverse-two-ways-3">
             <statement>
               <p>
                 <m>f(x)=\sin(\cos^{-1}(x))</m>
@@ -1382,7 +1382,7 @@
         </exercise>
 
         <exercise label="ex-deriv-inverse-two-ways-4">
-          <webwork xml:id="ex-deriv-inverse-two-ways-4">
+          <webwork xml:id="webwork-ex-deriv-inverse-two-ways-4">
             <statement>
               <p>
                 <m>f(x)=\sin(2\sin^{-1}(x))</m>
@@ -1429,7 +1429,7 @@
           </p>
         </introduction>
         <exercise label="deriv-inverse-tangent-1">
-          <webwork xml:id="deriv-inverse-tangent-1">
+          <webwork xml:id="webwork-deriv-inverse-tangent-1">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1467,7 +1467,7 @@
         </exercise>
 
         <exercise label="deriv-inverse-tangent-2">
-          <webwork xml:id="deriv-inverse-tangent-2">
+          <webwork xml:id="webwork-deriv-inverse-tangent-2">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1511,7 +1511,7 @@
     <subexercises>
       <title>Review</title>
       <exercise label="deriv-inverse-review-1">
-        <webwork xml:id="deriv-inverse-review-1">
+        <webwork xml:id="webwork-deriv-inverse-review-1">
           <pg-code>
             Context()->variables->add(y=>'Real');
             ($m,$n) = (1..4)[NchooseK(4,2)];
@@ -1535,7 +1535,7 @@
       </exercise>
 
       <exercise label="deriv-inverse-review-2">
-        <webwork xml:id="deriv-inverse-review-2">
+        <webwork xml:id="webwork-deriv-inverse-review-2">
           <pg-code>
             Context("Fraction");
             Context()->variables->add(y=>'Real');
@@ -1565,7 +1565,7 @@
       </exercise>
 
       <exercise label="deriv-inverse-review-3">
-        <webwork xml:id="deriv-inverse-review-3">
+        <webwork xml:id="webwork-deriv-inverse-review-3">
           <pg-code>
             $n = random(3,4,1);
             $b = non_zero_random(-2,2,1);

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -770,7 +770,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-deriv-prodquot-1">
-        <webwork xml:id="TaC-deriv-prodquot-1">
+        <webwork xml:id="webwork-TaC-deriv-prodquot-1">
           <pg-code>
             $t=PopUp(['?','True','False'],1);
             $f=PopUp(['?','True','False'],2);
@@ -785,7 +785,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-prodquot-2">
-        <webwork xml:id="TaC-deriv-prodquot-2">
+        <webwork xml:id="webwork-TaC-deriv-prodquot-2">
           <pg-code>
             $t=PopUp(['?','True','False'],1);
             $f=PopUp(['?','True','False'],2);
@@ -800,7 +800,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-prodquot-3">
-        <webwork xml:id="TaC-deriv-prodquot-3">
+        <webwork xml:id="webwork-TaC-deriv-prodquot-3">
           <pg-code>
             $t=PopUp(['?','True','False'],1);
             $f=PopUp(['?','True','False'],2);
@@ -816,7 +816,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-prodquot-4">
-        <webwork xml:id="TaC-deriv-prodquot-4">
+        <webwork xml:id="webwork-TaC-deriv-prodquot-4">
           <pg-code>
             Context()->strings->add('the quotient rule'=>{});
             Context()->strings->add(
@@ -837,7 +837,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-prodquot-5">
-        <webwork xml:id="TaC-deriv-prodquot-5">
+        <webwork xml:id="webwork-TaC-deriv-prodquot-5">
           <pg-code>
             $t=PopUp(['?','True','False'],1);
             $f=PopUp(['?','True','False'],2);
@@ -853,7 +853,7 @@
       </exercise>
 
       <exercise label="TaC-deriv-prodquot-6">
-        <webwork xml:id="TaC-deriv-prodquot-6">
+        <webwork xml:id="webwork-TaC-deriv-prodquot-6">
           <statement>
             <p>
               In your own words,
@@ -888,7 +888,7 @@
         </introduction>
 
         <exercise label="ex-deriv-product-compare-1">
-          <webwork xml:id="ex-deriv-product-compare-1">
+          <webwork xml:id="webwork-ex-deriv-product-compare-1">
             <pg-code>
               $x = 'x';
               Context()->variables->are($x=>'Real');
@@ -907,7 +907,7 @@
         </exercise>
 
         <exercise label="ex-deriv-product-compare-2">
-          <webwork xml:id="ex-deriv-product-compare-2">
+          <webwork xml:id="webwork-ex-deriv-product-compare-2">
             <pg-code>
               $x = 'x';
               Context()->variables->are($x=>'Real');
@@ -926,7 +926,7 @@
         </exercise>
 
         <exercise label="ex-deriv-product-compare-3">
-          <webwork xml:id="ex-deriv-product-compare-3">
+          <webwork xml:id="webwork-ex-deriv-product-compare-3">
             <pg-code>
               $x = 's';
               Context()->variables->are($x=>'Real');
@@ -945,7 +945,7 @@
         </exercise>
 
         <exercise label="ex-deriv-product-compare-4">
-          <webwork xml:id="ex-deriv-product-compare-4">
+          <webwork xml:id="webwork-ex-deriv-product-compare-4">
             <pg-code>
               $x = 'x';
               Context()->variables->are($x=>'Real');
@@ -982,7 +982,7 @@
         </introduction>
 
         <exercise label="ex-deriv-quotient-compare-1">
-          <webwork xml:id="ex-deriv-quotient-compare-1">
+          <webwork xml:id="webwork-ex-deriv-quotient-compare-1">
             <pg-code>
               $x = 'x';
               Context()->variables->are($x=>'Real');
@@ -1001,7 +1001,7 @@
         </exercise>
 
         <exercise label="ex-deriv-quotient-compare-2">
-          <webwork xml:id="ex-deriv-quotient-compare-2">
+          <webwork xml:id="webwork-ex-deriv-quotient-compare-2">
             <pg-code>
               $x = 'x';
               Context()->variables->are($x=>'Real');
@@ -1020,7 +1020,7 @@
         </exercise>
 
         <exercise label="ex-deriv-quotient-compare-3">
-          <webwork xml:id="ex-deriv-quotient-compare-3">
+          <webwork xml:id="webwork-ex-deriv-quotient-compare-3">
             <pg-code>
               $x = 's';
               Context()->variables->are($x=>'Real');
@@ -1039,7 +1039,7 @@
         </exercise>
 
         <exercise label="ex-deriv-quotient-compare-4">
-          <webwork xml:id="ex-deriv-quotient-compare-4">
+          <webwork xml:id="webwork-ex-deriv-quotient-compare-4">
             <pg-code>
               $x = 't';
               Context()->variables->are($x=>'Real');
@@ -1066,7 +1066,7 @@
         </introduction>
 
         <exercise label="ex-deriv-prodquot-compute-1">
-          <webwork xml:id="ex-deriv-prodquot-compute-1">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-1">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1088,7 +1088,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-2">
-          <webwork xml:id="ex-deriv-prodquot-compute-2">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-2">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1111,7 +1111,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-3">
-          <webwork xml:id="ex-deriv-prodquot-compute-3">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-3">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1132,7 +1132,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-4">
-          <webwork xml:id="ex-deriv-prodquot-compute-4">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-4">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1156,7 +1156,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-5">
-          <webwork xml:id="ex-deriv-prodquot-compute-5">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-5">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1178,7 +1178,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-6">
-          <webwork xml:id="ex-deriv-prodquot-compute-6">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-6">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1203,7 +1203,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-7">
-          <webwork xml:id="ex-deriv-prodquot-compute-7">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-7">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1227,7 +1227,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-8">
-          <webwork xml:id="ex-deriv-prodquot-compute-8">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-8">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1249,7 +1249,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-9">
-          <webwork xml:id="ex-deriv-prodquot-compute-9">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-9">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1273,7 +1273,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-10">
-          <webwork xml:id="ex-deriv-prodquot-compute-10">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-10">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1296,7 +1296,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-11">
-          <webwork xml:id="ex-deriv-prodquot-compute-11">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-11">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1318,7 +1318,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-12">
-          <webwork xml:id="ex-deriv-prodquot-compute-12">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-12">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1341,7 +1341,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-13">
-          <webwork xml:id="ex-deriv-prodquot-compute-13">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-13">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1364,7 +1364,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-14">
-          <webwork xml:id="ex-deriv-prodquot-compute-14">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-14">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1387,7 +1387,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-15">
-          <webwork xml:id="ex-deriv-prodquot-compute-15">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-15">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1410,7 +1410,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-16">
-          <webwork xml:id="ex-deriv-prodquot-compute-16">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-16">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               Context()->variables->are(theta=>['Real',TeX=>'\theta']);
@@ -1436,7 +1436,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-17">
-          <webwork xml:id="ex-deriv-prodquot-compute-17">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-17">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1458,7 +1458,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-18">
-          <webwork xml:id="ex-deriv-prodquot-compute-18">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-18">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1483,7 +1483,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-19">
-          <webwork xml:id="ex-deriv-prodquot-compute-19">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-19">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1507,7 +1507,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-20">
-          <webwork xml:id="ex-deriv-prodquot-compute-20">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-20">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1531,7 +1531,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-21">
-          <webwork xml:id="ex-deriv-prodquot-compute-21">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-21">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1555,7 +1555,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-compute-22">
-          <webwork xml:id="ex-deriv-prodquot-compute-22">
+          <webwork xml:id="webwork-ex-deriv-prodquot-compute-22">
             <pg-code>
               $fname = list_random('f','g','h','j','k','p');
               $x = list_random('q','r','t','x','y','z');
@@ -1586,7 +1586,7 @@
         </introduction>
 
         <exercise label="ex-deriv-prodquot-tangent-1">
-          <webwork xml:id="ex-deriv-prodquot-tangent-1">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-1">
             <pg-code>
               $n = random(2,3,1);
               $a = list_random(-9..-1,1..9);
@@ -1629,7 +1629,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-tangent-2">
-          <webwork xml:id="ex-deriv-prodquot-tangent-2">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-2">
             <pg-code>
               Context()->flags->set(reduceConstants=>0);
               $trig = list_random('sin','cos','tan','cot','sec','csc');
@@ -1682,7 +1682,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-tangent-3">
-          <webwork xml:id="ex-deriv-prodquot-tangent-3">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-3">
             <pg-code>
               $a = list_random(-9..-1,1..9);
               $x0=$a+list_random(-2,-1,1,2);
@@ -1724,7 +1724,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-tangent-4">
-          <webwork xml:id="ex-deriv-prodquot-tangent-4">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-4">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               $trig = list_random('cos','sin');
@@ -1775,7 +1775,7 @@
         </introduction>
 
         <exercise label="ex-deriv-prodquot-tangent-horiz-1">
-          <webwork xml:id="ex-deriv-prodquot-tangent-horiz-1">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-horiz-1">
             <pg-code>
               Context("Fraction");
               Context()->noreduce('(-x)+y','(-x)-y');
@@ -1803,7 +1803,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-tangent-horiz-2">
-          <webwork xml:id="ex-deriv-prodquot-tangent-horiz-2">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-horiz-2">
             <pg-code>
               $points = List("0");
             </pg-code>
@@ -1824,7 +1824,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-tangent-horiz-3">
-          <webwork xml:id="ex-deriv-prodquot-tangent-horiz-3">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-horiz-3">
             <pg-code>
               Context("Fraction");
               Context()->noreduce('(-x)+y','(-x)-y');
@@ -1850,7 +1850,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-tangent-horiz-4">
-          <webwork xml:id="ex-deriv-prodquot-tangent-horiz-4">
+          <webwork xml:id="webwork-ex-deriv-prodquot-tangent-horiz-4">
             <pg-code>
               Context("Fraction");
               Context()->noreduce('(-x)+y','(-x)-y');
@@ -1885,7 +1885,7 @@
         </introduction>
 
         <exercise label="ex-deriv-prodquot-higher-1">
-          <webwork xml:id="ex-deriv-prodquot-higher-1">
+          <webwork xml:id="webwork-ex-deriv-prodquot-higher-1">
             <pg-code>
               $answer=Formula("2cos(x)-x*sin(x)");
             </pg-code>
@@ -1901,7 +1901,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-higher-2">
-          <webwork xml:id="ex-deriv-prodquot-higher-2">
+          <webwork xml:id="webwork-ex-deriv-prodquot-higher-2">
             <pg-code>
               $answer=Formula("-4cos(x)+x*sin(x)");
             </pg-code>
@@ -1917,7 +1917,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-higher-3">
-          <webwork xml:id="ex-deriv-prodquot-higher-3">
+          <webwork xml:id="webwork-ex-deriv-prodquot-higher-3">
             <pg-code>
               $trig = list_random('csc','cot','sec','tan');
               if($envir{problemSeed}==1){$trig = 'csc'};
@@ -1936,7 +1936,7 @@
         </exercise>
 
         <exercise label="ex-deriv-prodquot-higher-4">
-          <webwork xml:id="ex-deriv-prodquot-higher-4">
+          <webwork xml:id="webwork-ex-deriv-prodquot-higher-4">
             <pg-code>
               ($a,$b,$c,$d) = (-9..-1,1..9)[NchooseK(18,4)];
               $n = random(7,9,1);

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -643,7 +643,7 @@
     <subexercises xml:id="TaC-differentials">
       <title>Terms and Concepts</title>
       <exercise label="TaC-differentials-1">
-        <webwork xml:id="TaC-differentials-1">
+        <webwork xml:id="webwork-TaC-differentials-1">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -660,7 +660,7 @@
       </exercise>
 
       <exercise label="TaC-differentials-2">
-        <webwork xml:id="TaC-differentials-2">
+        <webwork xml:id="webwork-TaC-differentials-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -676,7 +676,7 @@
       </exercise>
 
       <exercise label="TaC-differentials-3">
-        <webwork xml:id="TaC-differentials-3">
+        <webwork xml:id="webwork-TaC-differentials-3">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -692,7 +692,7 @@
       </exercise>
 
       <exercise label="TaC-differentials-4">
-        <webwork xml:id="TaC-differentials-4">
+        <webwork xml:id="webwork-TaC-differentials-4">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -707,7 +707,7 @@
       </exercise>
 
       <exercise label="TaC-differentials-5">
-        <webwork xml:id="TaC-differentials-5">
+        <webwork xml:id="webwork-TaC-differentials-5">
           <statement>
             <p>
               How are differentials and tangent lines related?
@@ -720,7 +720,7 @@
       </exercise>
 
       <exercise label="TaC-differentials-6">
-        <webwork xml:id="TaC-differentials-6">
+        <webwork xml:id="webwork-TaC-differentials-6">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -748,7 +748,7 @@
         </introduction>
         <!-- Exercises 7 & 8: Square function -->
         <exercise label="ex-differentials-approximate-1">
-          <webwork xml:id="ex-differentials-approximate-1">
+          <webwork xml:id="webwork-ex-differentials-approximate-1">
             <pg-code>
               $x0 = random(2,9,1);
               $dx = random(0.03,0.09,0.01);
@@ -784,7 +784,7 @@
           </webwork>
         </exercise>
         <exercise label="ex-differentials-approximate-2">
-          <webwork xml:id="ex-differentials-approximate-2">
+          <webwork xml:id="webwork-ex-differentials-approximate-2">
             <pg-code>
               $x0 = random(2,9,1);
               $dx = -random(0.03,0.09,0.01);
@@ -821,7 +821,7 @@
         </exercise>
         <!-- Exercises 9 & 10: Cube function -->
         <exercise label="ex-differentials-approximate-3">
-          <webwork xml:id="ex-differentials-approximate-3">
+          <webwork xml:id="webwork-ex-differentials-approximate-3">
             <pg-code>
               $x0 = random(2,9,1);
               $dx = random(0.1,0.4,0.1);
@@ -857,7 +857,7 @@
           </webwork>
         </exercise>
         <exercise label="ex-differentials-approximate-4">
-          <webwork xml:id="ex-differentials-approximate-4">
+          <webwork xml:id="webwork-ex-differentials-approximate-4">
             <pg-code>
               $x0 = random(2,9,1);
               $dx = -random(0.1,0.4,0.1);
@@ -894,7 +894,7 @@
         </exercise>
         <!-- Exercises 11 & 12: Square root function -->
         <exercise label="ex-differentials-approximate-5">
-          <webwork xml:id="ex-differentials-approximate-5">
+          <webwork xml:id="webwork-ex-differentials-approximate-5">
             <pg-code>
               $x0 = list_random(9,16,25,36,49);
               $dx = random(0.3,0.9,0.1);
@@ -930,7 +930,7 @@
           </webwork>
         </exercise>
         <exercise label="ex-differentials-approximate-6">
-          <webwork xml:id="ex-differentials-approximate-6">
+          <webwork xml:id="webwork-ex-differentials-approximate-6">
             <pg-code>
               $x0 = list_random(9,16,25,36,49);
               $dx = -random(0.3,1.5,0.1);
@@ -967,7 +967,7 @@
         </exercise>
         <!-- Exercises 13 & 14: Cube root -->
         <exercise label="ex-differentials-approximate-7">
-          <webwork xml:id="ex-differentials-approximate-7">
+          <webwork xml:id="webwork-ex-differentials-approximate-7">
             <pg-code>
               $x0 = list_random(8,27,64,125,216);
               $dx = -random(0.3,1.5,0.1);
@@ -1004,7 +1004,7 @@
           </webwork>
         </exercise>
         <exercise label="ex-differentials-approximate-8">
-          <webwork xml:id="ex-differentials-approximate-8">
+          <webwork xml:id="webwork-ex-differentials-approximate-8">
             <pg-code>
               $x0 = list_random(8,27,64,125,216);
               $dx = random(0.3,1.5,0.1);
@@ -1042,7 +1042,7 @@
         </exercise>
         <!-- Exercise 15: sin(x) -->
         <exercise label="ex-differentials-approximate-9">
-          <webwork xml:id="ex-differentials-approximate-9">
+          <webwork xml:id="webwork-ex-differentials-approximate-9">
             <pg-code>
               $x0 = Compute("pi");
               $dx = 3-$x0;
@@ -1078,7 +1078,7 @@
         </exercise>
         <!-- Exercise 16: e^x -->
         <exercise label="ex-differentials-approximate-10">
-          <webwork xml:id="ex-differentials-approximate-10">
+          <webwork xml:id="webwork-ex-differentials-approximate-10">
             <pg-code>
               $x0 = 0;
               $dx = random(0.1,0.5,0.1);
@@ -1124,7 +1124,7 @@
           </p>
         </introduction>
         <exercise label="ex-differential-compute-1">
-          <webwork xml:id="ex-differential-compute-1">
+          <webwork xml:id="webwork-ex-differential-compute-1">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               $c = non_zero_random(-9,9,1);
@@ -1146,7 +1146,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-differential-compute-2">
-          <webwork xml:id="ex-differential-compute-2">
+          <webwork xml:id="webwork-ex-differential-compute-2">
             <pg-code>
               ($m,$n) = (3..9)[NchooseK(7,2)];
               $c = list_random(1,-1);
@@ -1168,7 +1168,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-differential-compute-3">
-          <webwork xml:id="ex-differential-compute-3">
+          <webwork xml:id="webwork-ex-differential-compute-3">
             <pg-code>
               ($m,$n) = (1..9)[NchooseK(9,2)];
               if($envir{problemSeed}==1){$m=4;$n=2;};
@@ -1189,7 +1189,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-differential-compute-4">
-          <webwork xml:id="ex-differential-compute-4">
+          <webwork xml:id="webwork-ex-differential-compute-4">
             <pg-code>
               $a = random(2,9,1);
               $n = random(2,3,1);
@@ -1211,7 +1211,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-differential-compute-5">
-          <webwork xml:id="ex-differential-compute-5">
+          <webwork xml:id="webwork-ex-differential-compute-5">
             <pg-code>
               ($m,$n) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$m=2;$n=3;};
@@ -1232,7 +1232,7 @@
         </exercise>
         <!-- Exercise 22       -->
         <exercise label="ex-differential-compute-6">
-          <webwork xml:id="ex-differential-compute-6">
+          <webwork xml:id="webwork-ex-differential-compute-6">
             <pg-code>
               $a = random(2,9,1);
               $b = random(2,9,1);
@@ -1254,7 +1254,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-differential-compute-7">
-          <webwork xml:id="ex-differential-compute-7">
+          <webwork xml:id="webwork-ex-differential-compute-7">
             <pg-code>
               $a = random(2,9,1);
               $b = random(1,9,1);
@@ -1276,7 +1276,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-differential-compute-8">
-          <webwork xml:id="ex-differential-compute-8">
+          <webwork xml:id="webwork-ex-differential-compute-8">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=5;};
@@ -1297,7 +1297,7 @@
         </exercise>
         <!-- Exercise 25 -->
         <exercise label="ex-differential-compute-9">
-          <webwork xml:id="ex-differential-compute-9">
+          <webwork xml:id="webwork-ex-differential-compute-9">
             <pg-code>
               $trig = list_random('sin','cos','tan','sec','csc','cot');
               if($envir{problemSeed}==1){$trig='sin';};
@@ -1318,7 +1318,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-differential-compute-10">
-          <webwork xml:id="ex-differential-compute-10">
+          <webwork xml:id="webwork-ex-differential-compute-10">
             <pg-code>
               ($trig1,$trig2) = ('sin','cos','tan','sec','csc','cot')[NchooseK(6,2)];
               if($envir{problemSeed}==1){$trig1='cos';$trig2='sin';};
@@ -1339,7 +1339,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <exercise label="ex-differential-compute-11">
-          <webwork xml:id="ex-differential-compute-11">
+          <webwork xml:id="webwork-ex-differential-compute-11">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$a=1;$b=2;};
@@ -1360,7 +1360,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-differential-compute-12">
-          <webwork xml:id="ex-differential-compute-12">
+          <webwork xml:id="webwork-ex-differential-compute-12">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=3;};
@@ -1381,7 +1381,7 @@
         </exercise>
         <!-- Exercise 29 -->
         <exercise label="ex-differential-compute-13">
-          <webwork xml:id="ex-differential-compute-13">
+          <webwork xml:id="webwork-ex-differential-compute-13">
             <pg-code>
               $fstring = list_random('x ln(x) - x','x arctan(x) - (1/2) ln(1+x^2)');
               if($envir{problemSeed}==1){$fstring='x ln(x) - x';};
@@ -1402,7 +1402,7 @@
         </exercise>
         <!-- Exercise 30 -->
         <exercise label="ex-differential-compute-14">
-          <webwork xml:id="ex-differential-compute-14">
+          <webwork xml:id="webwork-ex-differential-compute-14">
             <pg-code>
               $fstring = list_random('ln(sec(x))','ln(sin(x))',);
               if($envir{problemSeed}==1){$fstring='ln(sec(x))';};
@@ -1425,7 +1425,7 @@
 
       <!-- Exercise 31: Propogated error in a plastic sphere -->
       <exercise label="ex-differentials-error-1">
-        <webwork xml:id="ex-differentials-error-1">
+        <webwork xml:id="webwork-ex-differentials-error-1">
           <pg-code>
             $diameter = random(1,5,1);
             $dx = random(1,$diameter,1);
@@ -1451,7 +1451,7 @@
       </exercise>
       <!-- Exercise 32: Propagated error dropping a stone into a hole -->
       <exercise label="ex-differentials-error-2">
-        <webwork xml:id="ex-differentials-error-2">
+        <webwork xml:id="webwork-ex-differentials-error-2">
           <pg-code>
             $dx = random(1,4,1);
             $a = random(2,4,1);
@@ -1495,7 +1495,7 @@
       </exercise>
       <!-- Exercise 33: Propagated error in cross-sectional area of a log -->
       <exercise label="ex-differentials-error-3">
-        <webwork xml:id="ex-differentials-error-3">
+        <webwork xml:id="webwork-ex-differentials-error-3">
           <pg-code>
             $diameter = random(12,20,1);
             $dx = list_random(2,4,8,16);
@@ -1519,7 +1519,7 @@
       </exercise>
       <!-- Exercise 34: Propagated error in SA of wall -->
       <exercise label="ex-differentials-error-4">
-        <webwork xml:id="ex-differentials-error-4">
+        <webwork xml:id="webwork-ex-differentials-error-4">
           <pg-code>
             $h = random(8,10,1);
             $lft = random(10,20,1);
@@ -1558,7 +1558,7 @@
         </introduction>
         <!-- Exercise 35: Error in length of wall -->
         <exercise xml:id="exer_04_04_ex_35" label="ex-differentials-survey-1">
-           <webwork xml:id="ex-differentials-survey-1">
+           <webwork xml:id="webwork-ex-differentials-survey-1">
             <pg-code>
               $theta = 85.2;
               $d = 25;
@@ -1620,7 +1620,7 @@
         </exercise>
         <!-- Exercise 36: Length of the wall with a different angle and distance -->
         <exercise label="ex-differentials-survey-2">
-           <webwork xml:id="ex-differentials-survey-2">
+           <webwork xml:id="webwork-ex-differentials-survey-2">
             <pg-code>
               $theta = 71.5;
               $d = 100;
@@ -1684,7 +1684,7 @@
         </exercise>
         <!-- Exercise 37: Length of the wall if an isosceles triangle -->
         <exercise xml:id="exer_04_04_ex_37" label="ex-differentials-survey-3">
-           <webwork xml:id="ex-differentials-survey-3">
+           <webwork xml:id="webwork-ex-differentials-survey-3">
             <pg-code>
               $theta = 143;
               $d = 50;
@@ -1748,7 +1748,7 @@
         </exercise>
         <!-- Exercise 37: Compare errors in wall measurements from previous exercises -->
         <exercise label="ex-differentials-survey-4">
-          <webwork xml:id="ex-differentials-survey-4">
+          <webwork xml:id="webwork-ex-differentials-survey-4">
             <pg-code>
               $buttons = RadioButtons(
                 [
@@ -1772,7 +1772,7 @@
         </exercise>
         <!-- Exercise 38: Length of wall if the distance has the error instead of the angle -->
         <exercise label="ex-differentials-survey-5">
-           <webwork xml:id="ex-differentials-survey-5">
+           <webwork xml:id="webwork-ex-differentials-survey-5">
             <pg-code>
               $theta = 143;
               $d = 50;

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1108,7 +1108,7 @@
     <subexercises xml:id="TaC-directional-derivative">
       <title>Terms and Concepts</title>
       <exercise label="TaC-directional-derivative-1">
-        <!-- <webwork xml:id="TaC-directional-derivative-1">
+        <!-- <webwork xml:id="webwork-TaC-directional-derivative-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1127,7 +1127,7 @@
       </exercise>
 
       <exercise label="TaC-directional-derivative-2">
-        <webwork xml:id="TaC-directional-derivative-2">
+        <webwork xml:id="webwork-TaC-directional-derivative-2">
             <pg-code>
               Context("Vector2D");
             </pg-code>
@@ -1146,7 +1146,7 @@
       </exercise>
 
       <exercise label="TaC-directional-derivative-3">
-        <webwork xml:id="TaC-directional-derivative-3">
+        <webwork xml:id="webwork-TaC-directional-derivative-3">
             <pg-code>
               Context("Vector2D");
             </pg-code>
@@ -1165,7 +1165,7 @@
       </exercise>
 
       <exercise label="TaC-directional-derivative-4">
-        <webwork xml:id="TaC-directional-derivative-4">
+        <webwork xml:id="webwork-TaC-directional-derivative-4">
             <pg-code>
               Context()->strings->add('orthogonal'=>{},'perpendicular'=>{alias=>'orthogonal'});
             </pg-code>
@@ -1179,7 +1179,7 @@
       </exercise>
 
       <exercise label="TaC-directional-derivative-5">
-        <!-- <webwork xml:id="TaC-directional-derivative-5">
+        <!-- <webwork xml:id="webwork-TaC-directional-derivative-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1196,7 +1196,7 @@
       </exercise>
 
       <exercise label="TaC-directional-derivative-6">
-        <webwork xml:id="TaC-directional-derivative-6">
+        <webwork xml:id="webwork-TaC-directional-derivative-6">
             <pg-code>
               Context()->strings->add('dot'=>{},'cross'=>{});
             </pg-code>
@@ -1222,7 +1222,7 @@
         </introduction>
 
         <exercise xml:id="x12_05_ex_07" label="ex-directional-derivative-gradient-1">
-          <!-- <webwork xml:id="ex-directional-derivative-gradient-1">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-gradient-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1239,7 +1239,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-gradient-2">
-          <webwork xml:id="ex-directional-derivative-gradient-2">
+          <webwork xml:id="webwork-ex-directional-derivative-gradient-2">
               <pg-code>
                 Context("Vector2D");
                 $gradient=Compute("&lt;cos(x)cos(y),-sin(x)sin(y)>");
@@ -1258,7 +1258,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-gradient-3">
-          <!-- <webwork xml:id="ex-directional-derivative-gradient-3">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-gradient-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1275,7 +1275,7 @@
         </exercise>
 
         <exercise xml:id="x12_05_ex_10" label="ex-directional-derivative-gradient-4">
-          <webwork xml:id="ex-directional-derivative-gradient-4">
+          <webwork xml:id="webwork-ex-directional-derivative-gradient-4">
               <pg-code>
                 Context("Vector2D");
                 $gradient=Compute("&lt;-4,3>");
@@ -1294,7 +1294,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-gradient-5">
-          <!-- <webwork xml:id="ex-directional-derivative-gradient-5">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-gradient-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1311,7 +1311,7 @@
         </exercise>
 
         <exercise xml:id="x12_05_ex_22" label="ex-directional-derivative-gradient-6">
-          <webwork xml:id="ex-directional-derivative-gradient-6">
+          <webwork xml:id="webwork-ex-directional-derivative-gradient-6">
               <pg-code>
                 Context("Vector2D");
                 $gradient=Compute("&lt;2xy^3-2,3x^2y^2>");
@@ -1342,7 +1342,7 @@
         </introduction>
 
         <exercise xml:id="x12_05_ex_11" label="ex-directional-derivative-compute-1">
-          <!-- <webwork xml:id="ex-directional-derivative-compute-1">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-compute-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1393,7 +1393,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-compute-2">
-          <webwork xml:id="ex-directional-derivative-compute-2">
+          <webwork xml:id="webwork-ex-directional-derivative-compute-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $a=Compute("1/4 (1-sqrt(3))");
@@ -1434,7 +1434,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-compute-3">
-          <!-- <webwork xml:id="ex-directional-derivative-compute-3">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-compute-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1485,7 +1485,7 @@
         </exercise>
 
         <exercise xml:id="x12_05_ex_14" label="ex-directional-derivative-compute-4">
-          <webwork xml:id="ex-directional-derivative-compute-4">
+          <webwork xml:id="webwork-ex-directional-derivative-compute-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $a=Compute("-9/sqrt(10)");
@@ -1525,7 +1525,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-compute-5">
-          <!-- <webwork xml:id="ex-directional-derivative-compute-5">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-compute-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1575,7 +1575,7 @@
         </exercise>
 
         <exercise xml:id="x12_05_ex_23" label="ex-directional-derivative-compute-6">
-          <webwork xml:id="ex-directional-derivative-compute-6">
+          <webwork xml:id="webwork-ex-directional-derivative-compute-6">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $a=Compute("3/sqrt(2)");
@@ -1658,7 +1658,7 @@
         </introduction>
 
         <exercise label="ex-directional-derivative-maximum-1">
-          <!-- <webwork xml:id="ex-directional-derivative-maximum-1">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-maximum-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1703,7 +1703,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-maximum-2">
-          <webwork xml:id="ex-directional-derivative-maximum-2">
+          <webwork xml:id="webwork-ex-directional-derivative-maximum-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstants=>0,redcuceConstantFunctions=>0);
@@ -1751,7 +1751,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-maximum-3">
-          <!-- <webwork xml:id="ex-directional-derivative-maximum-3">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-maximum-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1796,7 +1796,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-maximum-4">
-          <webwork xml:id="ex-directional-derivative-maximum-4">
+          <webwork xml:id="webwork-ex-directional-derivative-maximum-4">
               <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstants=>0,redcuceConstantFunctions=>0);
@@ -1843,7 +1843,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-maximum-5">
-          <!-- <webwork xml:id="ex-directional-derivative-maximum-5">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-maximum-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1888,7 +1888,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-maximum-6">
-          <webwork xml:id="ex-directional-derivative-maximum-6">
+          <webwork xml:id="webwork-ex-directional-derivative-maximum-6">
               <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstants=>0,redcuceConstantFunctions=>0);
@@ -1961,7 +1961,7 @@
         </introduction>
 
         <exercise label="ex-directional-derivative-r3-1">
-          <!-- <webwork xml:id="ex-directional-derivative-r3-1">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-r3-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1991,7 +1991,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-r3-2">
-          <webwork xml:id="ex-directional-derivative-r3-2">
+          <webwork xml:id="webwork-ex-directional-derivative-r3-2">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,redcuceConstantFunctions=>0);
@@ -2022,7 +2022,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-r3-3">
-          <!-- <webwork xml:id="ex-directional-derivative-r3-3">
+          <!-- <webwork xml:id="webwork-ex-directional-derivative-r3-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2052,7 +2052,7 @@
         </exercise>
 
         <exercise label="ex-directional-derivative-r3-4">
-          <webwork xml:id="ex-directional-derivative-r3-4">
+          <webwork xml:id="webwork-ex-directional-derivative-r3-4">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,redcuceConstantFunctions=>0);

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -1754,7 +1754,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-volume-disk-1">
-        <!-- <webwork xml:id="TaC-volume-disk-1">
+        <!-- <webwork xml:id="webwork-TaC-volume-disk-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1771,7 +1771,7 @@
       </exercise>
 
       <exercise label="TaC-volume-disk-2">
-        <!-- <webwork xml:id="TaC-volume-disk-2">
+        <!-- <webwork xml:id="webwork-TaC-volume-disk-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1789,7 +1789,7 @@
       </exercise>
 
       <exercise label="TaC-volume-disk-3">
-        <!-- <webwork xml:id="TaC-volume-disk-3">
+        <!-- <webwork xml:id="webwork-TaC-volume-disk-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1822,7 +1822,7 @@
         </introduction>
 
         <exercise label="ex-volume-disk-x-axis-1">
-          <!-- <webwork xml:id="ex-volume-disk-x-axis-1">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-x-axis-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1862,7 +1862,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-x-axis-2">
-          <!-- <webwork xml:id="ex-volume-disk-x-axis-2">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-x-axis-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1904,7 +1904,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-x-axis-3">
-          <!-- <webwork xml:id="ex-volume-disk-x-axis-3">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-x-axis-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1946,7 +1946,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-x-axis-4">
-          <!-- <webwork xml:id="ex-volume-disk-x-axis-4">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-x-axis-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2001,7 +2001,7 @@
         </introduction>
 
         <exercise label="ex-volume-disk-y-axis-1">
-          <!-- <webwork xml:id="ex-volume-disk-y-axis-1">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-y-axis-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2043,7 +2043,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-y-axis-2">
-          <!-- <webwork xml:id="ex-volume-disk-y-axis-2">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-y-axis-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2085,7 +2085,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-y-axis-3">
-          <!-- <webwork xml:id="ex-volume-disk-y-axis-3">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-y-axis-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2132,7 +2132,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-y-axis-4">
-          <!-- <webwork xml:id="ex-volume-disk-y-axis-4">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-y-axis-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2187,7 +2187,7 @@
         </introduction>
 
         <exercise label="ex-volume-disk-both-1">
-          <!-- <webwork xml:id="ex-volume-disk-both-1">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-both-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2261,7 +2261,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-both-2">
-          <!-- <webwork xml:id="ex-volume-disk-both-2">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-both-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2334,7 +2334,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-both-3">
-          <!-- <webwork xml:id="ex-volume-disk-both-3">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-both-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2408,7 +2408,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-both-4">
-          <!-- <webwork xml:id="ex-volume-disk-both-4">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-both-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2469,7 +2469,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-both-5">
-          <!-- <webwork xml:id="ex-volume-disk-both-5">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-both-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2531,7 +2531,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-both-6">
-          <!-- <webwork xml:id="ex-volume-disk-both-6">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-both-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2616,7 +2616,7 @@
         </introduction>
 
         <exercise xml:id="ex_07_02_ex_18" label="ex-volume-disk-classic-1">
-          <!-- <webwork xml:id="ex-volume-disk-classic-1">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-classic-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2665,7 +2665,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-classic-2">
-          <!-- <webwork xml:id="ex-volume-disk-classic-2">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-classic-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2714,7 +2714,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-classic-3">
-          <!-- <webwork xml:id="ex-volume-disk-classic-3">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-classic-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2757,7 +2757,7 @@
         </exercise>
 
         <exercise label="ex-volume-disk-classic-4">
-          <!-- <webwork xml:id="ex-volume-disk-classic-4">
+          <!-- <webwork xml:id="webwork-ex-volume-disk-classic-4">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -1541,7 +1541,7 @@
     <subexercises xml:id="TaC-dot-product">
       <title>Terms and Concepts</title>
       <exercise label="TaC-dot-product-1">
-        <!--<webwork xml:id="TaC-dot-product-1">
+        <!--<webwork xml:id="webwork-TaC-dot-product-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1558,7 +1558,7 @@
       </exercise>
 
       <exercise label="TaC-dot-product-2">
-        <!--<webwork xml:id="TaC-dot-product-2">
+        <!--<webwork xml:id="webwork-TaC-dot-product-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1576,7 +1576,7 @@
       </exercise>
 
       <exercise label="TaC-dot-product-3">
-        <!--<webwork xml:id="TaC-dot-product-3">
+        <!--<webwork xml:id="webwork-TaC-dot-product-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1595,7 +1595,7 @@
       </exercise>
 
       <exercise label="TaC-dot-product-4">
-        <!--<webwork xml:id="TaC-dot-product-4">
+        <!--<webwork xml:id="webwork-TaC-dot-product-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1623,7 +1623,7 @@
         </introduction>
 
         <exercise label="ex-dot-product-compute-1">
-          <webwork xml:id="ex-dot-product-compute-1">
+          <webwork xml:id="webwork-ex-dot-product-compute-1">
               <pg-code>
                 Context("LimitedNumeric");
                 $dot=Real("-22");
@@ -1642,7 +1642,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-compute-2">
-          <webwork xml:id="ex-dot-product-compute-2">
+          <webwork xml:id="webwork-ex-dot-product-compute-2">
               <pg-code>
                 Context("LimitedNumeric");
                 $dot=Real("33");
@@ -1661,7 +1661,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-compute-3">
-          <webwork xml:id="ex-dot-product-compute-3">
+          <webwork xml:id="webwork-ex-dot-product-compute-3">
               <pg-code>
                 Context("LimitedNumeric");
                 $dot=Real("3");
@@ -1681,7 +1681,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-compute-4">
-          <webwork xml:id="ex-dot-product-compute-4">
+          <webwork xml:id="webwork-ex-dot-product-compute-4">
               <pg-code>
                 Context("LimitedNumeric");
                 $dot=Real("0");
@@ -1701,7 +1701,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-compute-5">
-          <!--<webwork xml:id="ex-dot-product-compute-5">
+          <!--<webwork xml:id="webwork-ex-dot-product-compute-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1718,7 +1718,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-compute-6">
-          <webwork xml:id="ex-dot-product-compute-6">
+          <webwork xml:id="webwork-ex-dot-product-compute-6">
               <pg-code>
                 Context("LimitedNumeric");
                 $dot=Real("0");
@@ -1740,7 +1740,7 @@
       </exercisegroup>
 
       <exercise label="ex-dot-product-distributive-check">
-        <!--<webwork xml:id="ex-dot-product-distributive-check">
+        <!--<webwork xml:id="webwork-ex-dot-product-distributive-check">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1759,7 +1759,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-scalar-check">
-        <!--<webwork xml:id="ex-dot-product-scalar-check">
+        <!--<webwork xml:id="webwork-ex-dot-product-scalar-check">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1786,7 +1786,7 @@
         </introduction>
 
         <exercise label="ex-dot-product-angle-1">
-          <webwork xml:id="ex-dot-product-angle-1">
+          <webwork xml:id="webwork-ex-dot-product-angle-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $theta=Formula("arccos(3/sqrt(10))");
@@ -1802,7 +1802,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-angle-2">
-          <webwork xml:id="ex-dot-product-angle-2">
+          <webwork xml:id="webwork-ex-dot-product-angle-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $theta=Formula("arccos(-1/sqrt(170))");
@@ -1818,7 +1818,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-angle-3">
-          <webwork xml:id="ex-dot-product-angle-3">
+          <webwork xml:id="webwork-ex-dot-product-angle-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $theta=Formula("pi/4");
@@ -1834,7 +1834,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-angle-4">
-          <webwork xml:id="ex-dot-product-angle-4">
+          <webwork xml:id="webwork-ex-dot-product-angle-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $theta=Formula("pi/2");
@@ -1860,7 +1860,7 @@
         </introduction>
 
         <exercise label="ex-dot-product-find-orthogonal-1">
-          <webwork xml:id="ex-dot-product-find-orthogonal-1">
+          <webwork xml:id="webwork-ex-dot-product-find-orthogonal-1">
               <pg-code>
                 Context("Vector");
                 $v=Vector("&lt;4,7>");
@@ -1897,7 +1897,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-find-orthogonal-2">
-          <webwork xml:id="ex-dot-product-find-orthogonal-2">
+          <webwork xml:id="webwork-ex-dot-product-find-orthogonal-2">
               <pg-code>
                 Context("Vector");
                 $v=Vector("&lt;-3,5>");
@@ -1934,7 +1934,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-find-orthogonal-3">
-          <webwork xml:id="ex-dot-product-find-orthogonal-3">
+          <webwork xml:id="webwork-ex-dot-product-find-orthogonal-3">
               <pg-code>
                 Context("Vector");
                 $v=Vector("&lt;1,1,1>");
@@ -1971,7 +1971,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-find-orthogonal-4">
-          <webwork xml:id="ex-dot-product-find-orthogonal-4">
+          <webwork xml:id="webwork-ex-dot-product-find-orthogonal-4">
               <pg-code>
                 Context("Vector");
                 $v=Vector("&lt;1,-2,3>");
@@ -2020,7 +2020,7 @@
         </introduction>
 
         <exercise xml:id="ex_10_03_ex_21" label="ex-dot-product-projection-1">
-          <webwork xml:id="ex-dot-product-projection-1">
+          <webwork xml:id="webwork-ex-dot-product-projection-1">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2047,7 +2047,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-projection-2">
-          <webwork xml:id="ex-dot-product-projection-2">
+          <webwork xml:id="webwork-ex-dot-product-projection-2">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2074,7 +2074,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-projection-3">
-          <webwork xml:id="ex-dot-product-projection-3">
+          <webwork xml:id="webwork-ex-dot-product-projection-3">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2101,7 +2101,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-projection-4">
-          <webwork xml:id="ex-dot-product-projection-4">
+          <webwork xml:id="webwork-ex-dot-product-projection-4">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2128,7 +2128,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-projection-5">
-          <webwork xml:id="ex-dot-product-projection-5">
+          <webwork xml:id="webwork-ex-dot-product-projection-5">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2155,7 +2155,7 @@
         </exercise>
 
         <exercise xml:id="ex_10_03_ex_24" label="ex-dot-product-projection-6">
-          <webwork xml:id="ex-dot-product-projection-6">
+          <webwork xml:id="webwork-ex-dot-product-projection-6">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2197,7 +2197,7 @@
         </introduction>
 
         <exercise label="ex-dot-product-ortho-decomp-1">
-          <webwork xml:id="ex-dot-product-ortho-decomp-1">
+          <webwork xml:id="webwork-ex-dot-product-ortho-decomp-1">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2267,7 +2267,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-ortho-decomp-2">
-          <webwork xml:id="ex-dot-product-ortho-decomp-2">
+          <webwork xml:id="webwork-ex-dot-product-ortho-decomp-2">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2337,7 +2337,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-ortho-decomp-3">
-          <webwork xml:id="ex-dot-product-ortho-decomp-3">
+          <webwork xml:id="webwork-ex-dot-product-ortho-decomp-3">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2407,7 +2407,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-ortho-decomp-4">
-          <webwork xml:id="ex-dot-product-ortho-decomp-4">
+          <webwork xml:id="webwork-ex-dot-product-ortho-decomp-4">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2477,7 +2477,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-ortho-decomp-5">
-          <webwork xml:id="ex-dot-product-ortho-decomp-5">
+          <webwork xml:id="webwork-ex-dot-product-ortho-decomp-5">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2547,7 +2547,7 @@
         </exercise>
 
         <exercise label="ex-dot-product-ortho-decomp-6">
-          <webwork xml:id="ex-dot-product-ortho-decomp-6">
+          <webwork xml:id="webwork-ex-dot-product-ortho-decomp-6">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2619,7 +2619,7 @@
       </exercisegroup>
 
       <exercise label="ex-dot-product-force-1">
-        <!--<webwork xml:id="ex-dot-product-force-1">
+        <!--<webwork xml:id="webwork-ex-dot-product-force-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2637,7 +2637,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-force-2">
-        <!--<webwork xml:id="ex-dot-product-force-2">
+        <!--<webwork xml:id="webwork-ex-dot-product-force-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2656,7 +2656,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-work-1">
-        <!--<webwork xml:id="ex-dot-product-work-1">
+        <!--<webwork xml:id="webwork-ex-dot-product-work-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2673,7 +2673,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-work-2">
-        <!--<webwork xml:id="ex-dot-product-work-2">
+        <!--<webwork xml:id="webwork-ex-dot-product-work-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2690,7 +2690,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-work-3">
-        <!--<webwork xml:id="ex-dot-product-work-3">
+        <!--<webwork xml:id="webwork-ex-dot-product-work-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2708,7 +2708,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-work-4">
-        <!--<webwork xml:id="ex-dot-product-work-4">
+        <!--<webwork xml:id="webwork-ex-dot-product-work-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2726,7 +2726,7 @@
       </exercise>
 
       <exercise label="ex-dot-product-work-5">
-        <!--<webwork xml:id="ex-dot-product-work-5">
+        <!--<webwork xml:id="webwork-ex-dot-product-work-5">
             <pg-code>
             </pg-code> -->
             <statement>

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -874,7 +874,7 @@
     <subexercises xml:id="TaC-double-int-polar">
       <title>Terms and Concepts</title>
       <exercise label="TaC-double-int-polar-1">
-        <!--<webwork xml:id="TaC-double-int-polar-1">
+        <!--<webwork xml:id="webwork-TaC-double-int-polar-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -892,7 +892,7 @@
       </exercise>
 
       <exercise label="TaC-double-int-polar-2">
-        <!--<webwork xml:id="TaC-double-int-polar-2">
+        <!--<webwork xml:id="webwork-TaC-double-int-polar-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -921,7 +921,7 @@
         </introduction>
 
         <exercise label="ex-double-int-polar-setup-1">
-          <webwork xml:id="ex-double-int-polar-setup-1">
+          <webwork xml:id="webwork-ex-double-int-polar-setup-1">
               <pg-code>
                 $int=Compute("4pi");
               </pg-code>
@@ -939,7 +939,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-2">
-          <!--<webwork xml:id="ex-double-int-polar-setup-2">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-setup-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -957,7 +957,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-3">
-          <webwork xml:id="ex-double-int-polar-setup-3">
+          <webwork xml:id="webwork-ex-double-int-polar-setup-3">
               <pg-code>
                 $int=Compute("16pi");
               </pg-code>
@@ -976,7 +976,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-4">
-          <!--<webwork xml:id="ex-double-int-polar-setup-4">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-setup-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -995,7 +995,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-5">
-          <!--<webwork xml:id="ex-double-int-polar-setup-5">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-setup-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1014,7 +1014,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-6">
-          <webwork xml:id="ex-double-int-polar-setup-6">
+          <webwork xml:id="webwork-ex-double-int-polar-setup-6">
               <pg-code>
                 $int=Compute("pi/2");
               </pg-code>
@@ -1032,7 +1032,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-7">
-          <!--<webwork xml:id="ex-double-int-polar-setup-7">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-setup-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1051,7 +1051,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-setup-8">
-          <!--<webwork xml:id="ex-double-int-polar-setup-8">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-setup-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1080,7 +1080,7 @@
         </introduction>
 
         <exercise label="ex-double-int-polar-convert-1">
-          <!--<webwork xml:id="ex-double-int-polar-convert-1">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-convert-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1097,7 +1097,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-convert-2">
-          <webwork xml:id="ex-double-int-polar-convert-2">
+          <webwork xml:id="webwork-ex-double-int-polar-convert-2">
               <pg-code>
                 $int=Compute("128/3");
               </pg-code>
@@ -1115,7 +1115,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-convert-3">
-          <!--<webwork xml:id="ex-double-int-polar-convert-3">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-convert-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1132,7 +1132,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-convert-4">
-          <!--<webwork xml:id="ex-double-int-polar-convert-4">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-convert-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1163,7 +1163,7 @@
         </introduction>
 
         <exercise xml:id="ex_double_int_polar_gaussian" label="ex_double_int_polar_gaussian">
-          <!--<webwork xml:id="ex_double_int_polar_gaussian">
+          <!--<webwork xml:id="webwork-ex_double_int_polar_gaussian">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1227,7 +1227,7 @@
         </exercise>
 
         <exercise label="ex-double-int-polar-cone">
-          <!--<webwork xml:id="ex-double-int-polar-cone">
+          <!--<webwork xml:id="webwork-ex-double-int-polar-cone">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -1580,7 +1580,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-double-int-volume-1">
-        <!--<webwork xml:id="TaC-double-int-volume-1">
+        <!--<webwork xml:id="webwork-TaC-double-int-volume-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1598,7 +1598,7 @@
       </exercise>
 
       <exercise label="TaC-double-int-volume-2">
-        <!--<webwork xml:id="TaC-double-int-volume-2">
+        <!--<webwork xml:id="webwork-TaC-double-int-volume-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1621,7 +1621,7 @@
       </exercise>
 
       <exercise label="TaC-double-int-volume-3">
-        <!--<webwork xml:id="TaC-double-int-volume-3">
+        <!--<webwork xml:id="webwork-TaC-double-int-volume-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1645,7 +1645,7 @@
       </exercise>
 
       <exercise label="TaC-double-int-volume-4">
-        <!--<webwork xml:id="TaC-double-int-volume-4">
+        <!--<webwork xml:id="webwork-TaC-double-int-volume-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1689,7 +1689,7 @@
         </introduction>
 
         <exercise xml:id="x13_02_ex_05" label="ex-double-int-volume-eval-change-order-1">
-          <!--<webwork xml:id="ex-double-int-volume-eval-change-order-1">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-eval-change-order-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1707,7 +1707,7 @@
 
         <!--TODO: the WW vode below does NOT produce a good static version-->
         <exercise label="ex-double-int-volume-eval-change-order-2">
-          <!-- <webwork xml:id="ex-double-int-volume-eval-change-order-2">
+          <!-- <webwork xml:id="webwork-ex-double-int-volume-eval-change-order-2">
 
               <pg-code>
                   Context()->variables->are(x=>"Real", dx=>"Real", y=>"Real", dy=>"Real");
@@ -1762,7 +1762,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-eval-change-order-3">
-          <!--<webwork xml:id="ex-double-int-volume-eval-change-order-3">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-eval-change-order-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1779,7 +1779,7 @@
         </exercise>
 
         <exercise xml:id="x13_02_ex_08" label="ex-double-int-volume-eval-change-order-4">
-          <!-- <webwork xml:id="ex-double-int-volume-eval-change-order-4">
+          <!-- <webwork xml:id="webwork-ex-double-int-volume-eval-change-order-4">
 
               <pg-code>
                   Context()->variables->are(x=>"Real", dx=>"Real", y=>"Real", dy=>"Real");
@@ -1835,7 +1835,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-eval-change-order-5">
-          <!--<webwork xml:id="ex-double-int-volume-eval-change-order-5">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-eval-change-order-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1852,7 +1852,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-eval-change-order-6">
-          <!-- <webwork xml:id="ex-double-int-volume-eval-change-order-6">
+          <!-- <webwork xml:id="webwork-ex-double-int-volume-eval-change-order-6">
 
               <pg-code>
                   Context()->variables->are(x=>"Real", dx=>"Real", y=>"Real", dy=>"Real");
@@ -1939,7 +1939,7 @@
         </introduction>
 
         <exercise label="ex-double-int-volume-sketch-eval-1">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-1">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2001,7 +2001,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-2">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-2">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2066,7 +2066,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-3">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-3">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2129,7 +2129,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-4">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-4">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2193,7 +2193,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-5">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-5">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2257,7 +2257,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-6">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-6">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2324,7 +2324,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-7">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-7">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2386,7 +2386,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-sketch-eval-8">
-          <!--<webwork xml:id="ex-double-int-volume-sketch-eval-8">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-sketch-eval-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2468,7 +2468,7 @@
         </introduction>
 
         <exercise label="ex-double-int-volume-change-order-1">
-          <!--<webwork xml:id="ex-double-int-volume-change-order-1">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-change-order-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2486,7 +2486,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-change-order-2">
-          <!--<webwork xml:id="ex-double-int-volume-change-order-2">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-change-order-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2504,7 +2504,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-change-order-3">
-          <!--<webwork xml:id="ex-double-int-volume-change-order-3">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-change-order-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2526,7 +2526,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-change-order-4">
-          <!--<webwork xml:id="ex-double-int-volume-change-order-4">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-change-order-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2559,7 +2559,7 @@
         </introduction>
 
         <exercise label="ex-double-int-volume-average-1">
-          <!--<webwork xml:id="ex-double-int-volume-average-1">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-average-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2576,7 +2576,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-average-2">
-          <!--<webwork xml:id="ex-double-int-volume-average-2">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-average-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2595,7 +2595,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-average-3">
-          <!--<webwork xml:id="ex-double-int-volume-average-3">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-average-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2613,7 +2613,7 @@
         </exercise>
 
         <exercise label="ex-double-int-volume-average-4">
-          <!--<webwork xml:id="ex-double-int-volume-average-4">
+          <!--<webwork xml:id="webwork-ex-double-int-volume-average-4">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -1248,7 +1248,7 @@
         </introduction>
 
         <exercise label="ex-graph-concavity-intervals-1">
-          <webwork xml:id="ex-graph-concavity-intervals-1">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -1306,7 +1306,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-2">
-          <webwork xml:id="ex-graph-concavity-intervals-2">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-2">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$a=-5; $b=7};
@@ -1364,7 +1364,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-3">
-          <webwork xml:id="ex-graph-concavity-intervals-3">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-3">
             <pg-code>
               $s = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -1423,7 +1423,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-4">
-          <webwork xml:id="ex-graph-concavity-intervals-4">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-4">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = non_zero_random(-9,9,1);
@@ -1487,7 +1487,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-5">
-          <webwork xml:id="ex-graph-concavity-intervals-5">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-5">
             <pg-code>
               $s = non_zero_random(-9,9,1);
               $k = ($s % 2 == 0) ? non_zero_random(2,8,2) : non_zero_random(1,9,2);
@@ -1555,7 +1555,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-6">
-          <webwork xml:id="ex-graph-concavity-intervals-6">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-6">
             <pg-code>
               ($r,$s,$t) = (-5..-1,1..5)[NchooseK(10,3)];
               $k = list_random(-12,-8,-4,4,8,12);
@@ -1644,7 +1644,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-7">
-          <webwork xml:id="ex-graph-concavity-intervals-7">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-7">
             <pg-code>
               $r = non_zero_random(-4,4,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -1707,7 +1707,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-8">
-          <webwork xml:id="ex-graph-concavity-intervals-8">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-8">
             <pg-code>
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
@@ -1762,7 +1762,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-9">
-          <webwork xml:id="ex-graph-concavity-intervals-9">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-9">
             <pg-code>
               $r = random(-9,9,1);
               $s = random(1,9,1);
@@ -1843,7 +1843,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-10">
-          <webwork xml:id="ex-graph-concavity-intervals-10">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-10">
             <pg-code>
               ($r,$s) = num_sort((-9..-1,1..9)[NchooseK(18,2)]);
               if($envir{problemSeed}==1){$r=-1; $s = 1;};
@@ -1903,7 +1903,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-11">
-          <webwork xml:id="ex-graph-concavity-intervals-11">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-11">
             <pg-code>
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
@@ -1958,7 +1958,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-12">
-          <webwork xml:id="ex-graph-concavity-intervals-12">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-12">
             <pg-code>
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
@@ -2013,7 +2013,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-13">
-          <webwork xml:id="ex-graph-concavity-intervals-13">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-13">
             <pg-code>
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
@@ -2068,7 +2068,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-14">
-          <webwork xml:id="ex-graph-concavity-intervals-14">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-14">
             <pg-code>
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));
@@ -2135,7 +2135,7 @@
         </introduction>
 
         <exercise label="ex-graph-concavity-second-test-1">
-          <webwork xml:id="ex-graph-concavity-second-test-1">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -2193,7 +2193,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-2">
-          <webwork xml:id="ex-graph-concavity-second-test-2">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-2">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$a=-5; $b=7};
@@ -2252,7 +2252,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-3">
-          <webwork xml:id="ex-graph-concavity-second-test-3">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-3">
             <pg-code>
               $s = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -2329,7 +2329,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-4">
-          <webwork xml:id="ex-graph-concavity-second-test-4">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-4">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = non_zero_random(-9,9,1);
@@ -2392,7 +2392,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-5">
-          <webwork xml:id="ex-graph-concavity-second-test-5">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-5">
             <pg-code>
               $s = non_zero_random(-9,9,1);
               $k = ($s % 2 == 0) ? non_zero_random(2,8,2) : non_zero_random(1,9,2);
@@ -2459,7 +2459,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-6">
-          <webwork xml:id="ex-graph-concavity-second-test-6">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-6">
             <pg-code>
               ($r,$s,$t) = (-5..-1,1..5)[NchooseK(10,3)];
               $k = list_random(-12,-8,-4,4,8,12);
@@ -2547,7 +2547,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-7">
-          <webwork xml:id="ex-graph-concavity-second-test-7">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-7">
             <pg-code>
               $r = non_zero_random(-4,4,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -2609,7 +2609,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-8">
-          <webwork xml:id="ex-graph-concavity-second-test-8">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-8">
             <pg-code>
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
@@ -2663,7 +2663,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-9">
-          <webwork xml:id="ex-graph-concavity-second-test-9">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-9">
             <pg-code>
               $r = random(-9,9,1);
               $s = random(1,9,1);
@@ -2743,7 +2743,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-10">
-          <webwork xml:id="ex-graph-concavity-second-test-10">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-10">
             <pg-code>
               ($r,$s) = num_sort((-9..-1,1..9)[NchooseK(18,2)]);
               if($envir{problemSeed}==1){$r=-1; $s = 1;};
@@ -2804,7 +2804,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-11">
-          <webwork xml:id="ex-graph-concavity-second-test-11">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-11">
             <pg-code>
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
@@ -2858,7 +2858,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-12">
-          <webwork xml:id="ex-graph-concavity-second-test-12">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-12">
             <pg-code>
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
@@ -2912,7 +2912,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-13">
-          <webwork xml:id="ex-graph-concavity-second-test-13">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-13">
             <pg-code>
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
@@ -2966,7 +2966,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-14">
-          <webwork xml:id="ex-graph-concavity-second-test-14">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-14">
             <pg-code>
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));
@@ -3030,7 +3030,7 @@
         </introduction>
 
         <exercise label="ex-graph-concavity-deriv-crit-1">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-1">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -3081,7 +3081,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-2">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-2">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-2">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$a=-5; $b=7};
@@ -3133,7 +3133,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-3">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-3">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-3">
             <pg-code>
               $s = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -3203,7 +3203,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-4">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-4">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-4">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = non_zero_random(-9,9,1);
@@ -3260,7 +3260,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-5">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-5">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-5">
             <pg-code>
               $s = non_zero_random(-9,9,1);
               $k = ($s % 2 == 0) ? non_zero_random(2,8,2) : non_zero_random(1,9,2);
@@ -3320,7 +3320,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-6">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-6">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-6">
             <pg-code>
               ($r,$s,$t) = (-5..-1,1..5)[NchooseK(10,3)];
               $k = list_random(-12,-8,-4,4,8,12);
@@ -3402,7 +3402,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-7">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-7">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-7">
             <pg-code>
               $r = non_zero_random(-4,4,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -3457,7 +3457,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-8">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-8">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-8">
             <pg-code>
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
@@ -3504,7 +3504,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-9">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-9">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-9">
             <pg-code>
               $r = random(-9,9,1);
               $s = random(1,9,1);
@@ -3577,7 +3577,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-10">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-10">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-10">
             <pg-code>
               ($r,$s) = num_sort((-9..-1,1..9)[NchooseK(18,2)]);
               if($envir{problemSeed}==1){$r=-1; $s = 1;};
@@ -3631,7 +3631,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-11">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-11">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-11">
             <pg-code>
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
@@ -3678,7 +3678,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-12">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-12">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-12">
             <pg-code>
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
@@ -3725,7 +3725,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-13">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-13">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-13">
             <pg-code>
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
@@ -3772,7 +3772,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-14">
-          <webwork xml:id="ex-graph-concavity-deriv-crit-14">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-14">
             <pg-code>
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -967,7 +967,7 @@
     <subexercises xml:id="TaC-graph-extreme-values">
       <title>Terms and Concepts</title>
       <exercise label="TaC-graph-extreme-values-1">
-        <webwork xml:id="TaC-graph-extreme-values-1">
+        <webwork xml:id="webwork-TaC-graph-extreme-values-1">
           <statement>
             <p>
               Describe what an <q>extreme value</q>
@@ -999,7 +999,7 @@
       </exercise>
 
       <exercise label="TaC-graph-extreme-values-3">
-        <webwork xml:id="TaC-graph-extreme-values-3">
+        <webwork xml:id="webwork-TaC-graph-extreme-values-3">
           <statement>
             <p>
               Describe the difference between absolute and relative maxima in your own words.
@@ -1030,7 +1030,7 @@
       </exercise>
 
       <exercise label="TaC-graph-extreme-values-5">
-        <webwork xml:id="TaC-graph-extreme-values-5">
+        <webwork xml:id="webwork-TaC-graph-extreme-values-5">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -1046,7 +1046,7 @@
       </exercise>
 
       <exercise label="TaC-graph-extreme-values-6">
-        <webwork xml:id="TaC-graph-extreme-values-6">
+        <webwork xml:id="webwork-TaC-graph-extreme-values-6">
           <pg-code>
             $zero = Real(0);
             Context()->strings->add('undefined'=>{});
@@ -1075,7 +1075,7 @@
         </introduction>
 
         <exercise label="ex-graph-extreme-values-identify-points-1">
-          <webwork xml:id="ex-graph-extreme-values-identify-points-1">
+          <webwork xml:id="webwork-ex-graph-extreme-values-identify-points-1">
             <pg-code>
               $gr=init_graph(-0.5,-2.5,6.5,3.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1138,7 +1138,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-identify-points-2">
-          <webwork xml:id="ex-graph-extreme-values-identify-points-2">
+          <webwork xml:id="webwork-ex-graph-extreme-values-identify-points-2">
             <pg-code>
               $gr=init_graph(-0.5,-2.5,5.5,2.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1202,7 +1202,7 @@
         </introduction>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-1">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-1">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-1">
             <pg-code>
               $gr=init_graph(-5.5,-0.5,5.5,2.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1231,7 +1231,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-2">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-2">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-2">
             <pg-code>
               $gr=init_graph(-4,-1,4,6.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1268,7 +1268,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-3">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-3">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-3">
             <pg-code>
               $gr=init_graph(-0.5,-1.4,6.5,1.4,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1305,7 +1305,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-4">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-4">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-4">
             <pg-code>
               $gr=init_graph(-2.5,-2,4.5,11,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1350,7 +1350,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-5">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-5">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-5">
             <pg-code>
               $gr=init_graph(-1,-0.5,11,6.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1390,7 +1390,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-6">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-6">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-6">
             <pg-code>
               $gr=init_graph(-2.5,-0.5,2.5,3.5,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1432,7 +1432,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-7">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-7">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-7">
             <pg-code>
               $gr=init_graph(-1.1,-0.6,1.1,1.1,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1463,7 +1463,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-evaluate-fprime-8">
-          <webwork xml:id="ex-graph-extreme-values-evaluate-fprime-8">
+          <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-8">
             <pg-code>
               $gr=init_graph(-1.1,-0.6,1.1,1.1,axes=>[0,0],size=>[282,282]);
               $gr->lb('reset');
@@ -1501,7 +1501,7 @@
           </p>
         </introduction>
         <exercise label="ex-graph-extreme-values-find-1">
-          <webwork xml:id="ex-graph-extreme-values-find-1">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-1">
             <pg-code>
               ($b,$c) = (-9..-1,1..9)[NchooseK(18,2)];
               ($l,$h) = (1..4)[NchooseK(4,2)];
@@ -1534,7 +1534,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-2">
-          <webwork xml:id="ex-graph-extreme-values-find-2">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-2">
             <pg-code>
               Context("Fraction-NoDecimals");
               $r = random(-9,-1,1);
@@ -1570,7 +1570,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-3">
-          <webwork xml:id="ex-graph-extreme-values-find-3">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-3">
             <pg-code>
               Context("Fraction-NoDecimals");
               $c = random(2,4,1);
@@ -1609,7 +1609,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-4">
-          <webwork xml:id="ex-graph-extreme-values-find-4">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-4">
             <pg-code>
               Context("Fraction-NoDecimals");
               $n = list_random(2,4,6);
@@ -1644,7 +1644,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-5">
-          <webwork xml:id="ex-graph-extreme-values-find-5">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-5">
             <pg-code>
               Context("Fraction-NoDecimals");
               $a = list_random(2,3,5,6,7);
@@ -1676,7 +1676,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-6">
-          <webwork xml:id="ex-graph-extreme-values-find-6">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-6">
             <pg-code>
               Context("Fraction-NoDecimals");
               $n = random(2,4,2);
@@ -1709,7 +1709,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-7">
-          <webwork xml:id="ex-graph-extreme-values-find-7">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-7">
             <pg-code>
               Context("Numeric");
               $trig='cos';
@@ -1741,7 +1741,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-8">
-          <webwork xml:id="ex-graph-extreme-values-find-8">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-8">
             <pg-code>
               Context("Numeric");
               $trig='sin';
@@ -1773,7 +1773,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-9">
-          <webwork xml:id="ex-graph-extreme-values-find-9">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-9">
             <pg-code>
               Context("Numeric");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1807,7 +1807,7 @@
         </exercise>
 
         <exercise label="ex-graph-extreme-values-find-10">
-          <webwork xml:id="ex-graph-extreme-values-find-10">
+          <webwork xml:id="webwork-ex-graph-extreme-values-find-10">
             <pg-code>
               Context("Fraction-NoDecimals");
               $d = random(2,5,1);
@@ -1847,7 +1847,7 @@
     <subexercises>
       <title>Review</title>
       <exercise label="ex-graph-extreme-values-review-1">
-        <webwork xml:id="ex-graph-extreme-values-review-1">
+        <webwork xml:id="webwork-ex-graph-extreme-values-review-1">
           <pg-code>
             Context()->variables->add(y=>'Real');
             ($m,$n) = (1..4)[NchooseK(4,2)];
@@ -1871,7 +1871,7 @@
       </exercise>
 
       <exercise label="ex-graph-extreme-values-review-2">
-        <webwork xml:id="ex-graph-extreme-values-review-2">
+        <webwork xml:id="webwork-ex-graph-extreme-values-review-2">
           <pg-code>
             Context("Fraction");
             Context()->variables->add(y=>'Real');
@@ -1901,7 +1901,7 @@
       </exercise>
 
       <exercise label="ex-graph-extreme-values-review-3">
-        <webwork xml:id="ex-graph-extreme-values-review-3">
+        <webwork xml:id="webwork-ex-graph-extreme-values-review-3">
           <pg-code>
             $n = random(3,4,1);
             $b = non_zero_random(-2,2,1);

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -996,7 +996,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-graph-incr-decr-1">
-        <webwork xml:id="TaC-graph-incr-decr-1">
+        <webwork xml:id="webwork-TaC-graph-incr-decr-1">
           <statement>
             <p>
               In your own words describe what it means for a function to be increasing.
@@ -1009,7 +1009,7 @@
       </exercise>
 
       <exercise label="TaC-graph-incr-decr-2">
-        <webwork xml:id="TaC-graph-incr-decr-2">
+        <webwork xml:id="webwork-TaC-graph-incr-decr-2">
           <statement>
             <p>
               What does a decreasing function <q>look like</q>?
@@ -1044,7 +1044,7 @@
       </exercise>
 
       <exercise label="TaC-graph-incr-decr-4">
-        <webwork xml:id="TaC-graph-incr-decr-4">
+        <webwork xml:id="webwork-TaC-graph-incr-decr-4">
           <statement>
             <p>
               Give an example of a function describing a situation where it is <q>bad</q>
@@ -1058,7 +1058,7 @@
       </exercise>
 
       <exercise label="TaC-graph-incr-decr-5">
-        <webwork xml:id="TaC-graph-incr-decr-5">
+        <webwork xml:id="webwork-TaC-graph-incr-decr-5">
           <pg-code>
             $False = PopUp(['?','True','False'],2);
           </pg-code>
@@ -1079,7 +1079,7 @@
       </exercise>
 
       <exercise label="TaC-graph-incr-decr-6">
-        <webwork xml:id="TaC-graph-incr-decr-6">
+        <webwork xml:id="webwork-TaC-graph-incr-decr-6">
           <statement>
             <p>
               A function <m>f</m> has derivative <m>\fp(x) = (\sin x +2)e^{x^2+1}</m>,
@@ -1213,7 +1213,7 @@
         </introduction>
 
         <exercise label="ex-graph-incr-decr-intervals-1">
-          <webwork xml:id="ex-graph-incr-decr-intervals-1">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-1">
             <pg-code>
               Context("Fraction");
               ($r,$s) = (-9..9)[NchooseK(19,2)];
@@ -1298,7 +1298,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-2">
-          <webwork xml:id="ex-graph-incr-decr-intervals-2">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-2">
             <pg-code>
               Context("Fraction");
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -1384,7 +1384,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-3">
-          <webwork xml:id="ex-graph-incr-decr-intervals-3">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-3">
             <pg-code>
               Context("Fraction");
               #roots of derivative
@@ -1482,7 +1482,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-4">
-          <webwork xml:id="ex-graph-incr-decr-intervals-4">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-4">
             <pg-code>
               $r = non_zero_random(-5,5,1);
               $crit=List($r);
@@ -1569,7 +1569,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-5">
-          <webwork xml:id="ex-graph-incr-decr-intervals-5">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-5">
             <pg-code>
               $r = non_zero_random(-5,5,1);
               $crit=List($r);
@@ -1655,7 +1655,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-6">
-          <webwork xml:id="ex-graph-incr-decr-intervals-6">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-6">
             <pg-code>
               ($r,$t) = (1..9)[NchooseK(9,2)];
               $R = ($r)**2;
@@ -1744,7 +1744,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-7">
-          <webwork xml:id="ex-graph-incr-decr-intervals-7">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-7">
             <pg-code>
               ($r,$s) = num_sort((-9..-1,1..9)[NchooseK(18,2)]);
               $rs = $r*$s;
@@ -1842,7 +1842,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-8">
-          <webwork xml:id="ex-graph-incr-decr-intervals-8">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-8">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               $crit = List($r,3*$r);
@@ -1932,7 +1932,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-9">
-          <webwork xml:id="ex-graph-incr-decr-intervals-9">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-9">
             <pg-code>
               Context("Interval");
               Context()->flags->set(ignoreEndpointTypes => 1);
@@ -2013,7 +2013,7 @@
         </exercise>
 
         <exercise label="ex-graph-incr-decr-intervals-10">
-          <webwork xml:id="ex-graph-incr-decr-intervals-10">
+          <webwork xml:id="webwork-ex-graph-incr-decr-intervals-10">
             <pg-code>
               $n = random(3,9,1);
               if ($n == 3) {
@@ -2125,7 +2125,7 @@
       <title>Review</title>
 
       <exercise label="ex-graph-incr-decr-review-1">
-        <webwork xml:id="ex-graph-incr-decr-review-1">
+        <webwork xml:id="webwork-ex-graph-incr-decr-review-1">
           <pg-code>
             Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
             $c=Formula("1/2");
@@ -2150,7 +2150,7 @@
       </exercise>
 
       <exercise label="ex-graph-incr-decr-review-2">
-        <webwork xml:id="ex-graph-incr-decr-review-2">
+        <webwork xml:id="webwork-ex-graph-incr-decr-review-2">
           <pg-code>
             Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
             $c=Formula("acos(2/pi),-acos(2/pi)");

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -469,7 +469,7 @@
     <subexercises xml:id="TaC-graph-MVT">
       <title>Terms and Concepts</title>
       <exercise label="TaC-graph-MVT-1">
-        <webwork xml:id="TaC-graph-MVT-1">
+        <webwork xml:id="webwork-TaC-graph-MVT-1">
           <statement>
             <p>
               Explain in your own words what the Mean Value Theorem states.
@@ -487,7 +487,7 @@
       </exercise>
 
       <exercise label="TaC-graph-MVT-2">
-        <webwork xml:id="TaC-graph-MVT-2">
+        <webwork xml:id="webwork-TaC-graph-MVT-2">
           <statement>
             <p>
               Explain in your own words what Rolle's Theorem states.
@@ -516,7 +516,7 @@
           </p>
         </introduction>
         <exercise label="ex-graph-MVT-Rolles-1">
-          <webwork xml:id="ex-graph-MVT-Rolles-1">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-1">
             <pg-code>
               Context("Interval");
               Context()->strings->add('does not apply'=>{});
@@ -543,7 +543,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-2">
-          <webwork xml:id="ex-graph-MVT-Rolles-2">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-2">
             <pg-code>
               Context("Interval");
               Context()->strings->add('does not apply'=>{});
@@ -570,7 +570,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-3">
-          <webwork xml:id="ex-graph-MVT-Rolles-3">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-3">
             <pg-code>
               Context("Fraction");
               Context()->strings->add('does not apply'=>{});
@@ -597,7 +597,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-4">
-          <webwork xml:id="ex-graph-MVT-Rolles-4">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-4">
             <pg-code>
               Context("Fraction");
               Context()->strings->add('does not apply'=>{});
@@ -624,7 +624,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-5">
-          <webwork xml:id="ex-graph-MVT-Rolles-5">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-5">
             <pg-code>
               Context("Interval");
               Context()->strings->add('does not apply'=>{});
@@ -651,7 +651,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-6">
-          <webwork xml:id="ex-graph-MVT-Rolles-6">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-6">
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -679,7 +679,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-7">
-          <webwork xml:id="ex-graph-MVT-Rolles-7">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-7">
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -707,7 +707,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-Rolles-8">
-          <webwork xml:id="ex-graph-MVT-Rolles-8">
+          <webwork xml:id="webwork-ex-graph-MVT-Rolles-8">
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -744,7 +744,7 @@
           </p>
         </introduction>
         <exercise label="ex-graph-MVT-check-1">
-          <webwork xml:id="ex-graph-MVT-check-1">
+          <webwork xml:id="webwork-ex-graph-MVT-check-1">
             <pg-code>
               Context("Interval");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -772,7 +772,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-2">
-          <webwork xml:id="ex-graph-MVT-check-2">
+          <webwork xml:id="webwork-ex-graph-MVT-check-2">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -800,7 +800,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-3">
-          <webwork xml:id="ex-graph-MVT-check-3">
+          <webwork xml:id="webwork-ex-graph-MVT-check-3">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -828,7 +828,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-4">
-          <webwork xml:id="ex-graph-MVT-check-4">
+          <webwork xml:id="webwork-ex-graph-MVT-check-4">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -856,7 +856,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-5">
-          <webwork xml:id="ex-graph-MVT-check-5">
+          <webwork xml:id="webwork-ex-graph-MVT-check-5">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -884,7 +884,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-6">
-          <webwork xml:id="ex-graph-MVT-check-6">
+          <webwork xml:id="webwork-ex-graph-MVT-check-6">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -912,7 +912,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-7">
-          <webwork xml:id="ex-graph-MVT-check-7">
+          <webwork xml:id="webwork-ex-graph-MVT-check-7">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -940,7 +940,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-8">
-          <webwork xml:id="ex-graph-MVT-check-8">
+          <webwork xml:id="webwork-ex-graph-MVT-check-8">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -968,7 +968,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-9">
-          <webwork xml:id="ex-graph-MVT-check-9">
+          <webwork xml:id="webwork-ex-graph-MVT-check-9">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -996,7 +996,7 @@
         </exercise>
 
         <exercise label="ex-graph-MVT-check-10">
-          <webwork xml:id="ex-graph-MVT-check-10">
+          <webwork xml:id="webwork-ex-graph-MVT-check-10">
             <pg-code>
               Context("Fraction");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1028,7 +1028,7 @@
     <subexercises>
       <title>Review</title>
       <exercise label="ex-graph-MVT-review-1">
-        <webwork xml:id="ex-graph-MVT-review-1">
+        <webwork xml:id="webwork-ex-graph-MVT-review-1">
           <pg-code>
             ($b,$c) = (-9..-1,1..9)[NchooseK(18,2)];
             ($l,$h) = (1..4)[NchooseK(4,2)];
@@ -1061,7 +1061,7 @@
       </exercise>
 
       <exercise label="ex-graph-MVT-review-2">
-        <webwork xml:id="ex-graph-MVT-review-2">
+        <webwork xml:id="webwork-ex-graph-MVT-review-2">
           <statement>
             <p>
               Describe the critical points of <m>f(x) = \cos(x)</m>.
@@ -1079,7 +1079,7 @@
       </exercise>
 
       <exercise label="ex-graph-MVT-review-3">
-        <webwork xml:id="ex-graph-MVT-review-3">
+        <webwork xml:id="webwork-ex-graph-MVT-review-3">
           <pg-code>
           </pg-code>
           <statement>

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -942,7 +942,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-graph-sketch-1">
-        <webwork xml:id="TaC-graph-sketch-1">
+        <webwork xml:id="webwork-TaC-graph-sketch-1">
             <pg-code>
             </pg-code>
 
@@ -964,7 +964,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise label="TaC-graph-sketch-2">
-        <webwork xml:id="TaC-graph-sketch-2">
+        <webwork xml:id="webwork-TaC-graph-sketch-2">
             <pg-code>
             </pg-code>
 
@@ -986,7 +986,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise label="TaC-graph-sketch-3">
-        <webwork xml:id="TaC-graph-sketch-3">
+        <webwork xml:id="webwork-TaC-graph-sketch-3">
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
@@ -1006,7 +1006,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise label="TaC-graph-sketch-4">
-        <webwork xml:id="TaC-graph-sketch-4">
+        <webwork xml:id="webwork-TaC-graph-sketch-4">
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
@@ -1026,7 +1026,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
       </exercise>
 
       <exercise label="TaC-graph-sketch-5">
-        <webwork xml:id="TaC-graph-sketch-5">
+        <webwork xml:id="webwork-TaC-graph-sketch-5">
             <pg-code>
               $tf=PopUp(['?','True','False'],1);
             </pg-code>
@@ -1362,7 +1362,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
         </introduction>
 
         <exercise label="ex-graph-sketch-parameters-1">
-  <!--         <webwork xml:id="ex-graph-sketch-parameters-1">
+  <!--         <webwork xml:id="webwork-ex-graph-sketch-parameters-1">
 
               <pg-code>
               </pg-code>
@@ -1402,7 +1402,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
         </exercise>
 
         <exercise label="ex-graph-sketch-parameters-2">
-  <!--         <webwork xml:id="ex-graph-sketch-parameters-2">
+  <!--         <webwork xml:id="webwork-ex-graph-sketch-parameters-2">
 
               <pg-code>
                 $crit=Formula("(a+b)/2");
@@ -1446,7 +1446,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
         </exercise>
 
         <exercise label="ex-graph-sketch-parameters-3">
-  <!--         <webwork xml:id="ex-graph-sketch-parameters-3">
+  <!--         <webwork xml:id="webwork-ex-graph-sketch-parameters-3">
 
               <pg-code>
                 Context()->strings->add('does not apply'=>{});
@@ -1489,7 +1489,7 @@ replaced Greg's sign diagram image here... Also, can we consider having separate
         </exercise>
 
         <exercise label="ex-graph-sketch-parameters-4">
-  <!--         <webwork xml:id="ex-graph-sketch-parameters-4">
+  <!--         <webwork xml:id="webwork-ex-graph-sketch-parameters-4">
               <pg-code>
               </pg-code>
             -->

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -1108,7 +1108,7 @@
       <title>Terms and Concepts</title>
 <!-- Exercise 1 -->
       <exercise label="TaC-hyperbolic-1">
-        <webwork xml:id="TaC-hyperbolic-1">
+        <webwork xml:id="webwork-TaC-hyperbolic-1">
             <pg-code>
             </pg-code>
 
@@ -1133,7 +1133,7 @@
       </exercise>
 <!-- Exercise 2 -->
       <exercise label="TaC-hyperbolic-2">
-        <webwork xml:id="TaC-hyperbolic-2">
+        <webwork xml:id="webwork-TaC-hyperbolic-2">
             <pg-code>
             </pg-code>
 
@@ -1169,7 +1169,7 @@
         </introduction>
   <!-- Exercise 3 -->
         <exercise label="ex-hyperbolic-verify-identity-1">
-          <webwork xml:id="ex-hyperbolic-verify-identity-1">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-1">
               <pg-code>
               </pg-code>
 
@@ -1195,7 +1195,7 @@
         </exercise>
   <!-- Exercise 4 -->
         <exercise label="ex-hyperbolic-verify-identity-2">
-          <webwork xml:id="ex-hyperbolic-verify-identity-2">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-2">
               <pg-code>
               </pg-code>
 
@@ -1222,7 +1222,7 @@
         </exercise>
   <!-- Exercise 5 -->
         <exercise label="ex-hyperbolic-verify-identity-3">
-          <webwork xml:id="ex-hyperbolic-verify-identity-3">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-3">
               <pg-code>
               </pg-code>
 
@@ -1249,7 +1249,7 @@
         </exercise>
   <!-- Exercise 6 -->
         <exercise label="ex-hyperbolic-verify-identity-4">
-          <webwork xml:id="ex-hyperbolic-verify-identity-4">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-4">
               <pg-code>
               </pg-code>
 
@@ -1276,7 +1276,7 @@
         </exercise>
   <!-- Exercise 7 -->
         <exercise label="ex-hyperbolic-verify-identity-5">
-          <webwork xml:id="ex-hyperbolic-verify-identity-5">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-5">
               <pg-code>
               </pg-code>
 
@@ -1302,7 +1302,7 @@
         </exercise>
   <!-- Exercise 8 -->
         <exercise label="ex-hyperbolic-verify-identity-6">
-          <webwork xml:id="ex-hyperbolic-verify-identity-6">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-6">
               <pg-code>
               </pg-code>
 
@@ -1328,7 +1328,7 @@
         </exercise>
   <!-- Exercise 9 -->
         <exercise label="ex-hyperbolic-verify-identity-7">
-          <webwork xml:id="ex-hyperbolic-verify-identity-7">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-7">
               <pg-code>
               </pg-code>
 
@@ -1361,7 +1361,7 @@
         </exercise>
   <!-- Exercise 10 -->
         <exercise label="ex-hyperbolic-verify-identity-8">
-          <webwork xml:id="ex-hyperbolic-verify-identity-8">
+          <webwork xml:id="webwork-ex-hyperbolic-verify-identity-8">
               <pg-code>
               </pg-code>
 
@@ -1397,7 +1397,7 @@
         </introduction>
   <!-- Exercise 11 -->
         <exercise label="ex-hyperbolic-derivative-1">
-          <webwork xml:id="ex-hyperbolic-derivative-1">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-1">
               <pg-code>
                 $f = Formula("sinh(2x)");
                 $df = $f->D('x');
@@ -1416,7 +1416,7 @@
         </exercise>
   <!-- New problem -->
         <exercise label="ex-hyperbolic-derivative-2">
-          <webwork xml:id="ex-hyperbolic-derivative-2">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-2">
               <pg-code>
                 $f = Formula("(cosh(x))^2");
                 $df = $f->D('x');
@@ -1446,7 +1446,7 @@
 
   <!-- Exercise 12 -->
         <exercise label="ex-hyperbolic-derivative-3">
-          <webwork xml:id="ex-hyperbolic-derivative-3">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-3">
               <pg-code>
                 $f = Formula("tanh(x^2)");
                 $df = $f->D('x');
@@ -1465,7 +1465,7 @@
         </exercise>
   <!-- Exercise 13 -->
         <exercise label="ex-hyperbolic-derivative-4">
-          <webwork xml:id="ex-hyperbolic-derivative-4">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-4">
               <pg-code>
                 $f = Formula("ln(sinh(x))");
                 $df = $f->D('x');
@@ -1484,7 +1484,7 @@
         </exercise>
   <!-- Exercise 14 -->
         <exercise label="ex-hyperbolic-derivative-5">
-          <webwork xml:id="ex-hyperbolic-derivative-5">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-5">
               <pg-code>
                 $f = Formula("sinh(x)*cosh(x)");
                 $df = $f->D('x');
@@ -1503,7 +1503,7 @@
         </exercise>
   <!-- Exercise 15 -->
         <exercise label="ex-hyperbolic-derivative-6">
-          <webwork xml:id="ex-hyperbolic-derivative-6">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-6">
               <pg-code>
                 $f = Formula("x*sinh(x)-cosh(x)");
                 $df = $f->D('x');
@@ -1522,7 +1522,7 @@
         </exercise>
   <!-- Exercise 16 -->
         <exercise label="ex-hyperbolic-derivative-7">
-          <webwork xml:id="ex-hyperbolic-derivative-7">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-7">
               <pg-code>
                 $f = Formula("asech(x^2)");
                 $df = $f->D('x');
@@ -1541,7 +1541,7 @@
         </exercise>
   <!-- Exercise 17 -->
         <exercise label="ex-hyperbolic-derivative-8">
-          <webwork xml:id="ex-hyperbolic-derivative-8">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-8">
               <pg-code>
                 $f = Formula("asinh(3x)");
                 $df = $f->D('x');
@@ -1560,7 +1560,7 @@
         </exercise>
   <!-- Exercise 18 -->
         <exercise label="ex-hyperbolic-derivative-9">
-          <webwork xml:id="ex-hyperbolic-derivative-9">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-9">
               <pg-code>
                 $f = Formula("acosh(2x^2)");
                 $df = $f->D('x');
@@ -1579,7 +1579,7 @@
         </exercise>
   <!-- Exercise 19 -->
         <exercise label="ex-hyperbolic-derivative-10">
-          <webwork xml:id="ex-hyperbolic-derivative-10">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-10">
               <pg-code>
                 $f = Formula("atanh(x+5)");
                 $df = $f->D('x');
@@ -1598,7 +1598,7 @@
         </exercise>
   <!-- Exercise 20 -->
         <exercise label="ex-hyperbolic-derivative-11">
-          <webwork xml:id="ex-hyperbolic-derivative-11">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-11">
               <pg-code>
                 $f = Formula("atanh(cos(x))");
                 $df = $f->D('x');
@@ -1617,7 +1617,7 @@
         </exercise>
   <!-- Exercise 21 -->
         <exercise label="ex-hyperbolic-derivative-12">
-          <webwork xml:id="ex-hyperbolic-derivative-12">
+          <webwork xml:id="webwork-ex-hyperbolic-derivative-12">
               <pg-code>
                 $f = Formula("acosh(sec(x))");
                 $df = $f->D('x');
@@ -1647,7 +1647,7 @@
         </introduction>
   <!-- Exercise 22 -->
         <exercise label="ex-hyperbolic-tangent-1">
-          <webwork xml:id="ex-hyperbolic-tangent-1">
+          <webwork xml:id="webwork-ex-hyperbolic-tangent-1">
               <pg-code>
                 $x0 = 0;
                 $f = Formula("sinh(x)");
@@ -1677,7 +1677,7 @@
         </exercise>
   <!-- Exercise 23 -->
         <exercise label="ex-hyperbolic-tangent-2">
-          <webwork xml:id="ex-hyperbolic-tangent-2">
+          <webwork xml:id="webwork-ex-hyperbolic-tangent-2">
               <pg-code>
                 $x0 = ln(2);
                 $f = Formula("cosh(x)");
@@ -1707,7 +1707,7 @@
         </exercise>
   <!-- New problem -->
         <exercise label="ex-hyperbolic-tangent-3">
-          <webwork xml:id="ex-hyperbolic-tangent-3">
+          <webwork xml:id="webwork-ex-hyperbolic-tangent-3">
               <pg-code>
                 $x0 = -ln(3);
                 $f = Formula("tanh(x)");
@@ -1739,7 +1739,7 @@
 
   <!-- Exercise 24 -->
         <exercise label="ex-hyperbolic-tangent-4">
-          <webwork xml:id="ex-hyperbolic-tangent-4">
+          <webwork xml:id="webwork-ex-hyperbolic-tangent-4">
               <pg-code>
                 $x0 = ln(3);
                 $f = Formula("sech(x)^2");
@@ -1769,7 +1769,7 @@
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-hyperbolic-tangent-5">
-          <webwork xml:id="ex-hyperbolic-tangent-5">
+          <webwork xml:id="webwork-ex-hyperbolic-tangent-5">
               <pg-code>
                 $x0 = 0;
                 $f = Formula("asinh(x)");
@@ -1799,7 +1799,7 @@
         </exercise>
   <!-- Exercise 26 -->
         <exercise label="ex-hyperbolic-tangent-6">
-          <webwork xml:id="ex-hyperbolic-tangent-6">
+          <webwork xml:id="webwork-ex-hyperbolic-tangent-6">
               <pg-code>
                 $x0 = sqrt(2);
                 $f = Formula("acosh(x)");
@@ -1838,7 +1838,7 @@
         </introduction>
   <!-- Exercise 27 -->
         <exercise label="ex-hyperbolic-integral-1">
-          <webwork xml:id="ex-hyperbolic-integral-1">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-1">
               <pg-code>
                 $F = FormulaUpToConstant("1/2*ln(cosh(2x))");
               </pg-code>
@@ -1856,7 +1856,7 @@
         </exercise>
   <!-- Exercise 28 -->
         <exercise label="ex-hyperbolic-integral-2">
-          <webwork xml:id="ex-hyperbolic-integral-2">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-2">
               <pg-code>
                 $F = FormulaUpToConstant("1/3*sinh(3x-7)");
               </pg-code>
@@ -1874,7 +1874,7 @@
         </exercise>
   <!-- Exercise 29 -->
         <exercise label="ex-hyperbolic-integral-3">
-          <webwork xml:id="ex-hyperbolic-integral-3">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-3">
               <pg-code>
                 $F = FormulaUpToConstant("1/2*sinh(x)^2");
               </pg-code>
@@ -1892,7 +1892,7 @@
         </exercise>
   <!-- Exercise 30 -->
         <exercise label="ex-hyperbolic-integral-4">
-          <webwork xml:id="ex-hyperbolic-integral-4">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-4">
               <pg-code>
                 $F = FormulaUpToConstant("x*sinh(x)-cosh(x)");
               </pg-code>
@@ -1910,7 +1910,7 @@
         </exercise>
   <!-- Exercise 31 -->
         <exercise label="ex-hyperbolic-integral-5">
-          <webwork xml:id="ex-hyperbolic-integral-5">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-5">
               <pg-code>
                 $F = FormulaUpToConstant("x*cosh(x)-sinh(x)");
               </pg-code>
@@ -1955,7 +1955,7 @@
 
   <!-- Exercise 32 -->
         <exercise label="ex-hyperbolic-integral-8">
-          <webwork xml:id="ex-hyperbolic-integral-8">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-8">
               <pg-code>
                 $F = FormulaUpToConstant("1/2*ln(abs(x+1))-1/2*ln(abs(x-1))");
               </pg-code>
@@ -1982,7 +1982,7 @@
         </exercise>
   <!-- Exercise 33 -->
         <exercise label="ex-hyperbolic-integral-9">
-          <webwork xml:id="ex-hyperbolic-integral-9">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-9">
               <pg-code>
                 $F = FormulaUpToConstant("acosh(x^2/2)");
               </pg-code>
@@ -2000,7 +2000,7 @@
         </exercise>
   <!-- Exercise 34 -->
         <exercise label="ex-hyperbolic-integral-10">
-          <webwork xml:id="ex-hyperbolic-integral-10">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-10">
               <pg-code>
                 $F = FormulaUpToConstant("2/3*asinh(x^(3/2))");
               </pg-code>
@@ -2018,7 +2018,7 @@
         </exercise>
   <!-- Exercise 35 -->
         <exercise label="ex-hyperbolic-integral-11">
-          <webwork xml:id="ex-hyperbolic-integral-11">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-11">
               <pg-code>
                 $F = FormulaUpToConstant("-1/16*atan(x/2)+1/32*ln(abs(x-2))-1/32*ln(abs(x+2))");
               </pg-code>
@@ -2036,7 +2036,7 @@
         </exercise>
   <!-- Exercise 36 -->
         <exercise label="ex-hyperbolic-integral-12">
-          <webwork xml:id="ex-hyperbolic-integral-12">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-12">
               <pg-code>
                 $F = FormulaUpToConstant("ln(x)-ln(abs(x+1))");
               </pg-code>
@@ -2054,7 +2054,7 @@
         </exercise>
   <!-- Exercise 37 -->
         <exercise label="ex-hyperbolic-integral-13">
-          <webwork xml:id="ex-hyperbolic-integral-13">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-13">
               <pg-code>
                 $F = FormulaUpToConstant("atan(e^x)");
               </pg-code>
@@ -2072,7 +2072,7 @@
         </exercise>
   <!-- Exercise 38 -->
         <exercise label="ex-hyperbolic-integral-14">
-          <webwork xml:id="ex-hyperbolic-integral-14">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-14">
               <pg-code>
                 $F = FormulaUpToConstant("x*asinh(x)-sqrt(x^2+1)");
               </pg-code>
@@ -2090,7 +2090,7 @@
         </exercise>
   <!-- Exercise 39 -->
         <exercise label="ex-hyperbolic-integral-15">
-          <webwork xml:id="ex-hyperbolic-integral-15">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-15">
               <pg-code>
                 $F = FormulaUpToConstant("x*atanh(x)+1/2*ln(abs(x^2-1))");
               </pg-code>
@@ -2108,7 +2108,7 @@
         </exercise>
   <!-- Exercise 40 -->
         <exercise label="ex-hyperbolic-integral-16">
-          <webwork xml:id="ex-hyperbolic-integral-16">
+          <webwork xml:id="webwork-ex-hyperbolic-integral-16">
               <pg-code>
                 $F = FormulaUpToConstant("atan(sinh(x))");
               </pg-code>
@@ -2140,7 +2140,7 @@
         </introduction>
   <!-- Exercise 41 -->
         <exercise label="ex-hyperbolic-defint-1">
-          <webwork xml:id="ex-hyperbolic-defint-1">
+          <webwork xml:id="webwork-ex-hyperbolic-defint-1">
               <pg-code>
                 $a = -1;
                 $b = 1;
@@ -2162,7 +2162,7 @@
         </exercise>
   <!-- Exercise 42 -->
         <exercise label="ex-hyperbolic-defint-2">
-          <webwork xml:id="ex-hyperbolic-defint-2">
+          <webwork xml:id="webwork-ex-hyperbolic-defint-2">
               <pg-code>
                 $a = -ln(2);
                 $b = ln(2);
@@ -2184,7 +2184,7 @@
         </exercise>
   <!-- Exercise 43 -->
         <exercise label="ex-hyperbolic-defint-3">
-          <webwork xml:id="ex-hyperbolic-defint-3">
+          <webwork xml:id="webwork-ex-hyperbolic-defint-3">
               <pg-code>
                 $a = 0;
                 $b = 1;
@@ -2206,7 +2206,7 @@
         </exercise>
   <!-- New problem -->
         <exercise label="ex-hyperbolic-defint-4">
-          <webwork xml:id="ex-hyperbolic-defint-4">
+          <webwork xml:id="webwork-ex-hyperbolic-defint-4">
               <pg-code>
                 $a = 0;
                 $b = 2;

--- a/ptx/sec_improper_integration.ptx
+++ b/ptx/sec_improper_integration.ptx
@@ -1094,7 +1094,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-improper-integration-1">
-        <webwork xml:id="TaC-improper-integration-1">
+        <webwork xml:id="webwork-TaC-improper-integration-1">
             <pg-code>
             </pg-code>
             <statement>
@@ -1118,7 +1118,7 @@
       </exercise>
 <!-- Exercise 2 -->
       <exercise label="TaC-improper-integration-2">
-        <webwork xml:id="TaC-improper-integration-2">
+        <webwork xml:id="webwork-TaC-improper-integration-2">
             <pg-code>
             </pg-code>
             <statement>
@@ -1136,7 +1136,7 @@
       </exercise>
 <!-- Exercise 3 -->
       <exercise label="TaC-improper-integration-3">
-        <webwork xml:id="TaC-improper-integration-3">
+        <webwork xml:id="webwork-TaC-improper-integration-3">
             <pg-code>
             </pg-code>
             <statement>
@@ -1155,7 +1155,7 @@
       </exercise>
 <!-- Exercise 4 -->
       <exercise label="TaC-improper-integration-4">
-        <!-- <webwork xml:id="TaC-improper-integration-4">
+        <!-- <webwork xml:id="webwork-TaC-improper-integration-4">
             <pg-code> -->
 <!--               <todo>Make &le; and &ge; work in the popup (#8804 and #8805)</todo>
               <todo>Or just figure out how to handle entry like p \gt 1</todo>
@@ -1205,7 +1205,7 @@
       </exercise>
 <!-- Exercise 5 -->
       <exercise label="TaC-improper-integration-5">
-        <!-- <webwork xml:id="TaC-improper-integration-5">
+        <!-- <webwork xml:id="webwork-TaC-improper-integration-5">
             <pg-code> -->
             <!-- <todo>Make &le; and &ge; work in the popup (#8804 and #8805)</todo> -->
               <!-- $o = PopUp(['?','&lt;','>'],2);
@@ -1253,7 +1253,7 @@
       </exercise>
 <!-- Exercise 6 -->
       <exercise label="TaC-improper-integration-6">
-        <!-- <webwork xml:id="TaC-improper-integration-6">
+        <!-- <webwork xml:id="webwork-TaC-improper-integration-6">
             <pg-code> -->
             <!-- <todo>Make &le; and &ge; work in the popup (#8804 and #8805)</todo> -->
               <!-- $o = PopUp(['?','&lt;','>'],1);
@@ -1312,7 +1312,7 @@
         </introduction>
   <!-- Exercise 7 -->
         <exercise label="ex-improper-integration-evaluate-1">
-          <webwork xml:id="ex-improper-integration-evaluate-1">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-1">
               <pg-code>
                 $f = Formula("e^(5-2x)");
                 $l = Compute("e^5/2");
@@ -1330,7 +1330,7 @@
         </exercise>
   <!-- Exercise 8 -->
         <exercise label="ex-improper-integration-evaluate-2">
-          <webwork xml:id="ex-improper-integration-evaluate-2">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-2">
               <pg-code>
                 $f = Formula("1/x^3");
                 $l = Compute("1/2");
@@ -1348,7 +1348,7 @@
         </exercise>
   <!-- Exercise 9 -->
         <exercise label="ex-improper-integration-evaluate-3">
-          <webwork xml:id="ex-improper-integration-evaluate-3">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-3">
               <pg-code>
                 $f = Formula("x^-4");
                 $l = Compute("1/3");
@@ -1366,7 +1366,7 @@
         </exercise>
   <!-- Exercise 10 -->
         <exercise label="ex-improper-integration-evaluate-4">
-          <webwork xml:id="ex-improper-integration-evaluate-4">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-4">
               <pg-code>
                 $f = Formula("1/(x^2+9)");
                 $l = Compute("pi/3");
@@ -1384,7 +1384,7 @@
         </exercise>
   <!-- Exercise 11 -->
         <exercise label="ex-improper-integration-evaluate-5">
-          <webwork xml:id="ex-improper-integration-evaluate-5">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-5">
               <pg-code>
                 $f = Formula("2^x");
                 $l = Compute("1/ln(2)");
@@ -1402,7 +1402,7 @@
         </exercise>
   <!-- Exercise 12 -->
         <exercise label="ex-improper-integration-evaluate-6">
-          <webwork xml:id="ex-improper-integration-evaluate-6">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-6">
               <pg-code>
                 $f = Formula("(1/2)^x");  <!-- Renders as 0.5^x -->
                 $l = Compute("inf");
@@ -1420,7 +1420,7 @@
         </exercise>
   <!-- Exercise 13 -->
         <exercise label="ex-improper-integration-evaluate-7">
-          <webwork xml:id="ex-improper-integration-evaluate-7">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-7">
               <pg-code>
                 $f = Formula("x/(x^2+1)");
                 $l = Compute("inf");
@@ -1438,7 +1438,7 @@
         </exercise>
   <!-- Exercise 14 -->
         <exercise label="ex-improper-integration-evaluate-8">
-          <webwork xml:id="ex-improper-integration-evaluate-8">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-8">
               <pg-code>
                 $f = Formula("x/(x^2-4)");
                 $l = Compute("inf");
@@ -1456,7 +1456,7 @@
         </exercise>
   <!-- Exercise 15 -->
         <exercise label="ex-improper-integration-evaluate-9">
-          <webwork xml:id="ex-improper-integration-evaluate-9">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-9">
               <pg-code>
                 $f = Formula("1/(x-1)^2");
                 $l = Compute("1");
@@ -1474,7 +1474,7 @@
         </exercise>
   <!-- Exercise 16 -->
         <exercise label="ex-improper-integration-evaluate-10">
-          <webwork xml:id="ex-improper-integration-evaluate-10">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-10">
               <pg-code>
                 $f = Formula("1/(x-1)^2");
                 $l = Compute("inf");
@@ -1492,7 +1492,7 @@
         </exercise>
   <!-- Exercise 17 -->
         <exercise label="ex-improper-integration-evaluate-11">
-          <webwork xml:id="ex-improper-integration-evaluate-11">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-11">
               <pg-code>
                 $f = Formula("1/(x-1)");
                 $l = Compute("inf");
@@ -1510,7 +1510,7 @@
         </exercise>
   <!-- Exercise 18 -->
         <exercise label="ex-improper-integration-evaluate-12">
-          <webwork xml:id="ex-improper-integration-evaluate-12">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-12">
               <pg-code>
                 $f = Formula("1/(x-1)");
                 $l = Compute("inf");
@@ -1528,7 +1528,7 @@
         </exercise>
   <!-- Exercise 19 -->
         <exercise label="ex-improper-integration-evaluate-13">
-          <webwork xml:id="ex-improper-integration-evaluate-13">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-13">
               <pg-code>
                 $f = Formula("1/x");
                 $l = Compute("inf");
@@ -1546,7 +1546,7 @@
         </exercise>
   <!-- Exercise 20 -->
         <exercise label="ex-improper-integration-evaluate-14">
-          <webwork xml:id="ex-improper-integration-evaluate-14">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-14">
               <pg-code>
                 $f = Formula("1/(x-2)");
                 $l = Compute("inf");
@@ -1564,7 +1564,7 @@
         </exercise>
   <!-- Exercise 21 -->
         <exercise label="ex-improper-integration-evaluate-15">
-          <webwork xml:id="ex-improper-integration-evaluate-15">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-15">
               <pg-code>
                 $f = Formula("sec(x)^2");
                 $l = Compute("inf");
@@ -1582,7 +1582,7 @@
         </exercise>
   <!-- Exercise 22 -->
         <exercise label="ex-improper-integration-evaluate-16">
-          <webwork xml:id="ex-improper-integration-evaluate-16">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-16">
               <pg-code>
                 $f = Formula("1/sqrt(abs(x))");
                 $l = Compute("2+2*sqrt(2)");
@@ -1600,7 +1600,7 @@
         </exercise>
   <!-- Exercise 23 -->
         <exercise label="ex-improper-integration-evaluate-17">
-          <webwork xml:id="ex-improper-integration-evaluate-17">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-17">
               <pg-code>
                 $f = Formula("x*e^-x");
                 $l = Compute("1");
@@ -1618,7 +1618,7 @@
         </exercise>
   <!-- Exercise 24 -->
         <exercise label="ex-improper-integration-evaluate-18">
-          <webwork xml:id="ex-improper-integration-evaluate-18">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-18">
               <pg-code>
                 $f = Formula("x*e^(-x^2)");
                 $l = Compute("1/2");
@@ -1636,7 +1636,7 @@
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-improper-integration-evaluate-19">
-          <webwork xml:id="ex-improper-integration-evaluate-19">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-19">
               <pg-code>
                 $f = Formula("x*e^(-x^2)");
                 $l = Compute("0");
@@ -1654,7 +1654,7 @@
         </exercise>
   <!-- Exercise 26 -->
         <exercise label="ex-improper-integration-evaluate-20">
-          <webwork xml:id="ex-improper-integration-evaluate-20">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-20">
               <pg-code>
                 $f = Formula("1/(e^x+e^-x)");
                 $l = Compute("pi/2");
@@ -1672,7 +1672,7 @@
         </exercise>
   <!-- Exercise 27 -->
         <exercise label="ex-improper-integration-evaluate-21">
-          <webwork xml:id="ex-improper-integration-evaluate-21">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-21">
               <pg-code>
                 $f = Formula("x*ln(x)");
                 $l = Compute("-1/4");
@@ -1691,7 +1691,7 @@
 
   <!-- New problem -->
         <exercise label="ex-improper-integration-evaluate-22">
-          <webwork xml:id="ex-improper-integration-evaluate-22">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-22">
               <pg-code>
                 $f = Formula("x^2*ln(x)");
                 $l = Compute("-1/9");
@@ -1710,7 +1710,7 @@
 
   <!-- Exercise 28 -->
         <exercise label="ex-improper-integration-evaluate-23">
-          <webwork xml:id="ex-improper-integration-evaluate-23">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-23">
               <pg-code>
                 $f = Formula("ln(x)/x");
                 $l = Compute("inf");
@@ -1728,7 +1728,7 @@
         </exercise>
   <!-- Exercise 29 -->
         <exercise label="ex-improper-integration-evaluate-24">
-          <webwork xml:id="ex-improper-integration-evaluate-24">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-24">
               <pg-code>
                 $f = Formula("ln(x)");
                 $l = Compute("-1");
@@ -1746,7 +1746,7 @@
         </exercise>
   <!-- Exercise 30 -->
         <exercise label="ex-improper-integration-evaluate-25">
-          <webwork xml:id="ex-improper-integration-evaluate-25">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-25">
               <pg-code>
                 $f = Formula("ln(x)/x^2");
                 $l = Compute("1");
@@ -1764,7 +1764,7 @@
         </exercise>
   <!-- Exercise 31 -->
         <exercise label="ex-improper-integration-evaluate-26">
-          <webwork xml:id="ex-improper-integration-evaluate-26">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-26">
               <pg-code>
                 $f = Formula("ln(x)/sqrt(x)");
                 $l = Compute("inf");
@@ -1782,7 +1782,7 @@
         </exercise>
   <!-- Exercise 32 -->
         <exercise label="ex-improper-integration-evaluate-27">
-          <webwork xml:id="ex-improper-integration-evaluate-27">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-27">
               <pg-code>
                 $f = Formula("e^-x*sin(x)");
                 $l = Compute("1/2");
@@ -1800,7 +1800,7 @@
         </exercise>
   <!-- Exercise 33 -->
         <exercise label="ex-improper-integration-evaluate-28">
-          <webwork xml:id="ex-improper-integration-evaluate-28">
+          <webwork xml:id="webwork-ex-improper-integration-evaluate-28">
               <pg-code>
                 $f = Formula("e^-x*cos(x)");
                 $l = Compute("1/2");
@@ -1829,7 +1829,7 @@
         </introduction>
   <!-- Exercise 34 -->
         <exercise label="ex-improper-integration-compare-1">
-          <webwork xml:id="ex-improper-integration-compare-1">
+          <webwork xml:id="webwork-ex-improper-integration-compare-1">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1850,7 +1850,7 @@
         </exercise>
   <!-- Exercise 35 -->
         <exercise label="ex-improper-integration-compare-2">
-          <webwork xml:id="ex-improper-integration-compare-2">
+          <webwork xml:id="webwork-ex-improper-integration-compare-2">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1871,7 +1871,7 @@
         </exercise>
   <!-- Exercise 36 -->
         <exercise label="ex-improper-integration-compare-3">
-          <webwork xml:id="ex-improper-integration-compare-3">
+          <webwork xml:id="webwork-ex-improper-integration-compare-3">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1892,7 +1892,7 @@
         </exercise>
   <!-- Exercise 37 -->
         <exercise label="ex-improper-integration-compare-4">
-          <webwork xml:id="ex-improper-integration-compare-4">
+          <webwork xml:id="webwork-ex-improper-integration-compare-4">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1913,7 +1913,7 @@
         </exercise>
   <!-- Exercise 38 -->
         <exercise label="ex-improper-integration-compare-5">
-          <webwork xml:id="ex-improper-integration-compare-5">
+          <webwork xml:id="webwork-ex-improper-integration-compare-5">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1934,7 +1934,7 @@
         </exercise>
   <!-- Exercise 39 -->
         <exercise label="ex-improper-integration-compare-6">
-          <webwork xml:id="ex-improper-integration-compare-6">
+          <webwork xml:id="webwork-ex-improper-integration-compare-6">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1955,7 +1955,7 @@
         </exercise>
   <!-- Exercise 40 -->
         <exercise label="ex-improper-integration-compare-7">
-          <webwork xml:id="ex-improper-integration-compare-7">
+          <webwork xml:id="webwork-ex-improper-integration-compare-7">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1976,7 +1976,7 @@
         </exercise>
   <!-- Exercise 41 -->
         <exercise label="ex-improper-integration-compare-8">
-          <webwork xml:id="ex-improper-integration-compare-8">
+          <webwork xml:id="webwork-ex-improper-integration-compare-8">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -1998,7 +1998,7 @@
         </exercise>
   <!-- Exercise 42 -->
         <exercise label="ex-improper-integration-compare-9">
-          <webwork xml:id="ex-improper-integration-compare-9">
+          <webwork xml:id="webwork-ex-improper-integration-compare-9">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);
@@ -2019,7 +2019,7 @@
         </exercise>
   <!-- Exercise 43 -->
         <exercise label="ex-improper-integration-compare-10">
-          <webwork xml:id="ex-improper-integration-compare-10">
+          <webwork xml:id="webwork-ex-improper-integration-compare-10">
               <pg-code>
                 $DCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],1);
                 $LCT = PopUp(['?','Direct Comparison Test','Limit Comparison Test'],2);

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -776,7 +776,7 @@
     <subexercises xml:id="TaC-int-comp-tests">
       <title>Terms and Concepts</title>
       <exercise label="TaC-int-comp-tests-1">
-        <!--<webwork xml:id="TaC-int-comp-tests-1">
+        <!--<webwork xml:id="webwork-TaC-int-comp-tests-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -795,7 +795,7 @@
       </exercise>
 
       <exercise label="TaC-int-comp-tests-2">
-        <!--<webwork xml:id="TaC-int-comp-tests-2">
+        <!--<webwork xml:id="webwork-TaC-int-comp-tests-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -812,7 +812,7 @@
       </exercise>
 
       <exercise label="TaC-int-comp-tests-3">
-        <!--<webwork xml:id="TaC-int-comp-tests-3">
+        <!--<webwork xml:id="webwork-TaC-int-comp-tests-3">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -832,7 +832,7 @@
       </exercise>
 
       <exercise label="TaC-int-comp-tests-4">
-        <!--<webwork xml:id="TaC-int-comp-tests-4">
+        <!--<webwork xml:id="webwork-TaC-int-comp-tests-4">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -864,7 +864,7 @@
         </introduction>
 
         <exercise label="ex-integral-test-1">
-          <!--<webwork xml:id="ex-integral-test-1">
+          <!--<webwork xml:id="webwork-ex-integral-test-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -881,7 +881,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-2">
-          <!--<webwork xml:id="ex-integral-test-2">
+          <!--<webwork xml:id="webwork-ex-integral-test-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -898,7 +898,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-3">
-          <!--<webwork xml:id="ex-integral-test-3">
+          <!--<webwork xml:id="webwork-ex-integral-test-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -915,7 +915,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-4">
-          <!--<webwork xml:id="ex-integral-test-4">
+          <!--<webwork xml:id="webwork-ex-integral-test-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -932,7 +932,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-5">
-          <!--<webwork xml:id="ex-integral-test-5">
+          <!--<webwork xml:id="webwork-ex-integral-test-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -949,7 +949,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-6">
-          <!--<webwork xml:id="ex-integral-test-6">
+          <!--<webwork xml:id="webwork-ex-integral-test-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -966,7 +966,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-7">
-          <!--<webwork xml:id="ex-integral-test-7">
+          <!--<webwork xml:id="webwork-ex-integral-test-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -983,7 +983,7 @@
         </exercise>
 
         <exercise label="ex-integral-test-8">
-          <!--<webwork xml:id="ex-integral-test-8">
+          <!--<webwork xml:id="webwork-ex-integral-test-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1011,7 +1011,7 @@
         </introduction>
 
         <exercise label="ex-direct-comparison-1">
-          <!--<webwork xml:id="ex-direct-comparison-1">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1029,7 +1029,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-2">
-          <!--<webwork xml:id="ex-direct-comparison-2">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1047,7 +1047,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-3">
-          <!--<webwork xml:id="ex-direct-comparison-3">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1065,7 +1065,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-4">
-          <!--<webwork xml:id="ex-direct-comparison-4">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1083,7 +1083,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-5">
-          <!--<webwork xml:id="ex-direct-comparison-5">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1102,7 +1102,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-6">
-          <!--<webwork xml:id="ex-direct-comparison-6">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1120,7 +1120,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-7">
-          <!--<webwork xml:id="ex-direct-comparison-7">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1141,7 +1141,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-8">
-          <!--<webwork xml:id="ex-direct-comparison-8">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1159,7 +1159,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-9">
-          <!--<webwork xml:id="ex-direct-comparison-9">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1181,7 +1181,7 @@
         </exercise>
 
         <exercise label="ex-direct-comparison-10">
-          <!--<webwork xml:id="ex-direct-comparison-10">
+          <!--<webwork xml:id="webwork-ex-direct-comparison-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1210,7 +1210,7 @@
         </introduction>
 
         <exercise label="ex-limit-comparison-1">
-          <!--<webwork xml:id="ex-limit-comparison-1">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1227,7 +1227,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-2">
-          <!--<webwork xml:id="ex-limit-comparison-2">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1244,7 +1244,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-3">
-          <!--<webwork xml:id="ex-limit-comparison-3">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1261,7 +1261,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-4">
-          <!--<webwork xml:id="ex-limit-comparison-4">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1278,7 +1278,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-5">
-          <!--<webwork xml:id="ex-limit-comparison-5">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1295,7 +1295,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-6">
-          <!--<webwork xml:id="ex-limit-comparison-6">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1312,7 +1312,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-7">
-          <!--<webwork xml:id="ex-limit-comparison-7">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1331,7 +1331,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-8">
-          <!--<webwork xml:id="ex-limit-comparison-8">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1348,7 +1348,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-9">
-          <!--<webwork xml:id="ex-limit-comparison-9">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1365,7 +1365,7 @@
         </exercise>
 
         <exercise label="ex-limit-comparison-10">
-          <!--<webwork xml:id="ex-limit-comparison-10">
+          <!--<webwork xml:id="webwork-ex-limit-comparison-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1392,7 +1392,7 @@
         </introduction>
 
         <exercise label="ex-int-comp-choose-test-1">
-          <!--<webwork xml:id="ex-int-comp-choose-test-1">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1409,7 +1409,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-2">
-          <!--<webwork xml:id="ex-int-comp-choose-test-2">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1427,7 +1427,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-3">
-          <!--<webwork xml:id="ex-int-comp-choose-test-3">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1444,7 +1444,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-4">
-          <!--<webwork xml:id="ex-int-comp-choose-test-4">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1461,7 +1461,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-5">
-          <!--<webwork xml:id="ex-int-comp-choose-test-5">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1478,7 +1478,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-6">
-          <!--<webwork xml:id="ex-int-comp-choose-test-6">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1497,7 +1497,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-7">
-          <!--<webwork xml:id="ex-int-comp-choose-test-7">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1515,7 +1515,7 @@
         </exercise>
 
         <exercise label="ex-int-comp-choose-test-8">
-          <!--<webwork xml:id="ex-int-comp-choose-test-8">
+          <!--<webwork xml:id="webwork-ex-int-comp-choose-test-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1533,7 +1533,7 @@
       </exercisegroup>
 
       <exercise label="ex-int-comp-test-multi1">
-        <!--<webwork xml:id="ex-int-comp-test-multi1">
+        <!--<webwork xml:id="webwork-ex-int-comp-test-multi1">
             <pg-code>
             </pg-code>-->
             <introduction>

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -759,7 +759,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="ex-TaC-iterated-integrals-1">
-        <!--<webwork xml:id="ex-TaC-iterated-integrals-1">
+        <!--<webwork xml:id="webwork-ex-TaC-iterated-integrals-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -781,7 +781,7 @@
       </exercise>
 
       <exercise label="ex-TaC-iterated-integrals-2">
-        <!--<webwork xml:id="ex-TaC-iterated-integrals-2">
+        <!--<webwork xml:id="webwork-ex-TaC-iterated-integrals-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -798,7 +798,7 @@
       </exercise>
 
       <exercise label="ex-TaC-iterated-integrals-3">
-        <!--<webwork xml:id="ex-TaC-iterated-integrals-3">
+        <!--<webwork xml:id="webwork-ex-TaC-iterated-integrals-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -816,7 +816,7 @@
       </exercise>
 
       <exercise label="ex-TaC-iterated-integrals-4">
-        <!--<webwork xml:id="ex-TaC-iterated-integrals-4">
+        <!--<webwork xml:id="webwork-ex-TaC-iterated-integrals-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -845,7 +845,7 @@
         </introduction>
 
         <exercise label="ex-iterated-integrals-evaluate-1">
-          <!--<webwork xml:id="ex-iterated-integrals-evaluate-1">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-evaluate-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -886,7 +886,7 @@
         </exercise>
         <!--TODO: the webwork code here does not display well in static-->
         <exercise label="ex-iterated-integrals-evaluate-2">
-          <!-- <webwork xml:id="ex-iterated-integrals-evaluate-2">
+          <!-- <webwork xml:id="webwork-ex-iterated-integrals-evaluate-2">
 
               <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
@@ -932,7 +932,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-3">
-          <!--<webwork xml:id="ex-iterated-integrals-evaluate-3">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-evaluate-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -973,7 +973,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-4">
-          <!-- <webwork xml:id="ex-iterated-integrals-evaluate-4">
+          <!-- <webwork xml:id="webwork-ex-iterated-integrals-evaluate-4">
 
               <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
@@ -1020,7 +1020,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-5">
-          <!--<webwork xml:id="ex-iterated-integrals-evaluate-5">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-evaluate-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1061,7 +1061,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-6">
-          <!-- <webwork xml:id="ex-iterated-integrals-evaluate-6">
+          <!-- <webwork xml:id="webwork-ex-iterated-integrals-evaluate-6">
 
               <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
@@ -1111,7 +1111,7 @@
         </introduction>
 
         <exercise label="ex-iterated-integrals-both-orders-1">
-          <!--<webwork xml:id="ex-iterated-integrals-both-orders-1">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-both-orders-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1155,7 +1155,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-both-orders-2">
-          <!--<webwork xml:id="ex-iterated-integrals-both-orders-2">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-both-orders-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1199,7 +1199,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-both-orders-3">
-          <!--<webwork xml:id="ex-iterated-integrals-both-orders-3">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-both-orders-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1245,7 +1245,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-both-orders-4">
-          <!--<webwork xml:id="ex-iterated-integrals-both-orders-4">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-both-orders-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1289,7 +1289,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-both-orders-5">
-          <!--<webwork xml:id="ex-iterated-integrals-both-orders-5">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-both-orders-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1332,7 +1332,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-both-orders-6">
-          <!--<webwork xml:id="ex-iterated-integrals-both-orders-6">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-both-orders-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1387,7 +1387,7 @@
         </introduction>
 
         <exercise label="ex-iterated-integrals-change-order-1">
-          <!--<webwork xml:id="ex-iterated-integrals-change-order-1">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-change-order-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1428,7 +1428,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-change-order-2">
-          <!--<webwork xml:id="ex-iterated-integrals-change-order-2">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-change-order-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1471,7 +1471,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-change-order-3">
-          <!--<webwork xml:id="ex-iterated-integrals-change-order-3">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-change-order-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1512,7 +1512,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-change-order-4">
-          <!--<webwork xml:id="ex-iterated-integrals-change-order-4">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-change-order-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1553,7 +1553,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-change-order-5">
-          <!--<webwork xml:id="ex-iterated-integrals-change-order-5">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-change-order-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1597,7 +1597,7 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-change-order-6">
-          <!--<webwork xml:id="ex-iterated-integrals-change-order-6">
+          <!--<webwork xml:id="webwork-ex-iterated-integrals-change-order-6">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -556,7 +556,7 @@
       <title>Terms and Concepts</title>
 <!-- Exercise 1 -->
       <exercise label="TaC-lHospitals-rule-1">
-        <webwork xml:id="TaC-lHospitals-rule-1">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-1">
             <pg-code>
             </pg-code>
             <statement>
@@ -579,7 +579,7 @@
       </exercise>
 <!-- Exercise 2 -->
       <exercise label="TaC-lHospitals-rule-2">
-        <webwork xml:id="TaC-lHospitals-rule-2">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-2">
             <pg-code>
               $true = PopUp(['?','True','False'],1);
               $false = PopUp(['?','True','False'],2);
@@ -593,7 +593,7 @@
       </exercise>
 <!-- Exercise 3 -->
       <exercise label="TaC-lHospitals-rule-3">
-        <webwork xml:id="TaC-lHospitals-rule-3">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-3">
             <pg-code>
               $true = PopUp(['?','True','False'],1);
               $false = PopUp(['?','True','False'],2);
@@ -608,7 +608,7 @@
       </exercise>
 <!-- Exercise 4 -->
       <exercise label="TaC-lHospitals-rule-4">
-        <webwork xml:id="TaC-lHospitals-rule-4">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-4">
             <pg-code>
             </pg-code>
             <statement>
@@ -632,7 +632,7 @@
       </exercise>
 <!-- Exercise 5 -->
       <exercise label="TaC-lHospitals-rule-5">
-        <webwork xml:id="TaC-lHospitals-rule-5">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-5">
             <pg-code>
             </pg-code>
             <statement>
@@ -650,7 +650,7 @@
       </exercise>
 <!-- Exercise 6 -->
       <exercise label="TaC-lHospitals-rule-6">
-        <webwork xml:id="TaC-lHospitals-rule-6">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-6">
             <pg-code>
             </pg-code>
             <statement>
@@ -667,7 +667,7 @@
       </exercise>
 <!-- Exercise 7 -->
       <exercise label="TaC-lHospitals-rule-7">
-        <webwork xml:id="TaC-lHospitals-rule-7">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-7">
             <pg-code>
             </pg-code>
             <statement>
@@ -684,7 +684,7 @@
       </exercise>
 
       <exercise label="TaC-lHospitals-rule-8">
-        <webwork xml:id="TaC-lHospitals-rule-8">
+        <webwork xml:id="webwork-TaC-lHospitals-rule-8">
             <pg-code>
             </pg-code>
             <statement>
@@ -712,7 +712,7 @@
         </introduction>
   <!-- Exercise 8 -->
         <exercise label="ex-lHospitals-rule-evaluate-1">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-1">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-1">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = 1;
@@ -741,7 +741,7 @@
         </exercise>
   <!-- Exercise 9 -->
         <exercise label="ex-lHospitals-rule-evaluate-2">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-2">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-2">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = 2;
@@ -771,7 +771,7 @@
         </exercise>
   <!-- Exercise 10 -->
         <exercise label="ex-lHospitals-rule-evaluate-3">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-3">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-3">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = pi;
@@ -801,7 +801,7 @@
         </exercise>
   <!-- Exercise 11 -->
         <exercise label="ex-lHospitals-rule-evaluate-4">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-4">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-4">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = pi/4;
@@ -831,7 +831,7 @@
         </exercise>
   <!-- Exercise 12 -->
         <exercise label="ex-lHospitals-rule-evaluate-5">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-5">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-5">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = 0;
@@ -861,7 +861,7 @@
         </exercise>
   <!-- Exercise 13 -->
         <exercise label="ex-lHospitals-rule-evaluate-6">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-6">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-6">
               <pg-code>
               <!-- Not indeterminate - evaluate directly -->
                 $xlim = 0;
@@ -884,7 +884,7 @@
         </exercise>
   <!-- Exercise 14 -->
         <exercise label="ex-lHospitals-rule-evaluate-7">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-7">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-7">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = 0;
@@ -914,7 +914,7 @@
         </exercise>
   <!-- Exercise 15 -->
         <exercise label="ex-lHospitals-rule-evaluate-8">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-8">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-8">
               <pg-code>
               <!-- Form 0/0, one iteration -->
               <!-- This problem uses constants a and b, hence substitute not eval -->
@@ -945,7 +945,7 @@
         </exercise>
   <!-- Exercise 16 -->
         <exercise label="ex-lHospitals-rule-evaluate-9">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-9">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-9">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = 0;
@@ -975,7 +975,7 @@
         </exercise>
   <!-- Exercise 17 -->
         <exercise label="ex-lHospitals-rule-evaluate-10">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-10">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-10">
               <pg-code>
               <!-- Form 0/0, two iterations -->
                 $xlim = 0;
@@ -1005,7 +1005,7 @@
         </exercise>
   <!-- Exercise 18 -->
         <exercise label="ex-lHospitals-rule-evaluate-11">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-11">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-11">
               <pg-code>
               <!-- Form 0/0, two iterations -->
                 $xlim = 0;
@@ -1035,7 +1035,7 @@
         </exercise>
   <!-- Exercise 19 -->
         <exercise label="ex-lHospitals-rule-evaluate-12">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-12">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-12">
               <pg-code>
               <!-- Form inf/inf -->
               <!-- Not sure how to do this without just knowing what the result is and writing f(x)/g(x) to get that result, ala sec_limits_infy.mbx -->
@@ -1057,7 +1057,7 @@
         </exercise>
   <!-- Exercise 20 -->
         <exercise label="ex-lHospitals-rule-evaluate-13">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-13">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-13">
               <pg-code>
               <!-- Form inf/inf -->
                 $l = Compute("0");
@@ -1078,7 +1078,7 @@
         </exercise>
   <!-- New problem -->
         <exercise label="ex-lHospitals-rule-evaluate-14">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-14">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-14">
               <pg-code>
               <!-- Form inf/inf -->
                 $l = Compute("infinity");
@@ -1095,7 +1095,7 @@
         </exercise>
   <!-- Exercise 21 -->
         <exercise label="ex-lHospitals-rule-evaluate-15">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-15">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-15">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("e^x");
@@ -1116,7 +1116,7 @@
         </exercise>
   <!-- Exercise 22 -->
         <exercise label="ex-lHospitals-rule-evaluate-16">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-16">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-16">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("e^x");
@@ -1137,7 +1137,7 @@
         </exercise>
   <!-- Exercise 23 -->
         <exercise label="ex-lHospitals-rule-evaluate-17">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-17">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-17">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("e^x");
@@ -1158,7 +1158,7 @@
         </exercise>
   <!-- Exercise 24 -->
         <exercise label="ex-lHospitals-rule-evaluate-18">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-18">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-18">
               <pg-code>
               <!-- Form 0/0, two iterations -->
                 $xlim = 3;
@@ -1188,7 +1188,7 @@
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-lHospitals-rule-evaluate-19">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-19">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-19">
               <pg-code>
               <!-- Form 0/0, two iterations -->
                 $xlim = -2;
@@ -1218,7 +1218,7 @@
         </exercise>
   <!-- Exercise 26 -->
         <exercise label="ex-lHospitals-rule-evaluate-20">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-20">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-20">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("ln(x)");
@@ -1240,7 +1240,7 @@
         </exercise>
   <!-- Exercise 27 -->
         <exercise label="ex-lHospitals-rule-evaluate-21">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-21">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-21">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("ln(x^2)");
@@ -1264,7 +1264,7 @@
         </exercise>
   <!-- Exercise 28 -->
         <exercise label="ex-lHospitals-rule-evaluate-22">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-22">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-22">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("ln(x)^2");
@@ -1288,7 +1288,7 @@
         </exercise>
   <!-- Exercise 29 -->
         <exercise label="ex-lHospitals-rule-evaluate-23">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-23">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-23">
               <pg-code>
               <!-- Form 0*inf -->
                 $f1 = Formula("x");
@@ -1309,7 +1309,7 @@
         </exercise>
   <!-- Exercise 30 -->
         <exercise label="ex-lHospitals-rule-evaluate-24">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-24">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-24">
               <pg-code>
               <!-- Form 0*inf -->
                 $f1 = Formula("sqrt(x)");
@@ -1332,7 +1332,7 @@
   <!-- Exercise 31 -->
   <!-- Same as first example in on 0*inf -->
         <exercise label="ex-lHospitals-rule-evaluate-25">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-25">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-25">
               <pg-code>
               <!-- Form 0*inf -->
                 $f1 = Formula("x");
@@ -1353,7 +1353,7 @@
         </exercise>
   <!-- Exercise 32 -->
         <exercise label="ex-lHospitals-rule-evaluate-26">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-26">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-26">
               <pg-code>
               <!-- Form inf-inf -->
                 $f1 = Formula("x^3");
@@ -1375,7 +1375,7 @@
         </exercise>
   <!-- Exercise 33 -->
         <exercise label="ex-lHospitals-rule-evaluate-27">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-27">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-27">
               <pg-code>
               <!-- Form inf-inf -->
                 $f1 = Formula("sqrt(x)");
@@ -1396,7 +1396,7 @@
         </exercise>
   <!-- Exercise 34 -->
         <exercise label="ex-lHospitals-rule-evaluate-28">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-28">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-28">
               <pg-code>
               <!-- Form 0*inf -->
                 $f1 = Formula("x");
@@ -1417,7 +1417,7 @@
         </exercise>
   <!-- Exercise 35 -->
         <exercise label="ex-lHospitals-rule-evaluate-29">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-29">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-29">
               <pg-code>
               <!-- Form inf*0 -->
                 $f1 = Formula("1/x^2");
@@ -1438,7 +1438,7 @@
         </exercise>
   <!-- Exercise 36 -->
         <exercise label="ex-lHospitals-rule-evaluate-30">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-30">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-30">
               <pg-code>
               <!-- Form 1^inf -->
                 $fb = Formula("(1+x)");
@@ -1459,7 +1459,7 @@
         </exercise>
   <!-- Exercise 37 -->
         <exercise label="ex-lHospitals-rule-evaluate-31">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-31">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-31">
               <pg-code>
               <!-- Form 0^0 -->
                 $fb = Formula("2x");
@@ -1480,7 +1480,7 @@
         </exercise>
   <!-- Exercise 38 -->
         <exercise label="ex-lHospitals-rule-evaluate-32">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-32">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-32">
               <pg-code>
               <!-- Form inf^0 -->
                 $fb = Formula("2/x");
@@ -1501,7 +1501,7 @@
         </exercise>
   <!-- Exercise 39 -->
         <exercise label="ex-lHospitals-rule-evaluate-33">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-33">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-33">
               <pg-code>
               <!-- Form 0^0 -->
                 $fb = Formula("sin(x)");
@@ -1523,7 +1523,7 @@
         </exercise>
   <!-- Exercise 40 -->
         <exercise label="ex-lHospitals-rule-evaluate-34">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-34">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-34">
               <pg-code>
               <!-- Form 0^0 -->
                 $fb = Formula("1-x");
@@ -1544,7 +1544,7 @@
         </exercise>
   <!-- Exercise 41 -->
         <exercise label="ex-lHospitals-rule-evaluate-35">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-35">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-35">
               <pg-code>
               <!-- Form inf^0 -->
                 $fb = Formula("x");
@@ -1565,7 +1565,7 @@
         </exercise>
   <!-- Exercise 42 -->
         <exercise label="ex-lHospitals-rule-evaluate-36">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-36">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-36">
               <pg-code>
               <!-- Form 0^inf -->
                 $fb = Formula("1/x");
@@ -1586,7 +1586,7 @@
         </exercise>
   <!-- Exercise 43 -->
         <exercise label="ex-lHospitals-rule-evaluate-37">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-37">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-37">
               <pg-code>
               <!-- Form 0^0 -->
                 $fb = Formula("ln(x)");
@@ -1607,7 +1607,7 @@
         </exercise>
   <!-- Exercise 44 -->
         <exercise label="ex-lHospitals-rule-evaluate-38">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-38">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-38">
               <pg-code>
               <!-- Form inf^0 -->
                 $fb = Formula("1+x");
@@ -1628,7 +1628,7 @@
         </exercise>
   <!-- Exercise 45 -->
         <exercise label="ex-lHospitals-rule-evaluate-39">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-39">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-39">
               <pg-code>
               <!-- Form inf^0 -->
                 $fb = Formula("1+x^2");
@@ -1649,7 +1649,7 @@
         </exercise>
   <!-- Exercise 46 -->
         <exercise label="ex-lHospitals-rule-evaluate-40">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-40">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-40">
               <pg-code>
               <!-- Form inf*0 -->
                 $f1 = Formula("tan(x)");
@@ -1670,7 +1670,7 @@
         </exercise>
   <!-- Exercise 47 -->
         <exercise label="ex-lHospitals-rule-evaluate-41">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-41">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-41">
               <pg-code>
               <!-- Form inf*0 -->
                 $f1 = Formula("tan(x)");
@@ -1691,7 +1691,7 @@
         </exercise>
   <!-- Exercise 48 -->
         <exercise label="ex-lHospitals-rule-evaluate-42">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-42">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-42">
               <pg-code>
               <!-- Form inf-inf -->
                 $f1 = Formula("1/ln(x)");
@@ -1712,7 +1712,7 @@
         </exercise>
   <!-- Exercise 49 -->
         <exercise label="ex-lHospitals-rule-evaluate-43">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-43">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-43">
               <pg-code>
               <!-- Form inf-inf -->
                 $f1 = Formula("5/(x^2-9)");
@@ -1733,7 +1733,7 @@
         </exercise>
   <!-- Exercise 50 -->
         <exercise label="ex-lHospitals-rule-evaluate-44">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-44">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-44">
               <pg-code>
               <!-- Form inf*0 -->
                 $f1 = Formula("x");
@@ -1754,7 +1754,7 @@
         </exercise>
   <!-- Exercise 51 -->
         <exercise label="ex-lHospitals-rule-evaluate-45">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-45">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-45">
               <pg-code>
               <!-- Form inf/inf -->
                 $fu = Formula("ln(x)^3");
@@ -1775,7 +1775,7 @@
         </exercise>
   <!-- Exercise 52 -->
         <exercise label="ex-lHospitals-rule-evaluate-46">
-          <webwork xml:id="ex-lHospitals-rule-evaluate-46">
+          <webwork xml:id="webwork-ex-lHospitals-rule-evaluate-46">
               <pg-code>
               <!-- Form 0/0, one iteration -->
                 $xlim = 1;

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -1054,7 +1054,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-limit-analytically-1">
-        <webwork xml:id="TaC-limit-analytically-1">
+        <webwork xml:id="webwork-TaC-limit-analytically-1">
           <statement>
             <p>
               Explain in your own words,
@@ -1069,7 +1069,7 @@
       </exercise>
 
       <exercise label="TaC-limit-analytically-2">
-        <webwork xml:id="TaC-limit-analytically-2">
+        <webwork xml:id="webwork-TaC-limit-analytically-2">
           <statement>
             <p>
               Explain in your own words,
@@ -1084,7 +1084,7 @@
       </exercise>
 
       <exercise label="TaC-limit-analytically-3">
-        <webwork xml:id="TaC-limit-analytically-3">
+        <webwork xml:id="webwork-TaC-limit-analytically-3">
           <statement>
             <p>
               What does the text mean when it says that certain functions'
@@ -1107,7 +1107,7 @@
       </exercise>
 
       <exercise label="TaC-limit-analytically-5">
-        <webwork xml:id="TaC-limit-analytically-5">
+        <webwork xml:id="webwork-TaC-limit-analytically-5">
           <statement>
             <p>
               You are given the following information:
@@ -1132,7 +1132,7 @@
       </exercise>
 
       <exercise label="TaC-limit-analytically-6">
-        <webwork xml:id="TaC-limit-analytically-6">
+        <webwork xml:id="webwork-TaC-limit-analytically-6">
           <pg-code>
             $iszero=PopUp(['?','True','False'],'True');
             $showwork = '[@ explanation_box(message => "Use a theorem to defend your answer.") @]*';
@@ -1172,7 +1172,7 @@
         </introduction>
 
         <exercise label="ex-limit-analytically-eval-properties-1">
-          <webwork xml:id="ex-limit-analytically-eval-properties-1">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-1">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1211,7 +1211,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-2">
-          <webwork xml:id="ex-limit-analytically-eval-properties-2">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-2">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1263,7 +1263,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-3">
-          <webwork xml:id="ex-limit-analytically-eval-properties-3">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-3">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1304,7 +1304,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-4">
-          <webwork xml:id="ex-limit-analytically-eval-properties-4">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-4">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1345,7 +1345,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-5">
-          <webwork xml:id="ex-limit-analytically-eval-properties-5">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-5">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1384,7 +1384,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-6">
-          <webwork xml:id="ex-limit-analytically-eval-properties-6">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-6">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1423,7 +1423,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-7">
-          <webwork xml:id="ex-limit-analytically-eval-properties-7">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-7">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1462,7 +1462,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-properties-8">
-          <webwork xml:id="ex-limit-analytically-eval-properties-8">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-properties-8">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1514,7 +1514,7 @@
         </introduction>
 
         <exercise label="ex-limit-analytically-eval-more-props-1">
-          <webwork xml:id="ex-limit-analytically-eval-more-props-1">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-more-props-1">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1556,7 +1556,7 @@
           </webwork>
         </exercise>
         <exercise label="ex-limit-analytically-eval-more-props-2">
-          <webwork xml:id="ex-limit-analytically-eval-more-props-2">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-more-props-2">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1599,7 +1599,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-more-props-3">
-          <webwork xml:id="ex-limit-analytically-eval-more-props-3">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-more-props-3">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1642,7 +1642,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-eval-more-props-4">
-          <webwork xml:id="ex-limit-analytically-eval-more-props-4">
+          <webwork xml:id="webwork-ex-limit-analytically-eval-more-props-4">
             <pg-code>
               Context()->strings->add('not possible to know'=>{});
               Context()->strings->add('NPK'=>{alias=>'not possible to know'});
@@ -1694,7 +1694,7 @@
         </introduction>
 
         <exercise label="ex-limit-analytically-evaluate-1">
-          <webwork xml:id="ex-limit-analytically-evaluate-1">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-1">
             <pg-code>
               $a=random(2,8,1);
               $b=non_zero_random(-5,5,1);
@@ -1729,7 +1729,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-2">
-          <webwork xml:id="ex-limit-analytically-evaluate-2">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-2">
             <pg-code>
               ($b,$c)=(-9..-1,1..9)[NchooseK(18,2)];
               $n=random(3,9,1);
@@ -1763,7 +1763,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-3">
-          <webwork xml:id="ex-limit-analytically-evaluate-3">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-3">
             <pg-code>
               $d=list_random(3,4,6);
               if($envir{problemSeed}==1){$d=4;};
@@ -1801,7 +1801,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-4">
-          <webwork xml:id="ex-limit-analytically-evaluate-4">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-4">
             <pg-code>
               ($a,$d)=(-6..-1,1..6)[NchooseK(12,2)];
               $b=non_zero_random(-5,5,1);
@@ -1837,7 +1837,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-5">
-          <webwork xml:id="ex-limit-analytically-evaluate-5">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-5">
             <pg-code>
               $L=Compute("DNE");
             </pg-code>
@@ -1869,7 +1869,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-6">
-          <webwork xml:id="ex-limit-analytically-evaluate-6">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-6">
             <pg-code>
               ($a,$b)=(2,3,4)[NchooseK(3,2)];
               $c=$a**2-random(1,2,1);
@@ -1904,7 +1904,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-7">
-          <webwork xml:id="ex-limit-analytically-evaluate-7">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-7">
             <pg-code>
               $d=list_random(3,4,6);
               if($envir{problemSeed}==1){$d=6;};
@@ -1937,7 +1937,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-8">
-          <webwork xml:id="ex-limit-analytically-evaluate-8">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-8">
             <pg-code>
               Context()->flags->set(reduceConstantFunctions=>0);
               $a=random(1,9,1);
@@ -1961,7 +1961,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-9">
-          <webwork xml:id="ex-limit-analytically-evaluate-9">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-9">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               #ensure rational function doesn't reduce
@@ -2003,7 +2003,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-10">
-          <webwork xml:id="ex-limit-analytically-evaluate-10">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-10">
             <pg-code>
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
               $a=non_zero_random(-5,5,1);
@@ -2032,7 +2032,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-11">
-          <webwork xml:id="ex-limit-analytically-evaluate-11">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-11">
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$a=6;$b=-2;$c=7;};
@@ -2058,7 +2058,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-12">
-          <webwork xml:id="ex-limit-analytically-evaluate-12">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-12">
             <pg-code>
               ($b,$c)=(-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$b=-2;$c=2;};
@@ -2084,7 +2084,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-13">
-          <webwork xml:id="ex-limit-analytically-evaluate-13">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-13">
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$a=2;$b=-8;$c=1;};
@@ -2110,7 +2110,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-14">
-          <webwork xml:id="ex-limit-analytically-evaluate-14">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-14">
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$a=2;$b=8;$c=-1;};
@@ -2136,7 +2136,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-15">
-          <webwork xml:id="ex-limit-analytically-evaluate-15">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-15">
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$a=-2;$b=7;$c=-8;};
@@ -2162,7 +2162,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-evaluate-16">
-          <webwork xml:id="ex-limit-analytically-evaluate-16">
+          <webwork xml:id="webwork-ex-limit-analytically-evaluate-16">
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$a=-1;$b=-8;$c=7;};
@@ -2195,7 +2195,7 @@
           </p>
         </introduction>
         <exercise label="ex-limit-analytically-squeeze-1">
-          <webwork xml:id="ex-limit-analytically-squeeze-1">
+          <webwork xml:id="webwork-ex-limit-analytically-squeeze-1">
             <pg-code>
               $showwork = '[@ explanation_box(message=>"Show your work.") @]*';
             </pg-code>
@@ -2214,7 +2214,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-squeeze-2">
-          <webwork xml:id="ex-limit-analytically-squeeze-2">
+          <webwork xml:id="webwork-ex-limit-analytically-squeeze-2">
             <pg-code>
               $showwork = '[@ explanation_box(message=>"Show your work.") @]*';
             </pg-code>
@@ -2233,7 +2233,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-squeeze-3">
-          <webwork xml:id="ex-limit-analytically-squeeze-3">
+          <webwork xml:id="webwork-ex-limit-analytically-squeeze-3">
             <pg-code>
               $showwork = '[@ explanation_box(message=>"Show your work.") @]*';
             </pg-code>
@@ -2253,7 +2253,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-squeeze-4">
-          <webwork xml:id="ex-limit-analytically-squeeze-4">
+          <webwork xml:id="webwork-ex-limit-analytically-squeeze-4">
             <pg-code>
               $showwork = '[@ explanation_box(message=>"Show your work.") @]*';
             </pg-code>
@@ -2281,7 +2281,7 @@
         </introduction>
 
         <exercise label="ex-limit-analytically-challenge-1">
-          <webwork xml:id="ex-limit-analytically-challenge-1">
+          <webwork xml:id="webwork-ex-limit-analytically-challenge-1">
             <pg-code>
               $L=random(2,9,1);
               if($envir{problemSeed}==1){$L=3;};
@@ -2303,7 +2303,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-challenge-2">
-          <webwork xml:id="ex-limit-analytically-challenge-2">
+          <webwork xml:id="webwork-ex-limit-analytically-challenge-2">
             <pg-code>
               ($a,$b)=(2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$a=5;$b=8};
@@ -2327,7 +2327,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-challenge-3">
-          <webwork xml:id="ex-limit-analytically-challenge-3">
+          <webwork xml:id="webwork-ex-limit-analytically-challenge-3">
             <pg-code>
               $L=1;
             </pg-code>
@@ -2347,7 +2347,7 @@
         </exercise>
 
         <exercise label="ex-limit-analytically-challenge-4">
-          <webwork xml:id="ex-limit-analytically-challenge-4">
+          <webwork xml:id="webwork-ex-limit-analytically-challenge-4">
             <pg-code>
               Context()->flags->set(reduceConstants=>0);
               $L=Formula("pi/180");
@@ -2370,7 +2370,7 @@
       </exercisegroup>
 
       <exercise label="ex-limit-analytically-challenge-5">
-        <webwork xml:id="ex-limit-analytically-challenge-5">
+        <webwork xml:id="webwork-ex-limit-analytically-challenge-5">
           <statement>
             <p>
               Let <m>f(x)=0</m> and <m>g(x)=\frac{x}{x}</m>.

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1272,7 +1272,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-limit-continuity-1">
-        <webwork xml:id="TaC-limit-continuity-1">
+        <webwork xml:id="webwork-TaC-limit-continuity-1">
           <statement>
             <p>
               In your own words, describe what it means for a function to be continuous.
@@ -1285,7 +1285,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-2">
-        <webwork xml:id="TaC-limit-continuity-2">
+        <webwork xml:id="webwork-TaC-limit-continuity-2">
           <statement>
             <p>
               In your own words, describe what the Intermediate Value Theorem states.
@@ -1298,7 +1298,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-3">
-        <webwork xml:id="TaC-limit-continuity-3">
+        <webwork xml:id="webwork-TaC-limit-continuity-3">
           <statement>
             <p>
               What is a <q>root</q> of a function?
@@ -1316,7 +1316,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-4">
-        <webwork xml:id="TaC-limit-continuity-4">
+        <webwork xml:id="webwork-TaC-limit-continuity-4">
           <statement>
             <p>
               Given functions <m>f</m> and <m>g</m> on an interval <m>I</m>,
@@ -1336,7 +1336,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-5">
-        <webwork xml:id="TaC-limit-continuity-5">
+        <webwork xml:id="webwork-TaC-limit-continuity-5">
           <pg-code>
             $TF=PopUp(['?','True','False'],2);
           </pg-code>
@@ -1352,7 +1352,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-6">
-        <webwork xml:id="TaC-limit-continuity-6">
+        <webwork xml:id="webwork-TaC-limit-continuity-6">
           <pg-code>
             $TF=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1368,7 +1368,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-7">
-        <webwork xml:id="TaC-limit-continuity-7">
+        <webwork xml:id="webwork-TaC-limit-continuity-7">
           <pg-code>
             $TF=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1384,7 +1384,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-8">
-        <webwork xml:id="TaC-limit-continuity-8">
+        <webwork xml:id="webwork-TaC-limit-continuity-8">
           <pg-code>
             $TF=PopUp(['?','True','False'],2);
           </pg-code>
@@ -1399,7 +1399,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-9">
-        <webwork xml:id="TaC-limit-continuity-9">
+        <webwork xml:id="webwork-TaC-limit-continuity-9">
           <pg-code>
             $TF=PopUp(['?','True','False'],2);
           </pg-code>
@@ -1414,7 +1414,7 @@
       </exercise>
 
       <exercise label="TaC-limit-continuity-10">
-        <webwork xml:id="TaC-limit-continuity-10">
+        <webwork xml:id="webwork-TaC-limit-continuity-10">
           <pg-code>
             $TF=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1438,7 +1438,7 @@
           </p>
         </introduction>
         <exercise label="ex-limit-continuity-use-graph-1">
-          <webwork xml:id="ex-limit-continuity-use-graph-1">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-1">
             <pg-code>
               $a=1;
               @b=(1,2,1,2,0.5,0);
@@ -1480,7 +1480,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-2">
-          <webwork xml:id="ex-limit-continuity-use-graph-2">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-2">
             <pg-code>
               $a=1;
               @b=(0,1,2,2,1,0);
@@ -1521,7 +1521,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-3">
-          <webwork xml:id="ex-limit-continuity-use-graph-3">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-3">
             <pg-code>
               $a=1;
               @b=(0,Compute("INF"),Compute("DNE"),Compute("INF"),1,0);
@@ -1564,7 +1564,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-4">
-          <webwork xml:id="ex-limit-continuity-use-graph-4">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-4">
             <pg-code>
               $a=0;
               ($b[1],$b[2],$b[3],$b[4]) = (0,0.5,1,1.5,2)[NchooseK(5,4)];
@@ -1606,7 +1606,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-5">
-          <webwork xml:id="ex-limit-continuity-use-graph-5">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-5">
             <pg-code>
               $a=1;
               for my$i(0..5){$b[$i]=random(0,2,0.5)};
@@ -1648,7 +1648,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-6">
-          <webwork xml:id="ex-limit-continuity-use-graph-6">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-6">
             <pg-code>
               $a=4;
               ($b[1],$b[3]) = (-4..4)[NchooseK(9,2)];
@@ -1690,7 +1690,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-7">
-          <webwork xml:id="ex-limit-continuity-use-graph-7">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-7">
             <pg-code>
               @b=(0,2,0,2,0,0,0,2,Compute("DNE"),2,0);
               for my$i(0..3){$f[$i]=Formula("($b[3*$i+1]-$b[3*$i])/2*(x-(2*$i-4))+$b[3*$i]");}
@@ -1750,7 +1750,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-use-graph-8">
-          <webwork xml:id="ex-limit-continuity-use-graph-8">
+          <webwork xml:id="webwork-ex-limit-continuity-use-graph-8">
             <pg-code>
               Context()->flags->set(reduceConstants=>0);
               $a=Formula("3pi/2");
@@ -1803,7 +1803,7 @@
         </introduction>
 
         <exercise label="ex-limit-continuity-point-1">
-          <webwork xml:id="ex-limit-continuity-point-1">
+          <webwork xml:id="webwork-ex-limit-continuity-point-1">
             <pg-code>
               Context("PiecewiseFunction");
               @choices=('?',
@@ -1846,7 +1846,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-point-2">
-          <webwork xml:id="ex-limit-continuity-point-2">
+          <webwork xml:id="webwork-ex-limit-continuity-point-2">
             <pg-code>
               Context("PiecewiseFunction");
               #for my$i(0..3){$a[$i]=non_zero_random(-2,2,1)};
@@ -1896,7 +1896,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-point-3">
-          <webwork xml:id="ex-limit-continuity-point-3">
+          <webwork xml:id="webwork-ex-limit-continuity-point-3">
             <pg-code>
               #@a=map{$_-10}NchooseK(20,4);
               Context("PiecewiseFunction");
@@ -1943,7 +1943,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-point-4">
-          <webwork xml:id="ex-limit-continuity-point-4">
+          <webwork xml:id="webwork-ex-limit-continuity-point-4">
             <pg-code>
               #@a=map{$_-12}NchooseK(24,6);
               Context("PiecewiseFunction");
@@ -1999,7 +1999,7 @@
         </introduction>
 
         <exercise label="ex-limit-continuity-interval-1">
-          <webwork xml:id="ex-limit-continuity-interval-1">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-1">
             <pg-code>
               Context("Interval");
               $a=random(-9,9,1);
@@ -2029,7 +2029,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-2">
-          <webwork xml:id="ex-limit-continuity-interval-2">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-2">
             <pg-code>
               Context("Interval");
               $a=random(1,5,1);
@@ -2059,7 +2059,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-3">
-          <webwork xml:id="ex-limit-continuity-interval-3">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-3">
             <pg-code>
               Context("Interval");
               $a=random(1,5,1);
@@ -2089,7 +2089,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-4">
-          <webwork xml:id="ex-limit-continuity-interval-4">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-4">
             <pg-code>
               Context("Interval");
               $a=random(1,5,1);
@@ -2124,7 +2124,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-5">
-          <webwork xml:id="ex-limit-continuity-interval-5">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-5">
             <pg-code>
               Context("Interval");
               $a=random(2,5,1);
@@ -2149,7 +2149,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-6">
-          <webwork xml:id="ex-limit-continuity-interval-6">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-6">
             <pg-code>
               Context("Interval");
               $a=random(1,9,1);
@@ -2173,7 +2173,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-7">
-          <webwork xml:id="ex-limit-continuity-interval-7">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-7">
             <pg-code>
               Context("Interval");
               $a=random(1,9,1);
@@ -2198,7 +2198,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-8">
-          <webwork xml:id="ex-limit-continuity-interval-8">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-8">
             <pg-code>
               Context("Interval");
               $b=list_random(2..9,Formula("e"),Formula("pi"));
@@ -2221,7 +2221,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-9">
-          <webwork xml:id="ex-limit-continuity-interval-9">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-9">
             <pg-code>
               Context("Interval");
               Context()->variables->are(s=>'Real');
@@ -2245,7 +2245,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-10">
-          <webwork xml:id="ex-limit-continuity-interval-10">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-10">
             <pg-code>
               Context("Interval");
               Context()->variables->are(t=>'Real');
@@ -2268,7 +2268,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-11">
-          <webwork xml:id="ex-limit-continuity-interval-11">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-11">
             <pg-code>
               Context("Interval");
               $a=random(1,9,1);
@@ -2292,7 +2292,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-interval-12">
-          <webwork xml:id="ex-limit-continuity-interval-12">
+          <webwork xml:id="webwork-ex-limit-continuity-interval-12">
             <pg-code>
               Context("Interval");
               $a=list_random('sin','cos');
@@ -2325,7 +2325,7 @@
         </introduction>
 
         <exercise label="ex-limit-continuity-ivt-1">
-          <webwork xml:id="ex-limit-continuity-ivt-1">
+          <webwork xml:id="webwork-ex-limit-continuity-ivt-1">
             <statement>
               <p>
                 Let <m>f</m> be continuous on <m>[1,5]</m> where
@@ -2346,7 +2346,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-ivt-2">
-          <webwork xml:id="ex-limit-continuity-ivt-2">
+          <webwork xml:id="webwork-ex-limit-continuity-ivt-2">
             <statement>
               <p>
                 Let <m>g</m> be continuous on <m>[-3,7]</m> where
@@ -2369,7 +2369,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-ivt-3">
-          <webwork xml:id="ex-limit-continuity-ivt-3">
+          <webwork xml:id="webwork-ex-limit-continuity-ivt-3">
             <statement>
               <p>
                 Let <m>f</m> be continuous on <m>[-1,1]</m> where
@@ -2392,7 +2392,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-ivt-4">
-          <webwork xml:id="ex-limit-continuity-ivt-4">
+          <webwork xml:id="webwork-ex-limit-continuity-ivt-4">
             <statement>
               <p>
                 Let <m>h</m> be a function on <m>[-1,1]</m> where
@@ -2425,7 +2425,7 @@
         </introduction>
 
         <exercise label="ex-limit-continuity-bisection-1">
-          <webwork xml:id="ex-limit-continuity-bisection-1">
+          <webwork xml:id="webwork-ex-limit-continuity-bisection-1">
             <pg-code>
               Context("Interval");
               Context()->flags->set(tolType=>'absolute',tolerance=>0.00000005);
@@ -2510,7 +2510,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-bisection-2">
-          <webwork xml:id="ex-limit-continuity-bisection-2">
+          <webwork xml:id="webwork-ex-limit-continuity-bisection-2">
             <pg-code>
               Context("Interval");
               Context()->flags->set(tolType=>'absolute',tolerance=>0.00000005,reduceConstants=>0);
@@ -2593,7 +2593,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-bisection-3">
-          <webwork xml:id="ex-limit-continuity-bisection-3">
+          <webwork xml:id="webwork-ex-limit-continuity-bisection-3">
             <pg-code>
               Context("Interval");
               Context()->flags->set(tolType=>'absolute',tolerance=>0.00000005);
@@ -2676,7 +2676,7 @@
         </exercise>
 
         <exercise label="ex-limit-continuity-bisection-4">
-          <webwork xml:id="ex-limit-continuity-bisection-4">
+          <webwork xml:id="webwork-ex-limit-continuity-bisection-4">
             <pg-code>
               Context("Interval");
               Context()->flags->set(tolType=>'absolute',tolerance=>0.00000005);
@@ -2764,7 +2764,7 @@
       <title>Review</title>
 
       <exercise label="ex-limit-continuity-review-1">
-        <webwork xml:id="ex-limit-continuity-review-1">
+        <webwork xml:id="webwork-ex-limit-continuity-review-1">
           <pg-code>
             $a=random(-2,10,1);
             $b=non_zero_random(-5,5,1);
@@ -2828,7 +2828,7 @@
       </exercise>
 
       <exercise label="ex-limit-continuity-review-2">
-        <webwork xml:id="ex-limit-continuity-review-2">
+        <webwork xml:id="webwork-ex-limit-continuity-review-2">
           <pg-code>
             $b=list_random(-9..6,6..9);
             $c=non_zero_random(-5,5,1);
@@ -2942,7 +2942,7 @@
       </exercise>
 
       <exercise label="ex-limit-continuity-review-3">
-        <webwork xml:id="ex-limit-continuity-review-3">
+        <webwork xml:id="webwork-ex-limit-continuity-review-3">
             <statement>
               <p>
                 Give an example of a function <m>f</m> for which <m>\lim\limits_{x\to 0} f(x)</m> does not exist.

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -805,7 +805,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-limit-definition-1">
-        <webwork xml:id="TaC-limit-definition-1">
+        <webwork xml:id="webwork-TaC-limit-definition-1">
             <statement>
               <p>
                 What is wrong with the following
@@ -835,7 +835,7 @@
       </exercise>
 
       <exercise label="TaC-limit-definition-2">
-        <webwork xml:id="TaC-limit-definition-2">
+        <webwork xml:id="webwork-TaC-limit-definition-2">
             <pg-code>
               $limitequalsvalue=PopUp(['?','x-tolerance','y-tolerance'],2);
             </pg-code>
@@ -851,7 +851,7 @@
       </exercise>
 
       <exercise label="TaC-limit-definition-3">
-        <webwork xml:id="TaC-limit-definition-3">
+        <webwork xml:id="webwork-TaC-limit-definition-3">
             <pg-code>
               $ispositive=PopUp(['?','True','False'],'True');
             </pg-code>
@@ -865,7 +865,7 @@
       </exercise>
 
       <exercise label="TaC-limit-definition-4">
-        <webwork xml:id="TaC-limit-definition-4">
+        <webwork xml:id="webwork-TaC-limit-definition-4">
             <pg-code>
               $ispositive=PopUp(['?','True','False'],'True');
             </pg-code>
@@ -890,7 +890,7 @@
         </introduction>
 
         <exercise label="ex-limit-definition-proof-1">
-          <webwork xml:id="ex-limit-definition-proof-1">
+          <webwork xml:id="webwork-ex-limit-definition-proof-1">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 4} (2x+5) = 13</m>
@@ -933,7 +933,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-2">
-          <webwork xml:id="ex-limit-definition-proof-2">
+          <webwork xml:id="webwork-ex-limit-definition-proof-2">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 5}(3-x)=-2</m>
@@ -979,7 +979,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-3">
-          <webwork xml:id="ex-limit-definition-proof-3">
+          <webwork xml:id="webwork-ex-limit-definition-proof-3">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 3}\left(x^2-3\right)=6</m>
@@ -1034,7 +1034,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-4">
-          <webwork xml:id="ex-limit-definition-proof-4">
+          <webwork xml:id="webwork-ex-limit-definition-proof-4">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 4}\left(x^2+x-5\right)=15</m>
@@ -1089,7 +1089,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-5">
-          <webwork xml:id="ex-limit-definition-proof-5">
+          <webwork xml:id="webwork-ex-limit-definition-proof-5">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 1} \left(2x^2+3x+1\right) = 6</m>
@@ -1151,7 +1151,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-6">
-          <webwork xml:id="ex-limit-definition-proof-6">
+          <webwork xml:id="webwork-ex-limit-definition-proof-6">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 2}\left(x^3-1\right)=7</m>
@@ -1206,7 +1206,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-7">
-          <webwork xml:id="ex-limit-definition-proof-7">
+          <webwork xml:id="webwork-ex-limit-definition-proof-7">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 2}5=5</m>
@@ -1248,7 +1248,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-8">
-          <webwork xml:id="ex-limit-definition-proof-8">
+          <webwork xml:id="webwork-ex-limit-definition-proof-8">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 0}\left(e^{2x}-1\right)=0</m>
@@ -1299,7 +1299,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-9">
-          <webwork xml:id="ex-limit-definition-proof-9">
+          <webwork xml:id="webwork-ex-limit-definition-proof-9">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 1} \frac1x = 1</m>
@@ -1355,7 +1355,7 @@
         </exercise>
 
         <exercise label="ex-limit-definition-proof-10">
-          <webwork xml:id="ex-limit-definition-proof-10">
+          <webwork xml:id="webwork-ex-limit-definition-proof-10">
             <statement>
               <p>
                 <m>\lim\limits_{x\to 0} \sin(x)= 0</m>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1126,7 +1126,7 @@
       </title>
 
       <exercise label="TaC-limit-infinity-1">
-        <webwork xml:id="TaC-limit-infinity-1">
+        <webwork xml:id="webwork-TaC-limit-infinity-1">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],'False');
           </pg-code>
@@ -1141,7 +1141,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-2">
-        <webwork xml:id="TaC-limit-infinity-2">
+        <webwork xml:id="webwork-TaC-limit-infinity-2">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],'True');
           </pg-code>
@@ -1156,7 +1156,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-3">
-        <webwork xml:id="TaC-limit-infinity-3">
+        <webwork xml:id="webwork-TaC-limit-infinity-3">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],'False');
           </pg-code>
@@ -1171,7 +1171,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-4">
-        <webwork xml:id="TaC-limit-infinity-4">
+        <webwork xml:id="webwork-TaC-limit-infinity-4">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],'True');
           </pg-code>
@@ -1186,7 +1186,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-5">
-        <webwork xml:id="TaC-limit-infinity-5">
+        <webwork xml:id="webwork-TaC-limit-infinity-5">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],'True');
           </pg-code>
@@ -1200,7 +1200,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-6">
-        <webwork xml:id="TaC-limit-infinity-6">
+        <webwork xml:id="webwork-TaC-limit-infinity-6">
           <statement>
             <p>
               List five indeterminate forms.
@@ -1213,7 +1213,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-7">
-        <webwork xml:id="TaC-limit-infinity-7">
+        <webwork xml:id="webwork-TaC-limit-infinity-7">
           <statement>
             <p>
               Construct a function with a vertical asymptote at <m>x=5</m> and a horizontal asymptote at <m>y=5</m>.
@@ -1226,7 +1226,7 @@
       </exercise>
 
       <exercise label="TaC-limit-infinity-8">
-        <webwork xml:id="TaC-limit-infinity-8">
+        <webwork xml:id="webwork-TaC-limit-infinity-8">
           <statement>
             <p>
               Let <m>\lim\limits_{x\to 7} f(x) = \infty</m>.
@@ -1258,7 +1258,7 @@
         </introduction>
 
        <exercise label="ex-limit-infinity-use-graph-1">
-          <webwork xml:id="ex-limit-infinity-use-graph-1">
+          <webwork xml:id="webwork-ex-limit-infinity-use-graph-1">
             <pg-code>
               $a=non_zero_random(-3,3,1);
               $b=non_zero_random(-1,1,2);
@@ -1322,7 +1322,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-use-graph-2">
-          <webwork xml:id="ex-limit-infinity-use-graph-2">
+          <webwork xml:id="webwork-ex-limit-infinity-use-graph-2">
             <pg-code>
               @a=(1..9)[NchooseK(9,2)];
               $f=Formula("1/((x-$a[0])(x-$a[1])^(2))")->reduce;
@@ -1424,7 +1424,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-use-graph-3">
-          <webwork xml:id="ex-limit-infinity-use-graph-3">
+          <webwork xml:id="webwork-ex-limit-infinity-use-graph-3">
             <pg-code>
               $a=random(1,5,1);
               $b=random(-1,1,2);
@@ -1499,7 +1499,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-use-graph-4">
-          <webwork xml:id="ex-limit-infinity-use-graph-4">
+          <webwork xml:id="webwork-ex-limit-infinity-use-graph-4">
             <pg-code>
               $a=random(1,5,1);
               $n=random(1,4,2);
@@ -1574,7 +1574,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-use-graph-5">
-          <webwork xml:id="ex-limit-infinity-use-graph-5">
+          <webwork xml:id="webwork-ex-limit-infinity-use-graph-5">
             <pg-code>
               $a=random(1,5,1);
               $trigfun = list_random('sin','cos');
@@ -1633,7 +1633,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-use-graph-6">
-          <webwork xml:id="ex-limit-infinity-use-graph-6">
+          <webwork xml:id="webwork-ex-limit-infinity-use-graph-6">
             <pg-code>
               $b=random(1.5,2.5,0.1);
               $c=non_zero_random(-12,12,1);
@@ -1704,7 +1704,7 @@
         </introduction>
 
         <exercise label="ex-limit-infinity-numerical-1">
-          <webwork xml:id="ex-limit-infinity-numerical-1">
+          <webwork xml:id="webwork-ex-limit-infinity-numerical-1">
             <pg-code>
               @b=(-9..9)[NchooseK(19,4)];
               if($envir{problemSeed}==1){@b=(3,1,-1,-2);};
@@ -1819,7 +1819,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-numerical-2">
-          <webwork xml:id="ex-limit-infinity-numerical-2">
+          <webwork xml:id="webwork-ex-limit-infinity-numerical-2">
             <pg-code>
               @b=(-9..9)[NchooseK(19,4)];
               if($envir{problemSeed}==1){@b=(3,4,-9,-1);};
@@ -1934,7 +1934,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-numerical-3">
-          <webwork xml:id="ex-limit-infinity-numerical-3">
+          <webwork xml:id="webwork-ex-limit-infinity-numerical-3">
             <pg-code>
               @b=(-9..9)[NchooseK(19,4)];
               if($envir{problemSeed}==1){@b=(3,5,6,-2);};
@@ -2049,7 +2049,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-numerical-4">
-          <webwork xml:id="ex-limit-infinity-numerical-4">
+          <webwork xml:id="webwork-ex-limit-infinity-numerical-4">
             <pg-code>
               @b=(-9..9)[NchooseK(19,3)];
               if($envir{problemSeed}==1){@b=(3,6,-2);};
@@ -2173,7 +2173,7 @@
         </introduction>
 
         <exercise label="ex-limit-infinity-asymptotes-1">
-          <webwork xml:id="ex-limit-infinity-asymptotes-1">
+          <webwork xml:id="webwork-ex-limit-infinity-asymptotes-1">
             <pg-code>
               @b=(-9..-1,1..9)[NchooseK(18,3)];
               do {@c=(random(2,5,1),non_zero_random(-9,9,1))} until ($b[1] != $c[1]/$c[0] and $b[2] !=  $c[1]/$c[0]);
@@ -2207,7 +2207,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-asymptotes-2">
-          <webwork xml:id="ex-limit-infinity-asymptotes-2">
+          <webwork xml:id="webwork-ex-limit-infinity-asymptotes-2">
             <pg-code>
               @b=(-9..-1,1..9)[NchooseK(18,3)];
               @c=(list_random(-5..-2,2..5),non_zero_random(-9,9,1));
@@ -2242,7 +2242,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-asymptotes-3">
-          <webwork xml:id="ex-limit-infinity-asymptotes-3">
+          <webwork xml:id="webwork-ex-limit-infinity-asymptotes-3">
             <pg-code>
               @b=(-9..-1,1..9)[NchooseK(18,3)];
               @c=(random(1,5,1),non_zero_random(-9,9,1));
@@ -2278,7 +2278,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-asymptotes-4">
-          <webwork xml:id="ex-limit-infinity-asymptotes-4">
+          <webwork xml:id="webwork-ex-limit-infinity-asymptotes-4">
             <pg-code>
               @b=(-9..-1,1..9)[NchooseK(18,3)];
               @c=(random(1,5,1),non_zero_random(-9,9,1));
@@ -2314,7 +2314,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-asymptotes-5">
-          <webwork xml:id="ex-limit-infinity-asymptotes-5">
+          <webwork xml:id="webwork-ex-limit-infinity-asymptotes-5">
             <pg-code>
               @b=(-9..-1,1..9)[NchooseK(18,3)];
               @c=(random(1,5,1),non_zero_random(-9,9,1));
@@ -2349,7 +2349,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-asymptotes-6">
-          <webwork xml:id="ex-limit-infinity-asymptotes-6">
+          <webwork xml:id="webwork-ex-limit-infinity-asymptotes-6">
             <pg-code>
               @b=(-9..-1,1..9)[NchooseK(18,2)];
               $b[2]=random(-2,2,1);
@@ -2394,7 +2394,7 @@
         </introduction>
 
         <exercise label="ex-limit-infinity-evaluate-1">
-          <webwork xml:id="ex-limit-infinity-evaluate-1">
+          <webwork xml:id="webwork-ex-limit-infinity-evaluate-1">
             <pg-code>
               $a=list_random(Compute("inf"),Compute("-inf"));
               @b=(-9..-1,1..9)[NchooseK(18,3)];
@@ -2420,7 +2420,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-evaluate-2">
-          <webwork xml:id="ex-limit-infinity-evaluate-2">
+          <webwork xml:id="webwork-ex-limit-infinity-evaluate-2">
             <pg-code>
               $a=list_random(Compute("inf"),Compute("-inf"));
               @b=(-9..-1,1..9)[NchooseK(18,3)];
@@ -2446,7 +2446,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-evaluate-3">
-          <webwork xml:id="ex-limit-infinity-evaluate-3">
+          <webwork xml:id="webwork-ex-limit-infinity-evaluate-3">
             <pg-code>
               $a=list_random(Compute("inf"),Compute("-inf"));
               @b=(-9..-1,1..9)[NchooseK(18,3)];
@@ -2472,7 +2472,7 @@
         </exercise>
 
         <exercise label="ex-limit-infinity-evaluate-4">
-          <webwork xml:id="ex-limit-infinity-evaluate-4">
+          <webwork xml:id="webwork-ex-limit-infinity-evaluate-4">
             <pg-code>
               $a=list_random(Compute("inf"),Compute("-inf"));
               @b=(-9..-1,1..9)[NchooseK(18,3)];
@@ -2502,7 +2502,7 @@
     <subexercises>
       <title>Review</title>
       <exercise label="ex-limit-infinity-review-1">
-        <webwork xml:id="ex-limit-infinity-review-1">
+        <webwork xml:id="webwork-ex-limit-infinity-review-1">
           <statement>
             <p>
               Use an <m>\varepsilon</m>-<m>\delta</m> proof to prove that <m>\lim\limits_{x\to 1}(5x-2)=3</m>.
@@ -2549,7 +2549,7 @@
       </exercise>
 
       <exercise label="ex-limit-infinity-review-2">
-        <webwork xml:id="ex-limit-infinity-review-2">
+        <webwork xml:id="webwork-ex-limit-infinity-review-2">
           <pg-code>
             $a=random(-9,9,1);
             do{@L=(non_zero_random(-9,9,1),non_zero_random(-3,3,1));}until($L[0]!=$L[1]);
@@ -2611,7 +2611,7 @@
       </exercise>
 
       <exercise label="ex-limit-infinity-review-3">
-        <webwork xml:id="ex-limit-infinity-review-3">
+        <webwork xml:id="webwork-ex-limit-infinity-review-3">
           <pg-code>
             Context('Fraction')->noreduce('(-x)-y','(-x)+y');
             for my$i(0,3){$b[$i]=non_zero_random(-1,1,1);};
@@ -2643,7 +2643,7 @@
       </exercise>
 
       <exercise label="ex-limit-infinity-review-4">
-        <webwork xml:id="ex-limit-infinity-review-4">
+        <webwork xml:id="webwork-ex-limit-infinity-review-4">
           <pg-code>
             Context()->strings->add('does not exist'=>{alias=>'DNE'});
           </pg-code>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -1263,7 +1263,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-limit-intro-1">
-        <webwork xml:id="TaC-limit-intro-1">
+        <webwork xml:id="webwork-TaC-limit-intro-1">
           <statement>
             <p>
               In your own words, what does it mean to
@@ -1278,7 +1278,7 @@
       </exercise>
 
       <exercise label="TaC-limit-intro-2">
-        <webwork xml:id="TaC-limit-intro-2">
+        <webwork xml:id="webwork-TaC-limit-intro-2">
           <pg-code>
             $answer = "an indeterminate form";
             $undefined = "an undefined expression";
@@ -1303,7 +1303,7 @@
       </exercise>
 
       <exercise label="TaC-limit-intro-3">
-        <webwork xml:id="TaC-limit-intro-3">
+        <webwork xml:id="webwork-TaC-limit-intro-3">
           <pg-code>
             $limitequalsvalue = PopUp(['?','True','False'],2);
           </pg-code>
@@ -1323,7 +1323,7 @@
       </exercise>
 
       <exercise label="TaC-limit-intro-4">
-        <webwork xml:id="TaC-limit-intro-4">
+        <webwork xml:id="webwork-TaC-limit-intro-4">
           <statement>
             <p>
               Describe three situations where <m>\lim\limits_{x\to c}f(x)</m> does not exist.
@@ -1343,7 +1343,7 @@
       </exercise>
 
       <exercise label="TaC-limit-intro-5">
-        <webwork xml:id="TaC-limit-intro-5">
+        <webwork xml:id="webwork-TaC-limit-intro-5">
           <statement>
             <p>
               In your own words, what is a difference quotient?
@@ -1356,7 +1356,7 @@
       </exercise>
 
       <exercise label="TaC-limit-intro-6">
-        <webwork xml:id="TaC-limit-intro-6">
+        <webwork xml:id="webwork-TaC-limit-intro-6">
           <statement>
             <p>
               When <m>x</m> is near <m>0</m>,
@@ -1387,7 +1387,7 @@
         </introduction>
 
         <exercise label="ex-limit-intro-numerical-graphical-1">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-1">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-1">
             <pg-code>
               do {
                 $a = list_random(-1,1);
@@ -1470,7 +1470,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-2">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-2">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-2">
             <pg-code>
               do {
                 $a = random(-1,1,1);
@@ -1556,7 +1556,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-3">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-3">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-3">
             <pg-code>
               $a = 0;
               ($b,$c) = (-5..-1,1..5)[NchooseK(10,2)];
@@ -1651,7 +1651,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-4">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-4">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-4">
             <pg-code>
               ($a,$b,$c) = (-5..-1,1..5)[NchooseK(10,3)];
               if ($envir{problemSeed} == 1){
@@ -1750,7 +1750,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-5">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-5">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-5">
             <pg-code>
               ($a,$c) = (-5..-1,1..5)[NchooseK(10,2)];
               $b = list_random(-9..-6,6..9);
@@ -1850,7 +1850,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-6">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-6">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-6">
             <pg-code>
               ($a,$b,$c) = (-9..-1,1..9)[NchooseK(18,3)];
               if ($envir{problemSeed} == 1){
@@ -1945,7 +1945,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-7">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-7">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-7">
             <pg-code>
               $a = non_zero_random(-5,5,1);
               $b = non_zero_random(-5,5,1);
@@ -2039,7 +2039,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-8">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-8">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-8">
             <pg-code>
               do {
                 $a = non_zero_random(-3,3,1);
@@ -2137,7 +2137,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-9">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-9">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-9">
             <pg-code>
               $a=0;
               $b = non_zero_random(-5,5,1);
@@ -2230,7 +2230,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-10">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-10">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-10">
             <pg-code>
               Context()->flags->set(reduceConstants => 0);
               $a = list_random(Formula("pi/2"),Formula("pi/3"),Formula("pi/6"));
@@ -2325,7 +2325,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-11">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-11">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-11">
             <pg-code>
               $f = Formula("abs(x)^x");
               $a = 0;
@@ -2405,7 +2405,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-12">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-12">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-12">
             <pg-code>
               $f = Formula("e^(-e^(1/x))");
               $a = 0;
@@ -2486,7 +2486,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-13">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-13">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-13">
             <pg-code>
               %fact = (0 => 1, 1 => 1, 2 => 2, 3 => 6, 4 => 24, 5 => 120, 6 => 720);
               sub f {
@@ -2586,7 +2586,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-numerical-graphical-14">
-          <webwork xml:id="ex-limit-intro-numerical-graphical-14">
+          <webwork xml:id="webwork-ex-limit-intro-numerical-graphical-14">
             <pg-code>
               %fact = (0 => 1, 1 => 1, 2 => 2, 3 => 6, 4 => 24, 5 => 120, 6 => 720);
               sub f {
@@ -2693,7 +2693,7 @@
           </p>
         </introduction>
         <exercise label="ex-limit-intro-diffquot-1">
-          <webwork xml:id="ex-limit-intro-diffquot-1">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-1">
             <pg-code>
               #$m = non_zero_random(-9,9,1);
               #do {
@@ -2815,7 +2815,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-2">
-          <webwork xml:id="ex-limit-intro-diffquot-2">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-2">
             <pg-code>
               #$m = non_zero_random(-9,9,1);
               #$b = random(0.01,0.09,0.01) + random(0.1,0.9,0.1) + random(-9,9,1);
@@ -2935,7 +2935,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-3">
-          <webwork xml:id="ex-limit-intro-diffquot-3">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-3">
             <pg-code>
               #do {
               #  $b = non_zero_random(-5,5,1);
@@ -3058,7 +3058,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-4">
-          <webwork xml:id="ex-limit-intro-diffquot-4">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-4">
             <pg-code>
               #do {
               #  $b = non_zero_random(-5,5,1);
@@ -3179,7 +3179,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-5">
-          <webwork xml:id="ex-limit-intro-diffquot-5">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-5">
             <pg-code>
               #do {
               #  do {
@@ -3306,7 +3306,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-6">
-          <webwork xml:id="ex-limit-intro-diffquot-6">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-6">
             <pg-code>
               #$a = random(2,9,1);
               #if ($envir{problemSeed} == 1){
@@ -3423,7 +3423,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-7">
-          <webwork xml:id="ex-limit-intro-diffquot-7">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-7">
             <pg-code>
               Context()->flags->set(reduceConstants => 0);
               #$a = list_random(Formula("pi/3"),Formula("2pi/3"),Formula("pi"),Formula("4pi/3"),Formula("5pi/3"),);
@@ -3541,7 +3541,7 @@
         </exercise>
 
         <exercise label="ex-limit-intro-diffquot-8">
-          <webwork xml:id="ex-limit-intro-diffquot-8">
+          <webwork xml:id="webwork-ex-limit-intro-diffquot-8">
             <pg-code>
               Context()->flags->set(reduceConstants => 0);
               #$a = list_random(Formula("pi/3"),Formula("2pi/3"),Formula("pi"),Formula("4pi/3"),Formula("5pi/3"),);

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -700,7 +700,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-limit-onesided-1">
-        <webwork xml:id="TaC-limit-onesided-1">
+        <webwork xml:id="webwork-TaC-limit-onesided-1">
           <statement>
             <p>
               What are the three ways in which a limit may fail to exist?
@@ -720,7 +720,7 @@
       </exercise>
 
       <exercise label="TaC-limit-onesided-2">
-        <webwork xml:id="TaC-limit-onesided-2">
+        <webwork xml:id="webwork-TaC-limit-onesided-2">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],2);
           </pg-code>
@@ -740,7 +740,7 @@
       </exercise>
 
       <exercise label="TaC-limit-onesided-3">
-        <webwork xml:id="TaC-limit-onesided-3">
+        <webwork xml:id="webwork-TaC-limit-onesided-3">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],2);
           </pg-code>
@@ -761,7 +761,7 @@
       </exercise>
 
       <exercise label="TaC-limit-onesided-4">
-        <webwork xml:id="TaC-limit-onesided-4">
+        <webwork xml:id="webwork-TaC-limit-onesided-4">
           <pg-code>
             $truefalse=PopUp(['?','True','False'],1);
           </pg-code>
@@ -793,7 +793,7 @@
         </introduction>
 
         <exercise label="ex-limit-onesided-use-graph-1">
-          <webwork xml:id="ex-limit-onesided-use-graph-1">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-1">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @x=num_sort((0,(1..5)[NchooseK(5,2)]));
@@ -888,7 +888,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-2">
-          <webwork xml:id="ex-limit-onesided-use-graph-2">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-2">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @x=num_sort((0,(1..5)[NchooseK(5,2)]));
@@ -983,7 +983,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-3">
-          <webwork xml:id="ex-limit-onesided-use-graph-3">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-3">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @x=num_sort((0,(1..5)[NchooseK(5,2)]));
@@ -1081,7 +1081,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-4">
-          <webwork xml:id="ex-limit-onesided-use-graph-4">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-4">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @x=num_sort((0,(1..5)[NchooseK(5,2)]));
@@ -1157,7 +1157,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-5">
-          <webwork xml:id="ex-limit-onesided-use-graph-5">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-5">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @x=num_sort((0,(1..5)[NchooseK(5,2)]));
@@ -1232,7 +1232,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-6">
-          <webwork xml:id="ex-limit-onesided-use-graph-6">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-6">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               $x[0]=random(-6,-2,1);
@@ -1311,7 +1311,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-7">
-          <webwork xml:id="ex-limit-onesided-use-graph-7">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-7">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @L=(2,2,2,0,2,2,2,Compute("DNE"));
@@ -1413,7 +1413,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-use-graph-8">
-          <webwork xml:id="ex-limit-onesided-use-graph-8">
+          <webwork xml:id="webwork-ex-limit-onesided-use-graph-8">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               Context()->variables->are(a=>'Real');
@@ -1495,7 +1495,7 @@
         </introduction>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-1">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-1">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-1">
             <pg-code>
               $a=random(-2,4,1);
               $b=non_zero_random(-5,5,1);
@@ -1558,7 +1558,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-2">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-2">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-2">
             <pg-code>
               $a=random(-2,4,1);
               $b=non_zero_random(-2,2,1);
@@ -1621,7 +1621,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-3">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-3">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-3">
             <pg-code>
               ($a,$b)=num_sort((-5..-1,1..5)[NchooseK(10,2)]);
               if($envir{problemSeed}==1){$a=-1;$b=1;};
@@ -1717,7 +1717,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-4">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-4">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-4">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @f=(Formula("cos(x)"),Formula("sin(x)"));
@@ -1772,7 +1772,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-5">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-5">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-5">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               Context()->variables->add(a=>'Real');
@@ -1828,7 +1828,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-6">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-6">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-6">
             <pg-code>
               $a=random(-3,3,1);
               @y=(-2..2)[NchooseK(5,3)];
@@ -1890,7 +1890,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-7">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-7">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-7">
             <pg-code>
               $a=random(-3,3,1);
               @y=(-5..5)[NchooseK(5,2)];
@@ -1952,7 +1952,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-8">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-8">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-8">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               Context()->variables->add(c=>'Real');
@@ -2007,7 +2007,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-piecewise-evaluate-9">
-          <webwork xml:id="ex-limit-onesided-piecewise-evaluate-9">
+          <webwork xml:id="webwork-ex-limit-onesided-piecewise-evaluate-9">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @L=(-1,1,Compute("DNE"),0);
@@ -2072,7 +2072,7 @@
         </introduction>
 
         <exercise label="ex-limit-onesided-review-1">
-          <webwork xml:id="ex-limit-onesided-review-1">
+          <webwork xml:id="webwork-ex-limit-onesided-review-1">
             <pg-code>
               ($a,$b,$c)=(-9..-1,1..9)[NchooseK(18,3)];
               if($envir{problemSeed}==1){$a=-1;$b=-4;$c=4;};
@@ -2126,7 +2126,7 @@
         </exercise> -->
 
         <exercise label="ex-limit-onesided-review-2">
-          <webwork xml:id="ex-limit-onesided-review-2">
+          <webwork xml:id="webwork-ex-limit-onesided-review-2">
             <pg-code>
               @a=(-9..9)[NchooseK(19,4)];
               if($envir{problemSeed}==1){@a=(-6,6,9,0)};
@@ -2161,7 +2161,7 @@
         </introduction>
 
         <exercise label="ex-limit-onesided-review-3">
-          <webwork xml:id="ex-limit-onesided-review-3">
+          <webwork xml:id="webwork-ex-limit-onesided-review-3">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               ($a,$b,$c)=map{$_*random(-1,1,2)/10}NchooseK(99,3);
@@ -2187,7 +2187,7 @@
         </exercise>
 
         <exercise label="ex-limit-onesided-review-4">
-          <webwork xml:id="ex-limit-onesided-review-4">
+          <webwork xml:id="webwork-ex-limit-onesided-review-4">
             <pg-code>
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               ($a,$b,$c)=map{$_*random(-1,1,2)/10}NchooseK(99,3);

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -1115,7 +1115,7 @@
     <subexercises xml:id="TaC-vector-lines">
       <title>Terms and Concepts</title>
       <exercise label="TaC-vector-lines-1">
-        <!--<webwork xml:id="TaC-vector-lines-1">
+        <!--<webwork xml:id="webwork-TaC-vector-lines-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1133,7 +1133,7 @@
       </exercise>
 
       <exercise label="TaC-vector-lines-2">
-        <!--<webwork xml:id="TaC-vector-lines-2">
+        <!--<webwork xml:id="webwork-TaC-vector-lines-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1150,7 +1150,7 @@
       </exercise>
 
       <exercise label="TaC-vector-lines-3">
-        <!--<webwork xml:id="TaC-vector-lines-3">
+        <!--<webwork xml:id="webwork-TaC-vector-lines-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1168,7 +1168,7 @@
       </exercise>
 
       <exercise label="TaC-vector-lines-4">
-        <!--<webwork xml:id="TaC-vector-lines-4">
+        <!--<webwork xml:id="webwork-TaC-vector-lines-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1196,7 +1196,7 @@
         </introduction>
 
         <exercise label="ex-vector-lines-parametric-symmetric-1">
-          <!--<webwork xml:id="ex-vector-lines-parametric-symmetric-1">
+          <!--<webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1222,7 +1222,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-2">
-          <webwork xml:id="ex-vector-lines-parametric-symmetric-2">
+          <webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-2">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>"Real");
@@ -1362,7 +1362,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-3">
-          <!--<webwork xml:id="ex-vector-lines-parametric-symmetric-3">
+          <!--<webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1388,7 +1388,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-4">
-          <webwork xml:id="ex-vector-lines-parametric-symmetric-4">
+          <webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-4">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>"Real");
@@ -1537,7 +1537,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-5">
-          <!--<webwork xml:id="ex-vector-lines-parametric-symmetric-5">
+          <!--<webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1568,7 +1568,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-6">
-          <webwork xml:id="ex-vector-lines-parametric-symmetric-6">
+          <webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-6">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>"Real");
@@ -1663,7 +1663,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-7">
-          <webwork xml:id="ex-vector-lines-parametric-symmetric-7">
+          <webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-7">
               <pg-code>
                 Context("Vector");Context()->variables->are(t=>"Real");
                 $v=Compute("(7,2,-1)+t&lt;1,-1,2>");
@@ -1786,7 +1786,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-8">
-          <webwork xml:id="ex-vector-lines-parametric-symmetric-8">
+          <webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-8">
               <pg-code>
                 Context("Vector");Context()->variables->are(t=>"Real");
                 $v=Compute("(2,2,3)+t&lt;5,-1,-3>");
@@ -1909,7 +1909,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-9">
-          <!--<webwork xml:id="ex-vector-lines-parametric-symmetric-9">
+          <!--<webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-9">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1935,7 +1935,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-parametric-symmetric-10">
-          <webwork xml:id="ex-vector-lines-parametric-symmetric-10">
+          <webwork xml:id="webwork-ex-vector-lines-parametric-symmetric-10">
               <pg-code>
                 Context("Vector");Context()->variables->are(t=>"Real");
                 $v=Compute("(-2,5)+t&lt;0,1>");
@@ -2031,7 +2031,7 @@
         </introduction>
 
         <exercise label="ex-vector-lines-intersection-1">
-          <webwork xml:id="ex-vector-lines-intersection-1">
+          <webwork xml:id="webwork-ex-vector-lines-intersection-1">
               <pg-code>
                 Context("Point");
                 Context()->strings->add(same=>{},parallel=>{},skew=>{});
@@ -2057,7 +2057,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-2">
-          <webwork xml:id="ex-vector-lines-intersection-2">
+          <webwork xml:id="webwork-ex-vector-lines-intersection-2">
               <pg-code>
                 Context("Point");
                 Context()->strings->add(same=>{},parallel=>{},skew=>{});
@@ -2083,7 +2083,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-3">
-          <!--<webwork xml:id="ex-vector-lines-intersection-3">
+          <!--<webwork xml:id="webwork-ex-vector-lines-intersection-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2105,7 +2105,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-4">
-          <webwork xml:id="ex-vector-lines-intersection-4">
+          <webwork xml:id="webwork-ex-vector-lines-intersection-4">
               <pg-code>
                 Context("Point");
                 Context()->strings->add(same=>{},parallel=>{},skew=>{});
@@ -2131,7 +2131,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-5">
-          <webwork xml:id="ex-vector-lines-intersection-5">
+          <webwork xml:id="webwork-ex-vector-lines-intersection-5">
               <pg-code>
                 Context("Point");
                 Context()->strings->add(same=>{},parallel=>{},skew=>{});
@@ -2157,7 +2157,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-6">
-          <webwork xml:id="ex-vector-lines-intersection-6">
+          <webwork xml:id="webwork-ex-vector-lines-intersection-6">
               <pg-code>
                 Context("Point");
                 Context()->strings->add(same=>{},parallel=>{},skew=>{});
@@ -2183,7 +2183,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-7">
-          <!--<webwork xml:id="ex-vector-lines-intersection-7">
+          <!--<webwork xml:id="webwork-ex-vector-lines-intersection-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2203,7 +2203,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-intersection-8">
-          <webwork xml:id="ex-vector-lines-intersection-8">
+          <webwork xml:id="webwork-ex-vector-lines-intersection-8">
               <pg-code>
                 Context("Point");
                 Context()->strings->add(same=>{},parallel=>{},skew=>{});
@@ -2238,7 +2238,7 @@
         </introduction>
 
         <exercise label="ex-vector-lines-distance-point-line-1">
-          <!--<webwork xml:id="ex-vector-lines-distance-point-line-1">
+          <!--<webwork xml:id="webwork-ex-vector-lines-distance-point-line-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2255,7 +2255,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-distance-point-line-2">
-          <webwork xml:id="ex-vector-lines-distance-point-line-2">
+          <webwork xml:id="webwork-ex-vector-lines-distance-point-line-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $distance=Formula("3sqrt(2)");
@@ -2275,7 +2275,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-distance-point-line-3">
-          <!--<webwork xml:id="ex-vector-lines-distance-point-line-3">
+          <!--<webwork xml:id="webwork-ex-vector-lines-distance-point-line-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2292,7 +2292,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-distance-point-line-4">
-          <webwork xml:id="ex-vector-lines-distance-point-line-4">
+          <webwork xml:id="webwork-ex-vector-lines-distance-point-line-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $distance=Formula("5");
@@ -2320,7 +2320,7 @@
         </introduction>
 
         <exercise label="ex-vector-lines-distance-two-lines-1">
-          <!--<webwork xml:id="ex-vector-lines-distance-two-lines-1">
+          <!--<webwork xml:id="webwork-ex-vector-lines-distance-two-lines-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2341,7 +2341,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-distance-two-lines-2">
-          <webwork xml:id="ex-vector-lines-distance-two-lines-2">
+          <webwork xml:id="webwork-ex-vector-lines-distance-two-lines-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $distance=Formula("2");
@@ -2370,7 +2370,7 @@
         </introduction>
 
         <exercise label="ex-vector-lines-distance-formula-1">
-          <!--<webwork xml:id="ex-vector-lines-distance-formula-1">
+          <!--<webwork xml:id="webwork-ex-vector-lines-distance-formula-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2391,7 +2391,7 @@
         </exercise>
 
         <exercise xml:id="x10_05_ex_30" label="ex-vector-lines-distance-formula-2">
-          <!--<webwork xml:id="ex-vector-lines-distance-formula-2">
+          <!--<webwork xml:id="webwork-ex-vector-lines-distance-formula-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2417,7 +2417,7 @@
         </exercise>
 
         <exercise label="ex-vector-lines-distance-formula-3">
-          <!--<webwork xml:id="ex-vector-lines-distance-formula-3">
+          <!--<webwork xml:id="webwork-ex-vector-lines-distance-formula-3">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -775,7 +775,7 @@
     <subexercises xml:id="TaC-multi-chain">
       <title>Terms and Concepts</title>
       <exercise label="TaC-multi-chain-1">
-        <!-- <webwork xml:id="TaC-multi-chain-1">
+        <!-- <webwork xml:id="webwork-TaC-multi-chain-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -796,7 +796,7 @@
       </exercise>
 
       <exercise label="TaC-multi-chain-2">
-        <!-- <webwork xml:id="TaC-multi-chain-2">
+        <!-- <webwork xml:id="webwork-TaC-multi-chain-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -814,7 +814,7 @@
       </exercise>
 
       <exercise label="TaC-multi-chain-3">
-        <!-- <webwork xml:id="TaC-multi-chain-3">
+        <!-- <webwork xml:id="webwork-TaC-multi-chain-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -835,7 +835,7 @@
       </exercise>
 
       <exercise label="TaC-multi-chain-4">
-        <!-- <webwork xml:id="TaC-multi-chain-4">
+        <!-- <webwork xml:id="webwork-TaC-multi-chain-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -858,7 +858,7 @@
       </exercise>
 
       <exercise label="TaC-multi-chain-5">
-        <!-- <webwork xml:id="TaC-multi-chain-5">
+        <!-- <webwork xml:id="webwork-TaC-multi-chain-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -875,7 +875,7 @@
       </exercise>
 
       <exercise label="TaC-multi-chain-6">
-        <webwork xml:id="TaC-multi-chain-6">
+        <webwork xml:id="webwork-TaC-multi-chain-6">
             <pg-code>
               $partial="partial";
               Context()->strings->add($partial=>{},);
@@ -916,7 +916,7 @@
         </introduction>
 
         <exercise xml:id="x12_08_ex_07" label="ex-multi-chain-compute-evaluate-1">
-          <!-- <webwork xml:id="ex-multi-chain-compute-evaluate-1">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-compute-evaluate-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -945,7 +945,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-compute-evaluate-2">
-          <webwork xml:id="ex-multi-chain-compute-evaluate-2">
+          <webwork xml:id="webwork-ex-multi-chain-compute-evaluate-2">
               <pg-code>
                 Context()->variables->add(y=>'Real',t=>'Real');
                 $x=Compute("t");
@@ -986,7 +986,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-compute-evaluate-3">
-          <!-- <webwork xml:id="ex-multi-chain-compute-evaluate-3">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-compute-evaluate-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1016,7 +1016,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-compute-evaluate-4">
-          <webwork xml:id="ex-multi-chain-compute-evaluate-4">
+          <webwork xml:id="webwork-ex-multi-chain-compute-evaluate-4">
               <pg-code>
                 Context()->variables->add(y=>'Real',t=>'Real');
                 $x=Compute("cos(t)");
@@ -1057,7 +1057,7 @@
         </exercise>
 
         <exercise xml:id="x12_08_ex_10" label="ex-multi-chain-compute-evaluate-5">
-          <!-- <webwork xml:id="ex-multi-chain-compute-evaluate-5">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-compute-evaluate-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1088,7 +1088,7 @@
         </exercise>
 
         <exercise xml:id="x12_08_ex_08" label="ex-multi-chain-compute-evaluate-6">
-          <webwork xml:id="ex-multi-chain-compute-evaluate-6">
+          <webwork xml:id="webwork-ex-multi-chain-compute-evaluate-6">
               <pg-code>
                 Context()->variables->add(y=>'Real',t=>'Real');
                 $x=Compute("pi t");
@@ -1142,7 +1142,7 @@
         </introduction>
 
         <exercise label="ex-multi-chain-critical-1">
-          <!-- <webwork xml:id="ex-multi-chain-critical-1">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-critical-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1159,7 +1159,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-critical-2">
-          <webwork xml:id="ex-multi-chain-critical-2">
+          <webwork xml:id="webwork-ex-multi-chain-critical-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $zeros=Compute("-sqrt(3/2), 0, sqrt(3/2)");
@@ -1179,7 +1179,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-critical-3">
-          <!-- <webwork xml:id="ex-multi-chain-critical-3">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-critical-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1197,7 +1197,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-critical-4">
-          <webwork xml:id="ex-multi-chain-critical-4">
+          <webwork xml:id="webwork-ex-multi-chain-critical-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $zeros=Compute("0, pi");
@@ -1244,7 +1244,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-critical-5">
-          <!-- <webwork xml:id="ex-multi-chain-critical-5">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-critical-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1269,7 +1269,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-critical-6">
-          <webwork xml:id="ex-multi-chain-critical-6">
+          <webwork xml:id="webwork-ex-multi-chain-critical-6">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $zeros=Compute("0, 1/pi*arctan(sqrt(5)), 1- 1/pi*arctan(sqrt(5)), 1, 1+1/pi*arctan(sqrt(5)), 2-1/pi*arctan(sqrt(5))");
@@ -1396,7 +1396,7 @@
         </introduction>
 
         <exercise label="ex-multi-chain-2-to-2-compute-1">
-          <!-- <webwork xml:id="ex-multi-chain-2-to-2-compute-1">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-2-to-2-compute-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1429,7 +1429,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-2-to-2-compute-2">
-          <webwork xml:id="ex-multi-chain-2-to-2-compute-2">
+          <webwork xml:id="webwork-ex-multi-chain-2-to-2-compute-2">
               <pg-code>
                 Context()->variables->add(y=>'Real',s=>'Real', t=>'Real');
                 $x=Compute("st^2");
@@ -1494,7 +1494,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-2-to-2-compute-3">
-          <webwork xml:id="ex-multi-chain-2-to-2-compute-3">
+          <webwork xml:id="webwork-ex-multi-chain-2-to-2-compute-3">
               <pg-code>
                 Context()->variables->add(y=>'Real',s=>'Real', t=>'Real');
                 $x=Compute("st^2");
@@ -1559,7 +1559,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-2-to-2-compute-4">
-          <webwork xml:id="ex-multi-chain-2-to-2-compute-4">
+          <webwork xml:id="webwork-ex-multi-chain-2-to-2-compute-4">
               <pg-code>
                 Context()->variables->add(y=>'Real',s=>'Real', t=>'Real');
                 $x=Compute("st^2");
@@ -1635,7 +1635,7 @@
         </introduction>
 
         <exercise label="ex-multi-chain-implicit-1">
-          <!-- <webwork xml:id="ex-multi-chain-implicit-1">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-implicit-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1656,7 +1656,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-implicit-2">
-          <webwork xml:id="ex-multi-chain-implicit-2">
+          <webwork xml:id="webwork-ex-multi-chain-implicit-2">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $dydx=Compute("-x/y^2");
@@ -1677,7 +1677,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-implicit-3">
-          <!-- <webwork xml:id="ex-multi-chain-implicit-3">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-implicit-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1699,7 +1699,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-implicit-4">
-          <webwork xml:id="ex-multi-chain-implicit-4">
+          <webwork xml:id="webwork-ex-multi-chain-implicit-4">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $dydx=Compute("-(2x+y)/(2y+x)");
@@ -1732,7 +1732,7 @@
         </introduction>
 
         <exercise label="ex-multi-chain-with-data-1">
-          <!-- <webwork xml:id="ex-multi-chain-with-data-1">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-with-data-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1749,7 +1749,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-with-data-2">
-          <webwork xml:id="ex-multi-chain-with-data-2">
+          <webwork xml:id="webwork-ex-multi-chain-with-data-2">
               <pg-code>
                 $dzdt=Compute("0");
               </pg-code>
@@ -1770,7 +1770,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-with-data-3">
-          <!-- <webwork xml:id="ex-multi-chain-with-data-3">
+          <!-- <webwork xml:id="webwork-ex-multi-chain-with-data-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1795,7 +1795,7 @@
         </exercise>
 
         <exercise label="ex-multi-chain-with-data-4">
-          <webwork xml:id="ex-multi-chain-with-data-4">
+          <webwork xml:id="webwork-ex-multi-chain-with-data-4">
 
               <pg-code>
                 $dzds=Compute("-2");

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -1262,7 +1262,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-multi-extreme-values-1">
-        <webwork xml:id="TaC-multi-extreme-values-1">
+        <webwork xml:id="webwork-TaC-multi-extreme-values-1">
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -1281,7 +1281,7 @@
       </exercise>
 
       <exercise label="TaC-multi-extreme-values-2">
-        <webwork xml:id="TaC-multi-extreme-values-2">
+        <webwork xml:id="webwork-TaC-multi-extreme-values-2">
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -1298,7 +1298,7 @@
       </exercise>
 
       <exercise label="TaC-multi-extreme-values-3">
-        <webwork xml:id="TaC-multi-extreme-values-3">
+        <webwork xml:id="webwork-TaC-multi-extreme-values-3">
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -1315,7 +1315,7 @@
       </exercise>
 
       <exercise label="TaC-multi-extreme-values-4">
-        <!-- <webwork xml:id="TaC-multi-extreme-values-4">
+        <!-- <webwork xml:id="webwork-TaC-multi-extreme-values-4">
             <pg-code>
             </pg-code>
              -->
@@ -1350,7 +1350,7 @@
         </introduction>
 
         <exercise label="ex-multi-extreme-values-classify-critical-1">
-          <!-- <webwork xml:id="ex-multi-extreme-values-classify-critical-1">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-1">
               <pg-code>
               </pg-code>
                -->
@@ -1370,7 +1370,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-2">
-          <webwork xml:id="ex-multi-extreme-values-classify-critical-2">
+          <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-2">
               <pg-code>
                 Context("Point");
                 $max=List("None");
@@ -1424,7 +1424,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-3">
-          <!-- <webwork xml:id="ex-multi-extreme-values-classify-critical-3">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-3">
               <pg-code>
               </pg-code>
                -->
@@ -1443,7 +1443,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-4">
-          <webwork xml:id="ex-multi-extreme-values-classify-critical-4">
+          <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-4">
               <pg-code>
                 Context("Point");
                 $max=List("(0,0)");
@@ -1497,7 +1497,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-5">
-          <!-- <webwork xml:id="ex-multi-extreme-values-classify-critical-5">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-5">
               <pg-code>
               </pg-code>
                -->
@@ -1522,7 +1522,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-6">
-          <webwork xml:id="ex-multi-extreme-values-classify-critical-6">
+          <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-6">
               <pg-code>
                 Context("Point");
                 $max=List("(-1,-2)");
@@ -1576,7 +1576,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-7">
-          <!-- <webwork xml:id="ex-multi-extreme-values-classify-critical-7">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-7">
               <pg-code>
               </pg-code>
                -->
@@ -1599,7 +1599,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-8">
-          <webwork xml:id="ex-multi-extreme-values-classify-critical-8">
+          <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-8">
               <pg-code>
                 Context("Point");
                 $max=List("(0,-3)");
@@ -1653,7 +1653,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-9">
-          <!-- <webwork xml:id="ex-multi-extreme-values-classify-critical-9">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-9">
               <pg-code>
               </pg-code>
                -->
@@ -1681,7 +1681,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-classify-critical-10">
-          <webwork xml:id="ex-multi-extreme-values-classify-critical-10">
+          <webwork xml:id="webwork-ex-multi-extreme-values-classify-critical-10">
               <pg-code>
                 Context("Point");
                 $max=List("None");
@@ -1744,7 +1744,7 @@
         </introduction>
 
         <exercise label="ex-multi-extreme-values-absolute-1">
-          <webwork xml:id="ex-multi-extreme-values-absolute-1">
+          <webwork xml:id="webwork-ex-multi-extreme-values-absolute-1">
               <pg-code>
                 Context("Point");
                 $maxout = Compute("3");
@@ -1820,7 +1820,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-absolute-2">
-          <webwork xml:id="ex-multi-extreme-values-absolute-2">
+          <webwork xml:id="webwork-ex-multi-extreme-values-absolute-2">
               <pg-code>
                 Context("Point");
                 $maxout = Compute("25/28");
@@ -1889,7 +1889,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-absolute-3">
-          <!-- <webwork xml:id="ex-multi-extreme-values-absolute-3">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-absolute-3">
               <pg-code>
               </pg-code>
                -->
@@ -1941,7 +1941,7 @@
         </exercise>
 
         <exercise label="ex-multi-extreme-values-absolute-4">
-          <!-- <webwork xml:id="ex-multi-extreme-values-absolute-4">
+          <!-- <webwork xml:id="webwork-ex-multi-extreme-values-absolute-4">
               <pg-code>
               </pg-code>
                -->

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -862,7 +862,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-multi-intro-1">
-        <!--<webwork xml:id="TaC-multi-intro-1">
+        <!--<webwork xml:id="webwork-TaC-multi-intro-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -881,7 +881,7 @@
       </exercise>
 
       <exercise label="TaC-multi-intro-2">
-        <!--<webwork xml:id="TaC-multi-intro-2">
+        <!--<webwork xml:id="webwork-TaC-multi-intro-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -898,7 +898,7 @@
       </exercise>
 
       <exercise label="TaC-multi-intro-3">
-        <!--<webwork xml:id="TaC-multi-intro-3">
+        <!--<webwork xml:id="webwork-TaC-multi-intro-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -915,7 +915,7 @@
       </exercise>
 
       <exercise label="TaC-multi-intro-4">
-        <!--<webwork xml:id="TaC-multi-intro-4">
+        <!--<webwork xml:id="webwork-TaC-multi-intro-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -932,7 +932,7 @@
       </exercise>
 
       <exercise label="TaC-multi-intro-5">
-        <!--<webwork xml:id="TaC-multi-intro-5">
+        <!--<webwork xml:id="webwork-TaC-multi-intro-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -949,7 +949,7 @@
       </exercise>
 
       <exercise label="TaC-multi-intro-6">
-        <!--<webwork xml:id="TaC-multi-intro-6">
+        <!--<webwork xml:id="webwork-TaC-multi-intro-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -980,7 +980,7 @@
         </introduction>
 
         <exercise label="ex-multi-intro-domain-range-1">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-1">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1001,7 +1001,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-2">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-2">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1022,7 +1022,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-3">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-3">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1043,7 +1043,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-4">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-4">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1065,7 +1065,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-5">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-5">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1086,7 +1086,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-6">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-6">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1107,7 +1107,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-7">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-7">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1129,7 +1129,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-8">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-8">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1163,7 +1163,7 @@
         </introduction>
 
         <exercise label="ex-multi-intro-sketch-level-1">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-1">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1181,7 +1181,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-sketch-level-2">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-2">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1202,7 +1202,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-sketch-level-3">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-3">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1220,7 +1220,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-sketch-level-4">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-4">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1239,7 +1239,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-sketch-level-5">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-5">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1259,7 +1259,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-sketch-level-6">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-6">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1279,7 +1279,7 @@
         </exercise>
 
         <exercise xml:id="x12_01_ex_21" label="ex-multi-intro-sketch-level-7">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-7">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1298,7 +1298,7 @@
         </exercise>
 
         <exercise xml:id="x12_01_ex_22" label="ex-multi-intro-sketch-level-8">
-          <!--<webwork xml:id="ex-multi-intro-sketch-level-8">
+          <!--<webwork xml:id="webwork-ex-multi-intro-sketch-level-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1327,7 +1327,7 @@
         </introduction>
 
         <exercise label="ex-multi-intro-domain-range-3d-1">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-3d-1">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-3d-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1349,7 +1349,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-3d-2">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-3d-2">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-3d-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1371,7 +1371,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-3d-3">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-3d-3">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-3d-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1395,7 +1395,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-domain-range-3d-4">
-          <!--<webwork xml:id="ex-multi-intro-domain-range-3d-4">
+          <!--<webwork xml:id="webwork-ex-multi-intro-domain-range-3d-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1426,7 +1426,7 @@
         </introduction>
 
         <exercise label="ex-multi-intro-level-surface-1">
-          <!--<webwork xml:id="ex-multi-intro-level-surface-1">
+          <!--<webwork xml:id="webwork-ex-multi-intro-level-surface-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1444,7 +1444,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-level-surface-2">
-          <!--<webwork xml:id="ex-multi-intro-level-surface-2">
+          <!--<webwork xml:id="webwork-ex-multi-intro-level-surface-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1462,7 +1462,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-level-surface-3">
-          <!--<webwork xml:id="ex-multi-intro-level-surface-3">
+          <!--<webwork xml:id="webwork-ex-multi-intro-level-surface-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1480,7 +1480,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-level-surface-4">
-          <!--<webwork xml:id="ex-multi-intro-level-surface-4">
+          <!--<webwork xml:id="webwork-ex-multi-intro-level-surface-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1498,7 +1498,7 @@
         </exercise>
 
         <exercise label="ex-multi-intro-level-surface-5">
-          <!--<webwork xml:id="ex-multi-intro-level-surface-5">
+          <!--<webwork xml:id="webwork-ex-multi-intro-level-surface-5">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -1087,7 +1087,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-multi-limit-1">
-        <!--<webwork xml:id="TaC-multi-limit-1">
+        <!--<webwork xml:id="webwork-TaC-multi-limit-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1104,7 +1104,7 @@
       </exercise>
 
       <exercise label="TaC-multi-limit-2">
-        <!--<webwork xml:id="TaC-multi-limit-2">
+        <!--<webwork xml:id="webwork-TaC-multi-limit-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1123,7 +1123,7 @@
       </exercise>
 
       <exercise label="TaC-multi-limit-3">
-        <!--<webwork xml:id="TaC-multi-limit-3">
+        <!--<webwork xml:id="webwork-TaC-multi-limit-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1144,7 +1144,7 @@
       </exercise>
 
       <exercise label="TaC-multi-limit-4">
-        <!--<webwork xml:id="TaC-multi-limit-4">
+        <!--<webwork xml:id="webwork-TaC-multi-limit-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1165,7 +1165,7 @@
       </exercise>
 
       <exercise label="TaC-multi-limit-5">
-        <!--<webwork xml:id="TaC-multi-limit-5">
+        <!--<webwork xml:id="webwork-TaC-multi-limit-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1186,7 +1186,7 @@
       </exercise>
 
       <exercise label="TaC-multi-limit-6">
-        <!--<webwork xml:id="TaC-multi-limit-6">
+        <!--<webwork xml:id="webwork-TaC-multi-limit-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1240,7 +1240,7 @@
         </introduction>
 
         <exercise label="ex-multi-limit-topology-1">
-          <!--<webwork xml:id="ex-multi-limit-topology-1">
+          <!--<webwork xml:id="webwork-ex-multi-limit-topology-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1279,7 +1279,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-topology-2">
-          <!-- <webwork xml:id="ex-multi-limit-topology-2">
+          <!-- <webwork xml:id="webwork-ex-multi-limit-topology-2">
               <pg-code>
                 Context("Point");
                 $bp=Point("(3,9)");
@@ -1348,7 +1348,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-topology-3">
-          <!--<webwork xml:id="ex-multi-limit-topology-3">
+          <!--<webwork xml:id="webwork-ex-multi-limit-topology-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1387,7 +1387,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-topology-4">
-          <!-- <webwork xml:id="ex-multi-limit-topology-4">
+          <!-- <webwork xml:id="webwork-ex-multi-limit-topology-4">
               <pg-code>
                 Context("Point");
                 $bp=Point("(0,0)");
@@ -1464,7 +1464,7 @@
         </introduction>
 
         <exercise label="ex-multi-limit-domain-topology-1">
-          <!--<webwork xml:id="ex-multi-limit-domain-topology-1">
+          <!--<webwork xml:id="webwork-ex-multi-limit-domain-topology-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1499,7 +1499,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-domain-topology-2">
-          <!--<webwork xml:id="ex-multi-limit-domain-topology-2">
+          <!--<webwork xml:id="webwork-ex-multi-limit-domain-topology-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1534,7 +1534,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-domain-topology-3">
-          <!--<webwork xml:id="ex-multi-limit-domain-topology-3">
+          <!--<webwork xml:id="webwork-ex-multi-limit-domain-topology-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1569,7 +1569,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-domain-topology-4">
-          <!--<webwork xml:id="ex-multi-limit-domain-topology-4">
+          <!--<webwork xml:id="webwork-ex-multi-limit-domain-topology-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1615,7 +1615,7 @@
         </introduction>
 
         <exercise label="ex-multi-limit-two-paths-1">
-          <!--<webwork xml:id="ex-multi-limit-two-paths-1">
+          <!--<webwork xml:id="webwork-ex-multi-limit-two-paths-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1664,7 +1664,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-two-paths-2">
-          <!--<webwork xml:id="ex-multi-limit-two-paths-2">
+          <!--<webwork xml:id="webwork-ex-multi-limit-two-paths-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1702,7 +1702,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-two-paths-3">
-          <!--<webwork xml:id="ex-multi-limit-two-paths-3">
+          <!--<webwork xml:id="webwork-ex-multi-limit-two-paths-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1751,7 +1751,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-two-paths-4">
-          <!--<webwork xml:id="ex-multi-limit-two-paths-4">
+          <!--<webwork xml:id="webwork-ex-multi-limit-two-paths-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1810,7 +1810,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-two-paths-5">
-          <!--<webwork xml:id="ex-multi-limit-two-paths-5">
+          <!--<webwork xml:id="webwork-ex-multi-limit-two-paths-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1870,7 +1870,7 @@
         </exercise>
 
         <exercise label="ex-multi-limit-two-paths-6">
-          <!--<webwork xml:id="ex-multi-limit-two-paths-6">
+          <!--<webwork xml:id="webwork-ex-multi-limit-two-paths-6">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -1274,7 +1274,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-multi-tangent-1">
-        <!-- <webwork xml:id="TaC-multi-tangent-1">
+        <!-- <webwork xml:id="webwork-TaC-multi-tangent-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1297,7 +1297,7 @@
       </exercise>
 
       <exercise label="TaC-multi-tangent-2">
-        <!-- <webwork xml:id="TaC-multi-tangent-2">
+        <!-- <webwork xml:id="webwork-TaC-multi-tangent-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1320,7 +1320,7 @@
       </exercise>
 
       <exercise label="TaC-multi-tangent-3">
-        <webwork xml:id="TaC-multi-tangent-3">
+        <webwork xml:id="webwork-TaC-multi-tangent-3">
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -1339,7 +1339,7 @@
       </exercise>
 
       <exercise label="TaC-multi-tangent-4">
-        <!-- <webwork xml:id="TaC-multi-tangent-4">
+        <!-- <webwork xml:id="webwork-TaC-multi-tangent-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1403,7 +1403,7 @@
         </introduction>
 
         <exercise xml:id="x12_06_ex_05" label="ex-multi-tangent-parametric-1">
-          <!-- <webwork xml:id="ex-multi-tangent-parametric-1">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-parametric-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1442,7 +1442,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-parametric-2">
-          <webwork xml:id="ex-multi-tangent-parametric-2">
+          <webwork xml:id="webwork-ex-multi-tangent-parametric-2">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector");
@@ -1525,7 +1525,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-parametric-3">
-          <!-- <webwork xml:id="ex-multi-tangent-parametric-3">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-parametric-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1563,7 +1563,7 @@
         </exercise>
 
         <exercise xml:id="x12_06_ex_08" label="ex-multi-tangent-parametric-4">
-          <webwork xml:id="ex-multi-tangent-parametric-4">
+          <webwork xml:id="webwork-ex-multi-tangent-parametric-4">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector");
@@ -1657,7 +1657,7 @@
         </introduction>
 
         <exercise xml:id="x12_06_ex_09" label="ex-multi-tangent-normal-1">
-          <!-- <webwork xml:id="ex-multi-tangent-normal-1">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-normal-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1675,7 +1675,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-normal-2">
-          <webwork xml:id="ex-multi-tangent-normal-2">
+          <webwork xml:id="webwork-ex-multi-tangent-normal-2">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector");
@@ -1743,7 +1743,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-normal-3">
-          <!-- <webwork xml:id="ex-multi-tangent-normal-3">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-normal-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1761,7 +1761,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-normal-4">
-          <webwork xml:id="ex-multi-tangent-normal-4">
+          <webwork xml:id="webwork-ex-multi-tangent-normal-4">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector");
@@ -1839,7 +1839,7 @@
         </introduction>
 
         <exercise xml:id="x12_06_ex_13" label="ex-multi-tangent-2-units-from-surface-1">
-          <!-- <webwork xml:id="ex-multi-tangent-2-units-from-surface-1">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-2-units-from-surface-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1857,7 +1857,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-2-units-from-surface-2">
-          <!-- <webwork xml:id="ex-multi-tangent-2-units-from-surface-2">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-2-units-from-surface-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1874,7 +1874,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-2-units-from-surface-3">
-          <!-- <webwork xml:id="ex-multi-tangent-2-units-from-surface-3">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-2-units-from-surface-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1891,7 +1891,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-2-units-from-surface-4">
-          <!-- <webwork xml:id="ex-multi-tangent-2-units-from-surface-4">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-2-units-from-surface-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1919,7 +1919,7 @@
         </introduction>
 
         <exercise xml:id="x12_06_ex_17" label="ex-multi-tangent-plane-1">
-          <!-- <webwork xml:id="ex-multi-tangent-plane-1">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-plane-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1936,7 +1936,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-plane-2">
-          <webwork xml:id="ex-multi-tangent-plane-2">
+          <webwork xml:id="webwork-ex-multi-tangent-plane-2">
               <pg-code>
                 Context("ImplicitPlane");
                 $t=Compute("-3sqrt(3)/4(x-pi/3)+3sqrt(3)/4(y-pi/6)-(z-3/4)=0");
@@ -1958,7 +1958,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-plane-3">
-          <!-- <webwork xml:id="ex-multi-tangent-plane-3">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-plane-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1976,7 +1976,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-plane-4">
-          <webwork xml:id="ex-multi-tangent-plane-4">
+          <webwork xml:id="webwork-ex-multi-tangent-plane-4">
               <pg-code>
                 Context("ImplicitPlane");
                 $t=Compute("z=3");
@@ -2022,7 +2022,7 @@
         </introduction>
 
         <exercise label="ex-multi-tangent-implicit-gradient-1">
-          <!-- <webwork xml:id="ex-multi-tangent-implicit-gradient-1">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-implicit-gradient-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2059,7 +2059,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-implicit-gradient-2">
-          <webwork xml:id="ex-multi-tangent-implicit-gradient-2">
+          <webwork xml:id="webwork-ex-multi-tangent-implicit-gradient-2">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>"Real");
@@ -2134,7 +2134,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-implicit-gradient-3">
-          <!-- <webwork xml:id="ex-multi-tangent-implicit-gradient-3">
+          <!-- <webwork xml:id="webwork-ex-multi-tangent-implicit-gradient-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2169,7 +2169,7 @@
         </exercise>
 
         <exercise label="ex-multi-tangent-implicit-gradient-4">
-          <webwork xml:id="ex-multi-tangent-implicit-gradient-4">
+          <webwork xml:id="webwork-ex-multi-tangent-implicit-gradient-4">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>"Real");

--- a/ptx/sec_newton.ptx
+++ b/ptx/sec_newton.ptx
@@ -640,7 +640,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-newtons-method-1">
-        <webwork xml:id="TaC-newtons-method-1">
+        <webwork xml:id="webwork-TaC-newtons-method-1">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -655,7 +655,7 @@
       </exercise>
 
       <exercise label="TaC-newtons-method-2">
-        <webwork xml:id="TaC-newtons-method-2">
+        <webwork xml:id="webwork-TaC-newtons-method-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -686,7 +686,7 @@
         </introduction>
         <!--Exercise 3: Newton's Method with cos(x)-->
         <exercise label="ex-newtons-method-known-roots-1">
-          <webwork xml:id="ex-newtons-method-known-roots-1">
+          <webwork xml:id="webwork-ex-newtons-method-known-roots-1">
             <pg-code>
               $f=Compute('cos(x)');
               Context("LimitedNumeric");
@@ -727,7 +727,7 @@
         </exercise>
         <!--Exercise 4 sine function-->
         <exercise label="ex-newtons-method-known-roots-2">
-          <webwork xml:id="ex-newtons-method-known-roots-2">
+          <webwork xml:id="webwork-ex-newtons-method-known-roots-2">
             <pg-code>
               $f=Compute('sin(x)');
               Context("LimitedNumeric");
@@ -768,7 +768,7 @@
         </exercise>
         <!--Exercise 5 quadratic function-->
         <exercise label="ex-newtons-method-known-roots-3">
-          <webwork xml:id="ex-newtons-method-known-roots-3">
+          <webwork xml:id="webwork-ex-newtons-method-known-roots-3">
             <pg-code>
               $f=Compute('x^2+x-2');
               Context("LimitedNumeric");
@@ -809,7 +809,7 @@
         </exercise>
         <!--Exercise 6 quadratic function 2-->
         <exercise label="ex-newtons-method-known-roots-4">
-          <webwork xml:id="ex-newtons-method-known-roots-4">
+          <webwork xml:id="webwork-ex-newtons-method-known-roots-4">
             <pg-code>
               $f=Compute('x^2-2');
               Context("LimitedNumeric");
@@ -850,7 +850,7 @@
         </exercise>
         <!--Exercise 7 ln(x) -->
         <exercise label="ex-newtons-method-known-roots-5">
-          <webwork xml:id="ex-newtons-method-known-roots-5">
+          <webwork xml:id="webwork-ex-newtons-method-known-roots-5">
             <pg-code>
               $f=Compute('ln(x)');
               Context("LimitedNumeric");
@@ -891,7 +891,7 @@
         </exercise>
         <!--Exercise 8 x^3-x^2+x-1 -->
         <exercise label="ex-newtons-method-known-roots-6">
-          <webwork xml:id="ex-newtons-method-known-roots-6">
+          <webwork xml:id="webwork-ex-newtons-method-known-roots-6">
             <pg-code>
               $f=Compute('x^3-x^2+x-1');
               Context("LimitedNumeric");
@@ -943,7 +943,7 @@
         </introduction>
 
         <exercise label="ex-newtons-method-find-root-1">
-          <webwork xml:id="ex-newtons-method-find-root-1">
+          <webwork xml:id="webwork-ex-newtons-method-find-root-1">
             <pg-code>
               $f = Compute('x^3+5x^2-x-1');
               Context("FiniteSolutionSets");
@@ -971,7 +971,7 @@
         </exercise>
 
         <exercise label="ex-newtons-method-find-root-2">
-          <webwork xml:id="ex-newtons-method-find-root-2">
+          <webwork xml:id="webwork-ex-newtons-method-find-root-2">
             <pg-code>
               $f = Compute('x^4+2x^3-7x^2-x+5');
               Context("FiniteSolutionSets");
@@ -999,7 +999,7 @@
         </exercise>
 
         <exercise label="ex-newtons-method-find-root-3">
-          <webwork xml:id="ex-newtons-method-find-root-3">
+          <webwork xml:id="webwork-ex-newtons-method-find-root-3">
             <pg-code>
               $f = Compute('x^17-2x^13-10x^8+10');
               Context("FiniteSolutionSets");
@@ -1027,7 +1027,7 @@
         </exercise>
 
         <exercise label="ex-newtons-method-find-root-4">
-          <webwork xml:id="ex-newtons-method-find-root-4">
+          <webwork xml:id="webwork-ex-newtons-method-find-root-4">
             <pg-code>
               $f = Compute('x^2cos(x) + (x-1)sin(x)');
               Context("FiniteSolutionSets");
@@ -1067,7 +1067,7 @@
 
         <!--ONE OF FOUR-->
         <exercise label="ex-newtons-method-functions-equal-1">
-          <webwork xml:id="ex-newtons-method-functions-equal-1">
+          <webwork xml:id="webwork-ex-newtons-method-functions-equal-1">
             <pg-code>
               $f = Compute('x^2');
               $g = Compute('cos(x)');
@@ -1097,7 +1097,7 @@
 
         <!--TWO OF FOUR-->
         <exercise label="ex-newtons-method-functions-equal-2">
-          <webwork xml:id="ex-newtons-method-functions-equal-2">
+          <webwork xml:id="webwork-ex-newtons-method-functions-equal-2">
             <pg-code>
               $f = Compute('x^2-1');
               $g = Compute('sin(x)');
@@ -1127,7 +1127,7 @@
 
         <!--THREE OF FOUR-->
         <exercise label="ex-newtons-method-functions-equal-3">
-          <webwork xml:id="ex-newtons-method-functions-equal-3">
+          <webwork xml:id="webwork-ex-newtons-method-functions-equal-3">
             <pg-code>
               $f = Compute('e^(x^2)');
               $g = Compute('cos(x)');
@@ -1157,7 +1157,7 @@
 
         <!--FOUR OF FOUR-->
         <exercise label="ex-newtons-method-functions-equal-4">
-          <webwork xml:id="ex-newtons-method-functions-equal-4">
+          <webwork xml:id="webwork-ex-newtons-method-functions-equal-4">
             <pg-code>
               $f = Compute('x');
               $g = Compute('tan(x)');
@@ -1187,7 +1187,7 @@
       </exercisegroup>
 
       <exercise label="ex-newtons-method-explain-fail-1">
-        <webwork xml:id="ex-newtons-method-explain-fail-1">
+        <webwork xml:id="webwork-ex-newtons-method-explain-fail-1">
           <statement>
             <p>
               Why does Newton's Method fail in finding a root of <m>f(x) = x^3-3x^2+x+3</m> when <m>x_0=1</m>?
@@ -1205,7 +1205,7 @@
       </exercise>
 
       <exercise label="ex-newtons-method-explain-fail-2">
-        <webwork xml:id="ex-newtons-method-explain-fail-2">
+        <webwork xml:id="webwork-ex-newtons-method-explain-fail-2">
           <statement>
             <p>
               Why does Newton's Method fail in finding a root of <m>f(x) = -17x^4+130x^3-301x^2+156x+156</m> when <m>x_0=1</m>?

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -2024,7 +2024,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-numerical-integration-1">
-        <webwork xml:id="TaC-numerical-integration-1">
+        <webwork xml:id="webwork-TaC-numerical-integration-1">
             <pg-code>
               $true=PopUp(['?','True','False'],1);
               $false=PopUp(['?','True','False'],2);
@@ -2039,7 +2039,7 @@
       </exercise>
 
       <exercise label="TaC-numerical-integration-2">
-        <webwork xml:id="TaC-numerical-integration-2">
+        <webwork xml:id="webwork-TaC-numerical-integration-2">
             <pg-code>
             </pg-code>
 
@@ -2056,7 +2056,7 @@
       </exercise>
 
       <exercise label="TaC-numerical-integration-3">
-        <webwork xml:id="TaC-numerical-integration-3">
+        <webwork xml:id="webwork-TaC-numerical-integration-3">
             <pg-code>
             </pg-code>
 
@@ -2101,7 +2101,7 @@
         </introduction>
   <!-- Exercise 4       -->
         <exercise label="ex-numerical-integration-approx-exact-1">
-          <webwork xml:id="ex-numerical-integration-approx-exact-1">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-1">
             <pg-code>
               $a = -1;
               $b = 1;
@@ -2163,7 +2163,7 @@
         </exercise>
   <!-- Exercise 5 -->
         <exercise label="ex-numerical-integration-approx-exact-2">
-          <webwork xml:id="ex-numerical-integration-approx-exact-2">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-2">
             <pg-code>
               $a = 0;
               $b = 10;
@@ -2225,7 +2225,7 @@
         </exercise>
   <!-- Exercise 6 -->
         <exercise label="ex-numerical-integration-approx-exact-3">
-          <webwork xml:id="ex-numerical-integration-approx-exact-3">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-3">
             <pg-code>
               $a = 0;
               $b = pi;
@@ -2287,7 +2287,7 @@
         </exercise>
   <!-- Exercise 7 -->
         <exercise label="ex-numerical-integration-approx-exact-4">
-          <webwork xml:id="ex-numerical-integration-approx-exact-4">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-4">
             <pg-code>
               $a = 0;
               $b = 4;
@@ -2349,7 +2349,7 @@
         </exercise>
   <!-- Exercise 8 -->
         <exercise label="ex-numerical-integration-approx-exact-5">
-          <webwork xml:id="ex-numerical-integration-approx-exact-5">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-5">
             <pg-code>
               $a = 0;
               $b = 3;
@@ -2411,7 +2411,7 @@
         </exercise>
   <!-- Exercise 9 -->
         <exercise label="ex-numerical-integration-approx-exact-6">
-          <webwork xml:id="ex-numerical-integration-approx-exact-6">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-6">
             <pg-code>
               $a = 0;
               $b = 1;
@@ -2473,7 +2473,7 @@
         </exercise>
   <!-- Exercise 10 -->
         <exercise label="ex-numerical-integration-approx-exact-7">
-          <webwork xml:id="ex-numerical-integration-approx-exact-7">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-7">
             <pg-code>
               $a = 0;
               $b = 2*pi;
@@ -2535,7 +2535,7 @@
         </exercise>
   <!-- Exercise 11 -->
         <exercise label="ex-numerical-integration-approx-exact-8">
-          <webwork xml:id="ex-numerical-integration-approx-exact-8">
+          <webwork xml:id="webwork-ex-numerical-integration-approx-exact-8">
             <pg-code>
               $a = -3;
               $b = 3;
@@ -2608,7 +2608,7 @@
         </introduction>
   <!-- Exercise 12 -->
         <exercise label="ex-numerical-integration-n6-approx-1">
-          <webwork xml:id="ex-numerical-integration-n6-approx-1">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-1">
             <pg-code>
               $a = 0;
               $b = 1;
@@ -2660,7 +2660,7 @@
         </exercise>
   <!-- Exercise 13 -->
         <exercise label="ex-numerical-integration-n6-approx-2">
-          <webwork xml:id="ex-numerical-integration-n6-approx-2">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-2">
             <pg-code>
               $a = -1;
               $b = 1;
@@ -2712,7 +2712,7 @@
         </exercise>
   <!-- Exercise 14 -->
         <exercise label="ex-numerical-integration-n6-approx-3">
-          <webwork xml:id="ex-numerical-integration-n6-approx-3">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-3">
             <pg-code>
               $a = 0;
               $b = 5;
@@ -2764,7 +2764,7 @@
         </exercise>
   <!-- Exercise 15 -->
         <exercise label="ex-numerical-integration-n6-approx-4">
-          <webwork xml:id="ex-numerical-integration-n6-approx-4">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-4">
             <pg-code>
               $a = 0;
               $b = pi;
@@ -2816,7 +2816,7 @@
         </exercise>
   <!-- Exercise 16 -->
         <exercise label="ex-numerical-integration-n6-approx-5">
-          <webwork xml:id="ex-numerical-integration-n6-approx-5">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-5">
             <pg-code>
               $a = 0;
               $b = pi/2;
@@ -2868,7 +2868,7 @@
         </exercise>
   <!-- Exercise 17 -->
         <exercise label="ex-numerical-integration-n6-approx-6">
-          <webwork xml:id="ex-numerical-integration-n6-approx-6">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-6">
             <pg-code>
               $a = 1;
               $b = 4;
@@ -2920,7 +2920,7 @@
         </exercise>
   <!-- Exercise 18 -->
         <exercise label="ex-numerical-integration-n6-approx-7">
-          <webwork xml:id="ex-numerical-integration-n6-approx-7">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-7">
             <pg-code>
               $a = -1;
               $b = 1;
@@ -2972,7 +2972,7 @@
         </exercise>
   <!-- Exercise 19 -->
         <exercise label="ex-numerical-integration-n6-approx-8">
-          <webwork xml:id="ex-numerical-integration-n6-approx-8">
+          <webwork xml:id="webwork-ex-numerical-integration-n6-approx-8">
             <pg-code>
               $a = 0;
               $b = 6;
@@ -3035,7 +3035,7 @@
         </introduction>
   <!-- Exercise 20 -->
         <exercise label="ex-numerical-integration-bound-error-1">
-          <webwork xml:id="ex-numerical-integration-bound-error-1">
+          <webwork xml:id="webwork-ex-numerical-integration-bound-error-1">
             <pg-code>
               $a = 0;
               $b = pi;
@@ -3086,7 +3086,7 @@
         </exercise>
   <!-- Exercise 21 -->
         <exercise label="ex-numerical-integration-bound-error-2">
-          <webwork xml:id="ex-numerical-integration-bound-error-2">
+          <webwork xml:id="webwork-ex-numerical-integration-bound-error-2">
             <pg-code>
               $a = 1;
               $b = 4;
@@ -3127,7 +3127,7 @@
         </exercise>
   <!-- Exercise 22 -->
         <exercise label="ex-numerical-integration-bound-error-3">
-          <webwork xml:id="ex-numerical-integration-bound-error-3">
+          <webwork xml:id="webwork-ex-numerical-integration-bound-error-3">
             <pg-code>
               $a = 0;
               $b = pi;
@@ -3168,7 +3168,7 @@
         </exercise>
   <!-- Exercise 23 -->
         <exercise label="ex-numerical-integration-bound-error-4">
-          <webwork xml:id="ex-numerical-integration-bound-error-4">
+          <webwork xml:id="webwork-ex-numerical-integration-bound-error-4">
             <pg-code>
               $a = 0;
               $b = 5;
@@ -3237,7 +3237,7 @@
         </introduction>
   <!-- Exercise 24 -->
         <exercise label="ex-numerical-integration-area-1">
-          <!-- <webwork xml:id="ex-numerical-integration-area-1">
+          <!-- <webwork xml:id="webwork-ex-numerical-integration-area-1">
               <pg-code>
                 $a = 0;
                 $b = 6;
@@ -3304,7 +3304,7 @@
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-numerical-integration-area-2">
-          <!--<webwork xml:id="ex-numerical-integration-area-2">
+          <!--<webwork xml:id="webwork-ex-numerical-integration-area-2">
               <pg-code>
                 $a = 0;
                 $b = 6;

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -2136,7 +2136,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-1a"> 
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/><!-- 3/4 -->
@@ -2144,7 +2144,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-1b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/><!-- 2/3 -->
@@ -2152,7 +2152,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-1c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/><!-- 2/3 -->
@@ -2198,7 +2198,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-2a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/> <!-- 250 -->
@@ -2206,7 +2206,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-2b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/> <!-- 250 -->
@@ -2214,7 +2214,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-2c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/> <!-- 250 -->
@@ -2260,7 +2260,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-3a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/> <!-- 1/4*(1+sqrt(2))*pi -->
@@ -2268,7 +2268,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-3b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 1/6*(1+2*sqrt(2))*pi -->
@@ -2276,7 +2276,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-3c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/> <!-- 2 -->
@@ -2322,7 +2322,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-4a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/> <!-- 2+sqrt(2)+sqrt(3) -->
@@ -2330,7 +2330,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-4b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/> <!-- 2/3*(3+sqrt(2)+2*sqrt(3)) -->
@@ -2338,7 +2338,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-4c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/> <!-- 16/3 -->
@@ -2384,7 +2384,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-5a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/> <!-- 38.5781 -->
@@ -2392,7 +2392,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-5b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/> <!-- 147/4 -->
@@ -2400,7 +2400,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-5c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/> <!-- 147/4 -->
@@ -2446,7 +2446,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-6a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/> <!-- 0.2207 -->
@@ -2454,7 +2454,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-6b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/> <!-- 0.2005 -->
@@ -2462,7 +2462,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-6c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/>  <!-- 1/5 -->
@@ -2508,7 +2508,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-7a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/> <!-- 0 -->
@@ -2516,7 +2516,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-7b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/> <!-- 0 -->
@@ -2524,7 +2524,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-7c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/> <!-- 0 -->
@@ -2570,7 +2570,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-8a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 9/2*(1+sqrt(3)), 12.294 -->
@@ -2578,7 +2578,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-8b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 3+6*sqrt(3), 13.392 -->
@@ -2586,7 +2586,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-approx-exact-8c">
               <statement>
                 <p>
                   Find the exact value: <var name="$exact" width="20"/>  <!-- 9*pi/2, 14.137 -->
@@ -2641,7 +2641,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-1a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 0.9006 -->
@@ -2649,7 +2649,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-1b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 0.90452 -->
@@ -2693,7 +2693,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-2a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 3.0241 -->
@@ -2701,7 +2701,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-2b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 2.9315 -->
@@ -2745,7 +2745,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-3a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 13.9604 -->
@@ -2753,7 +2753,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-3b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 13.9066 -->
@@ -2797,7 +2797,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-4a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 3.0695 -->
@@ -2805,7 +2805,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-4b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 3.14295 -->
@@ -2849,7 +2849,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-5a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 1.1703 -->
@@ -2857,7 +2857,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-5b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 1.1873 -->
@@ -2901,7 +2901,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-6a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 2.52971 -->
@@ -2909,7 +2909,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-6b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 2.5447 -->
@@ -2953,7 +2953,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-7a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 1.0803 -->
@@ -2961,7 +2961,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-7b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 1.077 -->
@@ -3005,7 +3005,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-8a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/>  <!-- 3.4682 -->
@@ -3013,7 +3013,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-n6-approx-8b">
               <statement>
                 <p>
                   Approximate using Simpson's rule: <var name="$simp" width="20"/>  <!-- 3.4985 -->
@@ -3057,7 +3057,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-1a">
               <statement>
                 <p>
                   Trapezoid rule: <m>n  \gt = </m><var name="$nt" width="20"/> <!-- 161 -->
@@ -3070,7 +3070,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-1b">
               <statement>
                 <p>
                   Simpson's rule: <m>n  \gt = </m><var name="$ns" width="20"/> <!-- 12 -->
@@ -3108,7 +3108,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-2a">
               <statement>
                 <p>
                   Trapezoid rule: <m>n  \gt = </m><var name="$nt" width="20"/>  <!-- 130 -->
@@ -3116,7 +3116,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-2b">
               <statement>
                 <p>
                   Simpson's rule: <m>n  \gt = </m><var name="$ns" width="20"/> <!-- 18 -->
@@ -3149,7 +3149,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-3a">
               <statement>
                 <p>
                   Trapezoid rule: <m>n  \gt = </m><var name="$nt" width="20"/>  <!-- 994 but orig sol'n said 1004 -->
@@ -3157,7 +3157,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-3b">
               <statement>
                 <p>
                   Simpson's rule: <m>n  \gt = </m><var name="$ns" width="20"/> <!-- 62 -->
@@ -3190,7 +3190,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-4a">
               <statement>
                 <p>
                   Trapezoid rule: <m>n  \gt = </m><var name="$nt" width="20"/>  <!-- 5591 -->
@@ -3198,7 +3198,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-numerical-integration-bound-error-4b">
               <statement>
                 <p>
                   Simpson's rule: <m>n  \gt = </m><var name="$ns" width="20"/> <!-- 46 -->

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -697,7 +697,7 @@
     <subexercises xml:id="TaC-optimization">
       <title>Terms and Concepts</title>
       <exercise label="TaC-optimization-1">
-        <webwork xml:id="TaC-optimization-1">
+        <webwork xml:id="webwork-TaC-optimization-1">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -714,7 +714,7 @@
       </exercise>
 
       <exercise label="TaC-optimization-2">
-        <webwork xml:id="TaC-optimization-2">
+        <webwork xml:id="webwork-TaC-optimization-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -734,7 +734,7 @@
       <title>Problems</title>
       <!--Exercise 3: Maximize product of two numbers-->
       <exercise label="ex-optimization-product">
-        <webwork xml:id="ex-optimization-product">
+        <webwork xml:id="webwork-ex-optimization-product">
           <pg-code>
             $sum = random(50,200,2);
             if($envir{problemSeed}==1){$sum=100;};
@@ -757,7 +757,7 @@
       </exercise>
       <!-- Exercise 4: Minimize sum of two numbers       -->
       <exercise label="ex-optimization-sum-1">
-        <webwork xml:id="ex-optimization-sum-1">
+        <webwork xml:id="webwork-ex-optimization-sum-1">
           <pg-code>
             $prod = random(400,600,10);
             if($envir{problemSeed}==1){$prod=500;};
@@ -779,7 +779,7 @@
       </exercise>
       <!-- Exercise 5: Maximum sum of two numbers -->
       <exercise label="ex-optimization-sum-2">
-        <webwork xml:id="ex-optimization-sum-2">
+        <webwork xml:id="webwork-ex-optimization-sum-2">
           <pg-code>
             $prod = random(400,600,10);
             if($envir{problemSeed}==1){$prod=500;};
@@ -808,7 +808,7 @@
       </exercise>
       <!-- Exercise 6: Maximum sum with a boundary condition -->
       <exercise label="ex-optimization-sum-3">
-        <webwork xml:id="ex-optimization-sum-3">
+        <webwork xml:id="webwork-ex-optimization-sum-3">
           <pg-code>
             $prod = random(400,600,10);
             $upper = random(200,500,10);
@@ -833,7 +833,7 @@
       </exercise>
       <!-- Exercise 7: Maximum area of a right triangle -->
       <exercise label="ex-optimization-triangle">
-        <webwork xml:id="ex-optimization-triangle">
+        <webwork xml:id="webwork-ex-optimization-triangle">
           <pg-code>
             $hyp = random(1,9,1);
             if($envir{problemSeed}==1){$hyp=1;};
@@ -852,7 +852,7 @@
       </exercise>
       <!--Exercise 8: Two adjacent rectangular pens-->
       <exercise label="ex-optimization-pens">
-        <webwork xml:id="ex-optimization-pens">
+        <webwork xml:id="webwork-ex-optimization-pens">
           <pg-code>
             $total = random(800,1500,100);
             if($envir{problemSeed}==1){$total=1000;};
@@ -902,7 +902,7 @@
       </exercise>
       <!-- Exercise 9: Dimensions of the optimal cylindrical can -->
       <exercise label="ex-optimization-can-1">
-        <webwork xml:id="ex-optimization-can-1">
+        <webwork xml:id="webwork-ex-optimization-can-1">
           <pg-code>
             $V = NumberWithUnits("355 cm^3");
             parser::Root->Enable;
@@ -942,7 +942,7 @@
       </exercise>
       <!-- Exercise 10: Optimal different cylindrical can -->
       <exercise label="ex-optimization-can-2">
-        <webwork xml:id="ex-optimization-can-2">
+        <webwork xml:id="webwork-ex-optimization-can-2">
           <pg-code>
             $V = NumberWithUnits("206 in^3");
             parser::Root->Enable;
@@ -986,7 +986,7 @@
       </exercise>
       <!-- Exercise 11: Dimensions of the optimal cylindrical can, part 2 -->
       <exercise label="ex-optimization-can-3">
-        <webwork xml:id="ex-optimization-can-3">
+        <webwork xml:id="webwork-ex-optimization-can-3">
           <pg-code>
             $V = NumberWithUnits("355 cm^3");
             parser::Root->Enable;
@@ -1029,7 +1029,7 @@
       </exercise>
       <!-- Exercise 12: USPS shipping box -->
       <exercise label="ex-optimization-box">
-        <webwork xml:id="ex-optimization-box">
+        <webwork xml:id="webwork-ex-optimization-box">
           <pg-code>
             $V = NumberWithUnits("36*18**2 in^3");
           </pg-code>
@@ -1053,7 +1053,7 @@
       </exercise>
       <!-- Exercise 13: Strength of a beam -->
       <exercise label="ex-optimization-beam">
-        <webwork xml:id="ex-optimization-beam">
+        <webwork xml:id="webwork-ex-optimization-beam">
           <pg-code>
             $D = random(10,20,1);
             if($envir{problemSeed}==1){$D=12;};
@@ -1109,7 +1109,7 @@
       </exercise>
       <!-- Exercise 14: Power line by land and by sea -->
       <exercise label="ex-optimization-power-line-1">
-        <webwork xml:id="ex-optimization-power-line-1">
+        <webwork xml:id="webwork-ex-optimization-power-line-1">
           <pg-code>
             do {
               ($x,$y) = (2,3,4,5,6)[NchooseK(5,2)];
@@ -1159,7 +1159,7 @@
       </exercise>
       <!-- Exercise 15: Different power line by land and by sea, this time boundary condition will matter  -->
       <exercise label="ex-optimization-power-line-2">
-        <webwork xml:id="ex-optimization-power-line-2">
+        <webwork xml:id="webwork-ex-optimization-power-line-2">
           <pg-code>
             do {
               ($x,$y) = (2,3,4,5,6)[NchooseK(5,2)];
@@ -1209,7 +1209,7 @@
       </exercise>
       <!--Exercise 16: Dog, stick, water: Classic -->
       <exercise label="ex-optimization-dog-stick-water-1">
-        <webwork xml:id="ex-optimization-dog-stick-water-1">
+        <webwork xml:id="webwork-ex-optimization-dog-stick-water-1">
           <pg-code>
             ($x,$y) = (10..40)[NchooseK(31,2)];
             $run = random(18,25,1);
@@ -1243,7 +1243,7 @@
       </exercise>
       <!--Exercise 17: Dog, stick, water 2-->
       <exercise label="ex-optimization-dog-stick-water-2">
-        <webwork xml:id="ex-optimization-dog-stick-water-2">
+        <webwork xml:id="webwork-ex-optimization-dog-stick-water-2">
           <pg-code>
             ($x,$y) = (10..40)[NchooseK(31,2)];
             $run = random(18,25,1);
@@ -1277,7 +1277,7 @@
       </exercise>
       <!-- Exercise 18: Rectangle inside the unit circle -->
       <exercise label="ex-optimization-inscribed-rectangle">
-        <webwork xml:id="ex-optimization-inscribed-rectangle">
+        <webwork xml:id="webwork-ex-optimization-inscribed-rectangle">
           <pg-code>
             $w = Compute("sqrt(2)");
             $multians = MultiAnswer($w,$w)->with(

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -1019,7 +1019,7 @@
     <subexercises xml:id="TaC-parametric-calc">
       <title>Terms and Concepts</title>
       <exercise label="TaC-parametric-calc-1">
-        <webwork xml:id="TaC-parametric-calc-1">
+        <webwork xml:id="webwork-TaC-parametric-calc-1">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1038,7 +1038,7 @@
       </exercise>
 
       <exercise label="TaC-parametric-calc-2">
-        <!-- <webwork xml:id="TaC-parametric-calc-2">
+        <!-- <webwork xml:id="webwork-TaC-parametric-calc-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1056,7 +1056,7 @@
       </exercise>
 
       <exercise label="TaC-parametric-calc-3">
-        <webwork xml:id="TaC-parametric-calc-3">
+        <webwork xml:id="webwork-TaC-parametric-calc-3">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1075,7 +1075,7 @@
       </exercise>
 
       <exercise label="TaC-parametric-calc-4">
-        <webwork xml:id="TaC-parametric-calc-4">
+        <webwork xml:id="webwork-TaC-parametric-calc-4">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1125,7 +1125,7 @@
         </introduction>
 
         <exercise xml:id="ex_09_03_ex_05" label="ex-parametric-tangent-1">
-          <!-- <webwork xml:id="ex-parametric-tangent-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1155,7 +1155,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-2">
-          <!-- <webwork xml:id="ex-parametric-tangent-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1185,7 +1185,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-3">
-          <!-- <webwork xml:id="ex-parametric-tangent-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1215,7 +1215,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-4">
-          <!-- <webwork xml:id="ex-parametric-tangent-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1247,7 +1247,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-5">
-          <!-- <webwork xml:id="ex-parametric-tangent-5">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1279,7 +1279,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-6">
-          <!-- <webwork xml:id="ex-parametric-tangent-6">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1310,7 +1310,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-7">
-          <!-- <webwork xml:id="ex-parametric-tangent-7">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1341,7 +1341,7 @@
         </exercise>
 
         <exercise xml:id="ex_09_03_ex_12" label="ex-parametric-tangent-8">
-          <!-- <webwork xml:id="ex-parametric-tangent-8">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1382,7 +1382,7 @@
         </introduction>
 
         <exercise label="ex-parametric-tangent-horizontal-1">
-          <!-- <webwork xml:id="ex-parametric-tangent-horizontal-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-horizontal-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1399,7 +1399,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-2">
-          <!-- <webwork xml:id="ex-parametric-tangent-horizontal-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-horizontal-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1417,7 +1417,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-3">
-          <webwork xml:id="ex-parametric-tangent-horizontal-3">
+          <webwork xml:id="webwork-ex-parametric-tangent-horizontal-3">
 
               <pg-code>
                 $hort=List("-1/2");
@@ -1452,7 +1452,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-4">
-          <!-- <webwork xml:id="ex-parametric-tangent-horizontal-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-horizontal-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1469,7 +1469,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-5">
-          <!-- <webwork xml:id="ex-parametric-tangent-horizontal-5">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-horizontal-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1486,7 +1486,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-6">
-          <webwork xml:id="ex-parametric-tangent-horizontal-6">
+          <webwork xml:id="webwork-ex-parametric-tangent-horizontal-6">
 
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1521,7 +1521,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-7">
-          <!-- <webwork xml:id="ex-parametric-tangent-horizontal-7">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-horizontal-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1542,7 +1542,7 @@
         </exercise>
 
         <exercise label="ex-parametric-tangent-horizontal-8">
-          <!-- <webwork xml:id="ex-parametric-tangent-horizontal-8">
+          <!-- <webwork xml:id="webwork-ex-parametric-tangent-horizontal-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1569,7 +1569,7 @@
         </introduction>
 
         <exercise label="ex-parametric-nonsmooth-1">
-          <webwork xml:id="ex-parametric-nonsmooth-1">
+          <webwork xml:id="webwork-ex-parametric-nonsmooth-1">
 
               <pg-code>
                 $t0 = Real("0");
@@ -1600,7 +1600,7 @@
         </exercise>
 
         <exercise label="ex-parametric-nonsmooth-2">
-          <webwork xml:id="ex-parametric-nonsmooth-2">
+          <webwork xml:id="webwork-ex-parametric-nonsmooth-2">
 
               <pg-code>
                 $t0 = Real("2");
@@ -1631,7 +1631,7 @@
         </exercise>
 
         <exercise label="ex-parametric-nonsmooth-3">
-          <!-- <webwork xml:id="ex-parametric-nonsmooth-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-nonsmooth-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1648,7 +1648,7 @@
         </exercise>
 
         <exercise label="ex-parametric-nonsmooth-4">
-          <!-- <webwork xml:id="ex-parametric-nonsmooth-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-nonsmooth-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1679,7 +1679,7 @@
         </introduction>
 
         <exercise label="ex-parametric-concavity-1">
-          <!-- <webwork xml:id="ex-parametric-concavity-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-concavity-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1696,7 +1696,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-2">
-          <!-- <webwork xml:id="ex-parametric-concavity-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-concavity-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1713,7 +1713,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-3">
-          <webwork xml:id="ex-parametric-concavity-3">
+          <webwork xml:id="webwork-ex-parametric-concavity-3">
 
 
               <pg-code>
@@ -1760,7 +1760,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-4">
-          <!-- <webwork xml:id="ex-parametric-concavity-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-concavity-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1779,7 +1779,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-5">
-          <!-- <webwork xml:id="ex-parametric-concavity-5">
+          <!-- <webwork xml:id="webwork-ex-parametric-concavity-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1798,7 +1798,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-6">
-          <webwork xml:id="ex-parametric-concavity-6">
+          <webwork xml:id="webwork-ex-parametric-concavity-6">
 
 
               <pg-code>
@@ -1846,7 +1846,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-7">
-          <!-- <webwork xml:id="ex-parametric-concavity-7">
+          <!-- <webwork xml:id="webwork-ex-parametric-concavity-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1866,7 +1866,7 @@
         </exercise>
 
         <exercise label="ex-parametric-concavity-8">
-          <!-- <webwork xml:id="ex-parametric-concavity-8">
+          <!-- <webwork xml:id="webwork-ex-parametric-concavity-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1894,7 +1894,7 @@
         </introduction>
 
         <exercise label="ex-parametric-arclength-1">
-          <webwork xml:id="ex-parametric-arclength-1">
+          <webwork xml:id="webwork-ex-parametric-arclength-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0);
                 $length=Formula("6pi");
@@ -1913,7 +1913,7 @@
         </exercise>
 
         <exercise label="ex-parametric-arclength-2">
-          <webwork xml:id="ex-parametric-arclength-2">
+          <webwork xml:id="webwork-ex-parametric-arclength-2">
 
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1947,7 +1947,7 @@
         </exercise>
 
         <exercise label="ex-parametric-arclength-3">
-          <webwork xml:id="ex-parametric-arclength-3">
+          <webwork xml:id="webwork-ex-parametric-arclength-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $length=Formula("2sqrt(34)");
@@ -1966,7 +1966,7 @@
         </exercise>
 
         <exercise label="ex-parametric-arclength-4">
-          <!-- <webwork xml:id="ex-parametric-arclength-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-arclength-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1992,7 +1992,7 @@
         </introduction>
 
         <exercise label="ex-parametric-arclength-numerical-1">
-          <!-- <webwork xml:id="ex-parametric-arclength-numerical-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-arclength-numerical-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2010,7 +2010,7 @@
         </exercise>
 
         <exercise label="ex-parametric-arclength-numerical-2">
-          <!-- <webwork xml:id="ex-parametric-arclength-numerical-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-arclength-numerical-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2028,7 +2028,7 @@
         </exercise>
 
         <exercise label="ex-parametric-arclength-numerical-3">
-          <!-- <webwork xml:id="ex-parametric-arclength-numerical-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-arclength-numerical-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2045,7 +2045,7 @@
         </exercise>
 
         <exercise label="ex-parametric-arclength-numerical-4">
-          <!-- <webwork xml:id="ex-parametric-arclength-numerical-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-arclength-numerical-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2076,7 +2076,7 @@
         </introduction>
 
         <exercise label="ex-parametric-surface-area-1">
-          <!-- <webwork xml:id="ex-parametric-surface-area-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-surface-area-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2112,7 +2112,7 @@
         </exercise>
 
         <exercise label="ex-parametric-surface-area-2">
-          <!-- <webwork xml:id="ex-parametric-surface-area-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-surface-area-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2132,7 +2132,7 @@
         </exercise>
 
         <exercise label="ex-parametric-surface-area-3">
-          <!-- <webwork xml:id="ex-parametric-surface-area-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-surface-area-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2153,7 +2153,7 @@
         </exercise>
 
         <exercise label="ex-parametric-surface-area-4">
-          <!-- <webwork xml:id="ex-parametric-surface-area-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-surface-area-4">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -1156,7 +1156,7 @@
     <subexercises xml:id="TaC-parametric-equations">
       <title>Terms and Concepts</title>
       <exercise label="TaC-parametric-equations-1">
-        <webwork xml:id="TaC-parametric-equations-1">
+        <webwork xml:id="webwork-TaC-parametric-equations-1">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1175,7 +1175,7 @@
       </exercise>
 
       <exercise label="TaC-parametric-equations-2">
-        <webwork xml:id="TaC-parametric-equations-2">
+        <webwork xml:id="webwork-TaC-parametric-equations-2">
             <pg-code>
               Context("ArbitraryString");
               $orientation=Compute("orientation");
@@ -1197,7 +1197,7 @@
       </exercise>
 
       <exercise label="TaC-parametric-equations-3">
-        <webwork xml:id="TaC-parametric-equations-3">
+        <webwork xml:id="webwork-TaC-parametric-equations-3">
             <pg-code>
               Context("ArbitraryString");
               $rectangular=Compute("rectangular");
@@ -1218,7 +1218,7 @@
       </exercise>
 
       <exercise label="TaC-parametric-equations-4">
-        <!-- <webwork xml:id="TaC-parametric-equations-4">
+        <!-- <webwork xml:id="webwork-TaC-parametric-equations-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1250,7 +1250,7 @@
         </introduction>
 
         <exercise label="ex-parametric-sketch-by-hand-1">
-          <!-- <webwork xml:id="ex-parametric-sketch-by-hand-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-by-hand-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1289,7 +1289,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-by-hand-2">
-          <!-- <webwork xml:id="ex-parametric-sketch-by-hand-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-by-hand-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1328,7 +1328,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-by-hand-3">
-          <!-- <webwork xml:id="ex-parametric-sketch-by-hand-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-by-hand-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1367,7 +1367,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-by-hand-4">
-          <!-- <webwork xml:id="ex-parametric-sketch-by-hand-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-by-hand-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1417,7 +1417,7 @@
         </introduction>
 
         <exercise label="ex-parametric-sketch-with-tech-1">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1454,7 +1454,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-2">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1491,7 +1491,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-3">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1528,7 +1528,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-4">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1567,7 +1567,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-5">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-5">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1604,7 +1604,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-6">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-6">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1640,7 +1640,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-7">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-7">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1710,7 +1710,7 @@
 
 
         <exercise label="ex-parametric-sketch-with-tech-9">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-9">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-9">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1747,7 +1747,7 @@
         </exercise>
 
         <exercise label="ex-parametric-sketch-with-tech-10">
-          <!-- <webwork xml:id="ex-parametric-sketch-with-tech-10">
+          <!-- <webwork xml:id="webwork-ex-parametric-sketch-with-tech-10">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1795,7 +1795,7 @@
         </introduction>
 
         <exercise label="ex-parametric-equations-compare-1">
-          <!-- <webwork xml:id="ex-parametric-equations-compare-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-equations-compare-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1866,7 +1866,7 @@
         </exercise>
 
         <exercise label="ex-parametric-equations-compare-2">
-          <!-- <webwork xml:id="ex-parametric-equations-compare-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-equations-compare-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1940,7 +1940,7 @@
         </introduction>
 
         <exercise label="ex-parametric-eliminate-parameter-1">
-          <webwork xml:id="ex-parametric-eliminate-parameter-1">
+          <webwork xml:id="webwork-ex-parametric-eliminate-parameter-1">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("3x+2y=17",limits=>[[-3,3],[6,11]]);
@@ -1961,7 +1961,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-2">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1978,7 +1978,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-3">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1995,7 +1995,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-4">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2012,7 +2012,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-5">
-          <webwork xml:id="ex-parametric-eliminate-parameter-5">
+          <webwork xml:id="webwork-ex-parametric-eliminate-parameter-5">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("y-2x=3",limits=>[[-3,3],[0,6]]);
@@ -2033,7 +2033,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-6">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-6">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2050,7 +2050,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-7">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-7">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2067,7 +2067,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-8">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-8">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2084,7 +2084,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-9">
-          <!-- <webwork xml:id="ex-parametric-eliminate-parameter-9">
+          <!-- <webwork xml:id="webwork-ex-parametric-eliminate-parameter-9">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2101,7 +2101,7 @@
         </exercise>
 
         <exercise label="ex-parametric-eliminate-parameter-10">
-          <webwork xml:id="ex-parametric-eliminate-parameter-10">
+          <webwork xml:id="webwork-ex-parametric-eliminate-parameter-10">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("x=1-2y^2",limits=>[[-1,2],[-2,2]]);
@@ -2133,7 +2133,7 @@
         </introduction>
 
         <exercise label="ex-parametric-describe-rectangular-1">
-          <!-- <webwork xml:id="ex-parametric-describe-rectangular-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-rectangular-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2151,7 +2151,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-rectangular-2">
-          <!-- <webwork xml:id="ex-parametric-describe-rectangular-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-rectangular-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2169,7 +2169,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-rectangular-3">
-          <!-- <webwork xml:id="ex-parametric-describe-rectangular-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-rectangular-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2187,7 +2187,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-rectangular-4">
-          <!-- <webwork xml:id="ex-parametric-describe-rectangular-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-rectangular-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2220,7 +2220,7 @@
         </introduction>
 
         <exercise label="ex-parametric-parametrize-slope-1">
-          <webwork xml:id="ex-parametric-parametrize-slope-1">
+          <webwork xml:id="webwork-ex-parametric-parametrize-slope-1">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $x=Formula("(t+11)/6");
@@ -2280,7 +2280,7 @@
         </exercise>
 
         <exercise label="ex-parametric-parametrize-slope-2">
-          <webwork xml:id="ex-parametric-parametrize-slope-2">
+          <webwork xml:id="webwork-ex-parametric-parametrize-slope-2">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->variables->set(t=>{limits=>[0.1,10]});
@@ -2341,7 +2341,7 @@
         </exercise>
 
         <exercise label="ex-parametric-parametrize-slope-3">
-          <webwork xml:id="ex-parametric-parametrize-slope-3">
+          <webwork xml:id="webwork-ex-parametric-parametrize-slope-3">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->variables->set(t=>{limits=>[-0.9,0.9]});
@@ -2402,7 +2402,7 @@
         </exercise>
 
         <exercise label="ex-parametric-parametrize-slope-4">
-          <!-- <webwork xml:id="ex-parametric-parametrize-slope-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-parametrize-slope-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2434,7 +2434,7 @@
         </introduction>
 
         <exercise label="ex-parametric-find-intersection-1">
-          <webwork xml:id="ex-parametric-find-intersection-1">
+          <webwork xml:id="webwork-ex-parametric-find-intersection-1">
 
               <pg-code>
                 $crossings=List("-1,1");
@@ -2468,7 +2468,7 @@
         </exercise>
 
         <exercise label="ex-parametric-find-intersection-2">
-          <!-- <webwork xml:id="ex-parametric-find-intersection-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-find-intersection-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2485,7 +2485,7 @@
         </exercise>
 
         <exercise label="ex-parametric-find-intersection-3">
-          <!-- <webwork xml:id="ex-parametric-find-intersection-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-find-intersection-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2502,7 +2502,7 @@
         </exercise>
 
         <exercise label="ex-parametric-find-intersection-4">
-          <!-- <webwork xml:id="ex-parametric-find-intersection-4">
+          <!-- <webwork xml:id="webwork-ex-parametric-find-intersection-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2529,7 +2529,7 @@
         </introduction>
 
         <exercise label="ex-parametric-smooth-1">
-          <!-- <webwork xml:id="ex-parametric-smooth-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-smooth-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2546,7 +2546,7 @@
         </exercise>
 
         <exercise label="ex-parametric-smooth-2">
-          <webwork xml:id="ex-parametric-smooth-2">
+          <webwork xml:id="webwork-ex-parametric-smooth-2">
 
               <pg-code>
                 $cusps=List("2");
@@ -2580,7 +2580,7 @@
         </exercise>
 
         <exercise label="ex-parametric-smooth-3">
-          <!-- <webwork xml:id="ex-parametric-smooth-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-smooth-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2597,7 +2597,7 @@
         </exercise>
 
         <exercise label="ex-parametric-smooth-4">
-          <webwork xml:id="ex-parametric-smooth-4">
+          <webwork xml:id="webwork-ex-parametric-smooth-4">
               <pg-code>
                 $cusps=List("0");
                 Context("Point");
@@ -2645,7 +2645,7 @@
         </introduction>
 
         <exercise label="ex-parametric-describe-situation-1">
-          <!-- <webwork xml:id="ex-parametric-describe-situation-1">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-situation-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2663,7 +2663,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-2">
-          <!-- <webwork xml:id="ex-parametric-describe-situation-2">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-situation-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2681,7 +2681,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-3">
-          <!-- <webwork xml:id="ex-parametric-describe-situation-3">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-situation-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2699,7 +2699,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-4">
-          <webwork xml:id="ex-parametric-describe-situation-4">
+          <webwork xml:id="webwork-ex-parametric-describe-situation-4">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $x=Formula("2cos(t)");
@@ -2750,7 +2750,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-5">
-          <webwork xml:id="ex-parametric-describe-situation-5">
+          <webwork xml:id="webwork-ex-parametric-describe-situation-5">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $x=Formula("3cos(2 pi t)+1");
@@ -2802,7 +2802,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-6">
-          <webwork xml:id="ex-parametric-describe-situation-6">
+          <webwork xml:id="webwork-ex-parametric-describe-situation-6">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $x=Formula("3cos(2 pi t)+1");
@@ -2838,7 +2838,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-7">
-          <!-- <webwork xml:id="ex-parametric-describe-situation-7">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-situation-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2856,7 +2856,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-8">
-          <!-- <webwork xml:id="ex-parametric-describe-situation-8">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-situation-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2875,7 +2875,7 @@
         </exercise>
 
         <exercise label="ex-parametric-describe-situation-9">
-          <!-- <webwork xml:id="ex-parametric-describe-situation-9">
+          <!-- <webwork xml:id="webwork-ex-parametric-describe-situation-9">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -1316,7 +1316,7 @@
     <subexercises xml:id="TaC-partial-derivatives">
       <title>Terms and Concepts</title>
       <exercise label="TaC-partial-derivatives-1">
-        <!-- <webwork xml:id="TaC-partial-derivatives-1">
+        <!-- <webwork xml:id="webwork-TaC-partial-derivatives-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1334,7 +1334,7 @@
       </exercise>
 
       <exercise label="TaC-partial-derivatives-2">
-        <!-- <webwork xml:id="TaC-partial-derivatives-2">
+        <!-- <webwork xml:id="webwork-TaC-partial-derivatives-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1353,7 +1353,7 @@
       </exercise>
 
       <exercise label="TaC-partial-derivatives-3">
-        <webwork xml:id="TaC-partial-derivatives-3">
+        <webwork xml:id="webwork-TaC-partial-derivatives-3">
             <pg-code>
               $first=RadioButtons(['\(f_x\)', '\(f_y\)'],0,labels=>[f_x,f_y],displayLabels => 0 );
             </pg-code>
@@ -1372,7 +1372,7 @@
       </exercise>
 
       <exercise label="TaC-partial-derivatives-4">
-        <webwork xml:id="TaC-partial-derivatives-4">
+        <webwork xml:id="webwork-TaC-partial-derivatives-4">
             <pg-code>
               $first=RadioButtons(['\(f_x\)', '\(f_y\)'],1,labels=>[f_x,f_y],displayLabels => 0 );
             </pg-code>
@@ -1403,7 +1403,7 @@
         </introduction>
 
         <exercise label="ex-partial-derivatives-evaluate-at-point-1">
-          <!-- <webwork xml:id="ex-partial-derivatives-evaluate-at-point-1">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-evaluate-at-point-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1424,7 +1424,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-evaluate-at-point-2">
-          <webwork xml:id="ex-partial-derivatives-evaluate-at-point-2">
+          <webwork xml:id="webwork-ex-partial-derivatives-evaluate-at-point-2">
               <pg-code>
                 $fx=0;
                 $fy=0;
@@ -1453,7 +1453,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-evaluate-at-point-3">
-          <!-- <webwork xml:id="ex-partial-derivatives-evaluate-at-point-3">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-evaluate-at-point-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1475,7 +1475,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-evaluate-at-point-4">
-          <webwork xml:id="ex-partial-derivatives-evaluate-at-point-4">
+          <webwork xml:id="webwork-ex-partial-derivatives-evaluate-at-point-4">
               <pg-code>
                 Context("Fraction");
                 $fx=Fraction(-1,2);
@@ -1517,7 +1517,7 @@
         </introduction>
 
         <exercise label="ex-partial-derivatives-first-and-second-1">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-1">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1542,7 +1542,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-2">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-2">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-2">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("3x^2+6xy+3y^2");
@@ -1604,7 +1604,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-3">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-3">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1629,7 +1629,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-4">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-4">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-4">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("-4/(x^2y)");
@@ -1691,7 +1691,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-5">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-5">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1718,7 +1718,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-6">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-6">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-6">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("e^(x+2y)");
@@ -1780,7 +1780,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-7">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-7">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1807,7 +1807,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-8">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-8">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-8">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("3(x+y)^2");
@@ -1869,7 +1869,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-9">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-9">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-9">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1896,7 +1896,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-10">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-10">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-10">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("10x cos(5x^2+2y^3)");
@@ -1958,7 +1958,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-11">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-11">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-11">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("2y^2/sqrt(4xy^2+1)");
@@ -2020,7 +2020,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-12">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-12">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-12">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2047,7 +2047,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-13">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-13">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-13">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2075,7 +2075,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-14">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-14">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-14">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("5");
@@ -2137,7 +2137,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-15">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-15">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-15">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2162,7 +2162,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-16">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-16">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-16">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("2x/(x^2+y)");
@@ -2224,7 +2224,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-17">
-          <!-- <webwork xml:id="ex-partial-derivatives-first-and-second-17">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-17">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2251,7 +2251,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-first-and-second-18">
-          <webwork xml:id="ex-partial-derivatives-first-and-second-18">
+          <webwork xml:id="webwork-ex-partial-derivatives-first-and-second-18">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $fx=Compute("5e^x sin(y)");
@@ -2323,7 +2323,7 @@
         </introduction>
 
         <exercise label="ex-partial-derivatives-antider-1">
-          <!-- <webwork xml:id="ex-partial-derivatives-antider-1">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-antider-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2341,7 +2341,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-antider-2">
-          <webwork xml:id="ex-partial-derivatives-antider-2">
+          <webwork xml:id="webwork-ex-partial-derivatives-antider-2">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $f=Compute("1/2x^2+xy+1/2y^2");
@@ -2361,7 +2361,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-antider-3">
-          <!-- <webwork xml:id="ex-partial-derivatives-antider-3">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-antider-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2379,7 +2379,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-antider-4">
-          <webwork xml:id="ex-partial-derivatives-antider-4">
+          <webwork xml:id="webwork-ex-partial-derivatives-antider-4">
               <pg-code>
                 Context()->variables->add(y=>'Real');
                 $f=Compute("ln(x^2+y^2)");
@@ -2409,7 +2409,7 @@
         </introduction>
 
         <exercise label="ex-partial-derivatives-three-1">
-          <!-- <webwork xml:id="ex-partial-derivatives-three-1">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-three-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2432,7 +2432,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-three-2">
-          <webwork xml:id="ex-partial-derivatives-three-2">
+          <webwork xml:id="webwork-ex-partial-derivatives-three-2">
               <pg-code>
                 Context()->variables->add(y=>'Real',z=>'Real');
                 $fx=Compute("3x^2y^2+3x^2z");
@@ -2486,7 +2486,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-three-3">
-          <!-- <webwork xml:id="ex-partial-derivatives-three-3">
+          <!-- <webwork xml:id="webwork-ex-partial-derivatives-three-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2510,7 +2510,7 @@
         </exercise>
 
         <exercise label="ex-partial-derivatives-three-4">
-          <webwork xml:id="ex-partial-derivatives-three-4">
+          <webwork xml:id="webwork-ex-partial-derivatives-three-4">
               <pg-code>
                 Context()->variables->add(y=>'Real',z=>'Real');
                 $fx=Compute("1/x");

--- a/ptx/sec_partial_fraction.ptx
+++ b/ptx/sec_partial_fraction.ptx
@@ -638,7 +638,7 @@
     <subexercises xml:id="TaC-partial-fractions">
       <title>Terms and Concepts</title>
       <exercise label="TaC-partial-fractions-1">
-        <webwork xml:id="TaC-partial-fractions-1">
+        <webwork xml:id="webwork-TaC-partial-fractions-1">
           <pg-code>
             Context()->strings->add('rational'=>{});
             $rational = Compute("rational");
@@ -652,7 +652,7 @@
       </exercise>
       <!-- Exercise 2 -->
       <exercise label="TaC-partial-fractions-2">
-        <webwork xml:id="TaC-partial-fractions-2">
+        <webwork xml:id="webwork-TaC-partial-fractions-2">
           <pg-code>
             $true = PopUp(['?','True','False'],1);
             $false = PopUp(['?','True','False'],2);
@@ -674,7 +674,7 @@
         </introduction>
         <!-- Exercise 3 -->
         <exercise label="ex-partial-fractions-decompose-no-solve-1">
-          <webwork xml:id="ex-partial-fractions-decompose-no-solve-1">
+          <webwork xml:id="webwork-ex-partial-fractions-decompose-no-solve-1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=-3};
@@ -721,7 +721,7 @@
         </exercise>
         <!-- Exercise 4 -->
         <exercise label="ex-partial-fractions-decompose-no-solve-2">
-          <webwork xml:id="ex-partial-fractions-decompose-no-solve-2">
+          <webwork xml:id="webwork-ex-partial-fractions-decompose-no-solve-2">
             <pg-code>
               $r = random(1,9,1);
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -769,7 +769,7 @@
         </exercise>
         <!-- Exercise 5 -->
         <exercise label="ex-partial-fractions-decompose-no-solve-3">
-          <webwork xml:id="ex-partial-fractions-decompose-no-solve-3">
+          <webwork xml:id="webwork-ex-partial-fractions-decompose-no-solve-3">
             <pg-code>
               $r = list_random(2,3,5,6,7,10,11,13,14,15);
               $b = non_zero_random(-9,9,1);
@@ -817,7 +817,7 @@
         </exercise>
         <!-- Exercise 6 -->
         <exercise label="ex-partial-fractions-decompose-no-solve-4">
-          <webwork xml:id="ex-partial-fractions-decompose-no-solve-4">
+          <webwork xml:id="webwork-ex-partial-fractions-decompose-no-solve-4">
             <pg-code>
               $r = random(2,9,1);
               ($a,$b) = (1..9)[NchooseK(9,2)];
@@ -881,7 +881,7 @@
         </introduction>
         <!-- Exercise 7 -->
         <exercise label="ex-partial-fractions-evaluate-1">
-          <webwork xml:id="ex-partial-fractions-evaluate-1">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-1">
             <pg-code>
               ($r,$s) = num_sort((-9..-1,1..9)[NchooseK(18,2)]);
               ($A,$B) = (1..9)[NchooseK(9,2)];
@@ -902,7 +902,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-partial-fractions-evaluate-2">
-          <webwork xml:id="ex-partial-fractions-evaluate-2">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-2">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               ($A,$B) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -924,7 +924,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-partial-fractions-evaluate-3">
-          <webwork xml:id="ex-partial-fractions-evaluate-3">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-3">
             <pg-code>
               $r = random(-9,-1,1);
               $c = random(2,5,1);
@@ -952,7 +952,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-partial-fractions-evaluate-4">
-          <webwork xml:id="ex-partial-fractions-evaluate-4">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-4">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               $m = list_random(-9..-2,2..9);
@@ -974,7 +974,7 @@
         </exercise>
         <!-- Exercise 11 -->
         <exercise label="ex-partial-fractions-evaluate-5">
-          <webwork xml:id="ex-partial-fractions-evaluate-5">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-5">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               ($A,$B) = (1..9)[NchooseK(9,2)];
@@ -996,7 +996,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-partial-fractions-evaluate-6">
-          <webwork xml:id="ex-partial-fractions-evaluate-6">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-6">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               ($A,$B) = (1..9)[NchooseK(9,2)];
@@ -1019,7 +1019,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise label="ex-partial-fractions-evaluate-7">
-          <webwork xml:id="ex-partial-fractions-evaluate-7">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-7">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               ($A,$B,$C) = (1..9)[NchooseK(9,3)];
@@ -1041,7 +1041,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-partial-fractions-evaluate-8">
-          <webwork xml:id="ex-partial-fractions-evaluate-8">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-8">
             <pg-code>
               ($r,$s) = (-9..-1,1..9)[NchooseK(18,2)];
               ($m,$n) = (-9..-2,2..9)[NchooseK(16,2)];
@@ -1065,7 +1065,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-partial-fractions-evaluate-9">
-          <webwork xml:id="ex-partial-fractions-evaluate-9">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-9">
             <pg-code>
               ($m,$n,$p) = (2..9)[NchooseK(8,3)];
               ($A,$B,$C) = (1..3)[NchooseK(3,3)];
@@ -1097,7 +1097,7 @@
         </exercise>
         <!-- Exercise 16 -->
         <exercise label="ex-partial-fractions-evaluate-10">
-          <webwork xml:id="ex-partial-fractions-evaluate-10">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-10">
             <pg-code>
               ($r,$s) = (-9..-1,1..9)[NchooseK(18,2)];
               ($A,$B) = (-3..-1,1..3)[NchooseK(6,2)];
@@ -1119,7 +1119,7 @@
         </exercise>
         <!-- Exercise 17 -->
         <exercise label="ex-partial-fractions-evaluate-11">
-          <webwork xml:id="ex-partial-fractions-evaluate-11">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-11">
             <pg-code>
               ($r,$s) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$r=-4;$s=5;};
@@ -1142,7 +1142,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-partial-fractions-evaluate-12">
-          <webwork xml:id="ex-partial-fractions-evaluate-12">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-12">
             <pg-code>
               $h = non_zero_random(-4,4,1);
               $k = random(1,5,1);
@@ -1164,7 +1164,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-partial-fractions-evaluate-13">
-          <webwork xml:id="ex-partial-fractions-evaluate-13">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-13">
             <pg-code>
               $h = non_zero_random(-4,4,1);
               $k = list_random(2,3,5);
@@ -1190,7 +1190,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-partial-fractions-evaluate-14">
-          <webwork xml:id="ex-partial-fractions-evaluate-14">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-14">
             <pg-code>
               $h = non_zero_random(-4,4,1);
               $k = list_random(2,3,5,6);
@@ -1215,7 +1215,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-partial-fractions-evaluate-15">
-          <webwork xml:id="ex-partial-fractions-evaluate-15">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-15">
             <pg-code>
               $a = random(2,9,1);
               ($b,$c) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -1240,7 +1240,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-partial-fractions-evaluate-16">
-          <webwork xml:id="ex-partial-fractions-evaluate-16">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-16">
             <pg-code>
               $h = non_zero_random(-4,4,1);
               $r = non_zero_random(-9,9,1);
@@ -1266,7 +1266,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-partial-fractions-evaluate-17">
-          <webwork xml:id="ex-partial-fractions-evaluate-17">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-17">
             <pg-code>
               $k = list_random(4,9,16,25);
               $r = non_zero_random(-9,9,1);
@@ -1295,7 +1295,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-partial-fractions-evaluate-18">
-          <webwork xml:id="ex-partial-fractions-evaluate-18">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-18">
             <pg-code>
               $h = non_zero_random(-4,4,1);
               $k = list_random(4,9,16,25,36);
@@ -1324,7 +1324,7 @@
         </exercise>
         <!-- Exercise 25 -->
         <exercise label="ex-partial-fractions-evaluate-19">
-          <webwork xml:id="ex-partial-fractions-evaluate-19">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-19">
             <pg-code>
               $h = non_zero_random(-4,4,1);
               $k = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -1351,7 +1351,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-partial-fractions-evaluate-20">
-          <webwork xml:id="ex-partial-fractions-evaluate-20">
+          <webwork xml:id="webwork-ex-partial-fractions-evaluate-20">
             <pg-code>
               $h = non_zero_random(-9,9,1);
               $k = list_random(2,3,5);
@@ -1387,7 +1387,7 @@
         </introduction>
         <!-- Exercise 27 -->
         <exercise label="ex-partial-fractions-defint-1">
-          <webwork xml:id="ex-partial-fractions-defint-1">
+          <webwork xml:id="webwork-ex-partial-fractions-defint-1">
             <pg-code>
               $a = 1;
               $b = 2;
@@ -1412,7 +1412,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-partial-fractions-defint-2">
-          <webwork xml:id="ex-partial-fractions-defint-2">
+          <webwork xml:id="webwork-ex-partial-fractions-defint-2">
             <pg-code>
               $a = 0;
               $b = random(2,9,1);
@@ -1438,7 +1438,7 @@
         </exercise>
         <!-- Exercise 29 -->
         <exercise label="ex-partial-fractions-defint-3">
-          <webwork xml:id="ex-partial-fractions-defint-3">
+          <webwork xml:id="webwork-ex-partial-fractions-defint-3">
             <pg-code>
               $a = -1;
               $b = 1;
@@ -1479,7 +1479,7 @@
         <!-- Exercise 30 -->
         <!-- Not randomized owing to nature of the exercise -->
         <exercise label="ex-partial-fractions-defint-4">
-          <webwork xml:id="ex-partial-fractions-defint-4">
+          <webwork xml:id="webwork-ex-partial-fractions-defint-4">
             <pg-code>
               $a = 0;
               $b = 1;

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -936,7 +936,7 @@
     <subexercises xml:id="TaC-vectors-planes">
       <title>Terms and Concepts</title>
       <exercise label="TaC-vectors-planes-1">
-        <!--<webwork xml:id="TaC-vectors-planes-1">
+        <!--<webwork xml:id="webwork-TaC-vectors-planes-1">
             <pg-code>
             </pg-code>
             -->
@@ -955,7 +955,7 @@
       </exercise>
 
       <exercise label="TaC-vectors-planes-2">
-        <!--<webwork xml:id="TaC-vectors-planes-2">
+        <!--<webwork xml:id="webwork-TaC-vectors-planes-2">
             <pg-code>
             </pg-code>
             -->
@@ -983,7 +983,7 @@
         </introduction>
 
         <exercise label="ex-vectors-planes-find-points-1">
-          <!--<webwork xml:id="ex-vectors-planes-find-points-1">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-find-points-1">
               <pg-code>
               </pg-code>
               -->
@@ -1001,7 +1001,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-find-points-2">
-          <webwork xml:id="ex-vectors-planes-find-points-2">
+          <webwork xml:id="webwork-ex-vectors-planes-find-points-2">
               <pg-code>
                 Context("Point");
                 $points=List("(-2,9,0),(2,9,3)");
@@ -1052,7 +1052,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-find-points-3">
-          <!--<webwork xml:id="ex-vectors-planes-find-points-3">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-find-points-3">
               <pg-code>
               </pg-code>
               -->
@@ -1070,7 +1070,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-find-points-4">
-          <webwork xml:id="ex-vectors-planes-find-points-4">
+          <webwork xml:id="webwork-ex-vectors-planes-find-points-4">
               <pg-code>
                 Context("Point");
                 $points=List("(0,-2,6),(1,-2,6)");
@@ -1131,7 +1131,7 @@
         </introduction>
 
         <exercise label="ex-vectors-planes-equation-1">
-          <!--<webwork xml:id="ex-vectors-planes-equation-1">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-equation-1">
               <pg-code>
               </pg-code>
               -->
@@ -1157,7 +1157,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-2">
-          <webwork xml:id="ex-vectors-planes-equation-2">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-2">
               <pg-code>
                 sub grouped {
                   my $op = shift;
@@ -1221,7 +1221,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-3">
-          <!--<webwork xml:id="ex-vectors-planes-equation-3">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-equation-3">
               <pg-code>
               </pg-code>
               -->
@@ -1248,7 +1248,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-4">
-          <webwork xml:id="ex-vectors-planes-equation-4">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-4">
 
               <pg-code>
                 sub grouped {
@@ -1314,7 +1314,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-5">
-          <!--<webwork xml:id="ex-vectors-planes-equation-5">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-equation-5">
               <pg-code>
               </pg-code>
               -->
@@ -1348,7 +1348,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-6">
-          <webwork xml:id="ex-vectors-planes-equation-6">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-6">
 
               <pg-code>
                 sub grouped {
@@ -1414,7 +1414,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-7">
-          <!--<webwork xml:id="ex-vectors-planes-equation-7">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-equation-7">
               <pg-code>
               </pg-code>
               -->
@@ -1448,7 +1448,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-8">
-          <webwork xml:id="ex-vectors-planes-equation-8">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-8">
 
               <pg-code>
                 sub grouped {
@@ -1514,7 +1514,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-9">
-          <!--<webwork xml:id="ex-vectors-planes-equation-9">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-equation-9">
               <pg-code>
               </pg-code>
               -->
@@ -1547,7 +1547,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-10">
-          <webwork xml:id="ex-vectors-planes-equation-10">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-10">
 
               <pg-code>
                 sub grouped {
@@ -1612,7 +1612,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-11">
-          <webwork xml:id="ex-vectors-planes-equation-11">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-11">
 
               <pg-code>
                 sub grouped {
@@ -1677,7 +1677,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-12">
-          <webwork xml:id="ex-vectors-planes-equation-12">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-12">
 
               <pg-code>
                 sub grouped {
@@ -1742,7 +1742,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-13">
-          <webwork xml:id="ex-vectors-planes-equation-13">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-13">
 
               <pg-code>
                 sub grouped {
@@ -1808,7 +1808,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-equation-14">
-          <webwork xml:id="ex-vectors-planes-equation-14">
+          <webwork xml:id="webwork-ex-vectors-planes-equation-14">
 
               <pg-code>
                 sub grouped {
@@ -1883,7 +1883,7 @@
         </introduction>
 
         <exercise label="ex-vectors-planes-intersection-1">
-          <!--<webwork xml:id="ex-vectors-planes-intersection-1">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-intersection-1">
               <pg-code>
               </pg-code>
               -->
@@ -1912,7 +1912,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-intersection-2">
-          <webwork xml:id="ex-vectors-planes-intersection-2">
+          <webwork xml:id="webwork-ex-vectors-planes-intersection-2">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>"Real");
@@ -1952,7 +1952,7 @@
         </introduction>
 
         <exercise label="ex-vectors-planes-intersect-line-1">
-          <!--<webwork xml:id="ex-vectors-planes-intersect-line-1">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-intersect-line-1">
               <pg-code>
               </pg-code>
               -->
@@ -1974,7 +1974,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-intersect-line-2">
-          <webwork xml:id="ex-vectors-planes-intersect-line-2">
+          <webwork xml:id="webwork-ex-vectors-planes-intersect-line-2">
               <pg-code>
                 Context("Point");
                 Context()->strings->add('the entire line'=>{});
@@ -1998,7 +1998,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-intersect-line-3">
-          <!--<webwork xml:id="ex-vectors-planes-intersect-line-3">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-intersect-line-3">
               <pg-code>
               </pg-code>
               -->
@@ -2020,7 +2020,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-intersect-line-4">
-          <webwork xml:id="ex-vectors-planes-intersect-line-4">
+          <webwork xml:id="webwork-ex-vectors-planes-intersect-line-4">
               <pg-code>
                 Context("Point");
                 Context()->strings->add('the entire line'=>{});
@@ -2053,7 +2053,7 @@
         </introduction>
 
         <exercise label="ex-vectors-planes-distance-1">
-          <!--<webwork xml:id="ex-vectors-planes-distance-1">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-distance-1">
               <pg-code>
               </pg-code>
               -->
@@ -2075,7 +2075,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-distance-2">
-          <webwork xml:id="ex-vectors-planes-distance-2">
+          <webwork xml:id="webwork-ex-vectors-planes-distance-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $distance=Formula("8/sqrt(21)");
@@ -2094,7 +2094,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-distance-3">
-          <!--<webwork xml:id="ex-vectors-planes-distance-3">
+          <!--<webwork xml:id="webwork-ex-vectors-planes-distance-3">
               <pg-code>
               </pg-code>
               -->
@@ -2120,7 +2120,7 @@
         </exercise>
 
         <exercise label="ex-vectors-planes-distance-4">
-          <webwork xml:id="ex-vectors-planes-distance-4">
+          <webwork xml:id="webwork-ex-vectors-planes-distance-4">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $distance=Formula("3");
@@ -2142,7 +2142,7 @@
       </exercisegroup>
 
       <exercise label="ex-vectors-planes-distance-formula">
-        <!--<webwork xml:id="ex-vectors-planes-distance-formula">
+        <!--<webwork xml:id="webwork-ex-vectors-planes-distance-formula">
             <pg-code>
             </pg-code>
             -->
@@ -2165,7 +2165,7 @@
       </exercise>
 
       <exercise label="ex-vectors-planes-understand-lines">
-        <!--<webwork xml:id="ex-vectors-planes-understand-lines">
+        <!--<webwork xml:id="webwork-ex-vectors-planes-understand-lines">
             <pg-code>
             </pg-code>
             -->

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -1756,7 +1756,7 @@
     <subexercises xml:id="TaC-polar-coordinates">
       <title>Terms and Concepts</title>
       <exercise label="TaC-polar-coordinates-1">
-        <!-- <webwork xml:id="TaC-polar-coordinates-1">
+        <!-- <webwork xml:id="webwork-TaC-polar-coordinates-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1774,7 +1774,7 @@
       </exercise>
 
       <exercise label="TaC-polar-coordinates-2">
-        <webwork xml:id="TaC-polar-coordinates-2">
+        <webwork xml:id="webwork-TaC-polar-coordinates-2">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1792,7 +1792,7 @@
       </exercise>
 
       <exercise label="TaC-polar-coordinates-3">
-        <webwork xml:id="TaC-polar-coordinates-3">
+        <webwork xml:id="webwork-TaC-polar-coordinates-3">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1809,7 +1809,7 @@
       </exercise>
 
       <exercise label="TaC-polar-coordinates-4">
-        <webwork xml:id="TaC-polar-coordinates-4">
+        <webwork xml:id="webwork-TaC-polar-coordinates-4">
 
             <pg-code>
               $true=PopUp(['?','True','False'],1);
@@ -1828,7 +1828,7 @@
     <subexercises>
       <title>Problems</title>
         <exercise label="ex-polar-coordinates-plot-1">
-        <!-- <webwork xml:id="ex-polar-coordinates-plot-1">
+        <!-- <webwork xml:id="webwork-ex-polar-coordinates-plot-1">
             <pg-code>
             </pg-code> -->
           <statement>
@@ -1892,7 +1892,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-plot-2">
-          <!-- <webwork xml:id="ex-polar-coordinates-plot-2">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-plot-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1956,7 +1956,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-two-ways-1">
-          <!-- <webwork xml:id="ex-polar-coordinates-two-ways-1">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-two-ways-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2019,7 +2019,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-two-ways-2">
-          <webwork xml:id="ex-polar-coordinates-two-ways-2">
+          <webwork xml:id="webwork-ex-polar-coordinates-two-ways-2">
               <pg-code>
                 $gr = init_graph(-3.5,-3.5,3.5,3.5,size=>[400,400]);
                 $gr->moveTo(0,0); $gr->arrowTo(3.4,0,'black',1);
@@ -2134,7 +2134,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-1">
-          <webwork xml:id="ex-polar-coordinates-convert-1">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-1">
               <pg-code>
                 Context("Point");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2218,7 +2218,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-2">
-          <webwork xml:id="ex-polar-coordinates-convert-2">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-2">
             <pg-code>
               Context("Point");
               Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2310,7 +2310,7 @@
           </introduction>
 
           <exercise label="ex-polar-coordinates-graph-function-1">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-1">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-1">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2345,7 +2345,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-2">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-2">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-2">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2381,7 +2381,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-3">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-3">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-3">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2416,7 +2416,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-4">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-4">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-4">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2451,7 +2451,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-5">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-5">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-5">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2486,7 +2486,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-6">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-6">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-6">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2521,7 +2521,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-7">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-7">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-7">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2556,7 +2556,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-8">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-8">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-8">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2593,7 +2593,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-9">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-9">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-9">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2629,7 +2629,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-10">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-10">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-10">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2666,7 +2666,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-11">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-11">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-11">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2702,7 +2702,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-12">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-12">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-12">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2737,7 +2737,7 @@
           </exercise>
 
           <exercise label="ex-polar-coordinates-graph-function-13">
-            <!-- <webwork xml:id="ex-polar-coordinates-graph-function-13">
+            <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-13">
                 <pg-code>
                 </pg-code> -->
                 <statement>
@@ -2800,7 +2800,7 @@
 
 
         <exercise label="ex-polar-coordinates-graph-function-15">
-          <!-- <webwork xml:id="ex-polar-coordinates-graph-function-15">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-15">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2835,7 +2835,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-graph-function-16">
-          <!-- <webwork xml:id="ex-polar-coordinates-graph-function-16">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-16">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2870,7 +2870,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-graph-function-17">
-          <!-- <webwork xml:id="ex-polar-coordinates-graph-function-17">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-17">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2905,7 +2905,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-graph-function-18">
-          <!-- <webwork xml:id="ex-polar-coordinates-graph-function-18">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-18">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2940,7 +2940,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-graph-function-19">
-          <!-- <webwork xml:id="ex-polar-coordinates-graph-function-19">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-19">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2975,7 +2975,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-graph-function-20">
-          <!-- <webwork xml:id="ex-polar-coordinates-graph-function-20">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-graph-function-20">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3020,7 +3020,7 @@
         </introduction>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-1">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-1">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-1">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("(x-3)^2+y^2=9", limits=>[[-1,7],[-4,4]]);
@@ -3042,7 +3042,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-2">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-2">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-2">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("x^2+(y+2)^2=4", limits=>[[-3,3],[-5,1]]);
@@ -3064,7 +3064,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-3">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-3">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-3">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("(x-1/2)^2+(y-1/2)^2=1/2", limits=>[[-1,2],[-1,2]]);
@@ -3086,7 +3086,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-4">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-4">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-4">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("y=2/5x+7/5", limits=>[[-3,3],[-2,4]]);
@@ -3108,7 +3108,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-5">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-5">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-5">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("x=3", limits=>[[0,6],[-3,3]]);
@@ -3130,7 +3130,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-6">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-6">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-6">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("y=4", limits=>[[-3,3],[1,7]]);
@@ -3152,7 +3152,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-7">
-          <!-- <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-7">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3182,7 +3182,7 @@
       </exercise>
 
         <exercise label="ex-polar-coordinates-convert-rectangular-eqn-9">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-9">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-9">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("x^2+y^2=4", limits=>[[-3,3],[-3,3]]);
@@ -3204,7 +3204,7 @@
         </exercise>
 
         <exercise  label="ex-polar-coordinates-convert-rectangular-eqn-10">
-          <webwork xml:id="ex-polar-coordinates-convert-rectangular-eqn-10">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-rectangular-eqn-10">
               <pg-code>
                 Context("ImplicitEquation");
                 $eq=ImplicitEquation("y=x/sqrt(3)", limits=>[[-3,3],[-3,3]]);
@@ -3236,7 +3236,7 @@
         </introduction>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-1">
-          <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-1">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-1">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(r=>'Real',theta=>['Real',TeX=>'\theta']);
@@ -3260,7 +3260,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-2">
-          <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-2">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-2">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(r=>'Real',theta=>['Real',TeX=>'\theta']);
@@ -3284,7 +3284,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-3">
-          <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-3">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-3">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(r=>'Real',theta=>['Real',TeX=>'\theta']);
@@ -3308,7 +3308,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-4">
-          <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-4">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-4">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(r=>'Real',theta=>['Real',TeX=>'\theta']);
@@ -3332,7 +3332,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-5">
-          <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-5">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-5">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(r=>'Real',theta=>['Real',TeX=>'\theta']);
@@ -3356,7 +3356,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-6">
-          <!-- <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-6">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3373,7 +3373,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-7">
-          <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-7">
+          <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-7">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(r=>'Real',theta=>['Real',TeX=>'\theta']);
@@ -3398,7 +3398,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-convert-polar-eqn-8">
-          <!-- <webwork xml:id="ex-polar-coordinates-convert-polar-eqn-8">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-convert-polar-eqn-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3425,7 +3425,7 @@
         </introduction>
 
         <exercise label="ex-polar-coordinates-intersection-1">
-          <webwork xml:id="ex-polar-coordinates-intersection-1">
+          <webwork xml:id="webwork-ex-polar-coordinates-intersection-1">
               <pg-code>
                 Context("Point");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -3452,7 +3452,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-2">
-          <!-- <webwork xml:id="ex-polar-coordinates-intersection-2">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-intersection-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3469,7 +3469,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-3">
-          <webwork xml:id="ex-polar-coordinates-intersection-3">
+          <webwork xml:id="webwork-ex-polar-coordinates-intersection-3">
               <pg-code>
                 Context("Point");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -3496,7 +3496,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-4">
-          <!-- <webwork xml:id="ex-polar-coordinates-intersection-4">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-intersection-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3514,7 +3514,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-5">
-          <!-- <webwork xml:id="ex-polar-coordinates-intersection-5">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-intersection-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3534,7 +3534,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-6">
-          <webwork xml:id="ex-polar-coordinates-intersection-6">
+          <webwork xml:id="webwork-ex-polar-coordinates-intersection-6">
               <pg-code>
                 Context("Point");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -3562,7 +3562,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-7">
-          <!-- <webwork xml:id="ex-polar-coordinates-intersection-7">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-intersection-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3580,7 +3580,7 @@
         </exercise>
 
         <exercise label="ex-polar-coordinates-intersection-8">
-          <!-- <webwork xml:id="ex-polar-coordinates-intersection-8">
+          <!-- <webwork xml:id="webwork-ex-polar-coordinates-intersection-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3601,7 +3601,7 @@
       </exercisegroup>
 
       <exercise label="ex-polar-coordinates-plot-technology-1">
-        <!-- <webwork xml:id="ex-polar-coordinates-plot-technology-1">
+        <!-- <webwork xml:id="webwork-ex-polar-coordinates-plot-technology-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3623,7 +3623,7 @@
       </exercise>
 
       <exercise label="ex-polar-coordinates-plot-technology-2">
-        <!-- <webwork xml:id="ex-polar-coordinates-plot-technology-2">
+        <!-- <webwork xml:id="webwork-ex-polar-coordinates-plot-technology-2">
             <pg-code>
             </pg-code> -->
             <statement>

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -1194,7 +1194,7 @@
     <subexercises xml:id="TaC-polar-calculus">
       <title>Terms and Concepts</title>
       <exercise label="TaC-polar-calculus-1">
-        <!-- <webwork xml:id="TaC-polar-calculus-1">
+        <!-- <webwork xml:id="webwork-TaC-polar-calculus-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1214,7 +1214,7 @@
       </exercise>
 
       <exercise label="TaC-polar-calculus-2">
-        <!-- <webwork xml:id="TaC-polar-calculus-2">
+        <!-- <webwork xml:id="webwork-TaC-polar-calculus-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1245,7 +1245,7 @@
         </introduction>
 
         <exercise label="ex-polar-calculus-tangent-1">
-          <webwork xml:id="ex-polar-calculus-tangent-1">
+          <webwork xml:id="webwork-ex-polar-calculus-tangent-1">
 
 
               <pg-code>
@@ -1290,7 +1290,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-2">
-          <webwork xml:id="ex-polar-calculus-tangent-2">
+          <webwork xml:id="webwork-ex-polar-calculus-tangent-2">
 
 
               <pg-code>
@@ -1335,7 +1335,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-3">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-3">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1365,7 +1365,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-4">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-4">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1397,7 +1397,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-5">
-          <webwork xml:id="ex-polar-calculus-tangent-5">
+          <webwork xml:id="webwork-ex-polar-calculus-tangent-5">
 
 
               <pg-code>
@@ -1442,7 +1442,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-6">
-          <webwork xml:id="ex-polar-calculus-tangent-6">
+          <webwork xml:id="webwork-ex-polar-calculus-tangent-6">
 
 
               <pg-code>
@@ -1487,7 +1487,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-7">
-          <webwork xml:id="ex-polar-calculus-tangent-7">
+          <webwork xml:id="webwork-ex-polar-calculus-tangent-7">
 
 
               <pg-code>
@@ -1532,7 +1532,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-8">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-8">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1570,7 +1570,7 @@
         </introduction>
 
         <exercise label="ex-polar-calculus-tangent-horizontal-1">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-horizontal-1">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-horizontal-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1591,7 +1591,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-horizontal-2">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-horizontal-2">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-horizontal-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1612,7 +1612,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-horizontal-3">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-horizontal-3">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-horizontal-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1633,7 +1633,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-horizontal-4">
-          <webwork xml:id="ex-polar-calculus-tangent-horizontal-4">
+          <webwork xml:id="webwork-ex-polar-calculus-tangent-horizontal-4">
 
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
@@ -1689,7 +1689,7 @@
         </introduction>
 
         <exercise label="ex-polar-calculus-tangent-pole-1">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-pole-1">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-pole-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1710,7 +1710,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-tangent-pole-2">
-          <!-- <webwork xml:id="ex-polar-calculus-tangent-pole-2">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-tangent-pole-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1741,7 +1741,7 @@
         </introduction>
 
         <exercise label="ex-polar-calculus-area-1">
-          <!-- <webwork xml:id="ex-polar-calculus-area-1">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-area-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1758,7 +1758,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-2">
-          <!-- <webwork xml:id="ex-polar-calculus-area-2">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-area-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1775,7 +1775,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-3">
-          <webwork xml:id="ex-polar-calculus-area-3">
+          <webwork xml:id="webwork-ex-polar-calculus-area-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("pi/12");
@@ -1807,7 +1807,7 @@
       </exercise>
 
         <exercise label="ex-polar-calculus-area-5">
-          <webwork xml:id="ex-polar-calculus-area-5">
+          <webwork xml:id="webwork-ex-polar-calculus-area-5">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("3pi/2");
@@ -1825,7 +1825,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-6">
-          <!-- <webwork xml:id="ex-polar-calculus-area-6">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-area-6">
               <pg-code>
               </pg-code> -->
               <!-- can't use &#xe7; in a WW. It leads to ç, which is not in the base64 charset -->
@@ -1843,7 +1843,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-7">
-          <webwork xml:id="ex-polar-calculus-area-7">
+          <webwork xml:id="webwork-ex-polar-calculus-area-7">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("2pi+3sqrt(3)/2");
@@ -1863,7 +1863,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-8">
-          <webwork xml:id="ex-polar-calculus-area-8">
+          <webwork xml:id="webwork-ex-polar-calculus-area-8">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("pi+3sqrt(3)");
@@ -1882,7 +1882,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-9">
-          <webwork xml:id="ex-polar-calculus-area-9">
+          <webwork xml:id="webwork-ex-polar-calculus-area-9">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("1");
@@ -1924,7 +1924,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-area-10">
-          <webwork xml:id="ex-polar-calculus-area-10">
+          <webwork xml:id="webwork-ex-polar-calculus-area-10">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("1/32(4pi-3sqrt(3))");
@@ -1967,7 +1967,7 @@
 
         <!-- TODO: there is no graph! So no area "as shown" -->
         <exercise label="ex-polar-calculus-area-11">
-          <!-- <webwork xml:id="ex-polar-calculus-area-11">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-area-11">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1987,7 +1987,7 @@
 
         <!-- TODO: there is no graph! So no area "as shown" -->
         <exercise label="ex-polar-calculus-area-12">
-          <!-- <webwork xml:id="ex-polar-calculus-area-12">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-area-12">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2015,7 +2015,7 @@
         </introduction>
 
         <exercise label="ex-polar-calculus-arclength-1">
-          <webwork xml:id="ex-polar-calculus-arclength-1">
+          <webwork xml:id="webwork-ex-polar-calculus-arclength-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $length=Formula("4pi");
@@ -2033,7 +2033,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-arclength-2">
-          <webwork xml:id="ex-polar-calculus-arclength-2">
+          <webwork xml:id="webwork-ex-polar-calculus-arclength-2">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $length=Formula("4pi");
@@ -2079,7 +2079,7 @@
       </exercise>
 
         <exercise label="ex-polar-calculus-arclength-5">
-          <webwork xml:id="ex-polar-calculus-arclength-5">
+          <webwork xml:id="webwork-ex-polar-calculus-arclength-5">
               <pg-code>
                 $length=OneOf("2.2592,2.22748");
               </pg-code>
@@ -2116,7 +2116,7 @@
         </exercise>-->
 
         <exercise label="ex-polar-calculus-arclength-6">
-          <!-- <webwork xml:id="ex-polar-calculus-arclength-6">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-arclength-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2150,7 +2150,7 @@
         </introduction>
 
         <exercise label="ex-polar-calculus-surfarea-1">
-          <!-- <webwork xml:id="ex-polar-calculus-surfarea-1">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-surfarea-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2168,7 +2168,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-surfarea-2">
-          <!-- <webwork xml:id="ex-polar-calculus-surfarea-2">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-surfarea-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2187,7 +2187,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-surfarea-3">
-          <!-- <webwork xml:id="ex-polar-calculus-surfarea-3">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-surfarea-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2205,7 +2205,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-surfarea-4">
-          <!-- <webwork xml:id="ex-polar-calculus-surfarea-4">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-surfarea-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2223,7 +2223,7 @@
         </exercise>
 
         <exercise label="ex-polar-calculus-surfarea-5">
-          <!-- <webwork xml:id="ex-polar-calculus-surfarea-5">
+          <!-- <webwork xml:id="webwork-ex-polar-calculus-surfarea-5">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_power_series.ptx
+++ b/ptx/sec_power_series.ptx
@@ -773,7 +773,7 @@
     <subexercises xml:id="TaC-power-series">
       <title>Terms and Concepts</title>
       <exercise label="TaC-power-series-1">
-        <!--<webwork xml:id="TaC-power-series-1">
+        <!--<webwork xml:id="webwork-TaC-power-series-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -791,7 +791,7 @@
       </exercise>
 
       <exercise label="TaC-power-series-2">
-        <!--<webwork xml:id="TaC-power-series-2">
+        <!--<webwork xml:id="webwork-TaC-power-series-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -813,7 +813,7 @@
       </exercise>
 
       <exercise label="TaC-power-series-3">
-        <!--<webwork xml:id="TaC-power-series-3">
+        <!--<webwork xml:id="webwork-TaC-power-series-3">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -831,7 +831,7 @@
       </exercise>
 
       <exercise label="TaC-power-series-4">
-        <!--<webwork xml:id="TaC-power-series-4">
+        <!--<webwork xml:id="webwork-TaC-power-series-4">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -861,7 +861,7 @@
         </introduction>
 
         <exercise label="ex-power-series-first-terms-1">
-          <!--<webwork xml:id="ex-power-series-first-terms-1">
+          <!--<webwork xml:id="webwork-ex-power-series-first-terms-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -878,7 +878,7 @@
         </exercise>
 
         <exercise label="ex-power-series-first-terms-2">
-          <!--<webwork xml:id="ex-power-series-first-terms-2">
+          <!--<webwork xml:id="webwork-ex-power-series-first-terms-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -895,7 +895,7 @@
         </exercise>
 
         <exercise label="ex-power-series-first-terms-3">
-          <!--<webwork xml:id="ex-power-series-first-terms-3">
+          <!--<webwork xml:id="webwork-ex-power-series-first-terms-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -912,7 +912,7 @@
         </exercise>
 
         <exercise label="ex-power-series-first-terms-4">
-          <!--<webwork xml:id="ex-power-series-first-terms-4">
+          <!--<webwork xml:id="webwork-ex-power-series-first-terms-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -954,7 +954,7 @@
         </introduction>
 
         <exercise label="ex-power-series-radius-interval-1">
-          <!--<webwork xml:id="ex-power-series-radius-interval-1">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -983,7 +983,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-2">
-          <!--<webwork xml:id="ex-power-series-radius-interval-2">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1012,7 +1012,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-3">
-          <!--<webwork xml:id="ex-power-series-radius-interval-3">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1041,7 +1041,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-4">
-          <!--<webwork xml:id="ex-power-series-radius-interval-4">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1070,7 +1070,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-5">
-          <!--<webwork xml:id="ex-power-series-radius-interval-5">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1099,7 +1099,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-6">
-          <!--<webwork xml:id="ex-power-series-radius-interval-6">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1128,7 +1128,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-7">
-          <!--<webwork xml:id="ex-power-series-radius-interval-7">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1157,7 +1157,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-8">
-          <!--<webwork xml:id="ex-power-series-radius-interval-8">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1186,7 +1186,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-9">
-          <!--<webwork xml:id="ex-power-series-radius-interval-9">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1215,7 +1215,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-10">
-          <!--<webwork xml:id="ex-power-series-radius-interval-10">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1244,7 +1244,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-11">
-          <!--<webwork xml:id="ex-power-series-radius-interval-11">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-11">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1273,7 +1273,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-12">
-          <!--<webwork xml:id="ex-power-series-radius-interval-12">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-12">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1302,7 +1302,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-13">
-          <!--<webwork xml:id="ex-power-series-radius-interval-13">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-13">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1331,7 +1331,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-14">
-          <!--<webwork xml:id="ex-power-series-radius-interval-14">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-14">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1360,7 +1360,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-15">
-          <!--<webwork xml:id="ex-power-series-radius-interval-15">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-15">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1389,7 +1389,7 @@
         </exercise>
 
         <exercise label="ex-power-series-radius-interval-16">
-          <!--<webwork xml:id="ex-power-series-radius-interval-16">
+          <!--<webwork xml:id="webwork-ex-power-series-radius-interval-16">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1444,7 +1444,7 @@
       </introduction>
 
         <exercise label="ex-power-series-find-series-1">
-          <!--<webwork xml:id="ex-power-series-find-series-1">
+          <!--<webwork xml:id="webwork-ex-power-series-find-series-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1474,7 +1474,7 @@
         </exercise>
 
         <exercise label="ex-power-series-find-series-2">
-          <!--<webwork xml:id="ex-power-series-find-series-2">
+          <!--<webwork xml:id="webwork-ex-power-series-find-series-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1504,7 +1504,7 @@
         </exercise>
 
         <exercise label="ex-power-series-find-series-3">
-          <!--<webwork xml:id="ex-power-series-find-series-3">
+          <!--<webwork xml:id="webwork-ex-power-series-find-series-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1534,7 +1534,7 @@
         </exercise>
 
         <exercise label="ex-power-series-find-series-4">
-          <!--<webwork xml:id="ex-power-series-find-series-4">
+          <!--<webwork xml:id="webwork-ex-power-series-find-series-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1564,7 +1564,7 @@
         </exercise>
 
         <exercise label="ex-power-series-find-series-5">
-          <!--<webwork xml:id="ex-power-series-find-series-5">
+          <!--<webwork xml:id="webwork-ex-power-series-find-series-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1595,7 +1595,7 @@
         </exercise>
 
         <exercise label="ex-power-series-find-series-6">
-          <!--<webwork xml:id="ex-power-series-find-series-6">
+          <!--<webwork xml:id="webwork-ex-power-series-find-series-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1636,7 +1636,7 @@
         </introduction>
 
         <exercise label="ex-power-series-diffyQ-1">
-          <!--<webwork xml:id="ex-power-series-diffyQ-1">
+          <!--<webwork xml:id="webwork-ex-power-series-diffyQ-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1653,7 +1653,7 @@
         </exercise>
 
         <exercise label="ex-power-series-diffyQ-2">
-          <!--<webwork xml:id="ex-power-series-diffyQ-2">
+          <!--<webwork xml:id="webwork-ex-power-series-diffyQ-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1670,7 +1670,7 @@
         </exercise>
 
         <exercise label="ex-power-series-diffyQ-3">
-          <!--<webwork xml:id="ex-power-series-diffyQ-3">
+          <!--<webwork xml:id="webwork-ex-power-series-diffyQ-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1687,7 +1687,7 @@
         </exercise>
 
         <exercise label="ex-power-series-diffyQ-4">
-          <!--<webwork xml:id="ex-power-series-diffyQ-4">
+          <!--<webwork xml:id="webwork-ex-power-series-diffyQ-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1704,7 +1704,7 @@
         </exercise>
 
         <exercise label="ex-power-series-diffyQ-5">
-          <!--<webwork xml:id="ex-power-series-diffyQ-5">
+          <!--<webwork xml:id="webwork-ex-power-series-diffyQ-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1721,7 +1721,7 @@
         </exercise>
 
         <exercise label="ex-power-series-diffyQ-6">
-          <!--<webwork xml:id="ex-power-series-diffyQ-6">
+          <!--<webwork xml:id="webwork-ex-power-series-diffyQ-6">
               <pg-code>
               </pg-code>-->
               <statement>

--- a/ptx/sec_ratio_root_tests.ptx
+++ b/ptx/sec_ratio_root_tests.ptx
@@ -391,7 +391,7 @@
     <subexercises xml:id="TaC-ratio-root-tests">
       <title>Terms and Concepts</title>
       <exercise label="TaC-ratio-root-tests-1">
-        <!--<webwork xml:id="TaC-ratio-root-tests-1">
+        <!--<webwork xml:id="webwork-TaC-ratio-root-tests-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -408,7 +408,7 @@
       </exercise>
 
       <exercise label="TaC-ratio-root-tests-2">
-        <!--<webwork xml:id="TaC-ratio-root-tests-2">
+        <!--<webwork xml:id="webwork-TaC-ratio-root-tests-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -425,7 +425,7 @@
       </exercise>
 
       <exercise label="TaC-ratio-root-tests-3">
-        <!--<webwork xml:id="TaC-ratio-root-tests-3">
+        <!--<webwork xml:id="webwork-TaC-ratio-root-tests-3">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -442,7 +442,7 @@
       </exercise>
 
       <exercise label="TaC-ratio-root-tests-4">
-        <!--<webwork xml:id="TaC-ratio-root-tests-4">
+        <!--<webwork xml:id="webwork-TaC-ratio-root-tests-4">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -472,7 +472,7 @@
         </introduction>
 
         <exercise label="ex-ratio-test-convergence-1">
-          <!--<webwork xml:id="ex-ratio-test-convergence-1">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -489,7 +489,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-2">
-          <!--<webwork xml:id="ex-ratio-test-convergence-2">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -506,7 +506,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-3">
-          <!--<webwork xml:id="ex-ratio-test-convergence-3">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -523,7 +523,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-4">
-          <!--<webwork xml:id="ex-ratio-test-convergence-4">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -540,7 +540,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-5">
-          <!--<webwork xml:id="ex-ratio-test-convergence-5">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -558,7 +558,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-6">
-          <!--<webwork xml:id="ex-ratio-test-convergence-6">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -576,7 +576,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-7">
-          <!--<webwork xml:id="ex-ratio-test-convergence-7">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -593,7 +593,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-8">
-          <!--<webwork xml:id="ex-ratio-test-convergence-8">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -610,7 +610,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-9">
-          <!--<webwork xml:id="ex-ratio-test-convergence-9">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -628,7 +628,7 @@
         </exercise>
 
         <exercise label="ex-ratio-test-convergence-10">
-          <!--<webwork xml:id="ex-ratio-test-convergence-10">
+          <!--<webwork xml:id="webwork-ex-ratio-test-convergence-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -658,7 +658,7 @@
         </introduction>
 
         <exercise label="ex-root-test-convergence-1">
-          <!--<webwork xml:id="ex-root-test-convergence-1">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -675,7 +675,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-2">
-          <!--<webwork xml:id="ex-root-test-convergence-2">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -692,7 +692,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-3">
-          <!--<webwork xml:id="ex-root-test-convergence-3">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -709,7 +709,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-4">
-          <!--<webwork xml:id="ex-root-test-convergence-4">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -726,7 +726,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-5">
-          <!--<webwork xml:id="ex-root-test-convergence-5">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -743,7 +743,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-6">
-          <!--<webwork xml:id="ex-root-test-convergence-6">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -760,7 +760,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-7">
-          <!--<webwork xml:id="ex-root-test-convergence-7">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -781,7 +781,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-8">
-          <!--<webwork xml:id="ex-root-test-convergence-8">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -798,7 +798,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-9">
-          <!--<webwork xml:id="ex-root-test-convergence-9">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -815,7 +815,7 @@
         </exercise>
 
         <exercise label="ex-root-test-convergence-10">
-          <!--<webwork xml:id="ex-root-test-convergence-10">
+          <!--<webwork xml:id="webwork-ex-root-test-convergence-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -842,7 +842,7 @@
         </introduction>
 
         <exercise label="ex-ratio-root-test-choose-1">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-1">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -859,7 +859,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-2">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-2">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -876,7 +876,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-3">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-3">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -893,7 +893,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-4">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-4">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -910,7 +910,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-5">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-5">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -927,7 +927,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-6">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-6">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -944,7 +944,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-7">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-7">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -961,7 +961,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-8">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-8">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -978,7 +978,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-9">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-9">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -995,7 +995,7 @@
         </exercise>
 
         <exercise label="ex-ratio-root-test-choose-10">
-          <!--<webwork xml:id="ex-ratio-root-test-choose-10">
+          <!--<webwork xml:id="webwork-ex-ratio-root-test-choose-10">
               <pg-code>
               </pg-code>-->
               <statement>

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -733,7 +733,7 @@
       <title>Terms and Concepts</title>
       <!--Exercise 1: T/F-->
       <exercise label="TaC-related-rates-1">
-        <webwork xml:id="TaC-related-rates-1">
+        <webwork xml:id="webwork-TaC-related-rates-1">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -749,7 +749,7 @@
       </exercise>
       <!--Exercise 2: Bizarre T/F-->
       <exercise label="TaC-related-rates-2">
-        <webwork xml:id="TaC-related-rates-2">
+        <webwork xml:id="webwork-TaC-related-rates-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -768,7 +768,7 @@
       <title>Problems</title>
       <!--Exercise 3: Puddle of depth 10 cm growing-->
       <exercise label="ex-related-rates-puddle">
-        <webwork xml:id="ex-related-rates-puddle">
+        <webwork xml:id="webwork-ex-related-rates-puddle">
           <pg-code>
             ($rate,$depth) = (4..10)[NchooseK(7,2)];
             $a = random(1,4,1);
@@ -822,7 +822,7 @@
       </exercise>
       <!--Exercise 4: Spherical balloon radius increasing-->
       <exercise label="ex-related-rates-balloon">
-        <webwork xml:id="ex-related-rates-balloon">
+        <webwork xml:id="webwork-ex-related-rates-balloon">
           <pg-code>
             $rate = random(4,12,1);
             $a = random(1,4,1);
@@ -874,7 +874,7 @@
       </exercise>
       <!--Exercise 5: Refer to Example 100-->
       <exercise label="ex-related-rates-radar-1">
-        <webwork xml:id="ex-related-rates-radar-1">
+        <webwork xml:id="webwork-ex-related-rates-radar-1">
           <pg-code>
             Context("Fraction");
             $f = list_random(Fraction(1,2),Fraction(3,4),Fraction(2,3),Fraction(3,5),Fraction(4,5));
@@ -902,7 +902,7 @@
       </exercise>
       <!--Exercise 6: Also refer to Example 100-->
       <exercise label="ex-related-rates-radar-2">
-        <webwork xml:id="ex-related-rates-radar-2">
+        <webwork xml:id="webwork-ex-related-rates-radar-2">
           <pg-code>
             Context("Fraction");
             $f = list_random(Fraction(1,2),Fraction(3,4),Fraction(2,3),Fraction(3,5),Fraction(4,5));
@@ -954,7 +954,7 @@
       </exercise>
       <!--Exercise 7: Anti-aircraft gun-->
       <exercise xml:id="exer_04_02_ex_07" label="ex-related-rates-aircraft-1">
-        <webwork xml:id="ex-related-rates-aircraft-1">
+        <webwork xml:id="webwork-ex-related-rates-aircraft-1">
           <pg-code>
             Context()->flags->set(reduceConstants=>0);
             $spd = random(300,800,10);
@@ -1045,7 +1045,7 @@
       </exercise>
       <!--Exercise 8: Anti-aircraft gun 2-->
       <exercise label="ex-related-rates-aircraft-2">
-        <webwork xml:id="ex-related-rates-aircraft-2">
+        <webwork xml:id="webwork-ex-related-rates-aircraft-2">
           <pg-code>
             Context()->flags->set(reduceConstants=>0);
             $speed = random(400,600,50);
@@ -1110,7 +1110,7 @@
       <!--Exercise 9: Ladder sliding down a house-->
       <!-- not currently randomized -->
       <exercise label="ex-related-rates-ladder">
-        <webwork xml:id="ex-related-rates-ladder">
+        <webwork xml:id="webwork-ex-related-rates-ladder">
           <pg-code>
             $f = Compute("x/sqrt(24^2-x^2)");
             $a = Compute($f->eval(x=>1));
@@ -1203,7 +1203,7 @@
       <!--Exercise 10: Winch that boat in-->
       <!-- not yet randomized -->
       <exercise label="ex-related-rates-boat">
-        <webwork xml:id="ex-related-rates-boat">
+        <webwork xml:id="webwork-ex-related-rates-boat">
           <pg-code>
             $f = Compute("30*sqrt(10^2+x^2)/x");
             $a = Compute($f->eval(x=>50));
@@ -1293,7 +1293,7 @@
       </exercise>
       <!--Exercise 11: Inverted cylindrical cone-->
       <exercise label="ex-related-rates-cone">
-        <webwork xml:id="ex-related-rates-cone">
+        <webwork xml:id="webwork-ex-related-rates-cone">
           <pg-code>
             ($depth,$diameter) = (10..30)[NchooseK(21,2)];
             $rate = random(8,12,1);
@@ -1355,7 +1355,7 @@
       <!--Exercise 12: Rope, pulley, man standing next to the weight and walking away-->
       <!-- not yet randomized -->
       <exercise xml:id="exer_04_02_ex_12" label="ex-related-rates-pulley-1">
-        <webwork xml:id="ex-related-rates-pulley-1">
+        <webwork xml:id="webwork-ex-related-rates-pulley-1">
           <pg-code>
             $f = Compute("2x/sqrt(x^2+30^2)");
             $a = Compute($f->eval(x=>10));
@@ -1440,7 +1440,7 @@
       </exercise>
       <!--Exercise 13: Same setup, but starting further away-->
       <exercise label="ex-related-rates-pulley-2">
-        <webwork xml:id="ex-related-rates-pulley-2">
+        <webwork xml:id="webwork-ex-related-rates-pulley-2">
           <pg-code>
             # Height is fixed at 30 ft
             # Need an initial distance that makes a Pythagorean triple with 30
@@ -1512,7 +1512,7 @@
       </exercise>
       <!--Exercise 14: Hot air balloon rising while being tracked-->
       <exercise label="ex-related-rates-hot-air">
-        <webwork xml:id="ex-related-rates-hot-air">
+        <webwork xml:id="webwork-ex-related-rates-hot-air">
           <pg-code>
             $distance = random(80,120,5);
             $height = random(5,6,1);
@@ -1557,7 +1557,7 @@
       </exercise>
       <!--Exercise 15: Sand being dumped into a conical pile-->
       <exercise label="ex-related-rates-sand-cone">
-        <webwork xml:id="ex-related-rates-sand-cone">
+        <webwork xml:id="webwork-ex-related-rates-sand-cone">
           <pg-code>
             $rate = random(3,8,1);
             $nd = list_random([2,3],[4,5],[4,7],[5,6],[5,7],[5,8]);

--- a/ptx/sec_riemann.ptx
+++ b/ptx/sec_riemann.ptx
@@ -1565,7 +1565,7 @@
     <subexercises xml:id="TaC-riemann-sums">
       <title>Terms and Concepts</title>
       <exercise label="TaC-riemann-sums-1">
-        <webwork xml:id="TaC-riemann-sums-1">
+        <webwork xml:id="webwork-TaC-riemann-sums-1">
           <pg-code>
             Context()->strings->add('limits'=>{});
             Context()->strings->add('limit'=>{alias=>'limits'});
@@ -1580,7 +1580,7 @@
       </exercise>
       <!-- Exercise 2 -->
       <exercise label="TaC-riemann-sums-2">
-        <webwork xml:id="TaC-riemann-sums-2">
+        <webwork xml:id="webwork-TaC-riemann-sums-2">
           <pg-code>
             $lb = random(2,9,1);
             $ub = random(12,20,1);
@@ -1603,7 +1603,7 @@
       </exercise>
       <!-- Exercise 3 -->
       <exercise label="TaC-riemann-sums-3">
-        <webwork xml:id="TaC-riemann-sums-3">
+        <webwork xml:id="webwork-TaC-riemann-sums-3">
           <pg-code>
             Context()->strings->add('rectangles'=>{});
             Context()->strings->add('rectangle'=>{alias=>'rectangles'});
@@ -1620,7 +1620,7 @@
       </exercise>
       <!-- Exercise 4 -->
       <exercise label="TaC-riemann-sums-4">
-        <webwork xml:id="TaC-riemann-sums-4">
+        <webwork xml:id="webwork-TaC-riemann-sums-4">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -1645,7 +1645,7 @@
         </introduction>
         <!-- Exercise 5 -->
         <exercise label="ex-riemann-write-sum-1">
-          <webwork xml:id="ex-riemann-write-sum-1">
+          <webwork xml:id="webwork-ex-riemann-write-sum-1">
             <pg-code>
               $lb = random(2,5,1);
               $ub = $lb + random(2,3,1);
@@ -1682,7 +1682,7 @@
         </exercise>
         <!-- Exercise 6 -->
         <exercise label="ex-riemann-write-sum-2">
-          <webwork xml:id="ex-riemann-write-sum-2">
+          <webwork xml:id="webwork-ex-riemann-write-sum-2">
             <pg-code>
               $lb = random(-3,-1,1);
               $ub = random(1,3,1);
@@ -1723,7 +1723,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-riemann-write-sum-3">
-          <webwork xml:id="ex-riemann-write-sum-3">
+          <webwork xml:id="webwork-ex-riemann-write-sum-3">
             <pg-code>
               $lb = random(-3,-1,1);
               $ub = random(1,3,1);
@@ -1763,7 +1763,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-riemann-write-sum-4">
-          <webwork xml:id="ex-riemann-write-sum-4">
+          <webwork xml:id="webwork-ex-riemann-write-sum-4">
             <pg-code>
               $lb = 1;
               ($ub,$c) = (5..10)[NchooseK(5,2)];
@@ -1802,7 +1802,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-riemann-write-sum-5">
-          <webwork xml:id="ex-riemann-write-sum-5">
+          <webwork xml:id="webwork-ex-riemann-write-sum-5">
             <pg-code>
               $lb = 1;
               $ub = random(4,6,1);
@@ -1842,7 +1842,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-riemann-write-sum-6">
-          <webwork xml:id="ex-riemann-write-sum-6">
+          <webwork xml:id="webwork-ex-riemann-write-sum-6">
             <pg-code>
               $lb = 1;
               $ub = random(4,8,1);
@@ -1881,7 +1881,7 @@
         </exercise>
         <!-- Exercise 11 -->
         <exercise label="ex-riemann-write-sum-7">
-          <webwork xml:id="ex-riemann-write-sum-7">
+          <webwork xml:id="webwork-ex-riemann-write-sum-7">
             <pg-code>
               $lb = 1;
               $ub = random(3,5,1);
@@ -1921,7 +1921,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-riemann-write-sum-8">
-          <webwork xml:id="ex-riemann-write-sum-8">
+          <webwork xml:id="webwork-ex-riemann-write-sum-8">
             <pg-code>
               $lb = random(0,1,1);
               $ub = random(4,6,1);
@@ -1968,7 +1968,7 @@
         </introduction>
         <!-- Exercise 13 -->
         <exercise label="ex-riemann-summation-notation-1">
-          <webwork xml:id="ex-riemann-summation-notation-1">
+          <webwork xml:id="webwork-ex-riemann-summation-notation-1">
             <pg-code>
               $lb = 1;
               $ub = random(4,6,1);
@@ -2030,7 +2030,7 @@
         </exercise>
 
         <exercise label="ex-riemann-summation-notation-2">
-          <webwork xml:id="ex-riemann-summation-notation-2">
+          <webwork xml:id="webwork-ex-riemann-summation-notation-2">
             <pg-code>
               $lb = 0;
               $ub = random(5,9,1);
@@ -2092,7 +2092,7 @@
         </exercise>
 
         <exercise label="ex-riemann-summation-notation-3">
-          <webwork xml:id="ex-riemann-summation-notation-3">
+          <webwork xml:id="webwork-ex-riemann-summation-notation-3">
             <pg-code>
               $lb = 1;
               $ub = random(4,6,1);
@@ -2156,7 +2156,7 @@
         </exercise>
 
         <exercise label="ex-riemann-summation-notation-4">
-          <webwork xml:id="ex-riemann-summation-notation-4">
+          <webwork xml:id="webwork-ex-riemann-summation-notation-4">
             <pg-code>
               $lb = list_random(0,1);
               $ub = $lb + 4;
@@ -2226,7 +2226,7 @@
         </introduction>
 
         <exercise label="ex-riemann-evaluate-sum-1">
-          <webwork xml:id="ex-riemann-evaluate-sum-1">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-1">
             <pg-code>
               $lb = 1;
               ($ub,$c) = (5..10)[NchooseK(5,2)];
@@ -2250,7 +2250,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-riemann-evaluate-sum-2">
-          <webwork xml:id="ex-riemann-evaluate-sum-2">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-2">
             <pg-code>
               $lb = 1;
               $ub = random(20,30,1);
@@ -2274,7 +2274,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-riemann-evaluate-sum-3">
-          <webwork xml:id="ex-riemann-evaluate-sum-3">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-3">
             <pg-code>
               $lb = 1;
               $ub = random(8,12,1);
@@ -2300,7 +2300,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-riemann-evaluate-sum-4">
-          <webwork xml:id="ex-riemann-evaluate-sum-4">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-4">
             <pg-code>
               $lb = 1;
               $ub = random(12,20,1);
@@ -2326,7 +2326,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-riemann-evaluate-sum-5">
-          <webwork xml:id="ex-riemann-evaluate-sum-5">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-5">
             <pg-code>
               $lb = 1;
               $ub = random(8,12,1);
@@ -2352,7 +2352,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-riemann-evaluate-sum-6">
-          <webwork xml:id="ex-riemann-evaluate-sum-6">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-6">
             <pg-code>
               $lb = 1;
               $ub = random(8,12,1);
@@ -2378,7 +2378,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-riemann-evaluate-sum-7">
-          <webwork xml:id="ex-riemann-evaluate-sum-7">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-7">
             <pg-code>
               $lb = 1;
               $ub = random(80,120,5);
@@ -2403,7 +2403,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-riemann-evaluate-sum-8">
-          <webwork xml:id="ex-riemann-evaluate-sum-8">
+          <webwork xml:id="webwork-ex-riemann-evaluate-sum-8">
             <pg-code>
               $lb = 1;
               $ub = random(16,30,1);
@@ -2443,7 +2443,7 @@
         </introduction>
         <!-- Exercise 25 -->
         <exercise label="ex-riemann-sum-with-properties-1">
-          <webwork xml:id="ex-riemann-sum-with-properties-1">
+          <webwork xml:id="webwork-ex-riemann-sum-with-properties-1">
             <pg-code>
               $lb = random(7,13,1);
               $ub = $lb + random(8,12,1);
@@ -2467,7 +2467,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-riemann-sum-with-properties-2">
-          <webwork xml:id="ex-riemann-sum-with-properties-2">
+          <webwork xml:id="webwork-ex-riemann-sum-with-properties-2">
             <pg-code>
               $lb = random(14,18,1);
               $ub = $lb + random(8,12,1);
@@ -2491,7 +2491,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <exercise label="ex-riemann-sum-with-properties-3">
-          <webwork xml:id="ex-riemann-sum-with-properties-3">
+          <webwork xml:id="webwork-ex-riemann-sum-with-properties-3">
             <pg-code>
               $lb = random(5,8,1);
               $ub = $lb + random(5,8,1);
@@ -2516,7 +2516,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-riemann-sum-with-properties-4">
-          <webwork xml:id="ex-riemann-sum-with-properties-4">
+          <webwork xml:id="webwork-ex-riemann-sum-with-properties-4">
             <pg-code>
               $lb = random(5,8,1);
               $ub = $lb + random(5,8,1);
@@ -2650,7 +2650,7 @@
         </introduction>
         <!-- Exercise 35 -->
         <exercise label="ex-riemann-integral-limit-1">
-          <webwork xml:id="ex-riemann-integral-limit-1">
+          <webwork xml:id="webwork-ex-riemann-integral-limit-1">
             <pg-code>
               $rule = list_random('Left Hand Rule','Right Hand Rule');
               if($envir{problemSeed}==1){$rule = 'Right Hand Rule';};
@@ -2706,7 +2706,7 @@
         </exercise>
         <!-- Exercise 36 -->
         <exercise label="ex-riemann-integral-limit-2">
-          <webwork xml:id="ex-riemann-integral-limit-2">
+          <webwork xml:id="webwork-ex-riemann-integral-limit-2">
             <pg-code>
               $rule = list_random('Left Hand Rule','Right Hand Rule');
               $lb = random(-2,-1,1);
@@ -2766,7 +2766,7 @@
         </exercise>
         <!-- Exercise 37 -->
         <exercise label="ex-riemann-integral-limit-3">
-          <webwork xml:id="ex-riemann-integral-limit-3">
+          <webwork xml:id="webwork-ex-riemann-integral-limit-3">
             <pg-code>
               $lb = random(-2,-1,1);
               $ub = random(1,4,1);
@@ -2822,7 +2822,7 @@
         </exercise>
         <!-- Exercise 38 -->
         <exercise label="ex-riemann-integral-limit-4">
-          <webwork xml:id="ex-riemann-integral-limit-4">
+          <webwork xml:id="webwork-ex-riemann-integral-limit-4">
             <pg-code>
               $rule = list_random('Left Hand Rule','Right Hand Rule');
               $lb = random(1,2,1);
@@ -2884,7 +2884,7 @@
         </exercise>
         <!-- Exercise 39 -->
         <exercise label="ex-riemann-integral-limit-5">
-          <webwork xml:id="ex-riemann-integral-limit-5">
+          <webwork xml:id="webwork-ex-riemann-integral-limit-5">
             <pg-code>
               $rule = list_random('Left Hand Rule','Right Hand Rule');
               $lb = random(-12,-7,1);
@@ -2941,7 +2941,7 @@
         </exercise>
         <!-- Exercise 40 -->
         <exercise label="ex-riemann-integral-limit-6">
-          <webwork xml:id="ex-riemann-integral-limit-6">
+          <webwork xml:id="webwork-ex-riemann-integral-limit-6">
             <pg-code>
               $rule = list_random('Left Hand Rule','Right Hand Rule');
               if($envir{problemSeed}==1){$rule='Right Hand Rule';};
@@ -3004,7 +3004,7 @@
         </introduction>
         <!-- Exercise 41 -->
         <exercise label="ex-riemann-review-1">
-          <webwork xml:id="ex-riemann-review-1">
+          <webwork xml:id="webwork-ex-riemann-review-1">
             <pg-code>
               $trig = list_random('tan','sec','csc','cot');
               $c = random(2,9,1);
@@ -3025,7 +3025,7 @@
         </exercise>
 
         <exercise label="ex-riemann-review-2">
-          <webwork xml:id="ex-riemann-review-2">
+          <webwork xml:id="webwork-ex-riemann-review-2">
             <pg-code>
               $c = random(2,9,1);
               if($envir{problemSeed}==1){$c=7;};
@@ -3044,7 +3044,7 @@
         </exercise>
 
         <exercise label="ex-riemann-review-3">
-          <webwork xml:id="ex-riemann-review-3">
+          <webwork xml:id="webwork-ex-riemann-review-3">
             <pg-code>
               ($a,$b,$c) = (-9..-1,1..9)[NchooseK(18,3)];
               ($m,$n,$p) = num_sort((0..5)[NchooseK(6,3)]);
@@ -3070,7 +3070,7 @@
         </exercise>
 
         <exercise label="ex-riemann-review-4">
-          <webwork xml:id="ex-riemann-review-4">
+          <webwork xml:id="webwork-ex-riemann-review-4">
             <pg-code>
               ($b,$c) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$b=8;$c=5;};
@@ -3091,7 +3091,7 @@
         </exercise>
 
         <exercise label="ex-riemann-review-5">
-          <webwork xml:id="ex-riemann-review-5">
+          <webwork xml:id="webwork-ex-riemann-review-5">
             <pg-code>
               Context()->variables->add(t=>"Real");
               $F = FormulaUpToConstant("sin(t)-cos(t)");
@@ -3108,7 +3108,7 @@
         </exercise>
 
         <exercise label="ex-riemann-review-6">
-          <webwork xml:id="ex-riemann-review-6">
+          <webwork xml:id="webwork-ex-riemann-review-6">
             <pg-code>
               $F = FormulaUpToConstant("2*sqrt(x)");
             </pg-code>

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -1588,7 +1588,7 @@
     <subexercises xml:id="TaC-sequences">
       <title>Terms and Concepts</title>
       <exercise label="TaC-sequences-1">
-        <!--<webwork xml:id="TaC-sequences-1">
+        <!--<webwork xml:id="webwork-TaC-sequences-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1605,7 +1605,7 @@
       </exercise>
 
       <exercise label="TaC-sequences-2">
-        <!--<webwork xml:id="TaC-sequences-2">
+        <!--<webwork xml:id="webwork-TaC-sequences-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1622,7 +1622,7 @@
       </exercise>
 
       <exercise label="TaC-sequences-3">
-        <!--<webwork xml:id="TaC-sequences-3">
+        <!--<webwork xml:id="webwork-TaC-sequences-3">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1640,7 +1640,7 @@
       </exercise>
 
       <exercise label="TaC-sequences-4">
-        <!--<webwork xml:id="TaC-sequences-4">
+        <!--<webwork xml:id="webwork-TaC-sequences-4">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1667,7 +1667,7 @@
         </introduction>
 
         <exercise label="ex-sequences-list-terms-1">
-          <!--<webwork xml:id="ex-sequences-list-terms-1">
+          <!--<webwork xml:id="webwork-ex-sequences-list-terms-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1684,7 +1684,7 @@
         </exercise>
 
         <exercise label="ex-sequences-list-terms-2">
-          <!--<webwork xml:id="ex-sequences-list-terms-2">
+          <!--<webwork xml:id="webwork-ex-sequences-list-terms-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1702,7 +1702,7 @@
         </exercise>
 
         <exercise label="ex-sequences-list-terms-3">
-          <!--<webwork xml:id="ex-sequences-list-terms-3">
+          <!--<webwork xml:id="webwork-ex-sequences-list-terms-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1719,7 +1719,7 @@
         </exercise>
 
         <exercise label="ex-sequences-list-terms-4">
-          <!--<webwork xml:id="ex-sequences-list-terms-4">
+          <!--<webwork xml:id="webwork-ex-sequences-list-terms-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1746,7 +1746,7 @@
         </introduction>
 
         <exercise label="ex-sequences-nth-term-1">
-          <!--<webwork xml:id="ex-sequences-nth-term-1">
+          <!--<webwork xml:id="webwork-ex-sequences-nth-term-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1763,7 +1763,7 @@
         </exercise>
 
         <exercise label="ex-sequences-nth-term-2">
-          <!--<webwork xml:id="ex-sequences-nth-term-2">
+          <!--<webwork xml:id="webwork-ex-sequences-nth-term-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1780,7 +1780,7 @@
         </exercise>
 
         <exercise label="ex-sequences-nth-term-3">
-          <!--<webwork xml:id="ex-sequences-nth-term-3">
+          <!--<webwork xml:id="webwork-ex-sequences-nth-term-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1797,7 +1797,7 @@
         </exercise>
 
         <exercise label="ex-sequences-nth-term-4">
-          <!--<webwork xml:id="ex-sequences-nth-term-4">
+          <!--<webwork xml:id="webwork-ex-sequences-nth-term-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1849,7 +1849,7 @@
         </introduction>
 
         <exercise label="ex-sequences-limit-properties-1">
-          <!--<webwork xml:id="ex-sequences-limit-properties-1">
+          <!--<webwork xml:id="webwork-ex-sequences-limit-properties-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1866,7 +1866,7 @@
         </exercise>
 
         <exercise label="ex-sequences-limit-properties-2">
-          <!--<webwork xml:id="ex-sequences-limit-properties-2">
+          <!--<webwork xml:id="webwork-ex-sequences-limit-properties-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1883,7 +1883,7 @@
         </exercise>
 
         <exercise label="ex-sequences-limit-properties-3">
-          <!--<webwork xml:id="ex-sequences-limit-properties-3">
+          <!--<webwork xml:id="webwork-ex-sequences-limit-properties-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1900,7 +1900,7 @@
         </exercise>
 
         <exercise label="ex-sequences-limit-properties-4">
-          <!--<webwork xml:id="ex-sequences-limit-properties-4">
+          <!--<webwork xml:id="webwork-ex-sequences-limit-properties-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1928,7 +1928,7 @@
         </introduction>
 
         <exercise label="ex-sequences-converge-diverge-1">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-1">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1945,7 +1945,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-2">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-2">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1962,7 +1962,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-3">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-3">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1979,7 +1979,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-4">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-4">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1997,7 +1997,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-5">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-5">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2014,7 +2014,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-6">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-6">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2031,7 +2031,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-7">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-7">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2048,7 +2048,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-8">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-8">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2065,7 +2065,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-9">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-9">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2082,7 +2082,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-10">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-10">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2099,7 +2099,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-11">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-11">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-11">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2116,7 +2116,7 @@
         </exercise>
 
         <exercise label="ex-sequences-converge-diverge-12">
-          <!--<webwork xml:id="ex-sequences-converge-diverge-12">
+          <!--<webwork xml:id="webwork-ex-sequences-converge-diverge-12">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2143,7 +2143,7 @@
         </introduction>
 
         <exercise label="ex-sequences-bounded-1">
-          <!--<webwork xml:id="ex-sequences-bounded-1">
+          <!--<webwork xml:id="webwork-ex-sequences-bounded-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2160,7 +2160,7 @@
         </exercise>
 
         <exercise label="ex-sequences-bounded-2">
-          <!--<webwork xml:id="ex-sequences-bounded-2">
+          <!--<webwork xml:id="webwork-ex-sequences-bounded-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2177,7 +2177,7 @@
         </exercise>
 
         <exercise label="ex-sequences-bounded-3">
-          <!--<webwork xml:id="ex-sequences-bounded-3">
+          <!--<webwork xml:id="webwork-ex-sequences-bounded-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2194,7 +2194,7 @@
         </exercise>
 
         <exercise label="ex-sequences-bounded-4">
-          <!--<webwork xml:id="ex-sequences-bounded-4">
+          <!--<webwork xml:id="webwork-ex-sequences-bounded-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2211,7 +2211,7 @@
         </exercise>
 
         <exercise label="ex-sequences-bounded-5">
-          <!--<webwork xml:id="ex-sequences-bounded-5">
+          <!--<webwork xml:id="webwork-ex-sequences-bounded-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2228,7 +2228,7 @@
         </exercise>
 
         <exercise label="ex-sequences-bounded-6">
-          <!--<webwork xml:id="ex-sequences-bounded-6">
+          <!--<webwork xml:id="webwork-ex-sequences-bounded-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2257,7 +2257,7 @@
         </introduction>
 
         <exercise label="ex-sequences-monotone-1">
-          <!--<webwork xml:id="ex-sequences-monotone-1">
+          <!--<webwork xml:id="webwork-ex-sequences-monotone-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2274,7 +2274,7 @@
         </exercise>
 
         <exercise label="ex-sequences-monotone-2">
-          <!--<webwork xml:id="ex-sequences-monotone-2">
+          <!--<webwork xml:id="webwork-ex-sequences-monotone-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2291,7 +2291,7 @@
         </exercise>
 
         <exercise label="ex-sequences-monotone-3">
-          <!--<webwork xml:id="ex-sequences-monotone-3">
+          <!--<webwork xml:id="webwork-ex-sequences-monotone-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2308,7 +2308,7 @@
         </exercise>
 
         <exercise label="ex-sequences-monotone-4">
-          <!--<webwork xml:id="ex-sequences-monotone-4">
+          <!--<webwork xml:id="webwork-ex-sequences-monotone-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2333,7 +2333,7 @@
         </introduction>
 
         <exercise label="ex-sequences-theory-1">
-          <!--<webwork xml:id="ex-sequences-theory-1">
+          <!--<webwork xml:id="webwork-ex-sequences-theory-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2358,7 +2358,7 @@
         </exercise>
 
         <exercise label="ex-sequences-theory-2">
-          <!--<webwork xml:id="ex-sequences-theory-2">
+          <!--<webwork xml:id="webwork-ex-sequences-theory-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2404,7 +2404,7 @@
         </exercise>
 
         <exercise label="ex-sequences-theory-3">
-          <!--<webwork xml:id="ex-sequences-theory-3">
+          <!--<webwork xml:id="webwork-ex-sequences-theory-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2436,7 +2436,7 @@
         </exercise>
 
         <exercise label="ex-sequences-theory-4">
-            <!--<webwork xml:id="ex-sequences-theory-4">
+            <!--<webwork xml:id="webwork-ex-sequences-theory-4">
               <pg-code>
               </pg-code>-->
 

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -1617,7 +1617,7 @@
     <subexercises xml:id="TaC-series">
       <title>Terms and Concepts</title>
       <exercise label="TaC-series-1">
-        <!--<webwork xml:id="TaC-series-1">
+        <!--<webwork xml:id="webwork-TaC-series-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1634,7 +1634,7 @@
       </exercise>
 
       <exercise label="TaC-series-2">
-        <!--<webwork xml:id="TaC-series-2">
+        <!--<webwork xml:id="webwork-TaC-series-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1651,7 +1651,7 @@
       </exercise>
 
       <exercise label="TaC-series-3">
-        <!--<webwork xml:id="TaC-series-3">
+        <!--<webwork xml:id="webwork-TaC-series-3">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1671,7 +1671,7 @@
       </exercise>
 
       <exercise label="TaC-series-4">
-        <!--<webwork xml:id="TaC-series-4">
+        <!--<webwork xml:id="webwork-TaC-series-4">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1688,7 +1688,7 @@
       </exercise>
 
       <exercise label="TaC-series-5">
-        <!--<webwork xml:id="TaC-series-5">
+        <!--<webwork xml:id="webwork-TaC-series-5">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1745,7 +1745,7 @@
         </introduction>
 
         <exercise label="ex-series-partial-sum-1">
-          <!--<webwork xml:id="ex-series-partial-sum-1">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1774,7 +1774,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-2">
-          <!--<webwork xml:id="ex-series-partial-sum-2">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1804,7 +1804,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-3">
-          <!--<webwork xml:id="ex-series-partial-sum-3">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1833,7 +1833,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-4">
-          <!--<webwork xml:id="ex-series-partial-sum-4">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1862,7 +1862,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-5">
-          <!--<webwork xml:id="ex-series-partial-sum-5">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1891,7 +1891,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-6">
-          <!--<webwork xml:id="ex-series-partial-sum-6">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1920,7 +1920,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-7">
-          <!--<webwork xml:id="ex-series-partial-sum-7">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1949,7 +1949,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-8">
-          <!--<webwork xml:id="ex-series-partial-sum-8">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1989,7 +1989,7 @@
         </introduction>
 
         <exercise label="ex-series-nth-term-divergence-1">
-          <!--<webwork xml:id="ex-series-nth-term-divergence-1">
+          <!--<webwork xml:id="webwork-ex-series-nth-term-divergence-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2007,7 +2007,7 @@
         </exercise>
 
         <exercise label="ex-series-nth-term-divergence-2">
-          <!--<webwork xml:id="ex-series-nth-term-divergence-2">
+          <!--<webwork xml:id="webwork-ex-series-nth-term-divergence-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2025,7 +2025,7 @@
         </exercise>
 
         <exercise label="ex-series-nth-term-divergence-3">
-          <!--<webwork xml:id="ex-series-nth-term-divergence-3">
+          <!--<webwork xml:id="webwork-ex-series-nth-term-divergence-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2043,7 +2043,7 @@
         </exercise>
 
         <exercise label="ex-series-nth-term-divergence-4">
-          <!--<webwork xml:id="ex-series-nth-term-divergence-4">
+          <!--<webwork xml:id="webwork-ex-series-nth-term-divergence-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2061,7 +2061,7 @@
         </exercise>
 
         <exercise label="ex-series-nth-term-divergence-5">
-          <!--<webwork xml:id="ex-series-nth-term-divergence-5">
+          <!--<webwork xml:id="webwork-ex-series-nth-term-divergence-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2079,7 +2079,7 @@
         </exercise>
 
         <exercise label="ex-series-nth-term-divergence-6">
-          <!--<webwork xml:id="ex-series-nth-term-divergence-6">
+          <!--<webwork xml:id="webwork-ex-series-nth-term-divergence-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2107,7 +2107,7 @@
         </introduction>
 
         <exercise label="ex-series-converge-diverge-1">
-          <!--<webwork xml:id="ex-series-converge-diverge-1">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2124,7 +2124,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-2">
-          <!--<webwork xml:id="ex-series-converge-diverge-2">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2141,7 +2141,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-3">
-          <!--<webwork xml:id="ex-series-converge-diverge-3">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2158,7 +2158,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-4">
-          <!--<webwork xml:id="ex-series-converge-diverge-4">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2175,7 +2175,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-5">
-          <!--<webwork xml:id="ex-series-converge-diverge-5">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2192,7 +2192,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-6">
-          <!--<webwork xml:id="ex-series-converge-diverge-6">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2211,7 +2211,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-7">
-          <!--<webwork xml:id="ex-series-converge-diverge-7">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2228,7 +2228,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-8">
-          <!--<webwork xml:id="ex-series-converge-diverge-8">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2245,7 +2245,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-9">
-          <!--<webwork xml:id="ex-series-converge-diverge-9">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2266,7 +2266,7 @@
         </exercise>
 
         <exercise label="ex-series-converge-diverge-10">
-          <!--<webwork xml:id="ex-series-converge-diverge-10">
+          <!--<webwork xml:id="webwork-ex-series-converge-diverge-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2310,7 +2310,7 @@
         </introduction>
 
         <exercise label="ex-series-partial-sum-formula-1">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-1">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2365,7 +2365,7 @@
 
 
         <exercise label="ex-series-partial-sum-formula-3">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-3">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2394,7 +2394,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-4">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-4">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2427,7 +2427,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-5">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-5">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2456,7 +2456,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-6">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-6">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2485,7 +2485,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-7">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-7">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-7">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2514,7 +2514,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-8">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-8">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-8">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2544,7 +2544,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-9">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-9">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-9">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2575,7 +2575,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-10">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-10">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-10">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2606,7 +2606,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-11">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-11">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-11">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2636,7 +2636,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-12">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-12">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-12">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2665,7 +2665,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-13">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-13">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-13">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2696,7 +2696,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-14">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-14">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-14">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2726,7 +2726,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-15">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-15">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-15">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2757,7 +2757,7 @@
         </exercise>
 
         <exercise label="ex-series-partial-sum-formula-16">
-          <!--<webwork xml:id="ex-series-partial-sum-formula-16">
+          <!--<webwork xml:id="webwork-ex-series-partial-sum-formula-16">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -2787,7 +2787,7 @@
       </exercisegroup>
 
       <exercise xml:id="x08_02_ex_24"  label="ex-series-harmonic-split">
-        <!--<webwork xml:id="ex-series-harmonic-split">
+        <!--<webwork xml:id="webwork-ex-series-harmonic-split">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -2886,7 +2886,7 @@
       </exercise>
 
       <exercise label="ex-series-partial-fraction">
-        <!--<webwork xml:id="ex-series-partial-fraction">
+        <!--<webwork xml:id="webwork-ex-series-partial-fraction">
             <pg-code>
             </pg-code>-->
             <statement>

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -1351,7 +1351,7 @@
     <subexercises xml:id="TaC-volume-shells">
       <title>Terms and Concepts</title>
       <exercise label="TaC-volume-shells-1">
-        <!-- <webwork xml:id="TaC-volume-shells-1">
+        <!-- <webwork xml:id="webwork-TaC-volume-shells-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1368,7 +1368,7 @@
       </exercise>
 
       <exercise label="TaC-volume-shells-2">
-        <!-- <webwork xml:id="TaC-volume-shells-2">
+        <!-- <webwork xml:id="webwork-TaC-volume-shells-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1385,7 +1385,7 @@
       </exercise>
 
       <exercise label="TaC-volume-shells-3">
-        <!-- <webwork xml:id="TaC-volume-shells-3">
+        <!-- <webwork xml:id="webwork-TaC-volume-shells-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1402,7 +1402,7 @@
       </exercise>
 
       <exercise label="TaC-volume-shells-4">
-        <!-- <webwork xml:id="TaC-volume-shells-4">
+        <!-- <webwork xml:id="webwork-TaC-volume-shells-4">
             <pg-code>
             </pg-code>
              -->
@@ -1433,7 +1433,7 @@
         </introduction>
 
         <exercise label="ex-volume-shells-y-axis-1">
-          <!-- <webwork xml:id="ex-volume-shells-y-axis-1">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-y-axis-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1474,7 +1474,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-y-axis-2">
-          <!-- <webwork xml:id="ex-volume-shells-y-axis-2">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-y-axis-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1515,7 +1515,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-y-axis-3">
-          <!-- <webwork xml:id="ex-volume-shells-y-axis-3">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-y-axis-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1556,7 +1556,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-y-axis-4">
-          <!-- <webwork xml:id="ex-volume-shells-y-axis-4">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-y-axis-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1610,7 +1610,7 @@
         </introduction>
 
         <exercise label="ex-volume-shells-x-axis-1">
-          <!-- <webwork xml:id="ex-volume-shells-x-axis-1">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-x-axis-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1650,7 +1650,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-x-axis-2">
-          <!-- <webwork xml:id="ex-volume-shells-x-axis-2">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-x-axis-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1691,7 +1691,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-x-axis-3">
-          <!-- <webwork xml:id="ex-volume-shells-x-axis-3">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-x-axis-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1732,7 +1732,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-x-axis-4">
-          <!-- <webwork xml:id="ex-volume-shells-x-axis-4">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-x-axis-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1786,7 +1786,7 @@
         </introduction>
 
         <exercise label="ex-volume-shells-both-axes-1">
-          <!-- <webwork xml:id="ex-volume-shells-both-axes-1">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-both-axes-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1860,7 +1860,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-both-axes-2">
-          <!-- <webwork xml:id="ex-volume-shells-both-axes-2">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-both-axes-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1933,7 +1933,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-both-axes-3">
-          <!-- <webwork xml:id="ex-volume-shells-both-axes-3">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-both-axes-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2007,7 +2007,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-both-axes-4">
-          <!-- <webwork xml:id="ex-volume-shells-both-axes-4">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-both-axes-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2068,7 +2068,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-both-axes-5">
-          <!-- <webwork xml:id="ex-volume-shells-both-axes-5">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-both-axes-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2118,7 +2118,7 @@
         </exercise>
 
         <exercise label="ex-volume-shells-both-axes-6">
-          <!-- <webwork xml:id="ex-volume-shells-both-axes-6">
+          <!-- <webwork xml:id="webwork-ex-volume-shells-both-axes-6">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -3678,7 +3678,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-space-coordinates-1">
-        <!-- <webwork xml:id="TaC-space-coordinates-1">
+        <!-- <webwork xml:id="webwork-TaC-space-coordinates-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3695,7 +3695,7 @@
       </exercise>
 
       <exercise label="TaC-space-coordinates-2">
-        <webwork xml:id="TaC-space-coordinates-2">
+        <webwork xml:id="webwork-TaC-space-coordinates-2">
             <!-- <pg-macros><macro-file>contextArbitraryString.pl</macro-file></pg-macros> -->
 
             <pg-code>
@@ -3732,7 +3732,7 @@
       </exercise>
 
       <exercise label="TaC-space-coordinates-3">
-        <!-- <webwork xml:id="TaC-space-coordinates-3">
+        <!-- <webwork xml:id="webwork-TaC-space-coordinates-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3750,7 +3750,7 @@
       </exercise>
 
       <exercise label="TaC-space-coordinates-4">
-        <webwork xml:id="TaC-space-coordinates-4">
+        <webwork xml:id="webwork-TaC-space-coordinates-4">
             <pg-code>
               $surfaces=PopUp(['?','Elliptic Paraboloid','Elliptic Cone','Ellipsoid','Hyperboloid of One Sheet','Hyperboloid of Two Sheets','Hyperbolic Paraboloid'],6);
             </pg-code>
@@ -3765,7 +3765,7 @@
       </exercise>
 
       <exercise label="TaC-space-coordinates-5">
-        <!-- <webwork xml:id="TaC-space-coordinates-5">
+        <!-- <webwork xml:id="webwork-TaC-space-coordinates-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3784,7 +3784,7 @@
       </exercise>
 
       <exercise label="TaC-space-coordinates-6">
-        <!-- <webwork xml:id="TaC-space-coordinates-6">
+        <!-- <webwork xml:id="webwork-TaC-space-coordinates-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3805,7 +3805,7 @@
     <subexercises>
       <title>Problems</title>
       <exercise label="ex-space-coordinates-distance">
-        <webwork xml:id="ex-space-coordinates-distance">
+        <webwork xml:id="webwork-ex-space-coordinates-distance">
             <pg-code>
               Context("Point");
               $A=Point("(1,4,2)");
@@ -3861,7 +3861,7 @@
       </exercise>
 
       <exercise label="ex-space-coordinates-quadrilateral">
-        <!-- <webwork xml:id="ex-space-coordinates-quadrilateral">
+        <!-- <webwork xml:id="webwork-ex-space-coordinates-quadrilateral">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3882,7 +3882,7 @@
       </exercise>
 
       <exercise label="ex-space-coordinates-circle">
-        <webwork xml:id="ex-space-coordinates-circle">
+        <webwork xml:id="webwork-ex-space-coordinates-circle">
             <pg-code>
               Context("Point");
               $center=Point("(4,-1,0)");
@@ -3909,7 +3909,7 @@
       </exercise>
 
       <exercise label="ex-space-coordinates-sphere">
-        <webwork xml:id="ex-space-coordinates-sphere">
+        <webwork xml:id="webwork-ex-space-coordinates-sphere">
             <pg-code>
               Context("Point");
               $center=Point("(-2,1,2)");
@@ -3946,7 +3946,7 @@
         </introduction>
 
         <exercise label="ex-space-coordinates-region-1">
-          <!-- <webwork xml:id="ex-space-coordinates-region-1">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-region-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3963,7 +3963,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-region-2">
-          <webwork xml:id="ex-space-coordinates-region-2">
+          <webwork xml:id="webwork-ex-space-coordinates-region-2">
               <pg-code>
               </pg-code>
 
@@ -3983,7 +3983,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-region-3">
-          <!-- <webwork xml:id="ex-space-coordinates-region-3">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-region-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4003,7 +4003,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-region-4">
-          <!-- <webwork xml:id="ex-space-coordinates-region-4">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-region-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4033,7 +4033,7 @@
         </introduction>
 
         <exercise label="ex-space-coordinates-sketch-cylinder-1">
-          <!-- <webwork xml:id="ex-space-coordinates-sketch-cylinder-1">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-sketch-cylinder-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4117,7 +4117,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-sketch-cylinder-2">
-          <!-- <webwork xml:id="ex-space-coordinates-sketch-cylinder-2">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-sketch-cylinder-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4187,7 +4187,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-sketch-cylinder-3">
-          <!-- <webwork xml:id="ex-space-coordinates-sketch-cylinder-3">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-sketch-cylinder-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4268,7 +4268,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-sketch-cylinder-4">
-          <!-- <webwork xml:id="ex-space-coordinates-sketch-cylinder-4">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-sketch-cylinder-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4367,7 +4367,7 @@
         </introduction>
 
         <exercise label="ex-space-coordinates-surface-revolution-1">
-          <webwork xml:id="ex-space-coordinates-surface-revolution-1">
+          <webwork xml:id="webwork-ex-space-coordinates-surface-revolution-1">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
@@ -4388,7 +4388,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-surface-revolution-2">
-          <webwork xml:id="ex-space-coordinates-surface-revolution-2">
+          <webwork xml:id="webwork-ex-space-coordinates-surface-revolution-2">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
@@ -4408,7 +4408,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-surface-revolution-3">
-          <webwork xml:id="ex-space-coordinates-surface-revolution-3">
+          <webwork xml:id="webwork-ex-space-coordinates-surface-revolution-3">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
@@ -4428,7 +4428,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-surface-revolution-4">
-          <webwork xml:id="ex-space-coordinates-surface-revolution-4">
+          <webwork xml:id="webwork-ex-space-coordinates-surface-revolution-4">
               <pg-code>
                 Context("ImplicitEquation");
                 Context()->variables->are(x=>'Real',y=>'Real',z=>'Real');
@@ -4458,7 +4458,7 @@
         </introduction>
         <!--TODO: probably should use an ordered list for the two options in each problem here.-->
         <exercise label="ex-space-coordinates-quadric-1">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-1">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4525,7 +4525,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-2">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-2">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4599,7 +4599,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-3">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-3">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4666,7 +4666,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-4">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-4">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4749,7 +4749,7 @@
         </introduction>
 
         <exercise label="ex-space-coordinates-quadric-sketch-1">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-sketch-1">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-sketch-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4806,7 +4806,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-sketch-2">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-sketch-2">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-sketch-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4862,7 +4862,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-sketch-3">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-sketch-3">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-sketch-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4918,7 +4918,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-sketch-4">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-sketch-4">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-sketch-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4981,7 +4981,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-sketch-5">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-sketch-5">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-sketch-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -5037,7 +5037,7 @@
         </exercise>
 
         <exercise label="ex-space-coordinates-quadric-sketch-6">
-          <!-- <webwork xml:id="ex-space-coordinates-quadric-sketch-6">
+          <!-- <webwork xml:id="webwork-ex-space-coordinates-quadric-sketch-6">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_substitution.ptx
+++ b/ptx/sec_substitution.ptx
@@ -1343,7 +1343,7 @@
     <subexercises xml:id="TaC-integrate-substitution">
       <title>Terms and Concepts</title>
       <exercise label="TaC-integrate-substitution-1">
-        <webwork xml:id="TaC-integrate-substitution-1">
+        <webwork xml:id="webwork-TaC-integrate-substitution-1">
           <pg-code>
             Context()->strings->add('the Chain Rule'=>{});
             Context()->strings->add('Chain Rule'=>{alias=>'the Chain Rule'});
@@ -1361,7 +1361,7 @@
       </exercise>
 
       <exercise label="TaC-integrate-substitution-2">
-        <webwork xml:id="TaC-integrate-substitution-2">
+        <webwork xml:id="webwork-TaC-integrate-substitution-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
           </pg-code>
@@ -1385,7 +1385,7 @@
         </introduction>
 
         <exercise label="ex-integrate-substitution-evaluate-1">
-          <webwork xml:id="ex-integrate-substitution-evaluate-1">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-1">
             <pg-code>
               $m = random(3,4,1);
               $b = non_zero_random(-9,9,1);
@@ -1409,7 +1409,7 @@
         </exercise>
 
         <exercise label="ex-integrate-substitution-evaluate-2">
-          <webwork xml:id="ex-integrate-substitution-evaluate-2">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-2">
             <pg-code>
               ($m,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               $n = random(3,9,1);
@@ -1432,7 +1432,7 @@
         </exercise>
         <!-- Exercise 5 -->
         <exercise label="ex-integrate-substitution-evaluate-3">
-          <webwork xml:id="ex-integrate-substitution-evaluate-3">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-3">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               $n = random(3,9,1);
@@ -1454,7 +1454,7 @@
         </exercise>
         <!-- Exercise 6 -->
         <exercise label="ex-integrate-substitution-evaluate-4">
-          <webwork xml:id="ex-integrate-substitution-evaluate-4">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-4">
             <pg-code>
               ($a,$b,$c) = (-9..-1,1..9)[NchooseK(18,3)];
               $n = random(3,9,1);
@@ -1478,7 +1478,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-integrate-substitution-evaluate-5">
-          <webwork xml:id="ex-integrate-substitution-evaluate-5">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-5">
             <pg-code>
               ($m,$b) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$m=2;$b=7;};
@@ -1500,7 +1500,7 @@
         </exercise>
         <!-- Exercise 8-->
         <exercise label="ex-integrate-substitution-evaluate-6">
-          <webwork xml:id="ex-integrate-substitution-evaluate-6">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-6">
             <pg-code>
               ($m,$b) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$m=2;$b=3;};
@@ -1522,7 +1522,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-integrate-substitution-evaluate-7">
-          <webwork xml:id="ex-integrate-substitution-evaluate-7">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-7">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b=3;};
@@ -1543,7 +1543,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-integrate-substitution-evaluate-8">
-          <webwork xml:id="ex-integrate-substitution-evaluate-8">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-8">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               $m = random(3,5,1);
@@ -1566,7 +1566,7 @@
         </exercise>
         <!-- Exercise 11 -->
         <exercise label="ex-integrate-substitution-evaluate-9">
-          <webwork xml:id="ex-integrate-substitution-evaluate-9">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-9">
             <pg-code>
               $F = FormulaUpToConstant("2*e^sqrt(x)");
               $F->{limits} = [0,4];
@@ -1583,7 +1583,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-integrate-substitution-evaluate-10">
-          <webwork xml:id="ex-integrate-substitution-evaluate-10">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-10">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               $m = random(4,8,1);
@@ -1609,7 +1609,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise label="ex-integrate-substitution-evaluate-11">
-          <webwork xml:id="ex-integrate-substitution-evaluate-11">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-11">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               $m = random(1,3,1);
@@ -1631,7 +1631,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-integrate-substitution-evaluate-12">
-          <webwork xml:id="ex-integrate-substitution-evaluate-12">
+          <webwork xml:id="webwork-ex-integrate-substitution-evaluate-12">
             <pg-code>
               $F = FormulaUpToConstant("ln(x)^2/2");
             </pg-code>
@@ -1655,7 +1655,7 @@
         </introduction>
         <!-- Exercise 15 -->
         <exercise label="ex-substitution-trig-1">
-          <webwork xml:id="ex-substitution-trig-1">
+          <webwork xml:id="webwork-ex-substitution-trig-1">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=2;};
@@ -1675,7 +1675,7 @@
         </exercise>
 
         <exercise label="ex-substitution-trig-2">
-          <webwork xml:id="ex-substitution-trig-2">
+          <webwork xml:id="webwork-ex-substitution-trig-2">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=3;};
@@ -1695,7 +1695,7 @@
         </exercise>
         <!-- Exercise 17 -->
         <exercise label="ex-substitution-trig-3">
-          <webwork xml:id="ex-substitution-trig-3">
+          <webwork xml:id="webwork-ex-substitution-trig-3">
             <pg-code>
               $m = random(-9,-1,1);
               $b = random(1,9,1);
@@ -1719,7 +1719,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-substitution-trig-4">
-          <webwork xml:id="ex-substitution-trig-4">
+          <webwork xml:id="webwork-ex-substitution-trig-4">
             <pg-code>
               $m = random(-9,-1,1);
               $b = random(1,9,1);
@@ -1741,7 +1741,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-substitution-trig-5">
-          <webwork xml:id="ex-substitution-trig-5">
+          <webwork xml:id="webwork-ex-substitution-trig-5">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=2;};
@@ -1763,7 +1763,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-substitution-trig-6">
-          <webwork xml:id="ex-substitution-trig-6">
+          <webwork xml:id="webwork-ex-substitution-trig-6">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=2;};
@@ -1783,7 +1783,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-substitution-trig-7">
-          <webwork xml:id="ex-substitution-trig-7">
+          <webwork xml:id="webwork-ex-substitution-trig-7">
             <pg-code>
               $m = random(2,9,1);
               $trig = list_random('sin','cos');
@@ -1806,7 +1806,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-substitution-trig-8">
-          <webwork xml:id="ex-substitution-trig-8">
+          <webwork xml:id="webwork-ex-substitution-trig-8">
             <pg-code>
               $F = FormulaUpToConstant("tan(x)-x");
             </pg-code>
@@ -1822,7 +1822,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-substitution-trig-9">
-          <webwork xml:id="ex-substitution-trig-9">
+          <webwork xml:id="webwork-ex-substitution-trig-9">
             <pg-code>
               Context()->variables->set(x => {limits => [0,2*pi]});
               $F = FormulaUpToConstant("ln(abs(sin(x)))");
@@ -1844,7 +1844,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-substitution-trig-10">
-          <webwork xml:id="ex-substitution-trig-10">
+          <webwork xml:id="webwork-ex-substitution-trig-10">
             <pg-code>
               Context()->variables->set(x => {limits => [0,2*pi]});
               $F = FormulaUpToConstant("-ln(abs(csc(x) + cot(x)))");
@@ -1874,7 +1874,7 @@
         </introduction>
         <!-- Exercise 25 -->
         <exercise label="ex-substitution-exponential-1">
-          <webwork xml:id="ex-substitution-exponential-1">
+          <webwork xml:id="webwork-ex-substitution-exponential-1">
             <pg-code>
               $m = random(2,9,1);
               $b = non_zero_random(-9,9,1);
@@ -1895,7 +1895,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-substitution-exponential-2">
-          <webwork xml:id="ex-substitution-exponential-2">
+          <webwork xml:id="webwork-ex-substitution-exponential-2">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=3;};
@@ -1915,7 +1915,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <exercise label="ex-substitution-exponential-3">
-          <webwork xml:id="ex-substitution-exponential-3">
+          <webwork xml:id="webwork-ex-substitution-exponential-3">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b=-1};
@@ -1936,7 +1936,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-substitution-exponential-4">
-          <webwork xml:id="ex-substitution-exponential-4">
+          <webwork xml:id="webwork-ex-substitution-exponential-4">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b=1};
@@ -1956,7 +1956,7 @@
         </exercise>
 
         <exercise label="ex-substitution-exponential-5">
-          <webwork xml:id="ex-substitution-exponential-5">
+          <webwork xml:id="webwork-ex-substitution-exponential-5">
             <pg-code>
               $b = non_zero_random(1,9,1);
               if($envir{problemSeed}==1){$b=1};
@@ -1976,7 +1976,7 @@
         </exercise>
         <!-- Exercise 30 -->
         <exercise label="ex-substitution-exponential-6">
-          <webwork xml:id="ex-substitution-exponential-6">
+          <webwork xml:id="webwork-ex-substitution-exponential-6">
             <pg-code>
               $c = list_random(-1,1);
               $m = random(2,5,1);
@@ -1997,7 +1997,7 @@
         </exercise>
         <!-- Exercise 31 -->
         <exercise label="ex-substitution-exponential-7">
-          <webwork xml:id="ex-substitution-exponential-7">
+          <webwork xml:id="webwork-ex-substitution-exponential-7">
             <pg-code>
               $b = random(2,9,1);
               if($envir{problemSeed}==1){$b=3;};
@@ -2018,7 +2018,7 @@
         </exercise>
         <!-- Exercise 32 -->
         <exercise label="ex-substitution-exponential-8">
-          <webwork xml:id="ex-substitution-exponential-8">
+          <webwork xml:id="webwork-ex-substitution-exponential-8">
             <pg-code>
               ($b,$c) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$b=4;$c=2;};
@@ -2048,7 +2048,7 @@
         <!-- Exercise 33 -->
         <!-- Repeat of #14 -->
         <exercise label="ex-substitution-logarithmic-1">
-          <webwork xml:id="ex-substitution-logarithmic-1">
+          <webwork xml:id="webwork-ex-substitution-logarithmic-1">
             <pg-code>
               $F = FormulaUpToConstant("ln(x)^2/2");
             </pg-code>
@@ -2064,7 +2064,7 @@
         </exercise>
         <!-- Exercise 34 -->
         <exercise label="ex-substitution-logarithmic-2">
-          <webwork xml:id="ex-substitution-logarithmic-2">
+          <webwork xml:id="webwork-ex-substitution-logarithmic-2">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=2;};
@@ -2085,7 +2085,7 @@
         </exercise>
 
         <exercise label="ex-substitution-logarithmic-3">
-          <webwork xml:id="ex-substitution-logarithmic-3">
+          <webwork xml:id="webwork-ex-substitution-logarithmic-3">
             <pg-code>
               $m = random(3,9,2);
               if($envir{problemSeed}==1){$m=3;};
@@ -2107,7 +2107,7 @@
         </exercise>
         <!-- Exercise 36 -->
         <exercise label="ex-substitution-logarithmic-4">
-          <webwork xml:id="ex-substitution-logarithmic-4">
+          <webwork xml:id="webwork-ex-substitution-logarithmic-4">
             <pg-code>
               $m = random(2,8,2);
               if($envir{problemSeed}==1){$m=2;};
@@ -2137,7 +2137,7 @@
         </introduction>
         <!-- Exercise 37 -->
         <exercise label="ex-substitution-rational-1">
-          <webwork xml:id="ex-substitution-rational-1">
+          <webwork xml:id="webwork-ex-substitution-rational-1">
             <pg-code>
               ($a,$b) = (-9..-1,1..9)[NchooseK(18,2)];
               if($envir{problemSeed}==1){$a=3;$b=1;};
@@ -2157,7 +2157,7 @@
         </exercise>
         <!-- Exercise 38 -->
         <exercise label="ex-substitution-rational-2">
-          <webwork xml:id="ex-substitution-rational-2">
+          <webwork xml:id="webwork-ex-substitution-rational-2">
             <pg-code>
               Context("Fraction");
               $f = Formula("(x^3 + x^2 + x + 1)/x")->reduce;
@@ -2175,7 +2175,7 @@
         </exercise>
         <!-- Exercise 39 -->
         <exercise label="ex-substitution-rational-3">
-          <webwork xml:id="ex-substitution-rational-3">
+          <webwork xml:id="webwork-ex-substitution-rational-3">
             <pg-code>
               $c = list_random(-1,1);
               $b = non_zero_random(-9,9,1);
@@ -2200,7 +2200,7 @@
         </exercise>
         <!-- Exercise 40 -->
         <exercise label="ex-substitution-rational-4">
-          <webwork xml:id="ex-substitution-rational-4">
+          <webwork xml:id="webwork-ex-substitution-rational-4">
             <pg-code>
               do {($a,$b,$c) = (-9..-1,1..9)[NchooseK(18,3)];} until ((-$c)^2 + $a*(-$c) + $b != 0);
               if($envir{problemSeed}==1){$a=2;$b=-5;$c=-3;};
@@ -2222,7 +2222,7 @@
         </exercise>
         <!-- Exercise 41 -->
         <exercise label="ex-substitution-rational-5">
-          <webwork xml:id="ex-substitution-rational-5">
+          <webwork xml:id="webwork-ex-substitution-rational-5">
             <pg-code>
               do {($a,$b,$c,$d) = (-9..-1,1..9)[NchooseK(18,4)];} until ($a*(-$d)^2 + $b*(-$d) + $c != 0);
               if($envir{problemSeed}==1){$a=3;$b=-5;$c=7;$d=1;};
@@ -2245,7 +2245,7 @@
         </exercise>
         <!-- Exercise 42 -->
         <exercise label="ex-substitution-rational-6">
-          <webwork xml:id="ex-substitution-rational-6">
+          <webwork xml:id="webwork-ex-substitution-rational-6">
             <pg-code>
               ($a,$b,$c) = (-9,-6,-3,0,3,6,9)[NchooseK(7,3)];
               if($envir{problemSeed}==1){$a=3;$b=3;$c=0;};
@@ -2279,7 +2279,7 @@
         </introduction>
         <!-- Exercise 43 -->
         <exercise label="ex-substitution-invserse-trig-1">
-          <webwork xml:id="ex-substitution-invserse-trig-1">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-1">
             <pg-code>
               $a = list_random(2,3,5,6,7,11,13,14,15,17);
               if($envir{problemSeed}==1){$a=7;};
@@ -2300,7 +2300,7 @@
         </exercise>
         <!-- Exercise 44 -->
         <exercise label="ex-substitution-invserse-trig-2">
-          <webwork xml:id="ex-substitution-invserse-trig-2">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-2">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=3;};
@@ -2322,7 +2322,7 @@
         </exercise>
         <!-- Exercise 45 -->
         <exercise label="ex-substitution-invserse-trig-3">
-          <webwork xml:id="ex-substitution-invserse-trig-3">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-3">
             <pg-code>
               $a = list_random(2,3,5,6,7,10,11,13,14,15);
               $b = random(2,20,1);
@@ -2345,7 +2345,7 @@
         </exercise>
         <!-- Exercise 46 -->
         <exercise label="ex-substitution-invserse-trig-4">
-          <webwork xml:id="ex-substitution-invserse-trig-4">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-4">
             <pg-code>
               ($a,$b) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$a=3;$b=2;};
@@ -2369,7 +2369,7 @@
         </exercise>
         <!-- Exercise 47 -->
         <exercise label="ex-substitution-invserse-trig-5">
-          <webwork xml:id="ex-substitution-invserse-trig-5">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-5">
             <pg-code>
               ($a,$b) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$a=4;$b=5;};
@@ -2393,7 +2393,7 @@
         </exercise>
         <!-- Exercise 48 -->
         <exercise label="ex-substitution-invserse-trig-6">
-          <webwork xml:id="ex-substitution-invserse-trig-6">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-6">
             <pg-code>
               Context()->variables->set(x => {limits => [-1,1]});
               $F = FormulaUpToConstant("1/2*asin(x^2)");
@@ -2410,7 +2410,7 @@
         </exercise>
         <!-- Exercise 49 -->
         <exercise label="ex-substitution-invserse-trig-7">
-          <webwork xml:id="ex-substitution-invserse-trig-7">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-7">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -2432,7 +2432,7 @@
         </exercise>
         <!-- Exercise 50 -->
         <exercise label="ex-substitution-invserse-trig-8">
-          <webwork xml:id="ex-substitution-invserse-trig-8">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-8">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               ($b,$c) = (2..9)[NchooseK(8,2)];
@@ -2457,7 +2457,7 @@
         </exercise>
         <!-- Exercise 51 -->
         <exercise label="ex-substitution-invserse-trig-9">
-          <webwork xml:id="ex-substitution-invserse-trig-9">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-9">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               ($b,$c) = (2..9)[NchooseK(8,2)];
@@ -2482,7 +2482,7 @@
         </exercise>
         <!-- Exercise 52 -->
         <exercise label="ex-substitution-invserse-trig-10">
-          <webwork xml:id="ex-substitution-invserse-trig-10">
+          <webwork xml:id="webwork-ex-substitution-invserse-trig-10">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = random(2,9,1);
@@ -2512,7 +2512,7 @@
         </introduction>
         <!-- Exercise 53 -->
         <exercise label="ex-substitution-evaluate-general-1">
-          <webwork xml:id="ex-substitution-evaluate-general-1">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-1">
             <pg-code>
               $m = random(3,9,1);
               $b = non_zero_random(-9,9,1);
@@ -2534,7 +2534,7 @@
         </exercise>
         <!-- Exercise 54 -->
         <exercise label="ex-substitution-evaluate-general-2">
-          <webwork xml:id="ex-substitution-evaluate-general-2">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-2">
             <pg-code>
               $a = random(1,9,1);
               ($b,$c) = (-9..-1,1..9)[NchooseK(18,2)];
@@ -2562,7 +2562,7 @@
         </exercise>
         <!-- Exercise 55 -->
         <exercise label="ex-substitution-evaluate-general-3">
-          <webwork xml:id="ex-substitution-evaluate-general-3">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-3">
             <pg-code>
               $a = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -2588,7 +2588,7 @@
         </exercise>
         <!-- Exercise 56 -->
         <exercise label="ex-substitution-evaluate-general-4">
-          <webwork xml:id="ex-substitution-evaluate-general-4">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-4">
             <pg-code>
               $m = random(3,9,1);
               $c = non_zero_random(-9,9,1);
@@ -2614,7 +2614,7 @@
         </exercise>
         <!-- Exercise 57 -->
         <exercise label="ex-substitution-evaluate-general-5">
-          <webwork xml:id="ex-substitution-evaluate-general-5">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-5">
             <pg-code>
               $trig = list_random('sin','-cos');
               if($envir{problemSeed}==1){$trig='-cos'};
@@ -2637,7 +2637,7 @@
         </exercise>
 
         <exercise label="ex-substitution-evaluate-general-6">
-          <webwork xml:id="ex-substitution-evaluate-general-6">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-6">
             <pg-code>
               $m = random(2,9,1);
               $b = non_zero_random(-9,9,1);
@@ -2661,7 +2661,7 @@
         </exercise>
         <!-- Exercise 59 -->
         <exercise label="ex-substitution-evaluate-general-7">
-          <webwork xml:id="ex-substitution-evaluate-general-7">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-7">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b=-5};
@@ -2684,7 +2684,7 @@
         </exercise>
         <!-- Exercise 60 -->
         <exercise label="ex-substitution-evaluate-general-8">
-          <webwork xml:id="ex-substitution-evaluate-general-8">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-8">
             <pg-code>
               ($a,$b,$c) = (1..9)[NchooseK(9,3)];
               if($envir{problemSeed}==1){$a=7;$b=3;$c=2;};
@@ -2708,7 +2708,7 @@
         </exercise>
         <!-- Exercise 61 -->
         <exercise label="ex-substitution-evaluate-general-9">
-          <webwork xml:id="ex-substitution-evaluate-general-9">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-9">
             <pg-code>
               do {($b,$c) = (-9..-1,1..9)[NchooseK(18,2)]} until (($b)**2 != 4*$c);
               $m = random(2,4,1);
@@ -2742,7 +2742,7 @@
         </exercise>
         <!-- Exercise 62 -->
         <exercise label="ex-substitution-evaluate-general-10">
-          <webwork xml:id="ex-substitution-evaluate-general-10">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-10">
             <pg-code>
               do {($b,$c) = (-9..-1,1..9)[NchooseK(18,2)]} until (($b)**2 != 4*$c);
               if($envir{problemSeed}==1){$b=7;$c=3;};
@@ -2773,7 +2773,7 @@
         </exercise>
         <!-- Exercise 63 -->
         <exercise label="ex-substitution-evaluate-general-11">
-          <webwork xml:id="ex-substitution-evaluate-general-11">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-11">
             <pg-code>
               do {($a,$b,$c) = (-9..-1,1..9)[NchooseK(18,3)]} until (($b)**2 != 4*$a*$c);
               $k = random(2,5,1);
@@ -2808,7 +2808,7 @@
         </exercise>
         <!-- Exercise 64 -->
         <exercise label="ex-substitution-evaluate-general-12">
-          <webwork xml:id="ex-substitution-evaluate-general-12">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-12">
             <pg-code>
               do {($b,$c) = (-9..-1,1..9)[NchooseK(18,2)]} until (($b)**2 != 4*$c);
               $k = non_zero_random(-9,9,1);
@@ -2843,7 +2843,7 @@
         </exercise>
         <!-- Exercise 65 -->
         <exercise label="ex-substitution-evaluate-general-13">
-          <webwork xml:id="ex-substitution-evaluate-general-13">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-13">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=9;};
@@ -2864,7 +2864,7 @@
         </exercise>
         <!-- Exercise 66 -->
         <exercise label="ex-substitution-evaluate-general-14">
-          <webwork xml:id="ex-substitution-evaluate-general-14">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-14">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=2;};
@@ -2885,7 +2885,7 @@
         </exercise>
         <!-- Exercise 67 -->
         <exercise label="ex-substitution-evaluate-general-15">
-          <webwork xml:id="ex-substitution-evaluate-general-15">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-15">
             <pg-code>
               $a = random(2,9,1);
               if($envir{problemSeed}==1){$a=2;};
@@ -2908,7 +2908,7 @@
         </exercise>
         <!-- Exercise 68 -->
         <exercise label="ex-substitution-evaluate-general-16">
-          <webwork xml:id="ex-substitution-evaluate-general-16">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-16">
             <pg-code>
               ($a,$b) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$a=4;$b=3;};
@@ -2930,7 +2930,7 @@
         </exercise>
         <!-- Exercise 69 -->
         <exercise label="ex-substitution-evaluate-general-17">
-          <webwork xml:id="ex-substitution-evaluate-general-17">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-17">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = random(2,9,1);
@@ -2958,7 +2958,7 @@
         </exercise>
         <!-- Exercise 70 -->
         <exercise label="ex-substitution-evaluate-general-18">
-          <webwork xml:id="ex-substitution-evaluate-general-18">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-18">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = random(2,9,1);
@@ -2986,7 +2986,7 @@
         </exercise>
         <!-- Exercise 71 -->
         <exercise label="ex-substitution-evaluate-general-19">
-          <webwork xml:id="ex-substitution-evaluate-general-19">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-19">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -3013,7 +3013,7 @@
         </exercise>
         <!-- Exercise 72 -->
         <exercise label="ex-substitution-evaluate-general-20">
-          <webwork xml:id="ex-substitution-evaluate-general-20">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-20">
             <pg-code>
               $b = random(2,9,1);
               if($envir{problemSeed}==1){$b=3;};
@@ -3035,7 +3035,7 @@
         </exercise>
         <!-- Exercise 73 -->
         <exercise label="ex-substitution-evaluate-general-21">
-          <webwork xml:id="ex-substitution-evaluate-general-21">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-21">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -3062,7 +3062,7 @@
         </exercise>
         <!-- Exercise 74 -->
         <exercise label="ex-substitution-evaluate-general-22">
-          <webwork xml:id="ex-substitution-evaluate-general-22">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-22">
             <pg-code>
               $F = FormulaUpToConstant("-atan(cos(x))");
             </pg-code>
@@ -3078,7 +3078,7 @@
         </exercise>
         <!-- Exercise 75 -->
         <exercise label="ex-substitution-evaluate-general-23">
-          <webwork xml:id="ex-substitution-evaluate-general-23">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-23">
             <pg-code>
               $F = FormulaUpToConstant("atan(sin(x))");
             </pg-code>
@@ -3094,7 +3094,7 @@
         </exercise>
         <!-- Exercise 76 -->
         <exercise label="ex-substitution-evaluate-general-24">
-          <webwork xml:id="ex-substitution-evaluate-general-24">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-24">
             <pg-code>
               $trig = list_random('sin','cos');
               if($envir{problemSeed}==1){$trig='sin'};
@@ -3122,7 +3122,7 @@
         </exercise>
         <!-- Exercise 77 -->
         <exercise label="ex-substitution-evaluate-general-25">
-          <webwork xml:id="ex-substitution-evaluate-general-25">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-25">
             <pg-code>
               $h = non_zero_random(-9,9,1);
               $k = random(-9,-1,1);
@@ -3148,7 +3148,7 @@
         </exercise>
         <!-- Exercise 78 -->
         <exercise label="ex-substitution-evaluate-general-26">
-          <webwork xml:id="ex-substitution-evaluate-general-26">
+          <webwork xml:id="webwork-ex-substitution-evaluate-general-26">
             <pg-code>
               $h = non_zero_random(-9,9,1);
               $k = random(-9,-1,1);
@@ -3182,7 +3182,7 @@
         </introduction>
         <!-- Exercise 79 -->
         <exercise label="ex-substitution-defint-1">
-          <webwork xml:id="ex-substitution-defint-1">
+          <webwork xml:id="webwork-ex-substitution-defint-1">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               ($lb,$ub) = num_sort((-$b-9..-$b-1)[NchooseK(9,2)]);
@@ -3205,7 +3205,7 @@
         </exercise>
         <!-- Exercise 80 -->
         <exercise label="ex-substitution-defint-2">
-          <webwork xml:id="ex-substitution-defint-2">
+          <webwork xml:id="webwork-ex-substitution-defint-2">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               ($lb,$ub) = num_sort((0,1,4,9,16,25,36,49,64,81)[NchooseK(10,2)]);
@@ -3231,7 +3231,7 @@
         </exercise>
         <!-- Exercise 81 -->
         <exercise label="ex-substitution-defint-3">
-          <webwork xml:id="ex-substitution-defint-3">
+          <webwork xml:id="webwork-ex-substitution-defint-3">
             <pg-code>
               $trig = list_random('sin','cos');
               $lb = list_random('-pi','-pi/2');
@@ -3263,7 +3263,7 @@
         </exercise>
         <!-- Exercise 82 -->
         <exercise label="ex-substitution-defint-4">
-          <webwork xml:id="ex-substitution-defint-4">
+          <webwork xml:id="webwork-ex-substitution-defint-4">
             <pg-code>
               $n = random(3,9,1);
               if($envir{problemSeed}==1){$n=4;};
@@ -3286,7 +3286,7 @@
         </exercise>
         <!-- Exercise 83 -->
         <exercise label="ex-substitution-defint-5">
-          <webwork xml:id="ex-substitution-defint-5">
+          <webwork xml:id="webwork-ex-substitution-defint-5">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               ($lb,$ub) = num_sort((-$b-2..-$b+2)[NchooseK(5,2)]);
@@ -3308,7 +3308,7 @@
         </exercise>
         <!-- Exercise 84 -->
         <exercise label="ex-substitution-defint-6">
-          <webwork xml:id="ex-substitution-defint-6">
+          <webwork xml:id="webwork-ex-substitution-defint-6">
             <pg-code>
               $A = Formula("pi/2")->reduce;
             </pg-code>
@@ -3324,7 +3324,7 @@
         </exercise>
         <!-- Exercise 85 -->
         <exercise label="ex-substitution-defint-7">
-          <webwork xml:id="ex-substitution-defint-7">
+          <webwork xml:id="webwork-ex-substitution-defint-7">
             <pg-code>
               $b = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$b=-3;};
@@ -3347,7 +3347,7 @@
         </exercise>
         <!-- Exercise 86 -->
         <exercise label="ex-substitution-defint-8">
-          <webwork xml:id="ex-substitution-defint-8">
+          <webwork xml:id="webwork-ex-substitution-defint-8">
             <pg-code>
               ($lbindex,$ubindex) = num_sort((0..8)[NchooseK(9,2)]);
               if($envir{problemSeed}==1){$lbindex=5;$ubindex=7;};

--- a/ptx/sec_surface_area.ptx
+++ b/ptx/sec_surface_area.ptx
@@ -716,7 +716,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-surface-area-1">
-        <!--<webwork xml:id="TaC-surface-area-1">
+        <!--<webwork xml:id="webwork-TaC-surface-area-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -733,7 +733,7 @@
       </exercise>
 
       <exercise label="TaC-surface-area-2">
-        <!--<webwork xml:id="TaC-surface-area-2">
+        <!--<webwork xml:id="webwork-TaC-surface-area-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -751,7 +751,7 @@
       </exercise>
 
       <exercise label="TaC-surface-area-3">
-        <!--<webwork xml:id="TaC-surface-area-3">
+        <!--<webwork xml:id="webwork-TaC-surface-area-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -769,7 +769,7 @@
       </exercise>
 
       <exercise label="TaC-surface-area-4">
-        <!--<webwork xml:id="TaC-surface-area-4">
+        <!--<webwork xml:id="webwork-TaC-surface-area-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -787,7 +787,7 @@
       </exercise>
 
       <exercise label="TaC-surface-area-5">
-        <!--<webwork xml:id="TaC-surface-area-5">
+        <!--<webwork xml:id="webwork-TaC-surface-area-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -813,7 +813,7 @@
       </exercise>
 
       <exercise label="TaC-surface-area-6">
-        <!--<webwork xml:id="TaC-surface-area-6">
+        <!--<webwork xml:id="webwork-TaC-surface-area-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -845,7 +845,7 @@
         </introduction>
 
         <exercise label="ex-surface-integral-setup-1">
-          <!-- <webwork xml:id="ex-surface-integral-setup-1">
+          <!-- <webwork xml:id="webwork-ex-surface-integral-setup-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -918,7 +918,7 @@
         </exercise>
 
         <exercise label="ex-surface-integral-setup-2">
-          <!--<webwork xml:id="ex-surface-integral-setup-2">
+          <!--<webwork xml:id="webwork-ex-surface-integral-setup-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -993,7 +993,7 @@
         </exercise>
 
         <exercise label="ex-surface-integral-setup-3">
-          <!--<webwork xml:id="ex-surface-integral-setup-3">
+          <!--<webwork xml:id="webwork-ex-surface-integral-setup-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1065,7 +1065,7 @@
         </exercise>
 
         <exercise label="ex-surface-integral-setup-4">
-          <!--<webwork xml:id="ex-surface-integral-setup-4">
+          <!--<webwork xml:id="webwork-ex-surface-integral-setup-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1149,7 +1149,7 @@
         </introduction>
 
         <exercise label="ex-surface-area-compute-1">
-          <!--<webwork xml:id="ex-surface-area-compute-1">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1167,7 +1167,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-2">
-          <!--<webwork xml:id="ex-surface-area-compute-2">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1186,7 +1186,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-3">
-          <!--<webwork xml:id="ex-surface-area-compute-3">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1208,7 +1208,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-4">
-          <!--<webwork xml:id="ex-surface-area-compute-4">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1231,7 +1231,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-5">
-          <!--<webwork xml:id="ex-surface-area-compute-5">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1254,7 +1254,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-6">
-          <!--<webwork xml:id="ex-surface-area-compute-6">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1276,7 +1276,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-7">
-          <!--<webwork xml:id="ex-surface-area-compute-7">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1301,7 +1301,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-8">
-          <!--<webwork xml:id="ex-surface-area-compute-8">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1325,7 +1325,7 @@
         </exercise>
 
         <exercise label="ex-surface-area-compute-9">
-          <!--<webwork xml:id="ex-surface-area-compute-9">
+          <!--<webwork xml:id="webwork-ex-surface-area-compute-9">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -973,7 +973,7 @@
     <subexercises xml:id="TaC-tangent-normal">
       <title>Terms and Concepts</title>
       <exercise label="TaC-tangent-normal-1">
-        <webwork xml:id="TaC-tangent-normal-1">
+        <webwork xml:id="webwork-TaC-tangent-normal-1">
             <statement>
               <p>
                 If <m>\unittangent(t)</m> is a unit tangent vector,
@@ -988,7 +988,7 @@
       </exercise>
 
       <exercise label="TaC-tangent-normal-2">
-        <webwork xml:id="TaC-tangent-normal-2">
+        <webwork xml:id="webwork-TaC-tangent-normal-2">
             <statement>
               <p>
                 If <m>\unitnormal(t)</m> is a unit normal vector,
@@ -1003,7 +1003,7 @@
       </exercise>
 
       <exercise label="TaC-tangent-normal-3">
-        <!-- <webwork xml:id="TaC-tangent-normal-3">
+        <!-- <webwork xml:id="webwork-TaC-tangent-normal-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1020,7 +1020,7 @@
       </exercise>
 
       <exercise label="TaC-tangent-normal-4">
-        <!-- <webwork xml:id="TaC-tangent-normal-4">
+        <!-- <webwork xml:id="webwork-TaC-tangent-normal-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1048,7 +1048,7 @@
         </introduction>
 
         <exercise xml:id="x11_04_ex_05" label="ex-unit-tangent-compute-1">
-          <!-- <webwork xml:id="ex-unit-tangent-compute-1">
+          <!-- <webwork xml:id="webwork-ex-unit-tangent-compute-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1066,7 +1066,7 @@
         </exercise>
 
         <exercise label="ex-unit-tangent-compute-2">
-          <webwork xml:id="ex-unit-tangent-compute-2">
+          <webwork xml:id="webwork-ex-unit-tangent-compute-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1096,7 +1096,7 @@
         </exercise>
 
         <exercise label="ex-unit-tangent-compute-3">
-          <!-- <webwork xml:id="ex-unit-tangent-compute-3">
+          <!-- <webwork xml:id="webwork-ex-unit-tangent-compute-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1117,7 +1117,7 @@
         </exercise>
 
         <exercise xml:id="x11_04_ex_08" label="ex-unit-tangent-compute-4">
-          <webwork xml:id="ex-unit-tangent-compute-4">
+          <webwork xml:id="webwork-ex-unit-tangent-compute-4">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1158,7 +1158,7 @@
         </introduction>
 
         <exercise label="ex-vector-tangent-line-1">
-          <webwork xml:id="ex-vector-tangent-line-1">
+          <webwork xml:id="webwork-ex-vector-tangent-line-1">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1182,7 +1182,7 @@
         </exercise>
 
         <exercise label="ex-vector-tangent-line-2">
-          <webwork xml:id="ex-vector-tangent-line-2">
+          <webwork xml:id="webwork-ex-vector-tangent-line-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1206,7 +1206,7 @@
         </exercise>
 
         <exercise label="ex-vector-tangent-line-3">
-          <!-- <webwork xml:id="ex-vector-tangent-line-3">
+          <!-- <webwork xml:id="webwork-ex-vector-tangent-line-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1229,7 +1229,7 @@
         </exercise>
 
         <exercise label="ex-vector-tangent-line-4">
-          <webwork xml:id="ex-vector-tangent-line-4">
+          <webwork xml:id="webwork-ex-vector-tangent-line-4">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1264,7 +1264,7 @@
         </introduction>
 
         <exercise label="ex-unit-normal-compute-1">
-          <!-- <webwork xml:id="ex-unit-normal-compute-1">
+          <!-- <webwork xml:id="webwork-ex-unit-normal-compute-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1282,7 +1282,7 @@
         </exercise>
 
         <exercise label="ex-unit-normal-compute-2">
-          <!-- <webwork xml:id="ex-unit-normal-compute-2">
+          <!-- <webwork xml:id="webwork-ex-unit-normal-compute-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1300,7 +1300,7 @@
         </exercise>
 
         <exercise label="ex-unit-normal-compute-3">
-          <!-- <webwork xml:id="ex-unit-normal-compute-3">
+          <!-- <webwork xml:id="webwork-ex-unit-normal-compute-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1318,7 +1318,7 @@
         </exercise>
 
         <exercise label="ex-unit-normal-compute-4">
-          <!-- <webwork xml:id="ex-unit-normal-compute-4">
+          <!-- <webwork xml:id="webwork-ex-unit-normal-compute-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1365,7 +1365,7 @@
         </introduction>
 
         <exercise label="ex-normal-from-tangent-1">
-          <!-- <webwork xml:id="ex-normal-from-tangent-1">
+          <!-- <webwork xml:id="webwork-ex-normal-from-tangent-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1394,7 +1394,7 @@
         </exercise>
 
         <exercise label="ex-normal-from-tangent-2">
-          <!-- <webwork xml:id="ex-normal-from-tangent-2">
+          <!-- <webwork xml:id="webwork-ex-normal-from-tangent-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1423,7 +1423,7 @@
         </exercise>
 
         <exercise label="ex-normal-from-tangent-3">
-          <!-- <webwork xml:id="ex-normal-from-tangent-3">
+          <!-- <webwork xml:id="webwork-ex-normal-from-tangent-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1452,7 +1452,7 @@
         </exercise>
 
         <exercise label="ex-normal-from-tangent-4">
-          <!-- <webwork xml:id="ex-normal-from-tangent-4">
+          <!-- <webwork xml:id="webwork-ex-normal-from-tangent-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1490,7 +1490,7 @@
         </introduction>
 
         <exercise label="ex-unit-normal-compute-5">
-          <!-- <webwork xml:id="ex-unit-normal-compute-5">
+          <!-- <webwork xml:id="webwork-ex-unit-normal-compute-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1508,7 +1508,7 @@
         </exercise>
 
         <exercise label="ex-unit-normal-compute-6">
-          <webwork xml:id="ex-unit-normal-compute-6">
+          <webwork xml:id="webwork-ex-unit-normal-compute-6">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real');
@@ -1530,7 +1530,7 @@
         </exercise>
 
         <exercise label="ex-unit-normal-compute-7">
-          <!-- <webwork xml:id="ex-unit-normal-compute-7">
+          <!-- <webwork xml:id="webwork-ex-unit-normal-compute-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1548,7 +1548,7 @@
         </exercise>
 
         <exercise label="ex-unit-normal-compute-8">
-          <webwork xml:id="ex-unit-normal-compute-8">
+          <webwork xml:id="webwork-ex-unit-normal-compute-8">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real',a=>'Real');
@@ -1582,7 +1582,7 @@
         </introduction>
 
         <exercise label="ex-acceleration-tangent-normal-1">
-          <!-- <webwork xml:id="ex-acceleration-tangent-normal-1">
+          <!-- <webwork xml:id="webwork-ex-acceleration-tangent-normal-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1617,7 +1617,7 @@
         </exercise>
 
         <exercise label="ex-acceleration-tangent-normal-2">
-          <webwork xml:id="ex-acceleration-tangent-normal-2">
+          <webwork xml:id="webwork-ex-acceleration-tangent-normal-2">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1686,7 +1686,7 @@
         </exercise>
 
         <exercise label="ex-acceleration-tangent-normal-3">
-          <!-- <webwork xml:id="ex-acceleration-tangent-normal-3">
+          <!-- <webwork xml:id="webwork-ex-acceleration-tangent-normal-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1722,7 +1722,7 @@
         </exercise>
 
         <exercise label="ex-acceleration-tangent-normal-4">
-          <webwork xml:id="ex-acceleration-tangent-normal-4">
+          <webwork xml:id="webwork-ex-acceleration-tangent-normal-4">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1789,7 +1789,7 @@
         </exercise>
 
         <exercise label="ex-acceleration-tangent-normal-5">
-          <!-- <webwork xml:id="ex-acceleration-tangent-normal-5">
+          <!-- <webwork xml:id="webwork-ex-acceleration-tangent-normal-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1827,7 +1827,7 @@
         </exercise>
 
         <exercise label="ex-acceleration-tangent-normal-6">
-          <webwork xml:id="ex-acceleration-tangent-normal-6">
+          <webwork xml:id="webwork-ex-acceleration-tangent-normal-6">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -1492,7 +1492,7 @@
     <subexercises xml:id="TaC-taylor-poly">
       <title>Terms and Concepts</title>
       <exercise label="TaC-taylor-poly-1">
-        <webwork xml:id="TaC-taylor-poly-1">
+        <webwork xml:id="webwork-TaC-taylor-poly-1">
           <pg-code>
           </pg-code>
           <statement>
@@ -1516,7 +1516,7 @@
       </exercise>
 
       <exercise label="TaC-taylor-poly-2">
-        <webwork xml:id="TaC-taylor-poly-2">
+        <webwork xml:id="webwork-TaC-taylor-poly-2">
           <pg-code>
             $approxtf=PopUp(['?','True','False'],'True');
           </pg-code>
@@ -1538,7 +1538,7 @@
       </exercise>
 
       <exercise label="TaC-taylor-poly-3">
-        <webwork xml:id="TaC-taylor-poly-3">
+        <webwork xml:id="webwork-TaC-taylor-poly-3">
           <pg-code>
             $x = 'x';
             $p = Formula("6+3*$x-4*$x^2");
@@ -1567,7 +1567,7 @@
       </exercise>
 
       <exercise label="TaC-taylor-poly-4">
-        <webwork xml:id="TaC-taylor-poly-4">
+        <webwork xml:id="webwork-TaC-taylor-poly-4">
           <pg-code>
           </pg-code>
           <statement>
@@ -1605,7 +1605,7 @@
         </introduction>
 
         <exercise label="ex-maclaurin-poly-compute-1">
-          <webwork xml:id="ex-maclaurin-poly-compute-1">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-1">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("1-$x+(1/2)*$x^2-(1/6)*$x^3");
@@ -1624,7 +1624,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-2">
-          <webwork xml:id="ex-maclaurin-poly-compute-2">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-2">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("$x-(1/6)*$x^3+(1/120)*$x^5-(1/5040)*$x^7");
@@ -1643,7 +1643,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-3">
-          <webwork xml:id="ex-maclaurin-poly-compute-3">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-3">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("$x+$x^2+(1/2)*$x^3+(1/6)*$x^4+(1/24)*$x^5");
@@ -1662,7 +1662,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-4">
-          <webwork xml:id="ex-maclaurin-poly-compute-4">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-4">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("$x+(1/3)*$x^3+(2/15)*$x^5");
@@ -1681,7 +1681,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-5">
-          <webwork xml:id="ex-maclaurin-poly-compute-5">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-5">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("1+2*$x+2*$x^2+(4/3)*$x^3+(2/3)*$x^4");
@@ -1700,7 +1700,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-6">
-          <webwork xml:id="ex-maclaurin-poly-compute-6">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-6">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("1+$x+$x^2+$x^3+$x^4");
@@ -1719,7 +1719,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-7">
-          <webwork xml:id="ex-maclaurin-poly-compute-7">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-7">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("1-$x+$x^2-$x^3+$x^4");
@@ -1738,7 +1738,7 @@
         </exercise>
 
         <exercise label="ex-maclaurin-poly-compute-8">
-          <webwork xml:id="ex-maclaurin-poly-compute-8">
+          <webwork xml:id="webwork-ex-maclaurin-poly-compute-8">
             <pg-code>
               $x = 'x';
               $macpoly = Formula("1-$x+$x^2-$x^3+$x^4-$x^5+$x^6-$x^7");
@@ -1767,7 +1767,7 @@
        </introduction>
 
         <exercise label="ex-taylor-poly-compute-1">
-          <webwork xml:id="ex-taylor-poly-compute-1">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-1">
             <pg-code>
               $x = 'x';
               $taypoly = Formula("1+(1/2)*($x-1)-(1/8)*($x-1)^2+(1/16)*($x-1)^3-(5/128)*($x-1)^4");
@@ -1786,7 +1786,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-2">
-          <webwork xml:id="ex-taylor-poly-compute-2">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-2">
             <pg-code>
               $x = 'x';
               $taypoly = Formula("ln(2)+(1/2)*($x-1)-(1/8)*($x-1)^2+(1/24)*($x-1)^3-(1/64)*($x-1)^4");
@@ -1805,7 +1805,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-3">
-          <webwork xml:id="ex-taylor-poly-compute-3">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-3">
             <pg-code>
               $x = 'x';
               $taypoly = Formula("(1/sqrt(2))-(1/sqrt(2))*($x-pi/4)-(1/(2*sqrt(2)))*($x-pi/4)^2+(1/(6*sqrt(2)))*($x-pi/4)^3+(1/(24*sqrt(2)))*($x-pi/4)^4-(1/(120*sqrt(2)))*($x-pi/4)^5-(1/(720*sqrt(2)))*($x-pi/4)^6");
@@ -1824,7 +1824,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-4">
-          <webwork xml:id="ex-taylor-poly-compute-4">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-4">
             <pg-code>
               $x = 'x';
               $taypoly = Formula("(1/2)+(sqrt(3)/2)*($x-pi/6)-(1/4)*($x-pi/6)^2-(sqrt(3)/12)*($x-pi/6)^3+(1/48)*($x-pi/6)^4+(sqrt(3)/240)*($x-pi/6)^5");
@@ -1843,7 +1843,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-5">
-          <webwork xml:id="ex-taylor-poly-compute-5">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-5">
             <pg-code>
               $x = 'x';
               $taypoly = Formula("(1/2)-(1/4)*($x-2)+(1/8)*($x-2)^2-(1/16)*($x-2)^3+(1/32)*($x-2)^4+(1/64)*($x-2)^5");
@@ -1862,7 +1862,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-6">
-          <webwork xml:id="ex-taylor-poly-compute-6">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-6">
             <pg-code>
               $x = 'x';
               $taypoly = Formula("1-2*($x-1)+3*($x-1)^2-4*($x-1)^3+5*($x-1)^4-6*($x-1)^5+7*($x-1)^6-8*($x-1)^7+9*($x-1)^8");
@@ -1881,7 +1881,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-7">
-          <webwork xml:id="ex-taylor-poly-compute-7">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-7">
             <pg-code>
               $x='x';
               $taypoly = Formula("1/2+(1/2)*($x+1)+(1/4)*($x+1)^2");
@@ -1900,7 +1900,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-compute-8">
-          <webwork xml:id="ex-taylor-poly-compute-8">
+          <webwork xml:id="webwork-ex-taylor-poly-compute-8">
             <pg-code>
               $x='x';
               $taypoly = Formula("-pi^2-2*pi*($x-pi)+((pi^2-2)/2)*($x-pi)^2");
@@ -1929,7 +1929,7 @@
         </introduction>
 
         <exercise label="ex-taylor-poly-error-bound-1">
-          <!--<webwork xml:id="ex-taylor-poly-error-bound-1">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-error-bound-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1950,7 +1950,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-error-bound-2">
-          <!--<webwork xml:id="ex-taylor-poly-error-bound-2">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-error-bound-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1971,7 +1971,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-error-bound-3">
-          <!--<webwork xml:id="ex-taylor-poly-error-bound-3">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-error-bound-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1993,7 +1993,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-error-bound-4">
-          <!--<webwork xml:id="ex-taylor-poly-error-bound-4">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-error-bound-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2024,7 +2024,7 @@
         </introduction>
 
         <exercise label="ex-taylor-poly-accuracy-1">
-          <!--<webwork xml:id="ex-taylor-poly-accuracy-1">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-accuracy-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2045,7 +2045,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-accuracy-2">
-          <!--<webwork xml:id="ex-taylor-poly-accuracy-2">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-accuracy-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2067,7 +2067,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-accuracy-3">
-          <!--<webwork xml:id="ex-taylor-poly-accuracy-3">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-accuracy-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2092,7 +2092,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-accuracy-4">
-          <!--<webwork xml:id="ex-taylor-poly-accuracy-4">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-accuracy-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2126,7 +2126,7 @@
         </introduction>
 
         <exercise label="ex-taylor-poly-nth-term-1">
-          <!--<webwork xml:id="ex-taylor-poly-nth-term-1">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-nth-term-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2144,7 +2144,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-nth-term-2">
-          <!--<webwork xml:id="ex-taylor-poly-nth-term-2">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-nth-term-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2180,7 +2180,7 @@
       </exercise>
 
         <exercise label="ex-taylor-poly-nth-term-4">
-          <!--<webwork xml:id="ex-taylor-poly-nth-term-4">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-nth-term-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2198,7 +2198,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-nth-term-5">
-          <!--<webwork xml:id="ex-taylor-poly-nth-term-5">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-nth-term-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2216,7 +2216,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-nth-term-6">
-          <!--<webwork xml:id="ex-taylor-poly-nth-term-6">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-nth-term-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2245,7 +2245,7 @@
         </introduction>
 
         <exercise label="ex-taylor-poly-ode-1">
-          <!--<webwork xml:id="ex-taylor-poly-ode-1">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-ode-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2257,7 +2257,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-ode-2">
-          <!--<webwork xml:id="ex-taylor-poly-ode-2">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-ode-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -2269,7 +2269,7 @@
         </exercise>
 
         <exercise label="ex-taylor-poly-ode-3">
-          <!--<webwork xml:id="ex-taylor-poly-ode-3">
+          <!--<webwork xml:id="webwork-ex-taylor-poly-ode-3">
             <pg-code>
             </pg-code> -->
             <statement>

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -1131,7 +1131,7 @@
     <subexercises xml:id="TaC-taylor-series">
       <title>Terms and Concepts</title>
       <exercise label="TaC-taylor-series-1">
-        <!--<webwork xml:id="TaC-taylor-series-1">
+        <!--<webwork xml:id="webwork-TaC-taylor-series-1">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1151,7 +1151,7 @@
       </exercise>
 
       <exercise label="TaC-taylor-series-2">
-        <!--<webwork xml:id="TaC-taylor-series-2">
+        <!--<webwork xml:id="webwork-TaC-taylor-series-2">
             <pg-code>
             </pg-code>-->
             <statement>
@@ -1181,7 +1181,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-identify-pattern-1">
-          <!--<webwork xml:id="ex-taylor-series-identify-pattern-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-identify-pattern-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1206,7 +1206,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-identify-pattern-2">
-          <!--<webwork xml:id="ex-taylor-series-identify-pattern-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-identify-pattern-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1230,7 +1230,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-identify-pattern-3">
-          <!--<webwork xml:id="ex-taylor-series-identify-pattern-3">
+          <!--<webwork xml:id="webwork-ex-taylor-series-identify-pattern-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1256,7 +1256,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-identify-pattern-4">
-          <!--<webwork xml:id="ex-taylor-series-identify-pattern-4">
+          <!--<webwork xml:id="webwork-ex-taylor-series-identify-pattern-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1312,7 +1312,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-find-nth-term-1">
-          <!--<webwork xml:id="ex-taylor-series-find-nth-term-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-find-nth-term-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1333,7 +1333,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-find-nth-term-2">
-          <!--<webwork xml:id="ex-taylor-series-find-nth-term-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-find-nth-term-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1354,7 +1354,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-find-nth-term-3">
-          <!--<webwork xml:id="ex-taylor-series-find-nth-term-3">
+          <!--<webwork xml:id="webwork-ex-taylor-series-find-nth-term-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1381,7 +1381,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-find-nth-term-4">
-          <!--<webwork xml:id="ex-taylor-series-find-nth-term-4">
+          <!--<webwork xml:id="webwork-ex-taylor-series-find-nth-term-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1407,7 +1407,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-find-nth-term-5">
-          <!--<webwork xml:id="ex-taylor-series-find-nth-term-5">
+          <!--<webwork xml:id="webwork-ex-taylor-series-find-nth-term-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1433,7 +1433,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-find-nth-term-6">
-          <!--<webwork xml:id="ex-taylor-series-find-nth-term-6">
+          <!--<webwork xml:id="webwork-ex-taylor-series-find-nth-term-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1481,7 +1481,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-remainder-limit-1">
-          <!--<webwork xml:id="ex-taylor-series-remainder-limit-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-remainder-limit-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1528,7 +1528,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-remainder-limit-2">
-          <!--<webwork xml:id="ex-taylor-series-remainder-limit-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-remainder-limit-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1574,7 +1574,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-remainder-limit-3">
-          <!--<webwork xml:id="ex-taylor-series-remainder-limit-3">
+          <!--<webwork xml:id="webwork-ex-taylor-series-remainder-limit-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1612,7 +1612,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-remainder-limit-4">
-          <!--<webwork xml:id="ex-taylor-series-remainder-limit-4">
+          <!--<webwork xml:id="webwork-ex-taylor-series-remainder-limit-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1668,7 +1668,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-check-identity-1">
-          <!--<webwork xml:id="ex-taylor-series-check-identity-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-check-identity-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1690,7 +1690,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-check-identity-2">
-          <!--<webwork xml:id="ex-taylor-series-check-identity-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-check-identity-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1712,7 +1712,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-check-identity-3">
-          <!--<webwork xml:id="ex-taylor-series-check-identity-3">
+          <!--<webwork xml:id="webwork-ex-taylor-series-check-identity-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1733,7 +1733,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-check-identity-4">
-          <!--<webwork xml:id="ex-taylor-series-check-identity-4">
+          <!--<webwork xml:id="webwork-ex-taylor-series-check-identity-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1773,7 +1773,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-binomial-1">
-          <!--<webwork xml:id="ex-taylor-series-binomial-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-binomial-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1790,7 +1790,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-binomial-2">
-          <!--<webwork xml:id="ex-taylor-series-binomial-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-binomial-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1807,7 +1807,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-binomial-3">
-          <!--<webwork xml:id="ex-taylor-series-binomial-3">
+          <!--<webwork xml:id="webwork-ex-taylor-series-binomial-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1824,7 +1824,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-binomial-4">
-          <!--<webwork xml:id="ex-taylor-series-binomial-4">
+          <!--<webwork xml:id="webwork-ex-taylor-series-binomial-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1853,7 +1853,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-for-function-1">
-          <!--<webwork xml:id="ex-taylor-series-for-function-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-for-function-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1870,7 +1870,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-for-function-2">
-          <!--<webwork xml:id="ex-taylor-series-for-function-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-for-function-2">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1887,7 +1887,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-for-function-3">
-          <!--<webwork xml:id="ex-taylor-series-for-function-3">
+          <!--<webwork xml:id="webwork-ex-taylor-series-for-function-3">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1904,7 +1904,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-for-function-4">
-          <!--<webwork xml:id="ex-taylor-series-for-function-4">
+          <!--<webwork xml:id="webwork-ex-taylor-series-for-function-4">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1921,7 +1921,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-for-function-5">
-          <!--<webwork xml:id="ex-taylor-series-for-function-5">
+          <!--<webwork xml:id="webwork-ex-taylor-series-for-function-5">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1938,7 +1938,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-for-function-6">
-          <!--<webwork xml:id="ex-taylor-series-for-function-6">
+          <!--<webwork xml:id="webwork-ex-taylor-series-for-function-6">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1965,7 +1965,7 @@
         </introduction>
 
         <exercise label="ex-taylor-series-approxiamte-integral-1">
-          <!--<webwork xml:id="ex-taylor-series-approxiamte-integral-1">
+          <!--<webwork xml:id="webwork-ex-taylor-series-approxiamte-integral-1">
               <pg-code>
               </pg-code>-->
               <statement>
@@ -1982,7 +1982,7 @@
         </exercise>
 
         <exercise label="ex-taylor-series-approxiamte-integral-2">
-          <!--<webwork xml:id="ex-taylor-series-approxiamte-integral-2">
+          <!--<webwork xml:id="webwork-ex-taylor-series-approxiamte-integral-2">
               <pg-code>
               </pg-code>-->
               <statement>

--- a/ptx/sec_total_differential.ptx
+++ b/ptx/sec_total_differential.ptx
@@ -703,7 +703,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-total-differential-1">
-        <!--<webwork xml:id="TaC-total-differential-1">
+        <!--<webwork xml:id="webwork-TaC-total-differential-1">
             <pg-code>
             </pg-code>
             -->
@@ -722,7 +722,7 @@
       </exercise>
 
       <exercise label="TaC-total-differential-2">
-        <!--<webwork xml:id="TaC-total-differential-2">
+        <!--<webwork xml:id="webwork-TaC-total-differential-2">
             <pg-code>
             </pg-code>
             -->
@@ -741,7 +741,7 @@
       </exercise>
 
       <exercise label="TaC-total-differential-3">
-        <!--<webwork xml:id="TaC-total-differential-3">
+        <!--<webwork xml:id="webwork-TaC-total-differential-3">
             <pg-code>
             </pg-code>
             -->
@@ -760,7 +760,7 @@
       </exercise>
 
       <exercise label="TaC-total-differential-4">
-        <!--<webwork xml:id="TaC-total-differential-4">
+        <!--<webwork xml:id="webwork-TaC-total-differential-4">
             <pg-code>
             </pg-code>
             -->
@@ -789,7 +789,7 @@
         </introduction>
 
         <exercise label="ex-total-differential-compute-1">
-          <!--<webwork xml:id="ex-total-differential-compute-1">
+          <!--<webwork xml:id="webwork-ex-total-differential-compute-1">
               <pg-code>
               </pg-code>
               -->
@@ -807,7 +807,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-compute-2">
-          <!--<webwork xml:id="ex-total-differential-compute-2">
+          <!--<webwork xml:id="webwork-ex-total-differential-compute-2">
               <pg-code>
               </pg-code>
               -->
@@ -825,7 +825,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-compute-3">
-          <!--<webwork xml:id="ex-total-differential-compute-3">
+          <!--<webwork xml:id="webwork-ex-total-differential-compute-3">
               <pg-code>
               </pg-code>
               -->
@@ -843,7 +843,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-compute-4">
-          <!--<webwork xml:id="ex-total-differential-compute-4">
+          <!--<webwork xml:id="webwork-ex-total-differential-compute-4">
               <pg-code>
               </pg-code>
               -->
@@ -871,7 +871,7 @@
         </introduction>
 
         <exercise label="ex-total-differential-approximate-1">
-          <!--<webwork xml:id="ex-total-differential-approximate-1">
+          <!--<webwork xml:id="webwork-ex-total-differential-approximate-1">
               <pg-code>
               </pg-code>
               -->
@@ -893,7 +893,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-approximate-2">
-          <!--<webwork xml:id="ex-total-differential-approximate-2">
+          <!--<webwork xml:id="webwork-ex-total-differential-approximate-2">
               <pg-code>
               </pg-code>
               -->
@@ -915,7 +915,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-approximate-3">
-          <!--<webwork xml:id="ex-total-differential-approximate-3">
+          <!--<webwork xml:id="webwork-ex-total-differential-approximate-3">
               <pg-code>
               </pg-code>
               -->
@@ -937,7 +937,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-approximate-4">
-          <!--<webwork xml:id="ex-total-differential-approximate-4">
+          <!--<webwork xml:id="webwork-ex-total-differential-approximate-4">
               <pg-code>
               </pg-code>
               -->
@@ -968,7 +968,7 @@
         </introduction>
 
         <exercise label="ex-total-differential-error-analysis-1">
-          <!--<webwork xml:id="ex-total-differential-error-analysis-1">
+          <!--<webwork xml:id="webwork-ex-total-differential-error-analysis-1">
               <pg-code>
               </pg-code>
               -->
@@ -989,7 +989,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-error-analysis-2">
-          <!--<webwork xml:id="ex-total-differential-error-analysis-2">
+          <!--<webwork xml:id="webwork-ex-total-differential-error-analysis-2">
               <pg-code>
               </pg-code>
               -->
@@ -1017,7 +1017,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-error-analysis-3">
-          <!--<webwork xml:id="ex-total-differential-error-analysis-3">
+          <!--<webwork xml:id="webwork-ex-total-differential-error-analysis-3">
               <pg-code>
               </pg-code>
               -->
@@ -1065,7 +1065,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-error-analysis-4">
-          <!--<webwork xml:id="ex-total-differential-error-analysis-4">
+          <!--<webwork xml:id="webwork-ex-total-differential-error-analysis-4">
               <pg-code>
               </pg-code>
               -->
@@ -1109,7 +1109,7 @@
         </introduction>
 
         <exercise label="ex-total-differential-r3-1">
-          <!--<webwork xml:id="ex-total-differential-r3-1">
+          <!--<webwork xml:id="webwork-ex-total-differential-r3-1">
               <pg-code>
               </pg-code>
               -->
@@ -1127,7 +1127,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-r3-2">
-          <!--<webwork xml:id="ex-total-differential-r3-2">
+          <!--<webwork xml:id="webwork-ex-total-differential-r3-2">
               <pg-code>
               </pg-code>
               -->
@@ -1155,7 +1155,7 @@
         </introduction>
 
         <exercise label="ex-total-differential-approx-from-data-1">
-          <!--<webwork xml:id="ex-total-differential-approx-from-data-1">
+          <!--<webwork xml:id="webwork-ex-total-differential-approx-from-data-1">
               <pg-code>
               </pg-code>
               -->
@@ -1177,7 +1177,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-approx-from-data-2">
-          <!--<webwork xml:id="ex-total-differential-approx-from-data-2">
+          <!--<webwork xml:id="webwork-ex-total-differential-approx-from-data-2">
               <pg-code>
               </pg-code>
               -->
@@ -1199,7 +1199,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-approx-from-data-3">
-          <!-- <webwork xml:id="ex-total-differential-approx-from-data-3">
+          <!-- <webwork xml:id="webwork-ex-total-differential-approx-from-data-3">
               <pg-code>
               </pg-code>
                -->
@@ -1224,7 +1224,7 @@
         </exercise>
 
         <exercise label="ex-total-differential-approx-from-data-4">
-          <!--<webwork xml:id="ex-total-differential-approx-from-data-4">
+          <!--<webwork xml:id="webwork-ex-total-differential-approx-from-data-4">
               <pg-code>
               </pg-code>
               -->

--- a/ptx/sec_trig_sub.ptx
+++ b/ptx/sec_trig_sub.ptx
@@ -653,7 +653,7 @@
       <title>Terms and Concepts</title>
       <!-- Exercise 1 -->
       <exercise label="TaC-trig-substitution-1">
-        <webwork xml:id="TaC-trig-substitution-1">
+        <webwork xml:id="webwork-TaC-trig-substitution-1">
           <pg-code>
             Context()->strings->add('backward'=>{});
             Context()->strings->add('backwards'=>{alias=>'backward'});
@@ -668,7 +668,7 @@
       </exercise>
       <!-- Exercise 2 -->
       <exercise label="TaC-trig-substitution-2">
-        <webwork xml:id="TaC-trig-substitution-2">
+        <webwork xml:id="webwork-TaC-trig-substitution-2">
           <pg-code>
             $m = random(2,9,1);
             if($envir{problemSeed}==1){$m=5;};
@@ -686,7 +686,7 @@
       </exercise>
       <!-- Exercise 3 -->
       <exercise label="TaC-trig-substitution-3">
-        <webwork xml:id="TaC-trig-substitution-3">
+        <webwork xml:id="webwork-TaC-trig-substitution-3">
           <pg-code>
             $m = random(2,9,1);
             if($envir{problemSeed}==1){$m=9;};
@@ -732,7 +732,7 @@
       </exercise>
       <!-- Exercise 4 -->
       <exercise label="TaC-trig-substitution-4">
-        <webwork xml:id="TaC-trig-substitution-4">
+        <webwork xml:id="webwork-TaC-trig-substitution-4">
           <statement>
             <p>
               Why does <xref ref="idea_trigsub">Key Idea</xref>(a) state that <m>\sqrt{a^2-x^2} = a\cos(\theta)</m>,
@@ -766,7 +766,7 @@
         </introduction>
         <!-- Exercise 5 -->
         <exercise label="ex-trig-sub-indefinite-1">
-          <webwork xml:id="ex-trig-sub-indefinite-1">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-1">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("1/2 (x sqrt(x^2 + 1) + ln(sqrt(x^2 + 1) + x))");
@@ -783,7 +783,7 @@
         </exercise>
         <!-- Exercise 6 -->
         <exercise label="ex-trig-sub-indefinite-2">
-          <webwork xml:id="ex-trig-sub-indefinite-2">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-2">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("x/2 sqrt(x^2 + 4) + 2 ln(sqrt(x^2 + 4)/2 + x/2)");
@@ -800,7 +800,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-trig-sub-indefinite-3">
-          <webwork xml:id="ex-trig-sub-indefinite-3">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-3">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-1,1]});
@@ -818,7 +818,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-trig-sub-indefinite-4">
-          <webwork xml:id="ex-trig-sub-indefinite-4">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-4">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-3,3]});
@@ -836,7 +836,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-trig-sub-indefinite-5">
-          <webwork xml:id="ex-trig-sub-indefinite-5">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-5">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[1,5]});
@@ -855,7 +855,7 @@
         </exercise>
         <!-- Exercise 10 -->
         <exercise label="ex-trig-sub-indefinite-6">
-          <webwork xml:id="ex-trig-sub-indefinite-6">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-6">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[4,9]});
@@ -874,7 +874,7 @@
         </exercise>
         <!-- Exercise 11 -->
         <exercise label="ex-trig-sub-indefinite-7">
-          <webwork xml:id="ex-trig-sub-indefinite-7">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-7">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=2;};
@@ -894,7 +894,7 @@
         </exercise>
         <!-- Exercise 12 -->
         <exercise label="ex-trig-sub-indefinite-8">
-          <webwork xml:id="ex-trig-sub-indefinite-8">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-8">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=3;};
@@ -915,7 +915,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise label="ex-trig-sub-indefinite-9">
-          <webwork xml:id="ex-trig-sub-indefinite-9">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-9">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=4;};
@@ -937,7 +937,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-trig-sub-indefinite-10">
-          <webwork xml:id="ex-trig-sub-indefinite-10">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-10">
             <pg-code>
               $a = random(2,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -959,7 +959,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-trig-sub-indefinite-11">
-          <webwork xml:id="ex-trig-sub-indefinite-11">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-11">
             <pg-code>
               $a = random(2,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -982,7 +982,7 @@
         </exercise>
         <!-- Exercise 16 -->
         <exercise label="ex-trig-sub-indefinite-12">
-          <webwork xml:id="ex-trig-sub-indefinite-12">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-12">
             <pg-code>
               $a = random(2,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -1015,7 +1015,7 @@
         </introduction>
         <!-- Exercise 17 -->
         <exercise label="ex-trig-sub-indefinite-13">
-          <webwork xml:id="ex-trig-sub-indefinite-13">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-13">
             <pg-code>
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
               if($envir{problemSeed}==1){$b=11};
@@ -1038,7 +1038,7 @@
         </exercise>
         <!-- Exercise 18 -->
         <exercise label="ex-trig-sub-indefinite-14">
-          <webwork xml:id="ex-trig-sub-indefinite-14">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-14">
             <pg-code>
               Context("Fraction");
               $F = FormulaUpToConstant("1/2 atan(x) + x/[2(x^2+1)]");
@@ -1055,7 +1055,7 @@
         </exercise>
         <!-- Exercise 19 -->
         <exercise label="ex-trig-sub-indefinite-15">
-          <webwork xml:id="ex-trig-sub-indefinite-15">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-15">
             <pg-code>
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
               if($envir{problemSeed}==1){$b=3};
@@ -1078,7 +1078,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-trig-sub-indefinite-16">
-          <webwork xml:id="ex-trig-sub-indefinite-16">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-16">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-1,1]});
@@ -1096,7 +1096,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-trig-sub-indefinite-17">
-          <webwork xml:id="ex-trig-sub-indefinite-17">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-17">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=3};
@@ -1117,7 +1117,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-trig-sub-indefinite-18">
-          <webwork xml:id="ex-trig-sub-indefinite-18">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-18">
             <pg-code>
               $a = random(2,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -1144,7 +1144,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-trig-sub-indefinite-19">
-          <webwork xml:id="ex-trig-sub-indefinite-19">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-19">
             <pg-code>
               $h = non_zero_random(-9,9,1);
               $m = random(1,9,1);
@@ -1168,7 +1168,7 @@
         </exercise>
         <!-- Exercise 24 -->
         <exercise label="ex-trig-sub-indefinite-20">
-          <webwork xml:id="ex-trig-sub-indefinite-20">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-20">
             <pg-code>
               Context("Fraction");
               Context()->variables->set(x=>{limits=>[-1,1]});
@@ -1186,7 +1186,7 @@
         </exercise>
         <!-- Exercise 25 -->
         <exercise label="ex-trig-sub-indefinite-21">
-          <webwork xml:id="ex-trig-sub-indefinite-21">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-21">
             <pg-code>
               $a = random(2,9,1);
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
@@ -1209,7 +1209,7 @@
         </exercise>
         <!-- Exercise 26 -->
         <exercise label="ex-trig-sub-indefinite-22">
-          <webwork xml:id="ex-trig-sub-indefinite-22">
+          <webwork xml:id="webwork-ex-trig-sub-indefinite-22">
             <pg-code>
               $b = list_random(2,3,5,6,7,10,11,13,14,15);
               if($envir{problemSeed}==1){$b=3;};
@@ -1241,7 +1241,7 @@
         </introduction>
         <!-- Exercise 27 -->
         <exercise label="ex-trig-sub-definite-1">
-          <webwork xml:id="ex-trig-sub-definite-1">
+          <webwork xml:id="webwork-ex-trig-sub-definite-1">
             <pg-code>
               $answer = Compute("pi/2");
             </pg-code>
@@ -1257,7 +1257,7 @@
         </exercise>
         <!-- Exercise 28 -->
         <exercise label="ex-trig-sub-definite-2">
-          <webwork xml:id="ex-trig-sub-definite-2">
+          <webwork xml:id="webwork-ex-trig-sub-definite-2">
             <pg-code>
               $b = random(5,10,1);
               if($envir{problemSeed}==1){$b=8;};
@@ -1290,7 +1290,7 @@
         </exercise>
         <!-- Exercise 29 -->
         <exercise label="ex-trig-sub-definite-3">
-          <webwork xml:id="ex-trig-sub-definite-3">
+          <webwork xml:id="webwork-ex-trig-sub-definite-3">
             <pg-code>
               $b = random(1,10,1);
               if($envir{problemSeed}==1){$b=2;};
@@ -1323,7 +1323,7 @@
         </exercise>
         <!-- Exercise 30 -->
         <exercise label="ex-trig-sub-definite-4">
-          <webwork xml:id="ex-trig-sub-definite-4">
+          <webwork xml:id="webwork-ex-trig-sub-definite-4">
             <pg-code>
               $b = random(1,10,1);
               if($envir{problemSeed}==1){$b=1;};
@@ -1344,7 +1344,7 @@
         </exercise>
         <!-- Exercise 31 -->
         <exercise label="ex-trig-sub-definite-5">
-          <webwork xml:id="ex-trig-sub-definite-5">
+          <webwork xml:id="webwork-ex-trig-sub-definite-5">
             <pg-code>
               $b = random(1,2,1);
               if($envir{problemSeed}==1){$b=1;};
@@ -1376,7 +1376,7 @@
         </exercise>
         <!-- Exercise 32 -->
         <exercise label="ex-trig-sub-definite-6">
-          <webwork xml:id="ex-trig-sub-definite-6">
+          <webwork xml:id="webwork-ex-trig-sub-definite-6">
             <pg-code>
               $answer = Formula("pi/8");
             </pg-code>

--- a/ptx/sec_trigint.ptx
+++ b/ptx/sec_trigint.ptx
@@ -729,7 +729,7 @@
       <title>Terms and Concepts</title>
       <exercise label="TaC-trig-integrals-1">
         <!-- Exercise 1 -->
-        <webwork xml:id="TaC-trig-integrals-1">
+        <webwork xml:id="webwork-TaC-trig-integrals-1">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -745,7 +745,7 @@
       </exercise>
       <!-- Exercise 2 -->
       <exercise label="TaC-trig-integrals-2">
-        <webwork xml:id="TaC-trig-integrals-2">
+        <webwork xml:id="webwork-TaC-trig-integrals-2">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -761,7 +761,7 @@
       </exercise>
       <!-- Exercise 3 -->
       <exercise label="TaC-trig-integrals-3">
-        <webwork xml:id="TaC-trig-integrals-3">
+        <webwork xml:id="webwork-TaC-trig-integrals-3">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -777,7 +777,7 @@
       </exercise>
       <!-- Exercise 4 -->
       <exercise label="TaC-trig-integrals-4">
-        <webwork xml:id="TaC-trig-integrals-4">
+        <webwork xml:id="webwork-TaC-trig-integrals-4">
           <pg-code>
             $true=PopUp(['?','True','False'],1);
             $false=PopUp(['?','True','False'],2);
@@ -806,7 +806,7 @@
         <!-- Exercise 5 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-1">
-          <webwork xml:id="ex-indefinite-trig-integral-1">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-1">
             <pg-code>
               $F = FormulaUpToConstant("-1/5*cos(x)^5");
             </pg-code>
@@ -823,7 +823,7 @@
         <!-- Exercise 6 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-2">
-          <webwork xml:id="ex-indefinite-trig-integral-2">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-2">
             <pg-code>
               $F = FormulaUpToConstant("1/4*sin(x)^4");
             </pg-code>
@@ -839,7 +839,7 @@
         </exercise>
         <!-- Exercise 7 -->
         <exercise label="ex-indefinite-trig-integral-3">
-          <webwork xml:id="ex-indefinite-trig-integral-3">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-3">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=2;};
@@ -859,7 +859,7 @@
         </exercise>
         <!-- Exercise 8 -->
         <exercise label="ex-indefinite-trig-integral-4">
-          <webwork xml:id="ex-indefinite-trig-integral-4">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-4">
             <pg-code>
               $m = random(2,9,1);
               $n = 3;
@@ -886,7 +886,7 @@
         </exercise>
         <!-- Exercise 9 -->
         <exercise label="ex-indefinite-trig-integral-5">
-          <webwork xml:id="ex-indefinite-trig-integral-5">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-5">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=6;};
@@ -907,7 +907,7 @@
         <!-- Exercise 10 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-6">
-          <webwork xml:id="ex-indefinite-trig-integral-6">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-6">
             <pg-code>
               $F = FormulaUpToConstant("-1/9*sin(x)^9+3/7*sin(x)^7-3/5*sin(x)^5+1/3*sin(x)^3");
             </pg-code>
@@ -924,7 +924,7 @@
         <!-- Exercise 11 -->
         <exercise label="ex-indefinite-trig-integral-7">
         <!-- Not randomized because of the special nature of sin^2 cos^2 -->
-          <webwork xml:id="ex-indefinite-trig-integral-7">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-7">
             <pg-code>
               $F = FormulaUpToConstant("x/8-1/32*sin(4x)");
             </pg-code>
@@ -941,7 +941,7 @@
         <!-- Exercise 12 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-8">
-          <webwork xml:id="ex-indefinite-trig-integral-8">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-8">
             <pg-code>
               $F = FormulaUpToConstant("1/2*(-1/8*cos(8x)-1/2*cos(2x))");
             </pg-code>
@@ -957,7 +957,7 @@
         </exercise>
         <!-- Exercise 13 -->
         <exercise label="ex-indefinite-trig-integral-9">
-          <webwork xml:id="ex-indefinite-trig-integral-9">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-9">
             <pg-code>
               ($m,$n) = (2..9)[NchooseK(8,2)];
               if (list_random(-1,1)) {$m = 1;} else {$n = 1;};
@@ -982,7 +982,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-indefinite-trig-integral-10">
-          <webwork xml:id="ex-indefinite-trig-integral-10">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-10">
             <pg-code>
               ($m,$n) = (2..9)[NchooseK(8,2)];
               if($envir{problemSeed}==1){$m=3;$n=7};
@@ -1006,7 +1006,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-indefinite-trig-integral-11">
-          <webwork xml:id="ex-indefinite-trig-integral-11">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-11">
             <pg-code>
               ($m,$n) = (2..9)[NchooseK(8,2)];
               if (list_random(-1,1)) {$m = 1;} else {$n = 1;};
@@ -1036,7 +1036,7 @@
         <!-- Exercise 16 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-12">
-          <webwork xml:id="ex-indefinite-trig-integral-12">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-12">
             <pg-code>
               $F = FormulaUpToConstant("1/2*(sin(x)+1/3*sin(3x))");
             </pg-code>
@@ -1052,7 +1052,7 @@
         </exercise>
         <!-- Exercise 17 -->
         <exercise label="ex-indefinite-trig-integral-13">
-          <webwork xml:id="ex-indefinite-trig-integral-13">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-13">
             <pg-code>
               ($m,$n) = ('pi/6','pi/4','pi/3','pi/2','pi')[NchooseK(5,2)];
               if($envir{problemSeed}==1){$m='pi/2';$n='pi'};
@@ -1085,7 +1085,7 @@
         <!-- Exercise 18 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-14">
-          <webwork xml:id="ex-indefinite-trig-integral-14">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-14">
             <pg-code>
               $F = FormulaUpToConstant("tan(x)^5/5");
             </pg-code>
@@ -1102,7 +1102,7 @@
         <!-- Exercise 19 -->
         <!-- Not randomized since it is resused in the next block -->
         <exercise label="ex-indefinite-trig-integral-15">
-          <webwork xml:id="ex-indefinite-trig-integral-15">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-15">
             <pg-code>
               $F = FormulaUpToConstant("tan(x)^5/5+tan(x)^3/3");
             </pg-code>
@@ -1118,7 +1118,7 @@
         </exercise>
         <!-- Exercise 20 -->
         <exercise label="ex-indefinite-trig-integral-16">
-          <webwork xml:id="ex-indefinite-trig-integral-16">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-16">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=3;};
@@ -1138,7 +1138,7 @@
         </exercise>
         <!-- Exercise 21 -->
         <exercise label="ex-indefinite-trig-integral-17">
-          <webwork xml:id="ex-indefinite-trig-integral-17">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-17">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=3;};
@@ -1158,7 +1158,7 @@
         </exercise>
         <!-- Exercise 22 -->
         <exercise label="ex-indefinite-trig-integral-18">
-          <webwork xml:id="ex-indefinite-trig-integral-18">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-18">
             <pg-code>
               $n = random(2,9,1);
               if($envir{problemSeed}==1){$n=3;};
@@ -1178,7 +1178,7 @@
         </exercise>
         <!-- Exercise 23 -->
         <exercise label="ex-indefinite-trig-integral-19">
-          <webwork xml:id="ex-indefinite-trig-integral-19">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-19">
             <pg-code>
               $n = random(2,9,1);
               if($envir{problemSeed}==1){$n=5;};
@@ -1200,7 +1200,7 @@
         <!-- Exercise 24 -->
         <!-- Not randomized because of the special nature of tan^4 -->
         <exercise label="ex-indefinite-trig-integral-20">
-          <webwork xml:id="ex-indefinite-trig-integral-20">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-20">
             <pg-code>
               $F = FormulaUpToConstant("tan(x)^3/3-tan(x)+x");
             </pg-code>
@@ -1217,7 +1217,7 @@
         <!-- Exercise 25 -->
         <!-- Not randomized because of the special nature of sec^5 -->
         <exercise label="ex-indefinite-trig-integral-21">
-          <webwork xml:id="ex-indefinite-trig-integral-21">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-21">
             <pg-code>
               $F = FormulaUpToConstant("1/4*tan(x)*sec(x)^3+3/8*(sec(x)*tan(x)+ln(abs(sec(x) + tan(x))))");
             </pg-code>
@@ -1234,7 +1234,7 @@
         <!-- Exercise 26 -->
         <!-- Not randomized because of the special nature of tan^2 sec -->
         <exercise label="ex-indefinite-trig-integral-22">
-          <webwork xml:id="ex-indefinite-trig-integral-22">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-22">
             <pg-code>
               $F = FormulaUpToConstant("1/2*(sec(x)*tan(x)-ln(abs(sec(x)+tan(x))))");
             </pg-code>
@@ -1251,7 +1251,7 @@
         <!-- Exercise 27 -->
         <!-- Not randomized because of the special nature of tan^2 sec^3 -->
         <exercise label="ex-indefinite-trig-integral-23">
-          <webwork xml:id="ex-indefinite-trig-integral-23">
+          <webwork xml:id="webwork-ex-indefinite-trig-integral-23">
             <pg-code>
               $F = FormulaUpToConstant("1/4*tan(x)*sec(x)^3-1/8*(sec(x)*tan(x)+ln(abs(sec(x)+tan(x))))");
             </pg-code>
@@ -1277,7 +1277,7 @@
         </introduction>
         <!-- Exercise 28 -->
         <exercise label="ex-definite-trig-integral-1">
-          <webwork xml:id="ex-definite-trig-integral-1">
+          <webwork xml:id="webwork-ex-definite-trig-integral-1">
             <pg-code>
               $b = list_random(pi/2,pi,3*pi/2,2*pi);
               if($envir{problemSeed}==1){$b=pi};
@@ -1304,7 +1304,7 @@
         </exercise>
         <!-- Exercise 29 -->
         <exercise label="ex-definite-trig-integral-2">
-          <webwork xml:id="ex-definite-trig-integral-2">
+          <webwork xml:id="webwork-ex-definite-trig-integral-2">
             <pg-code>
               $b = list_random(pi/2,pi,3*pi/2,2*pi);
               if($envir{problemSeed}==1){$b=pi};
@@ -1331,7 +1331,7 @@
         </exercise>
         <!-- Exercise 30 -->
         <exercise label="ex-definite-trig-integral-3">
-          <webwork xml:id="ex-definite-trig-integral-3">
+          <webwork xml:id="webwork-ex-definite-trig-integral-3">
             <pg-code>
               $b = list_random(pi/2,pi,3*pi/2,2*pi);
               if($envir{problemSeed}==1){$b=pi/2};
@@ -1358,7 +1358,7 @@
         </exercise>
         <!-- Exercise 31 -->
         <exercise label="ex-definite-trig-integral-4">
-          <webwork xml:id="ex-definite-trig-integral-4">
+          <webwork xml:id="webwork-ex-definite-trig-integral-4">
             <pg-code>
               $b = list_random(pi/4,pi/2,3*pi/4,pi,3*pi/2,2*pi);
               if($envir{problemSeed}==1){$b=pi/2};
@@ -1385,7 +1385,7 @@
         </exercise>
         <!-- Exercise 32 -->
         <exercise label="ex-definite-trig-integral-5">
-          <webwork xml:id="ex-definite-trig-integral-5">
+          <webwork xml:id="webwork-ex-definite-trig-integral-5">
             <pg-code>
               $b = list_random(pi/2,pi,3*pi/2,2*pi);
               if($envir{problemSeed}==1){$b=pi/2};
@@ -1412,7 +1412,7 @@
         </exercise>
         <!-- Exercise 33 -->
         <exercise label="ex-definite-trig-integral-6">
-          <webwork xml:id="ex-definite-trig-integral-6">
+          <webwork xml:id="webwork-ex-definite-trig-integral-6">
             <pg-code>
               $a = list_random(0,-pi/4);
               if($envir{problemSeed}==1){$a=0};
@@ -1439,7 +1439,7 @@
         </exercise>
         <!-- Exercise 34 -->
         <exercise label="ex-definite-trig-integral-7">
-          <webwork xml:id="ex-definite-trig-integral-7">
+          <webwork xml:id="webwork-ex-definite-trig-integral-7">
             <pg-code>
               $a = list_random(0,-pi/4);
               if($envir{problemSeed}==1){$a=-pi/4};

--- a/ptx/sec_triple_int.ptx
+++ b/ptx/sec_triple_int.ptx
@@ -3058,7 +3058,7 @@
     <subexercises xml:id="TaC-triple-integrals">
       <title>Terms and Concepts</title>
       <exercise label="TaC-triple-integrals-1">
-        <!--<webwork xml:id="TaC-triple-integrals-1">
+        <!--<webwork xml:id="webwork-TaC-triple-integrals-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3077,7 +3077,7 @@
       </exercise>
 
       <exercise label="TaC-triple-integrals-2">
-        <!--<webwork xml:id="TaC-triple-integrals-2">
+        <!--<webwork xml:id="webwork-TaC-triple-integrals-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3095,7 +3095,7 @@
       </exercise>
 
       <exercise label="TaC-triple-integrals-3">
-        <!--<webwork xml:id="TaC-triple-integrals-3">
+        <!--<webwork xml:id="webwork-TaC-triple-integrals-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3114,7 +3114,7 @@
       </exercise>
 
       <exercise label="TaC-triple-integrals-4">
-        <!--<webwork xml:id="TaC-triple-integrals-4">
+        <!--<webwork xml:id="webwork-TaC-triple-integrals-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -3146,7 +3146,7 @@
         </introduction>
 
         <exercise label="ex-triple-int-volume-between-1">
-          <!--<webwork xml:id="ex-triple-int-volume-between-1">
+          <!--<webwork xml:id="webwork-ex-triple-int-volume-between-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3167,7 +3167,7 @@
         </exercise>
 
         <exercise label="ex-triple-int-volume-between-2">
-          <webwork xml:id="ex-triple-int-volume-between-2">
+          <webwork xml:id="webwork-ex-triple-int-volume-between-2">
               <pg-code>
                   $int=Compute("52");
               </pg-code>
@@ -3188,7 +3188,7 @@
         </exercise>
 
         <exercise label="ex-triple-int-volume-between-3">
-          <!--<webwork xml:id="ex-triple-int-volume-between-3">
+          <!--<webwork xml:id="webwork-ex-triple-int-volume-between-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3211,7 +3211,7 @@
         </exercise>
 
         <exercise label="ex-triple-int-volume-between-4">
-          <webwork xml:id="ex-triple-int-volume-between-4">
+          <webwork xml:id="webwork-ex-triple-int-volume-between-4">
               <pg-code>
                   $int=Compute("3pi/2");
               </pg-code>
@@ -3246,7 +3246,7 @@
         </introduction>
 
         <exercise xml:id="x13_06_ex_07" label="ex-triple-integral-all-orders-1">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-1">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3359,7 +3359,7 @@
         </exercise>
 
         <exercise xml:id="x13_06_ex_08"  label="ex-triple-integral-all-orders-2">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-2">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3476,7 +3476,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-all-orders-3">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-3">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3594,7 +3594,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-all-orders-4">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-4">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3700,7 +3700,7 @@
         </exercise>
 
         <exercise xml:id="x13_06_ex_11"  label="ex-triple-integral-all-orders-5">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-5">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3804,7 +3804,7 @@
         </exercise>
 
         <exercise xml:id="x13_06_ex_12"  label="ex-triple-integral-all-orders-6">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-6">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -3912,7 +3912,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-all-orders-7">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-7">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4034,7 +4034,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-all-orders-8">
-          <!--<webwork xml:id="ex-triple-integral-all-orders-8">
+          <!--<webwork xml:id="webwork-ex-triple-integral-all-orders-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4152,7 +4152,7 @@
         </introduction>
 
         <exercise label="ex-triple-integral-evaluate-1">
-          <!--<webwork xml:id="ex-triple-integral-evaluate-1">
+          <!--<webwork xml:id="webwork-ex-triple-integral-evaluate-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4164,7 +4164,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-evaluate-2">
-          <webwork xml:id="ex-triple-integral-evaluate-2">
+          <webwork xml:id="webwork-ex-triple-integral-evaluate-2">
               <pg-code>
                   $int=Compute("7/8");
               </pg-code>
@@ -4182,7 +4182,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-evaluate-3">
-          <!--<webwork xml:id="ex-triple-integral-evaluate-3">
+          <!--<webwork xml:id="webwork-ex-triple-integral-evaluate-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4199,7 +4199,7 @@
         </exercise>
 
         <exercise label="ex-triple-integral-evaluate-4">
-          <webwork xml:id="ex-triple-integral-evaluate-4">
+          <webwork xml:id="webwork-ex-triple-integral-evaluate-4">
               <pg-code>
                   $int=Compute("0");
               </pg-code>
@@ -4227,7 +4227,7 @@
         </introduction>
 
         <exercise label="ex-triple-int-center-mass-1">
-          <!--<webwork xml:id="ex-triple-int-center-mass-1">
+          <!--<webwork xml:id="webwork-ex-triple-int-center-mass-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4257,7 +4257,7 @@
         </exercise>
 
         <exercise label="ex-triple-int-center-mass-2">
-          <!--<webwork xml:id="ex-triple-int-center-mass-2">
+          <!--<webwork xml:id="webwork-ex-triple-int-center-mass-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4288,7 +4288,7 @@
         </exercise>
 
         <exercise label="ex-triple-int-center-mass-3">
-          <!--<webwork xml:id="ex-triple-int-center-mass-3">
+          <!--<webwork xml:id="webwork-ex-triple-int-center-mass-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -4319,7 +4319,7 @@
         </exercise>
 
         <exercise label="ex-triple-int-center-mass-4">
-          <!--<webwork xml:id="ex-triple-int-center-mass-4">
+          <!--<webwork xml:id="webwork-ex-triple-int-center-mass-4">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1529,7 +1529,7 @@
       <title>Terms and Concepts</title>
 
       <exercise label="TaC-vector-intro-1">
-        <!-- <webwork xml:id="TaC-vector-intro-1">
+        <!-- <webwork xml:id="webwork-TaC-vector-intro-1">
             <pg-code>
             </pg-code>
              -->
@@ -1548,7 +1548,7 @@
       </exercise>
 
       <exercise label="TaC-vector-intro-2">
-        <!-- <webwork xml:id="TaC-vector-intro-2">
+        <!-- <webwork xml:id="webwork-TaC-vector-intro-2">
             <pg-code>
             </pg-code>
              -->
@@ -1567,7 +1567,7 @@
       </exercise>
 
       <exercise label="TaC-vector-intro-3">
-        <!-- <webwork xml:id="TaC-vector-intro-3">
+        <!-- <webwork xml:id="webwork-TaC-vector-intro-3">
             <pg-code>
             </pg-code>
              -->
@@ -1599,7 +1599,7 @@
 
 
       <exercise label="TaC-vector-intro-5">
-        <!-- <webwork xml:id="TaC-vector-intro-5">
+        <!-- <webwork xml:id="webwork-TaC-vector-intro-5">
             <pg-code>
             </pg-code>
              -->
@@ -1619,7 +1619,7 @@
       </exercise>
 
       <exercise label="TaC-vector-intro-6">
-        <!-- <webwork xml:id="TaC-vector-intro-6">
+        <!-- <webwork xml:id="webwork-TaC-vector-intro-6">
             <pg-code>
             </pg-code>
              -->
@@ -1649,7 +1649,7 @@
         </introduction>
 
         <exercise label="ex-vector-between-points-1">
-          <webwork xml:id="ex-vector-between-points-1">
+          <webwork xml:id="webwork-ex-vector-between-points-1">
 
               <pg-code>
                 Context("Vector2D");
@@ -1688,7 +1688,7 @@
         </exercise>
 
         <exercise label="ex-vector-between-points-2">
-          <webwork xml:id="ex-vector-between-points-2">
+          <webwork xml:id="webwork-ex-vector-between-points-2">
 
               <pg-code>
                 Context("Vector2D");
@@ -1727,7 +1727,7 @@
         </exercise>
 
         <exercise label="ex-vector-between-points-3">
-          <webwork xml:id="ex-vector-between-points-3">
+          <webwork xml:id="webwork-ex-vector-between-points-3">
 
               <pg-code>
                 Context("Vector");
@@ -1766,7 +1766,7 @@
         </exercise>
 
         <exercise label="ex-vector-between-points-4">
-          <webwork xml:id="ex-vector-between-points-4">
+          <webwork xml:id="webwork-ex-vector-between-points-4">
 
               <pg-code>
                 Context("Vector");
@@ -1807,7 +1807,7 @@
       </exercisegroup>
 
       <exercise label="ex-vector-arithmetic-1">
-        <!-- <webwork xml:id="ex-vector-arithmetic-1">
+        <!-- <webwork xml:id="webwork-ex-vector-arithmetic-1">
             <pg-code>
             </pg-code>
              -->
@@ -1863,7 +1863,7 @@
       </exercise>
 
       <exercise label="ex-vector-arithmetic-2">
-        <!-- <webwork xml:id="ex-vector-arithmetic-2">
+        <!-- <webwork xml:id="webwork-ex-vector-arithmetic-2">
             <pg-code>
             </pg-code>
              -->
@@ -1928,7 +1928,7 @@
         </introduction>
 
         <exercise label="ex-vector-sum-sketch-1">
-          <!-- <webwork xml:id="ex-vector-sum-sketch-1">
+          <!-- <webwork xml:id="webwork-ex-vector-sum-sketch-1">
               <pg-code>
               </pg-code>
                -->
@@ -1993,7 +1993,7 @@
         </exercise>
 
         <exercise label="ex-vector-sum-sketch-2">
-          <!-- <webwork xml:id="ex-vector-sum-sketch-2">
+          <!-- <webwork xml:id="webwork-ex-vector-sum-sketch-2">
               <pg-code>
               </pg-code>
                -->
@@ -2061,7 +2061,7 @@
         </exercise>
 
         <exercise label="ex-vector-sum-sketch-3">
-          <!-- <webwork xml:id="ex-vector-sum-sketch-3">
+          <!-- <webwork xml:id="webwork-ex-vector-sum-sketch-3">
               <pg-code>
               </pg-code>
                -->
@@ -2147,7 +2147,7 @@
         </exercise>
 
         <exercise label="ex-vector-sum-sketch-4">
-          <!-- <webwork xml:id="ex-vector-sum-sketch-4">
+          <!-- <webwork xml:id="webwork-ex-vector-sum-sketch-4">
               <pg-code>
               </pg-code>
                -->
@@ -2243,7 +2243,7 @@
         </introduction>
 
         <exercise label="ex-vector-magnitude-1">
-          <webwork xml:id="ex-vector-magnitude-1">
+          <webwork xml:id="webwork-ex-vector-magnitude-1">
               <pg-code>
                 Context()->flags->set(reduceConstantFunctions=>0);
                 $normu=Formula("sqrt(5)");
@@ -2277,7 +2277,7 @@
         </exercise>
 
         <exercise label="ex-vector-magnitude-2">
-          <webwork xml:id="ex-vector-magnitude-2">
+          <webwork xml:id="webwork-ex-vector-magnitude-2">
               <pg-code>
                 Context()->flags->set(reduceConstantFunctions=>0);
                 $normu=Formula("sqrt(17)");
@@ -2311,7 +2311,7 @@
         </exercise>
 
         <exercise label="ex-vector-magnitude-3">
-          <webwork xml:id="ex-vector-magnitude-3">
+          <webwork xml:id="webwork-ex-vector-magnitude-3">
               <pg-code>
                 Context()->flags->set(reduceConstantFunctions=>0);
                 $normu=Formula("sqrt(5)");
@@ -2345,7 +2345,7 @@
         </exercise>
 
         <exercise label="ex-vector-magnitude-4">
-          <webwork xml:id="ex-vector-magnitude-4">
+          <webwork xml:id="webwork-ex-vector-magnitude-4">
               <pg-code>
                 Context()->flags->set(reduceConstantFunctions=>0);
                 $normu=Formula("7");
@@ -2381,7 +2381,7 @@
       </exercisegroup>
 
       <exercise label="ex-vector-norm-sum-equal">
-        <!-- <webwork xml:id="ex-vector-norm-sum-equal">
+        <!-- <webwork xml:id="webwork-ex-vector-norm-sum-equal">
             <pg-code>
             </pg-code>
              -->
@@ -2409,7 +2409,7 @@
         </introduction>
 
         <exercise label="ex-find-unit-vector-1">
-          <webwork xml:id="ex-find-unit-vector-1">
+          <webwork xml:id="webwork-ex-find-unit-vector-1">
               <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstantFunctions=>0);
@@ -2429,7 +2429,7 @@
         </exercise>
 
         <exercise label="ex-find-unit-vector-2">
-          <webwork xml:id="ex-find-unit-vector-2">
+          <webwork xml:id="webwork-ex-find-unit-vector-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstantFunctions=>0);
@@ -2449,7 +2449,7 @@
         </exercise>
 
         <exercise label="ex-find-unit-vector-3">
-          <webwork xml:id="ex-find-unit-vector-3">
+          <webwork xml:id="webwork-ex-find-unit-vector-3">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
@@ -2469,7 +2469,7 @@
         </exercise>
 
         <exercise label="ex-find-unit-vector-4">
-          <webwork xml:id="ex-find-unit-vector-4">
+          <webwork xml:id="webwork-ex-find-unit-vector-4">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
@@ -2491,7 +2491,7 @@
       </exercisegroup>
 
       <exercise label="ex-unit-vector-angle-1">
-        <webwork xml:id="ex-unit-vector-angle-1">
+        <webwork xml:id="webwork-ex-unit-vector-angle-1">
             <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
@@ -2512,7 +2512,7 @@
       </exercise>
 
       <exercise label="ex-unit-vector-angle-2">
-        <webwork xml:id="ex-unit-vector-angle-2">
+        <webwork xml:id="webwork-ex-unit-vector-angle-2">
             <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstantFunctions=>0,reduceConstants=>0);
@@ -2533,7 +2533,7 @@
       </exercise>
 
       <exercise label="ex-vectors-verify-unit-trig">
-        <!-- <webwork xml:id="ex-vectors-verify-unit-trig">
+        <!-- <webwork xml:id="webwork-ex-vectors-verify-unit-trig">
             <pg-code>
             </pg-code>
              -->
@@ -2594,7 +2594,7 @@
         </introduction>
 
         <exercise label="ex-vectors-balance-forces-1">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-1">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-1">
               <pg-code>
               </pg-code>
                -->
@@ -2612,7 +2612,7 @@
         </exercise>
 
         <exercise label="ex-vectors-balance-forces-2">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-2">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-2">
               <pg-code>
               </pg-code>
                -->
@@ -2630,7 +2630,7 @@
         </exercise>
 
         <exercise label="ex-vectors-balance-forces-3">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-3">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-3">
               <pg-code>
               </pg-code>
                -->
@@ -2651,7 +2651,7 @@
         </exercise>
 
         <exercise label="ex-vectors-balance-forces-4">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-4">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-4">
               <pg-code>
               </pg-code>
                -->
@@ -2704,7 +2704,7 @@
         </introduction>
 
         <exercise label="ex-vectors-balance-forces-5">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-5">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-5">
               <pg-code>
               </pg-code>
                -->
@@ -2723,7 +2723,7 @@
         </exercise>
 
         <exercise label="ex-vectors-balance-forces-6">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-6">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-6">
               <pg-code>
               </pg-code>
                -->
@@ -2742,7 +2742,7 @@
         </exercise>
 
         <exercise label="ex-vectors-balance-forces-7">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-7">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-7">
               <pg-code>
               </pg-code>
                -->
@@ -2760,7 +2760,7 @@
         </exercise>
 
         <exercise label="ex-vectors-balance-forces-8">
-          <!-- <webwork xml:id="ex-vectors-balance-forces-8">
+          <!-- <webwork xml:id="webwork-ex-vectors-balance-forces-8">
               <pg-code>
               </pg-code>
                -->

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -795,7 +795,7 @@
     <subexercises xml:id="TaC-vector-valued-functions">
       <title>Terms and Concepts</title>
       <exercise label="TaC-vector-valued-functions-1">
-        <!-- <webwork xml:id="TaC-vector-valued-functions-1">
+        <!-- <webwork xml:id="webwork-TaC-vector-valued-functions-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -812,7 +812,7 @@
       </exercise>
 
       <exercise label="TaC-vector-valued-functions-2">
-        <!-- <webwork xml:id="TaC-vector-valued-functions-2">
+        <!-- <webwork xml:id="webwork-TaC-vector-valued-functions-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -830,7 +830,7 @@
       </exercise>
 
       <exercise label="TaC-vector-valued-functions-3">
-        <!-- <webwork xml:id="TaC-vector-valued-functions-3">
+        <!-- <webwork xml:id="webwork-TaC-vector-valued-functions-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -873,7 +873,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-sketch-1">
-          <!-- <webwork xml:id="ex-vector-function-sketch-1">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -911,7 +911,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-2">
-          <!-- <webwork xml:id="ex-vector-function-sketch-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -951,7 +951,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-3">
-          <!-- <webwork xml:id="ex-vector-function-sketch-3">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -991,7 +991,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-4">
-          <!-- <webwork xml:id="ex-vector-function-sketch-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1029,7 +1029,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-5">
-          <!-- <webwork xml:id="ex-vector-function-sketch-5">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1069,7 +1069,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-6">
-          <!-- <webwork xml:id="ex-vector-function-sketch-6">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1108,7 +1108,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-7">
-          <!-- <webwork xml:id="ex-vector-function-sketch-7">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1147,7 +1147,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-8">
-          <!-- <webwork xml:id="ex-vector-function-sketch-8">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-8">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1197,7 +1197,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-sketch-tech-1">
-          <!-- <webwork xml:id="ex-vector-function-sketch-tech-1">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-tech-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1243,7 +1243,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-tech-2">
-          <!-- <webwork xml:id="ex-vector-function-sketch-tech-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-tech-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1288,7 +1288,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-tech-3">
-          <!-- <webwork xml:id="ex-vector-function-sketch-tech-3">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-tech-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1333,7 +1333,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-sketch-tech-4">
-          <!-- <webwork xml:id="ex-vector-function-sketch-tech-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-sketch-tech-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1387,7 +1387,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-magnitude-1">
-          <webwork xml:id="ex-vector-function-magnitude-1">
+          <webwork xml:id="webwork-ex-vector-function-magnitude-1">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $norm=Formula("|t| sqrt(1+t^2)");
@@ -1403,7 +1403,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-magnitude-2">
-          <!-- <webwork xml:id="ex-vector-function-magnitude-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-magnitude-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1420,7 +1420,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-magnitude-3">
-          <webwork xml:id="ex-vector-function-magnitude-3">
+          <webwork xml:id="webwork-ex-vector-function-magnitude-3">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $norm=Formula("sqrt(4+t^2)");
@@ -1436,7 +1436,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-magnitude-4">
-          <!-- <webwork xml:id="ex-vector-function-magnitude-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-magnitude-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1462,7 +1462,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-match-graph-1">
-          <webwork xml:id="ex-vector-function-match-graph-1">
+          <webwork xml:id="webwork-ex-vector-function-match-graph-1">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1508,7 +1508,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-match-graph-2">
-          <!-- <webwork xml:id="ex-vector-function-match-graph-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-match-graph-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1538,7 +1538,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-match-graph-3">
-          <!-- <webwork xml:id="ex-vector-function-match-graph-3">
+          <!-- <webwork xml:id="webwork-ex-vector-function-match-graph-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1559,7 +1559,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-match-graph-4">
-          <!-- <webwork xml:id="ex-vector-function-match-graph-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-match-graph-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1588,7 +1588,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-match-graph-5">
-          <webwork xml:id="ex-vector-function-match-graph-5">
+          <webwork xml:id="webwork-ex-vector-function-match-graph-5">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector2D");
@@ -1612,7 +1612,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-match-graph-6">
-          <!-- <webwork xml:id="ex-vector-function-match-graph-6">
+          <!-- <webwork xml:id="webwork-ex-vector-function-match-graph-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1695,7 +1695,7 @@
       </exercise>
 
         <exercise label="ex-vector-function-match-graph-9">
-          <webwork xml:id="ex-vector-function-match-graph-9">
+          <webwork xml:id="webwork-ex-vector-function-match-graph-9">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real');
@@ -1731,7 +1731,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-match-graph-10">
-          <!-- <webwork xml:id="ex-vector-function-match-graph-10">
+          <!-- <webwork xml:id="webwork-ex-vector-function-match-graph-10">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1762,7 +1762,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-average-change-1">
-          <webwork xml:id="ex-vector-function-average-change-1">
+          <webwork xml:id="webwork-ex-vector-function-average-change-1">
               <pg-code>
                 Context("Vector2D");
                 $arc=Vector("&lt;1,0>");
@@ -1781,7 +1781,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-average-change-2">
-          <!-- <webwork xml:id="ex-vector-function-average-change-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-average-change-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1798,7 +1798,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-average-change-3">
-          <webwork xml:id="ex-vector-function-average-change-3">
+          <webwork xml:id="webwork-ex-vector-function-average-change-3">
               <pg-code>
                 Context("Vector");
                 $arc=Vector("&lt;0,0,1>");
@@ -1817,7 +1817,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-average-change-4">
-          <!-- <webwork xml:id="ex-vector-function-average-change-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-average-change-4">
               <pg-code>
               </pg-code> -->
               <statement>

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -1359,7 +1359,7 @@
     <subexercises xml:id="TaC-vector-functions-caluclus">
       <title>Terms and Concepts</title>
       <exercise label="TaC-vector-functions-caluclus-1">
-        <!-- <webwork xml:id="TaC-vector-functions-caluclus-1">
+        <!-- <webwork xml:id="webwork-TaC-vector-functions-caluclus-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1376,7 +1376,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-caluclus-2">
-        <!-- <webwork xml:id="TaC-vector-functions-caluclus-2">
+        <!-- <webwork xml:id="webwork-TaC-vector-functions-caluclus-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1393,7 +1393,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-caluclus-3">
-        <!-- <webwork xml:id="TaC-vector-functions-caluclus-3">
+        <!-- <webwork xml:id="webwork-TaC-vector-functions-caluclus-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1437,7 +1437,7 @@
         </introduction>
 
         <exercise label="ex-vector-functions-limit-1">
-          <webwork xml:id="ex-vector-functions-limit-1">
+          <webwork xml:id="webwork-ex-vector-functions-limit-1">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1456,7 +1456,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-limit-2">
-          <!-- <webwork xml:id="ex-vector-functions-limit-2">
+          <!-- <webwork xml:id="webwork-ex-vector-functions-limit-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1473,7 +1473,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-limit-3">
-          <webwork xml:id="ex-vector-functions-limit-3">
+          <webwork xml:id="webwork-ex-vector-functions-limit-3">
               <pg-code>
                 Context("Vector2D");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1492,7 +1492,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-limit-4">
-          <!-- <webwork xml:id="ex-vector-functions-limit-4">
+          <!-- <webwork xml:id="webwork-ex-vector-functions-limit-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1519,7 +1519,7 @@
         </introduction>
 
         <exercise label="ex-vector-functions-continuous-1">
-          <webwork xml:id="ex-vector-functions-continuous-1">
+          <webwork xml:id="webwork-ex-vector-functions-continuous-1">
               <pg-code>
                 Context("Interval");
                 $dom=Compute("(-inf,0)U(0,inf)");
@@ -1538,7 +1538,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-continuous-2">
-          <!-- <webwork xml:id="ex-vector-functions-continuous-2">
+          <!-- <webwork xml:id="webwork-ex-vector-functions-continuous-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1564,7 +1564,7 @@
         </introduction>
 
         <exercise label="ex-vector-functions-derivative-1">
-          <webwork xml:id="ex-vector-functions-derivative-1">
+          <webwork xml:id="webwork-ex-vector-functions-derivative-1">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real');
@@ -1585,7 +1585,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-derivative-2">
-          <!-- <webwork xml:id="ex-vector-functions-derivative-2">
+          <!-- <webwork xml:id="webwork-ex-vector-functions-derivative-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1602,7 +1602,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-derivative-3">
-          <webwork xml:id="ex-vector-functions-derivative-3">
+          <webwork xml:id="webwork-ex-vector-functions-derivative-3">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1623,7 +1623,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-derivative-4">
-          <webwork xml:id="ex-vector-functions-derivative-4">
+          <webwork xml:id="webwork-ex-vector-functions-derivative-4">
               <pg-code>
                 Context("Numeric");
                 Context()->variables->are(t=>'Real');
@@ -1644,7 +1644,7 @@
         </exercise>
 
         <exercise label="ex-vector-functions-derivative-5">
-          <webwork xml:id="ex-vector-functions-derivative-5">
+          <webwork xml:id="webwork-ex-vector-functions-derivative-5">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real');
@@ -1689,7 +1689,7 @@
         </introduction>
 
         <exercise label="ex-vector-derivative-sketch-1">
-          <!-- <webwork xml:id="ex-vector-derivative-sketch-1">
+          <!-- <webwork xml:id="webwork-ex-vector-derivative-sketch-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1730,7 +1730,7 @@
         </exercise>
 
         <exercise label="ex-vector-derivative-sketch-2">
-          <!-- <webwork xml:id="ex-vector-derivative-sketch-2">
+          <!-- <webwork xml:id="webwork-ex-vector-derivative-sketch-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1771,7 +1771,7 @@
         </exercise>
 
         <exercise label="ex-vector-derivative-sketch-3">
-          <!-- <webwork xml:id="ex-vector-derivative-sketch-3">
+          <!-- <webwork xml:id="webwork-ex-vector-derivative-sketch-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1812,7 +1812,7 @@
         </exercise>
 
         <exercise label="ex-vector-derivative-sketch-4">
-          <!-- <webwork xml:id="ex-vector-derivative-sketch-4">
+          <!-- <webwork xml:id="webwork-ex-vector-derivative-sketch-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1863,7 +1863,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-tangent-1">
-          <webwork xml:id="ex-vector-function-tangent-1">
+          <webwork xml:id="webwork-ex-vector-function-tangent-1">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector2D");
@@ -1887,7 +1887,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-tangent-2">
-          <webwork xml:id="ex-vector-function-tangent-2">
+          <webwork xml:id="webwork-ex-vector-function-tangent-2">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector2D");
@@ -1912,7 +1912,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-tangent-3">
-          <!-- <webwork xml:id="ex-vector-function-tangent-3">
+          <!-- <webwork xml:id="webwork-ex-vector-function-tangent-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1929,7 +1929,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-tangent-4">
-          <webwork xml:id="ex-vector-function-tangent-4">
+          <webwork xml:id="webwork-ex-vector-function-tangent-4">
               <!-- <pg-macros><macro-file>parserParametricLine.pl</macro-file></pg-macros> -->
               <pg-code>
                 Context("Vector");
@@ -1963,7 +1963,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-nonsmooth-1">
-          <!-- <webwork xml:id="ex-vector-function-nonsmooth-1">
+          <!-- <webwork xml:id="webwork-ex-vector-function-nonsmooth-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1981,7 +1981,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-nonsmooth-2">
-          <webwork xml:id="ex-vector-function-nonsmooth-2">
+          <webwork xml:id="webwork-ex-vector-function-nonsmooth-2">
               <pg-code>
                 $notsmooth=List("1");
               </pg-code>
@@ -2002,7 +2002,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-nonsmooth-3">
-          <!-- <webwork xml:id="ex-vector-function-nonsmooth-3">
+          <!-- <webwork xml:id="webwork-ex-vector-function-nonsmooth-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2020,7 +2020,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-nonsmooth-4">
-          <webwork xml:id="ex-vector-function-nonsmooth-4">
+          <webwork xml:id="webwork-ex-vector-function-nonsmooth-4">
               <pg-code>
                 $notsmooth=List("1,-1");
               </pg-code>
@@ -2053,7 +2053,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-deriv-prop-1">
-          <!-- <webwork xml:id="ex-vector-function-deriv-prop-1">
+          <!-- <webwork xml:id="webwork-ex-vector-function-deriv-prop-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2071,7 +2071,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-deriv-prop-2">
-          <!-- <webwork xml:id="ex-vector-function-deriv-prop-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-deriv-prop-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2089,7 +2089,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-deriv-prop-3">
-          <!-- <webwork xml:id="ex-vector-function-deriv-prop-3">
+          <!-- <webwork xml:id="webwork-ex-vector-function-deriv-prop-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2131,7 +2131,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-integral-1">
-          <!-- <webwork xml:id="ex-vector-function-integral-1">
+          <!-- <webwork xml:id="webwork-ex-vector-function-integral-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2148,7 +2148,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-integral-2">
-          <!-- <webwork xml:id="ex-vector-function-integral-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-integral-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2165,7 +2165,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-integral-3">
-          <webwork xml:id="ex-vector-function-integral-3">
+          <webwork xml:id="webwork-ex-vector-function-integral-3">
               <pg-code>
                 Context("Vector2D");
                 $int=Compute("&lt;-2,0>");
@@ -2180,7 +2180,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-integral-4">
-          <!-- <webwork xml:id="ex-vector-function-integral-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-integral-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2206,7 +2206,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-ivp-1">
-          <webwork xml:id="ex-vector-function-ivp-1">
+          <webwork xml:id="webwork-ex-vector-function-ivp-1">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -2227,7 +2227,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-ivp-2">
-          <!-- <webwork xml:id="ex-vector-function-ivp-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-ivp-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2249,7 +2249,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-ivp-3">
-          <webwork xml:id="ex-vector-function-ivp-3">
+          <webwork xml:id="webwork-ex-vector-function-ivp-3">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real');
@@ -2270,7 +2270,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-ivp-4">
-          <!-- <webwork xml:id="ex-vector-function-ivp-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-ivp-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2301,7 +2301,7 @@
         </introduction>
 
         <exercise label="ex-vector-function-arclength-1">
-          <webwork xml:id="ex-vector-function-arclength-1">
+          <webwork xml:id="webwork-ex-vector-function-arclength-1">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstatnFunctions=>0);
                 $l=Formula("2sqrt(13)pi");
@@ -2320,7 +2320,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-arclength-2">
-          <!-- <webwork xml:id="ex-vector-function-arclength-2">
+          <!-- <webwork xml:id="webwork-ex-vector-function-arclength-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2337,7 +2337,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-arclength-3">
-          <webwork xml:id="ex-vector-function-arclength-3">
+          <webwork xml:id="webwork-ex-vector-function-arclength-3">
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstatnFunctions=>0);
                 $l=Formula("1/54(22^(3/2)-8)");
@@ -2356,7 +2356,7 @@
         </exercise>
 
         <exercise label="ex-vector-function-arclength-4">
-          <!-- <webwork xml:id="ex-vector-function-arclength-4">
+          <!-- <webwork xml:id="webwork-ex-vector-function-arclength-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2375,7 +2375,7 @@
       </exercisegroup>
 
       <exercise label="ex-vector-function-prove-theorem">
-        <!-- <webwork xml:id="ex-vector-function-prove-theorem">
+        <!-- <webwork xml:id="webwork-ex-vector-function-prove-theorem">
             <pg-code>
             </pg-code> -->
             <statement>

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -1199,7 +1199,7 @@
     <subexercises xml:id="TaC-vector-functions-motion">
       <title>Terms and Concepts</title>
       <exercise label="TaC-vector-functions-motion-1">
-<!--        <webwork xml:id="TaC-vector-functions-motion-1">
+<!--        <webwork xml:id="webwork-TaC-vector-functions-motion-1">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1218,7 +1218,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-motion-2">
-<!--        <webwork xml:id="TaC-vector-functions-motion-2">
+<!--        <webwork xml:id="webwork-TaC-vector-functions-motion-2">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1239,7 +1239,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-motion-3">
-<!--        <webwork xml:id="TaC-vector-functions-motion-3">
+<!--        <webwork xml:id="webwork-TaC-vector-functions-motion-3">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1258,7 +1258,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-motion-4">
-<!--        <webwork xml:id="TaC-vector-functions-motion-4">
+<!--        <webwork xml:id="webwork-TaC-vector-functions-motion-4">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1275,7 +1275,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-motion-5">
-<!--        <webwork xml:id="TaC-vector-functions-motion-5">
+<!--        <webwork xml:id="webwork-TaC-vector-functions-motion-5">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1297,7 +1297,7 @@
       </exercise>
 
       <exercise label="TaC-vector-functions-motion-6">
-<!--        <webwork xml:id="TaC-vector-functions-motion-6">
+<!--        <webwork xml:id="webwork-TaC-vector-functions-motion-6">
             <pg-code>
             </pg-code> -->
             <statement>
@@ -1326,7 +1326,7 @@
         </introduction>
 
         <exercise label="ex-vector-velocity-acceleration-1">
-  <!--        <webwork xml:id="ex-vector-velocity-acceleration-1">
+  <!--        <webwork xml:id="webwork-ex-vector-velocity-acceleration-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1343,7 +1343,7 @@
         </exercise>
 
         <exercise label="ex-vector-velocity-acceleration-2">
-          <webwork xml:id="ex-vector-velocity-acceleration-2">
+          <webwork xml:id="webwork-ex-vector-velocity-acceleration-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -1374,7 +1374,7 @@
         </exercise>
 
         <exercise label="ex-vector-velocity-acceleration-3">
-  <!--        <webwork xml:id="ex-vector-velocity-acceleration-3">
+  <!--        <webwork xml:id="webwork-ex-vector-velocity-acceleration-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1392,7 +1392,7 @@
         </exercise>
 
         <exercise label="ex-vector-velocity-acceleration-4">
-          <webwork xml:id="ex-vector-velocity-acceleration-4">
+          <webwork xml:id="webwork-ex-vector-velocity-acceleration-4">
               <pg-code>
                 Context("Vector");
                 Context()->variables->are(t=>'Real');
@@ -1438,7 +1438,7 @@
         </introduction>
 
         <exercise label="ex-vector-derivatives-sketch-1">
-  <!--        <webwork xml:id="ex-vector-derivatives-sketch-1">
+  <!--        <webwork xml:id="webwork-ex-vector-derivatives-sketch-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1458,7 +1458,7 @@
         </exercise>
 
         <exercise label="ex-vector-derivatives-sketch-2">
-  <!--        <webwork xml:id="ex-vector-derivatives-sketch-2">
+  <!--        <webwork xml:id="webwork-ex-vector-derivatives-sketch-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1478,7 +1478,7 @@
         </exercise>
 
         <exercise label="ex-vector-derivatives-sketch-3">
-  <!--        <webwork xml:id="ex-vector-derivatives-sketch-3">
+  <!--        <webwork xml:id="webwork-ex-vector-derivatives-sketch-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1497,7 +1497,7 @@
         </exercise>
 
         <exercise label="ex-vector-derivatives-sketch-4">
-  <!--        <webwork xml:id="ex-vector-derivatives-sketch-4">
+  <!--        <webwork xml:id="webwork-ex-vector-derivatives-sketch-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1530,7 +1530,7 @@
         </introduction>
 
         <exercise label="ex-vector-max-speed-1">
-  <!--        <webwork xml:id="ex-vector-max-speed-1">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1551,7 +1551,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-2">
-          <webwork xml:id="ex-vector-max-speed-2">
+          <webwork xml:id="webwork-ex-vector-max-speed-2">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 $speed=Formula("|t| sqrt(9t^2-12t+8)");
@@ -1588,7 +1588,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-3">
-  <!--        <webwork xml:id="ex-vector-max-speed-3">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1609,7 +1609,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-4">
-  <!--        <webwork xml:id="ex-vector-max-speed-4">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1631,7 +1631,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-5">
-          <webwork xml:id="ex-vector-max-speed-5">
+          <webwork xml:id="webwork-ex-vector-max-speed-5">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1669,7 +1669,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-6">
-  <!--        <webwork xml:id="ex-vector-max-speed-6">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-6">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1690,7 +1690,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-7">
-  <!--        <webwork xml:id="ex-vector-max-speed-7">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-7">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1711,7 +1711,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-8">
-          <webwork xml:id="ex-vector-max-speed-8">
+          <webwork xml:id="webwork-ex-vector-max-speed-8">
               <pg-code>
                 Context()->variables->are(t=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -1749,7 +1749,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-9">
-  <!--        <webwork xml:id="ex-vector-max-speed-9">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-9">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1771,7 +1771,7 @@
         </exercise>
 
         <exercise label="ex-vector-max-speed-10">
-  <!--        <webwork xml:id="ex-vector-max-speed-10">
+  <!--        <webwork xml:id="webwork-ex-vector-max-speed-10">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1824,7 +1824,7 @@
         </introduction>
 
         <exercise label="ex-vector-compare-parametrizations-1">
-  <!--        <webwork xml:id="ex-vector-compare-parametrizations-1">
+  <!--        <webwork xml:id="webwork-ex-vector-compare-parametrizations-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1862,7 +1862,7 @@
         </exercise>
 
         <exercise label="ex-vector-compare-parametrizations-2">
-  <!--        <webwork xml:id="ex-vector-compare-parametrizations-2">
+  <!--        <webwork xml:id="webwork-ex-vector-compare-parametrizations-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1902,7 +1902,7 @@
         </exercise>
 
         <exercise label="ex-vector-compare-parametrizations-3">
-  <!--        <webwork xml:id="ex-vector-compare-parametrizations-3">
+  <!--        <webwork xml:id="webwork-ex-vector-compare-parametrizations-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1941,7 +1941,7 @@
         </exercise>
 
         <exercise label="ex-vector-compare-parametrizations-4">
-  <!--        <webwork xml:id="ex-vector-compare-parametrizations-4">
+  <!--        <webwork xml:id="webwork-ex-vector-compare-parametrizations-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -1991,7 +1991,7 @@
         </introduction>
 
         <exercise label="ex-vector-motion-find-position-1">
-  <!--        <webwork xml:id="ex-vector-motion-find-position-1">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-find-position-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2009,7 +2009,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-find-position-2">
-          <webwork xml:id="ex-vector-motion-find-position-2">
+          <webwork xml:id="webwork-ex-vector-motion-find-position-2">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -2032,7 +2032,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-find-position-3">
-  <!--        <webwork xml:id="ex-vector-motion-find-position-3">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-find-position-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2050,7 +2050,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-find-position-4">
-          <webwork xml:id="ex-vector-motion-find-position-4">
+          <webwork xml:id="webwork-ex-vector-motion-find-position-4">
               <pg-code>
                 Context("Vector2D");
                 Context()->variables->are(t=>'Real');
@@ -2083,7 +2083,7 @@
         </introduction>
 
         <exercise label="ex-vector-motion-displacement-1">
-  <!--        <webwork xml:id="ex-vector-motion-displacement-1">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-displacement-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2105,7 +2105,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-displacement-2">
-          <webwork xml:id="ex-vector-motion-displacement-2">
+          <webwork xml:id="webwork-ex-vector-motion-displacement-2">
               <pg-code>
                 Context("Vector2D");
                 $disp=Compute("&lt;-10,0>");
@@ -2149,7 +2149,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-displacement-3">
-  <!--        <webwork xml:id="ex-vector-motion-displacement-3">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-displacement-3">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2170,7 +2170,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-displacement-4">
-          <webwork xml:id="ex-vector-motion-displacement-4">
+          <webwork xml:id="webwork-ex-vector-motion-displacement-4">
               <pg-code>
                 Context("Vector");
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
@@ -2224,7 +2224,7 @@
         </introduction>
 
         <exercise label="ex-vector-motion-projectile-1">
-  <!--        <webwork xml:id="ex-vector-motion-projectile-1">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-projectile-1">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2248,7 +2248,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-projectile-2">
-  <!--        <webwork xml:id="ex-vector-motion-projectile-2">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-projectile-2">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2319,7 +2319,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-projectile-3">
-          <webwork xml:id="ex-vector-motion-projectile-3">
+          <webwork xml:id="webwork-ex-vector-motion-projectile-3">
               <pg-code>
                 Context()->flags->set(tolerance=>0.005);
                 $angle=NumberWithUnits("0.013 radians");
@@ -2363,7 +2363,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-projectile-4">
-  <!--        <webwork xml:id="ex-vector-motion-projectile-4">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-projectile-4">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2423,7 +2423,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-projectile-5">
-  <!--        <webwork xml:id="ex-vector-motion-projectile-5">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-projectile-5">
               <pg-code>
               </pg-code> -->
               <statement>
@@ -2447,7 +2447,7 @@
         </exercise>
 
         <exercise label="ex-vector-motion-projectile-6">
-  <!--        <webwork xml:id="ex-vector-motion-projectile-6">
+  <!--        <webwork xml:id="webwork-ex-vector-motion-projectile-6">
               <pg-code>
               </pg-code> -->
               <statement>


### PR DESCRIPTION
In an earlier commit, I used the labels added to exercises to create xml:ids for webwork elements. This should have been fine, but somehow it led to two elements in HTML getting the same ID. (I didn't think `@label` was used for HTML IDs.)

As a result, the Activate button for WeBWorK problems was not working correctly. This modifies the webwork xml:ids to be different from the labels, which fixes the issue with the activate button not working.