### PR TITLE
Convert ordered lists in exercises to tasks, where appropriate

### DIFF
--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -2077,7 +2077,7 @@
       <!-- Exercise 29 -->
       <exercise label="ex-FTC-even-odd-explain">
         <webwork xml:id="ex-FTC-even-odd-explain">
-          <task>
+          <task label="ex-FTC-even-odd-explain-a">
             <p>
               Explain why <m>\ds\int_{-1}^1 x^n\, dx=0</m>
               when <m>n</m> is a positive, odd integer.
@@ -2088,7 +2088,7 @@
             </p>
           </task>
 
-          <task>
+          <task label="ex-FTC-even-odd-explain-b">
             <statement>
               <p>
                 Explain why <m>\ds\int_{-1}^1 x^n\, dx = 2\int_{0}^1 x^n\, dx</m> when <m>n</m> is a positive,

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -2078,14 +2078,16 @@
       <exercise label="ex-FTC-even-odd-explain">
         <webwork xml:id="webwork-ex-FTC-even-odd-explain">
           <task label="ex-FTC-even-odd-explain-a">
-            <p>
-              Explain why <m>\ds\int_{-1}^1 x^n\, dx=0</m>
-              when <m>n</m> is a positive, odd integer.
-            </p>
+            <statement>
+              <p>
+                Explain why <m>\ds\int_{-1}^1 x^n\, dx=0</m>
+                when <m>n</m> is a positive, odd integer.
+              </p>
 
-            <p>
-              <var form="essay"/>
-            </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
           </task>
 
           <task label="ex-FTC-even-odd-explain-b">

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -2077,28 +2077,29 @@
       <!-- Exercise 29 -->
       <exercise label="ex-FTC-even-odd-explain">
         <webwork xml:id="ex-FTC-even-odd-explain">
-          <statement>
+          <task>
             <p>
-              Explain why:
-              <ol>
-                <li>
-                  <p>
-                    <m>\ds\int_{-1}^1 x^n\, dx=0</m>,
-                    when <m>n</m> is a positive, odd integer, and
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\ds\int_{-1}^1 x^n\, dx = 2\int_{0}^1 x^n\, dx</m> when <m>n</m> is a positive,
-                    even integer.
-                  </p>
-                </li>
-              </ol>
+              Explain why <m>\ds\int_{-1}^1 x^n\, dx=0</m>
+              when <m>n</m> is a positive, odd integer.
             </p>
+
             <p>
               <var form="essay"/>
             </p>
-          </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Explain why <m>\ds\int_{-1}^1 x^n\, dx = 2\int_{0}^1 x^n\, dx</m> when <m>n</m> is a positive,
+                even integer.
+              </p>
+
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+          </task>            
         </webwork>
       </exercise>
       <!-- Exercise 30 -->

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -1236,7 +1236,7 @@
             <m>\ds \int s^n\,dn</m>.
           </p>
         </introduction>
-        <task>
+        <task label="ex-antiderivatives-find-difference-a">
           <statement>
             <p>
               What is the difference between these two indefinite integrals?
@@ -1249,7 +1249,7 @@
             </p>
           </solution>
         </task>
-        <task>
+        <task label="ex-antiderivatives-find-difference-b">
           <statement>
             <p>
               Evaluate <m>\ds \int s^n\,ds</m>.
@@ -1261,7 +1261,7 @@
             </p>
           </solution>
         </task>
-        <task>
+        <task label="ex-antiderivatives-find-difference-c">
           <statement>
             <p>
               Evaluate <m>\ds \int s^n\,dn</m>.
@@ -1283,35 +1283,35 @@
               states that <m>\ds \int \frac1x\,dx = \ln\abs{x} + C</m>.
             </p>
           </introduction>
-          <task>
+          <task label="ex-antiderivatives-log-abs-a">
             <statement>
               <p>
                 What is the domain of <m>y = \ln(x)</m>?
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-antiderivatives-log-abs-b">
             <statement>
               <p>
                 Find <m>\lzoo{x}{\ln(x) }</m>.
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-antiderivatives-log-abs-c">
             <statement>
               <p>
                 What is the domain of <m>y = \ln(-x)</m>?
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-antiderivatives-log-abs-d">
             <statement>
               <p>
                 Find <m>\lzoo{x}{\ln(-x)}</m>.
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-antiderivatives-log-abs-e">
             <statement>
               <p>
                 You should find that <m>1/x</m> has two types of antiderivatives,

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -1230,96 +1230,103 @@
       </exercisegroup>
 
       <exercise label="ex-antiderivatives-find-difference">
-        <statement>
+        <introduction>
           <p>
             Consider the two integrals, <m>\ds \int s^n\,ds</m> and
             <m>\ds \int s^n\,dn</m>.
-            <ol>
-              <li>
-                <p>
-                  What is the difference between these two indefinite integrals?
-                </p>
-              </li>
-              <li>
-                <p>
-                  Evaluate <m>\ds \int s^n\,ds</m>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Evaluate <m>\ds \int s^n\,dn</m>.
-                </p>
-              </li>
-            </ol>
           </p>
-        </statement>
-        <solution>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  The indefinite integrals have different differentials,
-                  <ie/>, different variables of integration.
-                </p>
-              </li>
-              <li>
-                <p>
-                  <m>\frac{s^{n+1}}{n+1}+C</m>, <m>n\neq -1</m>
-                </p>
-              </li>
-              <li>
-                <p>
-                  <m>\frac{s^{n}}{\ln s}+C</m>, <m>s>0</m>
-                </p>
-              </li>
-            </ol>
-          </p>
-        </solution>
+        </introduction>
+        <task>
+          <statement>
+            <p>
+              What is the difference between these two indefinite integrals?
+            </p>
+          </statement>
+          <solution>
+            <p>
+              The indefinite integrals have different differentials,
+              <ie/>, different variables of integration.
+            </p>
+          </solution>
+        </task>
+        <task>
+          <statement>
+            <p>
+              Evaluate <m>\ds \int s^n\,ds</m>.
+            </p>
+          </statement>
+          <solution>
+            <p>
+              <m>\frac{s^{n+1}}{n+1}+C</m>, <m>n\neq -1</m>
+            </p>
+          </solution>
+        </task>
+        <task>
+          <statement>
+            <p>
+              Evaluate <m>\ds \int s^n\,dn</m>.
+            </p>
+          </statement>
+          <solution>
+            <p>
+              <m>\frac{s^{n}}{\ln s}+C</m>, <m>s>0</m>
+            </p>
+          </solution>
+        </task>
       </exercise>
 
       <exercise label="ex-antiderivatives-log-abs">
-        <webwork xml:id="ex-antiderivatives-log-abs">
-          <statement>
+        <!-- <webwork xml:id="ex-antiderivatives-log-abs"> -->
+          <introduction>
             <p>
               This problem investigates why <xref ref="thm_indef_alg">Theorem</xref>
               states that <m>\ds \int \frac1x\,dx = \ln\abs{x} + C</m>.
-              <ol>
-                <li>
-                  <p>
-                    What is the domain of <m>y = \ln(x)</m>?
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Find <m>\lzoo{x}{\ln(x) }</m>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    What is the domain of <m>y = \ln(-x)</m>?
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Find <m>\lzoo{x}{\ln(-x)}</m>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    You should find that <m>1/x</m> has two types of antiderivatives,
-                    depending on whether <m>x \gt 0</m> or <m>x\lt 0</m>.
-                    In one expression, give a formula for
-                    <m>\ds \int \frac{1}{x}\, dx</m> that takes these different domains into account,
-                    and explain your answer.
-                  </p>
-                </li>
-              </ol>
             </p>
-            <p>
-              <var form="essay"/>
-            </p>
-          </statement>
-        </webwork>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                What is the domain of <m>y = \ln(x)</m>?
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Find <m>\lzoo{x}{\ln(x) }</m>.
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                What is the domain of <m>y = \ln(-x)</m>?
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Find <m>\lzoo{x}{\ln(-x)}</m>.
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                You should find that <m>1/x</m> has two types of antiderivatives,
+                depending on whether <m>x \gt 0</m> or <m>x\lt 0</m>.
+                In one expression, give a formula for
+                <m>\ds \int \frac{1}{x}\, dx</m> that takes these different domains into account,
+                and explain your answer.
+              </p>
+
+              <!-- <p>
+                <var form="essay"/>
+              </p> -->
+            </statement>
+          </task>
+        <!-- </webwork> -->
       </exercise>
 
       <exercisegroup xml:id="exset-antiderivatives-ivp">

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -2887,7 +2887,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-conic-ellipse-foci-a">
               <statement>
                 <p>
                   Verify that the foci are located at <m>(1,3\pm 2\sqrt{2})</m>.
@@ -2900,7 +2900,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-conic-ellipse-foci-b">
               <statement>
                 <p>
                   The points <m>P_1 = (2,6)</m> and <m>P_2 = (1+\sqrt{2},3+\sqrt{6}) \approx (2.414,5.449)</m> lie on the ellipse.
@@ -2955,7 +2955,7 @@
               </tabular>
             </introduction>
 
-            <task>
+            <task label="ex-conic-ellipse-kepler-a">
               <statement>
                 <p>
                   In an ellipse,
@@ -2972,7 +2972,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-conic-ellipse-kepler-b">
               <statement>
                 <p>
                   For each planet,
@@ -2992,7 +2992,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-conic-ellipse-kepler-c">
               <statement>
                 <p>
                   Shift the equations so that the Sun lies at the origin.

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -2881,45 +2881,38 @@
         <!-- <webwork xml:id="ex-conic-ellipse-foci">
             <pg-code>
             </pg-code> -->
-            <statement>
+            <introduction>
               <p>
                 Consider the ellipse given by <m>\ds \frac{(x-1)^2}{4}+\frac{(y-3)^2}{12}=1</m>.
               </p>
+            </introduction>
 
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      Verify that the foci are located at <m>(1,3\pm 2\sqrt{2})</m>.
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Verify that the foci are located at <m>(1,3\pm 2\sqrt{2})</m>.
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  <m>c=\sqrt{12-4} = 2\sqrt{2}</m>.
+                </p>
+              </solution>
+            </task>
 
-                  <li>
-                    <p>
-                      The points <m>P_1 = (2,6)</m> and <m>P_2 = (1+\sqrt{2},3+\sqrt{6}) \approx (2.414,5.449)</m> lie on the ellipse.
-                      Verify that the sum of distances from each point to the foci is the same.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
-            <solution>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>c=\sqrt{12-4} = 2\sqrt{2}</m>.
-                    </p>
-                  </li>
-
-                  <li>
-                    <p>
-                      The sum of distances for each point is <m>2\sqrt{12}\approx 6.9282</m>.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </solution>
+            <task>
+              <statement>
+                <p>
+                  The points <m>P_1 = (2,6)</m> and <m>P_2 = (1+\sqrt{2},3+\sqrt{6}) \approx (2.414,5.449)</m> lie on the ellipse.
+                  Verify that the sum of distances from each point to the foci is the same.
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  The sum of distances for each point is <m>2\sqrt{12}\approx 6.9282</m>.
+                </p>
+              </solution>
+            </task>
         <!-- </webwork> -->
       </exercise>
 
@@ -2927,7 +2920,7 @@
         <!-- <webwork xml:id="ex-conic-ellipse-kepler">
             <pg-code>
             </pg-code> -->
-            <statement>
+            <introduction>
               <p>
                 Johannes Kepler discovered that the planets of our solar system have elliptical orbits with the Sun at one focus.
                 The Earth's elliptical orbit is used as a standard unit of distance;
@@ -2960,68 +2953,62 @@
                   <cell><m>0.0934</m></cell>
                 </row>
               </tabular>
+            </introduction>
 
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      In an ellipse,
-                      knowing <m>c^2=a^2-b^2</m> and <m>e=c/a</m> allows us to find <m>b</m> in terms of <m>a</m> and <m>e</m>.
-                      Show <m>b=a\sqrt{1-e^2}</m>.
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  In an ellipse,
+                  knowing <m>c^2=a^2-b^2</m> and <m>e=c/a</m> allows us to find <m>b</m> in terms of <m>a</m> and <m>e</m>.
+                  Show <m>b=a\sqrt{1-e^2}</m>.
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  Solve for <m>c</m> in <m>e=c/a</m>: <m>c=ae</m>.
+                  Thus <m>a^2e^2=a^2-b^2</m>, and <m>b^2=a^2-a^2e^2</m>.
+                  The result follows.
+                </p>
+              </solution>
+            </task>
 
-                  <li>
-                    <p>
-                      For each planet,
-                      find equations of their elliptical orbit of the form
-                      <m>\ds\frac{x^2}{a^2}+\frac{y^2}{b^2}=1</m>. (This places the center at <m>(0,0)</m>,
-                      but the Sun is in a different location for each planet.)
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  For each planet,
+                  find equations of their elliptical orbit of the form
+                  <m>\ds\frac{x^2}{a^2}+\frac{y^2}{b^2}=1</m>. (This places the center at <m>(0,0)</m>,
+                  but the Sun is in a different location for each planet.)
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  Mercury: <m>x^2/(0.387)^2 + y^2/(0.3787)^2=1</m>
 
-                  <li>
-                    <p>
-                      Shift the equations so that the Sun lies at the origin.
-                      Plot the three elliptical orbits.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
-            <solution>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      Solve for <m>c</m> in <m>e=c/a</m>: <m>c=ae</m>.
-                      Thus <m>a^2e^2=a^2-b^2</m>, and <m>b^2=a^2-a^2e^2</m>.
-                      The result follows.
-                    </p>
-                  </li>
+                  Earth:	<m>x^2+y^2/(0.99986)^2 = 1</m>
 
-                  <li>
-                    <p>
-                      Mercury: <m>x^2/(0.387)^2 + y^2/(0.3787)^2=1</m>
+                  Mars: <m>x^2/(1.524)^2+y^2/(1.517)^2=1</m>
+                </p>
+              </solution>
+            </task>
 
-                      Earth:	<m>x^2+y^2/(0.99986)^2 = 1</m>
+            <task>
+              <statement>
+                <p>
+                  Shift the equations so that the Sun lies at the origin.
+                  Plot the three elliptical orbits.
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  Mercury: <m>(x-0.08)^2/(0.387)^2 + y^2/(0.3787)^2=1</m>
 
-                      Mars: <m>x^2/(1.524)^2+y^2/(1.517)^2=1</m>
-                    </p>
-                  </li>
+                  Earth: <m>(x-0.0167)^2+y^2/(0.99986)^2 = 1</m>
 
-                  <li>
-                    <p>
-                      Mercury: <m>(x-0.08)^2/(0.387)^2 + y^2/(0.3787)^2=1</m>
-
-                      Earth: <m>(x-0.0167)^2+y^2/(0.99986)^2 = 1</m>
-
-                      Mars: <m>(x-0.1423)^2/(1.524)^2+y^2/(1.517)^2=1</m>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </solution>
+                  Mars: <m>(x-0.1423)^2/(1.524)^2+y^2/(1.517)^2=1</m>
+                </p>
+              </solution>
+            </task>
         <!-- </webwork> -->
       </exercise>
 

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -1583,7 +1583,7 @@
         </introduction>
 
         <exercise label="ex-cylindrical-spherical-convert-1">
-          <task>
+          <task label="ex-cylindrical-spherical-convert-1a">
             <statement>
               <p>
                 Points in rectangular coordinates:
@@ -1602,7 +1602,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-cylindrical-spherical-convert-1b">
             <statement>
               <p>
                 Points in cylindrical coordinates:
@@ -1621,7 +1621,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-cylindrical-spherical-convert-1c">
             <statement>
               <p>
                 Points in spherical coordinates:
@@ -1643,7 +1643,7 @@
         </exercise>
 
         <exercise label="ex-cylindrical-spherical-convert-2">
-          <task>
+          <task label="ex-cylindrical-spherical-convert-2a">
             <statement>
               <p>
                 Points in rectangular coordinates:
@@ -1661,7 +1661,7 @@
             </solution>
           </task>
 
-          <task>
+          <task label="ex-cylindrical-spherical-convert-2b">
             <statement>
               <p>
                 Points in cylindrical coordinates:
@@ -1679,7 +1679,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-cylindrical-spherical-convert-2c">
             <statement>
               <p>
                 Points in spherical coordinates:
@@ -1709,7 +1709,7 @@
         </introduction>
 
         <exercise label="ex-cylindrical-region-1">
-          <task>
+          <task label="ex-cylindrical-region-1a">
             <statement>
               <p>
                 <m>r=1</m>, <m>0\leq \theta\leq 2\pi</m>, <m>0\leq z\leq 1</m>
@@ -1722,7 +1722,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-cylindrical-region-1b">
             <statement>
               <p>
                 <m>1\leq r\leq 2</m>, <m>0\leq \theta\leq \pi</m>, <m>0\leq z\leq 1</m>
@@ -1740,7 +1740,7 @@
         </exercise>
 
         <exercise label="ex-cylindrical-region-2">
-          <task>
+          <task label="ex-cylindrical-region-2a">
             <statement>
               <p>
                 <m>1\leq r\leq 2</m>, <m>\theta= \pi/2</m>, <m>0\leq z\leq 1</m>
@@ -1754,7 +1754,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-cylindrical-region-2b">
             <statement>
               <p>
                 <m>r= 2</m>, <m>0\leq \theta\leq 2\pi</m>, <m>z=5</m>
@@ -1778,8 +1778,8 @@
           </p>
         </introduction>
 
-        <exercise xml:id="ex-spherical-region-1">
-          <task>
+        <exercise label="ex-spherical-region-1">
+          <task label="ex-spherical-region-1a">
             <statement>
               <p>
                 <m>\rho=3</m>, <m>0\leq \theta\leq2\pi</m>,
@@ -1792,7 +1792,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-spherical-region-1b">
             <statement>
               <p>
                 <m>2\leq\rho\leq3</m>, <m>0\leq \theta\leq2\pi</m>,
@@ -1809,8 +1809,8 @@
           </task>
         </exercise>
 
-        <exercise xml:id="ex-spherical-region-2">
-          <task>
+        <exercise label="ex-spherical-region-2">
+          <task label="ex-spherical-region-2a">
             <statement>
               <p>
                 <m>0\leq\rho\leq2</m>, <m>0\leq \theta\leq\pi</m>, <m>\varphi = \pi/4</m>
@@ -1825,7 +1825,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-spherical-region-2b">
             <statement>
               <p>
                 <m>\rho=2</m>,
@@ -1833,7 +1833,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-spherical-region-2c">
             <statement>
               <p>
                 This is a curve,

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -1583,278 +1583,265 @@
         </introduction>
 
         <exercise label="ex-cylindrical-spherical-convert-1">
-          <statement>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Points in rectangular coordinates:
-                    <m>(2,2,1)</m> and <m>(-\sqrt{3},1,0)</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Points in cylindrical coordinates:
-                    <m>(2,\pi/4,2)</m> and <m>(3,3\pi/2,-4)</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Points in spherical coordinates:
-                    <m>(2,\pi/4,\pi/4)</m> and <m>(1,0,0)</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Cylindrical:
-                    <m>(2\sqrt 2,\pi/4,1)</m> and <m>(2,5\pi/6,0)</m> Spherical:
-                    <m>(3,\pi/4,\cos^{-1}(3))</m> and <m>(2,5\pi/6,0)</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Rectangular:
-                    <m>(\sqrt 2,\sqrt 2,2)</m> and <m>(0,-3,-4)</m> Spherical:
-                    <m>(2\sqrt 2,\pi/4,\pi/4)</m> and <m>(5,3\pi/2,-\tan^{-1}(4/3))</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Rectangular:
-                    <m>(1,1,\sqrt{2})</m> and <m>(1,0,0)</m> Cylindrical:
-                    <m>(\sqrt{2},\pi/4,\sqrt{2})</m> and <m>(1,0,0)</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+          <task>
+            <statement>
+              <p>
+                Points in rectangular coordinates:
+                <m>(2,2,1)</m> and <m>(-\sqrt{3},1,0)</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Cylindrical:
+                <m>(2\sqrt 2,\pi/4,1)</m> and <m>(2,5\pi/6,0)</m> 
+              </p>
+              
+              <p>
+                Spherical:
+                <m>(3,\pi/4,\cos^{-1}(3))</m> and <m>(2,5\pi/6,0)</m>
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Points in cylindrical coordinates:
+                <m>(2,\pi/4,2)</m> and <m>(3,3\pi/2,-4)</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Rectangular:
+                <m>(\sqrt 2,\sqrt 2,2)</m> and <m>(0,-3,-4)</m>
+              </p>
+              
+              <p>
+                Spherical:
+                <m>(2\sqrt 2,\pi/4,\pi/4)</m> and <m>(5,3\pi/2,-\tan^{-1}(4/3))</m>
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Points in spherical coordinates:
+                <m>(2,\pi/4,\pi/4)</m> and <m>(1,0,0)</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Rectangular:
+                <m>(1,1,\sqrt{2})</m> and <m>(1,0,0)</m>
+              </p>
+              
+              <p>
+                Cylindrical:
+                <m>(\sqrt{2},\pi/4,\sqrt{2})</m> and <m>(1,0,0)</m>
+              </p>
+            </solution>
+          </task>
         </exercise>
 
         <exercise label="ex-cylindrical-spherical-convert-2">
-          <statement>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Points in rectangular coordinates:
-                    <m>(0,1,1)</m> and <m>(-1,0,1)</m>
-                  </p>
-                </li>
+          <task>
+            <statement>
+              <p>
+                Points in rectangular coordinates:
+                <m>(0,1,1)</m> and <m>(-1,0,1)</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Cylindrical: <m>(1,\pi/2,1)</m> and <m>(1,\pi,1)</m>
+              </p>
+              <p>
+                Spherical:
+                <m>(\sqrt 2,\pi/2,\pi/4)</m> and <m>(\sqrt{2}, \pi, \pi/4)</m>
+              </p>
+            </solution>
+          </task>
 
-                <li>
-                  <p>
-                    Points in cylindrical coordinates:
-                    <m>(0,\pi,1)</m> and <m>(2,4\pi/3,0)</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Points in spherical coordinates:
-                    <m>(2,\pi/6,0)</m> and <m>(3,\pi,-\pi/2)</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Cylindrical: <m>(1,\pi/2,1)</m> and <m>(1,\pi,1)</m> Spherical:
-                    <m>(\sqrt 2,\pi/2,\pi/4)</m> and <m>(\sqrt{2}, \pi, \pi/4)</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Rectangular:
-                    <m>(0,0,1)</m> and <m>(-1,-\sqrt 3,0)</m> Spherical:
-                    <m>(1,\pi,\pi/2)</m> and <m>(2,4\pi/3,0)</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    Rectangular:
-                    <m>(\sqrt 3,1,0)</m> and <m>(0,0,-3)</m> Cylindrical:
-                    <m>(2,\pi/6,0)</m> and <m>(0,\pi,-3)</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+          <task>
+            <statement>
+              <p>
+                Points in cylindrical coordinates:
+                <m>(0,\pi,1)</m> and <m>(2,4\pi/3,0)</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Rectangular:
+                <m>(0,0,1)</m> and <m>(-1,-\sqrt 3,0)</m>
+              </p>
+              <p>
+                Spherical:
+                <m>(1,\pi,\pi/2)</m> and <m>(2,4\pi/3,0)</m>
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Points in spherical coordinates:
+                <m>(2,\pi/6,0)</m> and <m>(3,\pi,-\pi/2)</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Rectangular:
+                <m>(\sqrt 3,1,0)</m> and <m>(0,0,-3)</m>
+              </p>
+              <p>
+                Cylindrical:
+                <m>(2,\pi/6,0)</m> and <m>(0,\pi,-3)</m>
+              </p>
+            </solution>
+          </task>
         </exercise>
       </exercisegroup>
 
-      <exercisegroup cols="2" xml:id="exset-cylindrical-spherical-region">
+      <exercisegroup cols="2" xml:id="exset-cylindrical-region">
         <introduction>
           <p>
             In the following exercises, describe the curve,
-            surface or region in space determined by the given bounds.
+            surface or region in space determined by the given bounds in cylindrical coordinates.
           </p>
         </introduction>
 
-        <exercise label="ex-cylindrical-spherical-region-1">
-          <statement>
-            <p>
-              Bounds in cylindrical coordinates:
-              <ol>
-                <li>
-                  <p>
-                    <m>r=1</m>, <m>0\leq \theta\leq 2\pi</m>, <m>0\leq z\leq 1</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    <m>1\leq r\leq 2</m>, <m>0\leq \theta\leq \pi</m>, <m>0\leq z\leq 1</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-
-            <p>
-              Bounds in spherical coordinates:
-              <ol>
-                <li>
-                  <p>
-                    <m>\rho=3</m>, <m>0\leq \theta\leq2\pi</m>,
-                    <m>0\leq\varphi\leq \pi/2</m>
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    <m>2\leq\rho\leq3</m>, <m>0\leq \theta\leq2\pi</m>,
-                    <m>-\pi/2\leq\varphi\leq \pi/2</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    A cylindrical surface or tube,
-                    centered along the <m>z</m>-axis of radius 1, extending from the <m>xy</m>-plane up to the plane <m>z=1</m> (<ie/>, the tube has a length of 1).
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    This is a region of space,
-                    being half of a tube with <q>thick</q>
-                    walls of inner radius 1 and outer radius 2, centered along the <m>z</m>-axis with a length of 1, where the half <q>below</q>
-                    the <m>xz</m>-plane is removed.
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    This is upper half of the sphere of radius 3 centered at the origin (<ie/>, the upper hemisphere).
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    This is a region of space,
-                    where the ball of radius 2, centered at the origin,
-                    is removed from the ball of radius 3, centered at the origin.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+        <exercise label="ex-cylindrical-region-1">
+          <task>
+            <statement>
+              <p>
+                <m>r=1</m>, <m>0\leq \theta\leq 2\pi</m>, <m>0\leq z\leq 1</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                A cylindrical surface or tube,
+                centered along the <m>z</m>-axis of radius 1, extending from the <m>xy</m>-plane up to the plane <m>z=1</m> (<ie/>, the tube has a length of 1).
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>1\leq r\leq 2</m>, <m>0\leq \theta\leq \pi</m>, <m>0\leq z\leq 1</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                This is a region of space,
+                being half of a tube with <q>thick</q>
+                walls of inner radius 1 and outer radius 2, centered along the <m>z</m>-axis with a length of 1, where the half <q>below</q>
+                the <m>xz</m>-plane is removed.
+              </p>
+            </solution>
+          </task>
         </exercise>
 
-        <exercise label="ex-cylindrical-spherical-region-2">
-          <statement>
-            <p>
-              Bounds in cylindrical coordinates:
-              <ol>
-                <li>
-                  <p>
-                    <m>1\leq r\leq 2</m>, <m>\theta= \pi/2</m>, <m>0\leq z\leq 1</m>
-                  </p>
-                </li>
+        <exercise label="ex-cylindrical-region-2">
+          <task>
+            <statement>
+              <p>
+                <m>1\leq r\leq 2</m>, <m>\theta= \pi/2</m>, <m>0\leq z\leq 1</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                A square portion of the <m>yz</m>-plane with corners at <m>(0,1,0)</m>,
+                <m>(0,1,1)</m>,
+                <m>(0,2,1)</m> and <m>(0,2,0)</m>.
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>r= 2</m>, <m>0\leq \theta\leq 2\pi</m>, <m>z=5</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                This is a curve, a circle of radius 2, centered at <m>(0,0,5)</m>,
+                lying parallel to the <m>xy</m>-plane (<ie/>, in the plane <m>z=5</m>).
+              </p>
+            </solution>
+          </task>
+        </exercise>
+      </exercisegroup>
 
-                <li>
-                  <p>
-                    <m>r= 2</m>, <m>0\leq \theta\leq 2\pi</m>, <m>z=5</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
+      <exercisegroup  cols="2" xml:id="exset-spherical-region">
+        <introduction>
+          <p>
+            In the following exercises, describe the curve,
+            surface or region in space determined by the given bounds in spherical coordinates.
+          </p>
+        </introduction>
 
-            <p>
-              Bounds in spherical coordinates:
-              <ol>
-                <li>
-                  <p>
-                    <m>0\leq\rho\leq2</m>, <m>0\leq \theta\leq\pi</m>, <m>\varphi = \pi/4</m>
-                  </p>
-                </li>
+        <exercise xml:id="ex-spherical-region-1">
+          <task>
+            <statement>
+              <p>
+                <m>\rho=3</m>, <m>0\leq \theta\leq2\pi</m>,
+                <m>0\leq\varphi\leq \pi/2</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                This is upper half of the sphere of radius 3 centered at the origin (<ie/>, the upper hemisphere).
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>2\leq\rho\leq3</m>, <m>0\leq \theta\leq2\pi</m>,
+                <m>-\pi/2\leq\varphi\leq \pi/2</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                This is a region of space,
+                where the ball of radius 2, centered at the origin,
+                is removed from the ball of radius 3, centered at the origin.
+              </p>
+            </solution>
+          </task>
+        </exercise>
 
-                <li>
-                  <p>
-                    <m>\rho=2</m>,
-                    <m>0\leq \theta\leq2\pi</m>, <m>\varphi = \pi/3</m>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    A square portion of the <m>yz</m>-plane with corners at <m>(0,1,0)</m>,
-                    <m>(0,1,1)</m>,
-                    <m>(0,2,1)</m> and <m>(0,2,0)</m>.
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    This is a curve, a circle of radius 2, centered at <m>(0,0,5)</m>,
-                    lying parallel to the <m>xy</m>-plane (<ie/>, in the plane <m>z=5</m>).
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    This is a region of space, a half of a solid cone with rounded top,
-                    where the rounded top is a portion of the ball of radius 2 centered at the origin and the sides of the cone make an angle of <m>\pi/4</m> with the positive <m>z</m>-axis.
-                    The bounds on <m>\theta</m> mean only the portion <q>above</q>
-                    the <m>xz</m>-plane are retained.
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    This is a curve,
-                    a circle of radius 1 centered at <m>(0,0,\sqrt 3)</m>,
-                    lying parallel to the <m>xy</m>-plane.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+        <exercise xml:id="ex-spherical-region-2">
+          <task>
+            <statement>
+              <p>
+                <m>0\leq\rho\leq2</m>, <m>0\leq \theta\leq\pi</m>, <m>\varphi = \pi/4</m>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                This is a region of space, a half of a solid cone with rounded top,
+                where the rounded top is a portion of the ball of radius 2 centered at the origin and the sides of the cone make an angle of <m>\pi/4</m> with the positive <m>z</m>-axis.
+                The bounds on <m>\theta</m> mean only the portion <q>above</q>
+                the <m>xz</m>-plane are retained.
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>\rho=2</m>,
+                <m>0\leq \theta\leq2\pi</m>, <m>\varphi = \pi/3</m>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                This is a curve,
+                a circle of radius 1 centered at <m>(0,0,\sqrt 3)</m>,
+                lying parallel to the <m>xy</m>-plane.
+              </p>
+            </statement>
+          </task>
         </exercise>
       </exercisegroup>
 

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -1076,7 +1076,7 @@
                 </image> -->
             </introduction>
 
-            <task>
+            <task label="ex-definite-integral-geometry-1a">
               <statement>
                 <p>
                   <m>\int_0^1 (-2x+4)\, dx</m>
@@ -1086,7 +1086,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-1b">
               <statement>
                 <p>
                   <m>\int_0^2 (-2x+4)\, dx</m>
@@ -1096,7 +1096,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-1c">
               <statement>
                 <p>
                   <m>\int_0^3 (-2x+4)\, dx</m>
@@ -1106,7 +1106,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-1d">
               <statement>
                 <p>
                   <m>\int_1^3 (-2x+4)\, dx</m>
@@ -1116,7 +1116,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-1e">
               <statement>
                 <p>
                   <m>\int_2^4 (-2x+4)\, dx</m>
@@ -1126,7 +1126,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-1f">
               <statement>
                 <p>
                   <m>\int_0^1 (-6x+12)\, d </m>
@@ -1181,7 +1181,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-geometry-2a">
               <statement>
                 <p>
                   <m>\int_0^2 f(x)\, dx</m>
@@ -1191,7 +1191,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-2b">
               <statement>
                 <p>
                   <m>\int_0^3 f(x)\, dx</m>
@@ -1201,7 +1201,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-2c">
               <statement>
                 <p>
                   <m>\int_0^5 f(x)\, dx</m>
@@ -1211,7 +1211,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-2d">
               <statement>
                 <p>
                   <m>\int_2^5 f(x)\, dx</m>
@@ -1221,7 +1221,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-2e">
               <statement>
                 <p>
                   <m>\int_5^3 f(x)\, dx</m>
@@ -1231,7 +1231,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-2f">
               <statement>
                 <p>
                   <m>\int_0^3 -2f(x)\, dx</m>
@@ -1286,7 +1286,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-geometry-3a">
               <statement>
                 <p>
                   <m>\int_0^2 f(x)\, dx</m>
@@ -1296,7 +1296,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-3b">
               <statement>
                 <p>
                   <m>\int_2^4 f(x)\, dx</m>
@@ -1306,7 +1306,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-3c">
               <statement>
                 <p>
                   <m>\int_2^4 2f(x)\, dx</m>
@@ -1316,7 +1316,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-3d">
               <statement>
                 <p>
                   <m>\int_0^1 4x\, dx</m>
@@ -1326,7 +1326,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-3e">
               <statement>
                 <p>
                   <m>\int_2^3 (2x-4)\, dx</m>
@@ -1336,7 +1336,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-3f">
               <statement>
                 <p>
                   <m>\int_2^3 (4x-8)\, dx</m>
@@ -1389,7 +1389,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-geometry-4a">
               <statement>
                 <p>
                   <m>\int_0^1 (x-1)\, dx</m>
@@ -1399,7 +1399,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-4b">
               <statement>
                 <p>
                   <m>\int_0^2 (x-1)\, dx</m>
@@ -1409,7 +1409,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-4c">
               <statement>
                 <p>
                   <m>\int_0^3 (x-1)\, dx</m>
@@ -1419,7 +1419,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-4d">
               <statement>
                 <p>
                   <m>\int_2^3 (x-1)\, dx</m>
@@ -1429,7 +1429,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-4e">
               <statement>
                 <p>
                   <m>\int_1^4 (x-1)\, dx</m>
@@ -1439,7 +1439,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-4f">
               <statement>
                 <p>
                   <m>\int_1^4 \big((x-1)+1\big)\, dx</m>
@@ -1498,7 +1498,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-geometry-5a">
               <statement>
                 <p>
                   <m>\int_0^2 f(x)\, dx</m>
@@ -1508,7 +1508,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-5b">
               <statement>
                 <p>
                   <m>\int_2^4 f(x)\, dx</m>
@@ -1518,7 +1518,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-5c">
               <statement>
                 <p>
                   <m>\int_0^4 f(x)\, dx</m>
@@ -1528,7 +1528,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-5d">
               <statement>
                 <p>
                   <m>\int_0^4 5f(x)\, dx</m>
@@ -1580,7 +1580,7 @@
                     </latex-image>
                   </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-geometry-6a">
               <statement>
                 <p>
                   <m>\int_0^5 f(x)\, dx</m>
@@ -1590,7 +1590,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-6b">
               <statement>
                 <p>
                   <m>\int_3^7 f(x)\, dx</m>
@@ -1600,7 +1600,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-6c">
               <statement>
                 <p>
                   <m>\int_0^0 f(x)\, dx</m>
@@ -1610,7 +1610,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-geometry-6d">
               <statement>
                 <p>
                   <m>\ds \int_a^b f(x)\, dx</m>, where
@@ -1687,7 +1687,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-area-1a">
               <statement>
                 <p>
                   <m>\int_0^1 f(x)\, dx</m>
@@ -1697,7 +1697,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-1b">
               <statement>
                 <p>
                   <m>\int_0^2 f(x)\, dx</m>
@@ -1707,7 +1707,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-1c">
               <statement>
                 <p>
                   <m>\int_0^3 f(x)\, dx</m>
@@ -1717,7 +1717,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-1d">
               <statement>
                 <p>
                   <m>\int_1^2 -3f(x)\, dx</m>
@@ -1780,7 +1780,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-area-2a">
               <statement>
                 <p>
                   <m>\int_0^2 f(x)\, dx</m>
@@ -1790,7 +1790,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-2b">
               <statement>
                 <p>
                   <m>\int_2^4 f(x)\, dx</m>
@@ -1800,7 +1800,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-2c">
               <statement>
                 <p>
                   <m>\int_0^4 f(x)\, dx</m>
@@ -1810,7 +1810,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-2d">
               <statement>
                 <p>
                   <m>\int_0^1 f(x)\, dx</m>
@@ -1884,7 +1884,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-area-3a">
               <statement>
                 <p>
                   <m>\int_{-2}^{-1} f(x)\, dx</m>
@@ -1894,7 +1894,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-3b">
               <statement>
                 <p>
                   <m>\int_1^2 f(x)\, dx</m>
@@ -1904,7 +1904,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-3c">
               <statement>
                 <p>
                   <m>\int_{-1}^1 f(x)\, dx</m>
@@ -1914,7 +1914,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-3d">
               <statement>
                 <p>
                   <m>\int_0^1 f(x)\, dx</m>
@@ -1986,7 +1986,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-area-4a">
               <statement>
                 <p>
                   <m>\int_{0}^{2} 5x^2\, dx</m>
@@ -1996,7 +1996,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-4b">
               <statement>
                 <p>
                   <m>\int_0^2 (x^2+3)\, dx</m>
@@ -2006,7 +2006,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-4c">
               <statement>
                 <p>
                   <m>\int_{1}^3 (x-1)^2\, dx</m>
@@ -2016,7 +2016,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-area-4d">
               <statement>
                 <p>
                   <m>\int_2^4 \big((x-2)^2+5\big)\, dx</m>
@@ -2078,7 +2078,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-velocity-1a">
               <statement>
                 <p>
                   What is the object's maximum velocity?
@@ -2088,7 +2088,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-velocity-1b">
               <statement>
                 <p>
                   What is the object's maximum displacement?
@@ -2098,7 +2098,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-velocity-1c">
               <statement>
                 <p>
                   What is the object's total displacement on <m>[0,3]</m>?
@@ -2158,7 +2158,7 @@
                   </latex-image>
                 </image> -->
             </introduction>
-            <task>
+            <task label="ex-definite-integral-velocity-2a">
               <statement>
                 <p>
                   What is the object's maximum velocity?
@@ -2168,7 +2168,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-velocity-2b">
               <statement>
                 <p>
                   What is the object's maximum displacement?
@@ -2178,7 +2178,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-definite-integral-velocity-2c">
               <statement>
                 <p>
                   What is the object's total displacement on <m>[0,5]</m>?
@@ -2207,7 +2207,7 @@
               where <m>t</m> is in seconds, from a height of <m>48</m> feet.
             </p>
           </introduction>
-          <task>
+          <task label="ex-definite-integral-velocity-3a">
             <statement>
               <p>
                 What is the object's maximum velocity?
@@ -2217,7 +2217,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-definite-integral-velocity-3b">
             <statement>
               <p>
                 What is the object's maximum displacement?
@@ -2227,7 +2227,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-definite-integral-velocity-3c">
             <statement>
               <p>
                 When does the maximum displacement occur?
@@ -2237,7 +2237,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-definite-integral-velocity-3d">
             <statement>
               <p>
                 When will the object reach a height of <m>0</m>? (Hint:
@@ -2266,7 +2266,7 @@
               where <m>t</m> is in seconds, from a height of <m>64</m> feet.
             </p>
           </introduction>
-          <task>
+          <task label="ex-definite-integral-velocity-4a">
             <statement>
               <p>
                 What is the object's initial velocity?
@@ -2276,7 +2276,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-definite-integral-velocity-4b">
             <statement>
               <p>
                 When is the object's displacement 0?
@@ -2286,7 +2286,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-definite-integral-velocity-4c">
             <statement>
               <p>
                 How long does it take for the object to return to its initial height?
@@ -2296,7 +2296,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-definite-integral-velocity-4d">
             <statement>
               <p>
                 What is the maximum height the object reaches?

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -1056,7 +1056,7 @@
               }
               @a = (3,4,3,0,-4,9);
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_05">
                   <description></description>
@@ -1074,59 +1074,68 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^1 (-2x+4)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^2 (-2x+4)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^3 (-2x+4)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_1^3 (-2x+4)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^4 (-2x+4)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[4]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^1 (-6x+12)\, d </m>
-                    </p>
-                    <p>
-                      <var name="$a[5]" width="3"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 (-2x+4)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 (-2x+4)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^3 (-2x+4)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_1^3 (-2x+4)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^4 (-2x+4)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[4]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 (-6x+12)\, d </m>
+                </p>
+                <p>
+                  <var name="$a[5]" width="3"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 6       -->
@@ -1150,7 +1159,7 @@
               }
               @a = (-4,-5,-3,1,-2,10);
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_06">
                   <description></description>
@@ -1171,59 +1180,67 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^2 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^3 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^5 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^5 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_5^3 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[4]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^3 -2f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[5]" width="3"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^3 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^5 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^5 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_5^3 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[4]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^3 -2f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[5]" width="3"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 7 -->
@@ -1246,7 +1263,7 @@
               }
               @a = (4,2,4,2,1,2);
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_07">
                   <description></description>
@@ -1268,59 +1285,67 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^2 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^4 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^4 2f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^1 4x\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^3 (2x-4)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[4]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^3 (4x-8)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[5]" width="3"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^4 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^4 2f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 4x\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^3 (2x-4)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[4]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^3 (4x-8)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[5]" width="3"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 8 -->
@@ -1343,7 +1368,7 @@
               Context("Fraction");
               @a = (Fraction(-1/2),Fraction(0),Fraction(3/2),Fraction(3/2),Fraction(9/2),Fraction(15/2));
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_08">
                   <description></description>
@@ -1363,59 +1388,67 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^1 (x-1)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^2 (x-1)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^3 (x-1)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^3 (x-1)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_1^4 (x-1)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[4]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_1^4 \big((x-1)+1\big)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[5]" width="3"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 (x-1)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 (x-1)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^3 (x-1)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^3 (x-1)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_1^4 (x-1)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[4]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_1^4 \big((x-1)+1\big)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[5]" width="3"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 9 -->
@@ -1444,7 +1477,7 @@
               }
               @a = (Formula("pi"),Formula("pi"),Formula("2 pi"),Formula("10 pi"));
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_09">
                   <description></description>
@@ -1464,43 +1497,47 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^2 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^4 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^4 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="3"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^4 5f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="3"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^4 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^4 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^4 5f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="3"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 10 -->
@@ -1523,7 +1560,7 @@
               Context()->variables->add(a=>'Real',b=>'Real');
               @a = (15,12,0,Formula("3(b-a)"));
             </pg-code>
-            <statement>
+            <introduction>
                 <image pg-name="$gr"/>
                   <!-- <image xml:id="img_05_02_ex_10">
                     <latex-image>
@@ -1542,44 +1579,48 @@
                       \end{tikzpicture}
                     </latex-image>
                   </image> -->
+            </introduction>
+            <task>
+              <statement>
                 <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        <m>\int_0^5 f(x)\, dx</m>
-                      </p>
-                      <p>
-                        <var name="$a[0]" width="3"/>
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        <m>\int_3^7 f(x)\, dx</m>
-                      </p>
-                      <p>
-                        <var name="$a[1]" width="3"/>
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        <m>\int_0^0 f(x)\, dx</m>
-                      </p>
-                      <p>
-                        <var name="$a[2]" width="3"/>
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        <m>\ds \int_a^b f(x)\, dx</m>, where
-                        <m>0\leq a\leq b\leq 10</m>
-                      </p>
-                      <p>
-                        <var name="$a[3]" width="3"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\int_0^5 f(x)\, dx</m>
                 </p>
-            </statement>
+                <p>
+                  <var name="$a[0]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_3^7 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^0 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="3"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\ds \int_a^b f(x)\, dx</m>, where
+                  <m>0\leq a\leq b\leq 10</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="3"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -1621,7 +1662,7 @@
               }
               @a = (-59,-48,-27,-33);
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_11">
                   <description></description>
@@ -1645,43 +1686,47 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^1 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^2 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^3 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_1^2 -3f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="4"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^3 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_1^2 -3f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="4"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 12 -->
@@ -1711,7 +1756,7 @@
               }
               @a = (Formula("4/pi"),Formula("-4/pi"),Formula("0"),Formula("2/pi"));
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_12">
                   <description></description>
@@ -1734,43 +1779,47 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_0^2 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^4 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^4 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^1 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="4"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^4 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^4 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="4"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 13 -->
@@ -1810,7 +1859,7 @@
               }
               @a = (4,4,-4,-2);
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_13">
                   <description></description>
@@ -1834,43 +1883,47 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_{-2}^{-1} f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_1^2 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_{-1}^1 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^1 f(x)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="4"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_{-2}^{-1} f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_1^2 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_{-1}^1 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^1 f(x)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="4"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 14 -->
@@ -1908,7 +1961,7 @@
               Context("Fraction");
               @a = (Fraction("40/3"),Fraction("26/3"),Fraction("8/3"),Fraction("38/3"));
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_14">
                   <description></description>
@@ -1932,43 +1985,47 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\int_{0}^{2} 5x^2\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[0]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_0^2 (x^2+3)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[1]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_{1}^3 (x-1)^2\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[2]" width="4"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\int_2^4 \big((x-2)^2+5\big)\, dx</m>
-                    </p>
-                    <p>
-                      <var name="$a[3]" width="4"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_{0}^{2} 5x^2\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[0]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_0^2 (x^2+3)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[1]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_{1}^3 (x-1)^2\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[2]" width="4"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\int_2^4 \big((x-2)^2+5\big)\, dx</m>
+                </p>
+                <p>
+                  <var name="$a[3]" width="4"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -2000,7 +2057,7 @@
               $md = NumberWithUnits("2 ft");
               $td = NumberWithUnits("1.5 ft");
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_15">
                   <description></description>
@@ -2020,35 +2077,37 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      What is the object's maximum velocity?
-                    </p>
-                    <p>
-                      <var name="$mv" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the object's maximum displacement?
-                    </p>
-                    <p>
-                      <var name="$md" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the object's total displacement on <m>[0,3]</m>?
-                    </p>
-                    <p>
-                      <var name="$td" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  What is the object's maximum velocity?
+                </p>
+                <p>
+                  <var name="$mv" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the object's maximum displacement?
+                </p>
+                <p>
+                  <var name="$md" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the object's total displacement on <m>[0,3]</m>?
+                </p>
+                <p>
+                  <var name="$td" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 16 -->
@@ -2074,7 +2133,7 @@
               $md = NumberWithUnits("9.5 ft");
               $td = NumberWithUnits("9.5 ft");
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
                 <!-- <image xml:id="img_05_02_ex_16">
                   <description></description>
@@ -2098,35 +2157,37 @@
                     \end{tikzpicture}
                   </latex-image>
                 </image> -->
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      What is the object's maximum velocity?
-                    </p>
-                    <p>
-                      <var name="$mv" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the object's maximum displacement?
-                    </p>
-                    <p>
-                      <var name="$md" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the object's total displacement on <m>[0,5]</m>?
-                    </p>
-                    <p>
-                      <var name="$td" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  What is the object's maximum velocity?
+                </p>
+                <p>
+                  <var name="$mv" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the object's maximum displacement?
+                </p>
+                <p>
+                  <var name="$md" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the object's total displacement on <m>[0,5]</m>?
+                </p>
+                <p>
+                  <var name="$td" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -2139,48 +2200,54 @@
             $md_t = NumberWithUnits("2 s");
             $h0_t = FormulaWithUnits("2+sqrt(7) s");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               An object is thrown straight up with a velocity,
               in ft/s, given by <m>v(t) = -32t+64</m>,
               where <m>t</m> is in seconds, from a height of <m>48</m> feet.
-              <ol>
-                <li>
-                  <p>
-                    What is the object's maximum velocity?
-                  </p>
-                  <p>
-                    <var name="$mv" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    What is the object's maximum displacement?
-                  </p>
-                  <p>
-                    <var name="$md" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    When does the maximum displacement occur?
-                  </p>
-                  <p>
-                    <var name="$md_t" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    When will the object reach a height of <m>0</m>? (Hint:
-                    find when the displacement is <m>-48</m>ft.)
-                  </p>
-                  <p>
-                    <var name="$h0_t" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                What is the object's maximum velocity?
+              </p>
+              <p>
+                <var name="$mv" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                What is the object's maximum displacement?
+              </p>
+              <p>
+                <var name="$md" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                When does the maximum displacement occur?
+              </p>
+              <p>
+                <var name="$md_t" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                When will the object reach a height of <m>0</m>? (Hint:
+                find when the displacement is <m>-48</m>ft.)
+              </p>
+              <p>
+                <var name="$h0_t" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!-- Exercise 18 -->
@@ -2192,49 +2259,53 @@
             $h0_2 = NumberWithUnits("6 s");
             $hmax = NumberWithUnits("-16*3^2+96*3+64 ft");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               An object is thrown straight up with a velocity,
               in ft/s, given by <m>v(t) = -32t+96</m>,
               where <m>t</m> is in seconds, from a height of <m>64</m> feet.
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    What is the object's initial velocity?
-                  </p>
-                  <p>
-                    <var name="$v0" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    When is the object's displacement 0?
-                  </p>
-                  <p>
-                    <var name="$d" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    How long does it take for the object to return to its initial height?
-                  </p>
-                  <p>
-                    <var name="$h0_2" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    What is the maximum height the object reaches?
-                  </p>
-                  <p>
-                    <var name="$hmax" width="20"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                What is the object's initial velocity?
+              </p>
+              <p>
+                <var name="$v0" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                When is the object's displacement 0?
+              </p>
+              <p>
+                <var name="$d" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                How long does it take for the object to return to its initial height?
+              </p>
+              <p>
+                <var name="$h0_2" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                What is the maximum height the object reaches?
+              </p>
+              <p>
+                <var name="$hmax" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1333,7 +1333,7 @@
               for all bases <m>a,b \gt 0,\neq 1</m>.
             </p>
           </introduction>
-          <task>
+          <task label="ex-deriv-basic-log-prop-a">
             <statement>
               <p>
                 Rewrite this identity when <m>b=e</m>,
@@ -1341,14 +1341,14 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-basic-log-prop-b">
             <statement>
               <p>
                 Use part (a) to find the derivative of <m>y=\log_{10}(x)</m>.
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-basic-log-prop-c">
             <statement>
               <p>
                 Find the derivative of <m>y=\log_a(x)</m> for any <m>a\gt0,\neq1</m>.

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1326,35 +1326,40 @@
       </exercisegroup>
 
       <exercise label="ex-deriv-basic-log-prop">
-        <webwork xml:id="ex-deriv-basic-log-prop">
-          <statement>
+        <!-- <webwork xml:id="ex-deriv-basic-log-prop"> -->
+          <introduction>
             <p>
               A property of logarithms is that <m>\log_a(x) = \frac{\log_b(x)}{\log_b(a)}</m>,
               for all bases <m>a,b \gt 0,\neq 1</m>.
-              <ol>
-                <li>
-                  <p>
-                    Rewrite this identity when <m>b=e</m>,
-                    <ie/>, using <m>\log_e(x) =\ln(x)</m>, with <m>a=10</m>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Use part (a) to find the derivative of <m>y=\log_{10}(x)</m>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Find the derivative of <m>y=\log_a(x)</m> for any <m>a\gt0,\neq1</m>.
-                  </p>
-                </li>
-              </ol>
             </p>
-            <p>
-              <var form="essay"/>
-            </p>
-          </statement>
-        </webwork>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                Rewrite this identity when <m>b=e</m>,
+                <ie/>, using <m>\log_e(x) =\ln(x)</m>, with <m>a=10</m>.
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Use part (a) to find the derivative of <m>y=\log_{10}(x)</m>.
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Find the derivative of <m>y=\log_a(x)</m> for any <m>a\gt0,\neq1</m>.
+              </p>
+
+              <!-- <p>
+                <var form="essay"/>
+              </p>   -->
+            </statement>
+          </task>
+        <!-- </webwork> -->
       </exercise>
 
       <exercisegroup cols="2" xml:id="exset-deriv-basic-higher">

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -1906,52 +1906,46 @@
           <pg-code>
             $sign=PopUp(['?','positive','negative'],2);
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               The <q>wind chill factor</q> is a measurement of how cold it <q>feels</q>
               during cold, windy weather.
               Let <m>W(w)</m> be the wind chill factor, in degrees Fahrenheit,
               when it is <m>25^\circ</m>F outside with a wind of <m>w</m> mph.
             </p>
-            <p>
-              <ol marker="a">
-                <li>
-                  <p>
-                    What are the units of <m>W'(w)</m>?
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    What would you expect the sign of <m>W'(10)</m> to be?
-                  </p>
-                  <p>
-                    <var name="$sign" form="popup"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol marker="a">
-                <li>
-                  <p>
-                    <m>^\circ</m>F/mph
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    The sign would be negative; when the wind is blowing at 10 mph,
-                    any increase in wind speed will make it feel colder,
-                    i.e., a lower number on the Fahrenheit scale.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                What are the units of <m>W'(w)</m>?
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                <m>^\circ</m>F/mph
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                What would you expect the sign of <m>W'(10)</m> to be?
+              </p>
+              <p>
+                <var name="$sign" form="popup"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                The sign would be negative; when the wind is blowing at 10 mph,
+                any increase in wind speed will make it feel colder,
+                <ie/>, a lower number on the Fahrenheit scale.
+              </p>
+            </solution>
+          </task>
         </webwork>
       </exercise>
 
@@ -1970,31 +1964,31 @@
             $fp=$f->D('x');
             $gp=$g->D('x');
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Find the derivatives of the following functions.
             </p>
-            <p>
-              <ol marker="a">
-                <li>
-                  <p>
-                    <m>f(x) = <var name="$f"/></m>
-                  </p>
-                  <p>
-                    <var name="$fp" width="40"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>g(x) = <var name="$g"/></m>
-                  </p>
-                  <p>
-                    <var name="$gp" width="40"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                <m>f(x) = <var name="$f"/></m>
+              </p>
+              <p>
+                <var name="$fp" width="40"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>g(x) = <var name="$g"/></m>
+              </p>
+              <p>
+                <var name="$gp" width="40"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
     </subexercises>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -1914,7 +1914,7 @@
               when it is <m>25^\circ</m>F outside with a wind of <m>w</m> mph.
             </p>
           </introduction>
-          <task>
+          <task label="ex-deriv-chain-review-1a">
             <statement>
               <p>
                 What are the units of <m>W'(w)</m>?
@@ -1929,7 +1929,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-deriv-chain-review-1b">
             <statement>
               <p>
                 What would you expect the sign of <m>W'(10)</m> to be?
@@ -1969,7 +1969,7 @@
               Find the derivatives of the following functions.
             </p>
           </introduction>
-          <task>
+          <task label="ex-deriv-chain-review-2a">
             <statement>
               <p>
                 <m>f(x) = <var name="$f"/></m>
@@ -1979,7 +1979,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-chain-review-2b">
             <statement>
               <p>
                 <m>g(x) = <var name="$g"/></m>

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -1704,14 +1704,14 @@
         </exercise>
       </exercisegroup>
 
-      <exercise label="ex-deriv-implicit-compute-14">
-        <webwork xml:id="ex-deriv-implicit-compute-14">
+      <exercise label="ex-deriv-implicit-compare">
+        <webwork xml:id="ex-deriv-implicit-compare">
           <introduction>
             <p>
               Show that <m>\lz{y}{x}</m> is the same for each of the following implicitly defined functions.
             </p>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-compare-a">
               <statement>
                 <p>
                   <m>xy=1</m>
@@ -1721,7 +1721,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-compare-b">
               <statement>
                 <p>
                   <m>x^2y^2=1</m>
@@ -1731,7 +1731,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-compare-c">
               <statement>
                 <p>
                   <m>\sin(xy) = 1</m>
@@ -1741,7 +1741,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-compare-d">
               <statement>
                 <p>
                   <m>\ln(xy) =1</m>
@@ -1792,7 +1792,7 @@
               </p>
               <image pg-name="$gr"/>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-tangent-1a">
               <statement>
                 <p>
                   At <m>(1,0)</m>.
@@ -1802,7 +1802,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-1b">
               <statement>
                 <p>
                   At <m>(0.1,0.2811)</m> (which does not <em>exactly</em>
@@ -1845,7 +1845,7 @@
               </p>
               <image pg-name="$gr"/>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-tangent-2a">
               <statement>
                 <p>
                   At <m>(1,0)</m>.
@@ -1855,7 +1855,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-2b">
               <statement>
                 <p>
                   At <m>\left(\sqrt{0.6},\sqrt{0.8}\right)</m>.
@@ -1897,7 +1897,7 @@
               </p>
               <image pg-name="$gr"/>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-tangent-3a">
               <statement>
                 <p>
                   At <m>(0,4)</m>.
@@ -1907,7 +1907,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-3b">
               <statement>
                 <p>
                   At <m>\left(2,-\sqrt[4]{108}\right)</m>.
@@ -1949,7 +1949,7 @@
               </p>
               <image pg-name="$gr"/>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-tangent-4a">
               <statement>
                 <p>
                   At <m>(0,1)</m>.
@@ -1959,7 +1959,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-4b">
               <statement>
                 <p>
                   At <m>\left(-\frac{3}{4}, \frac{3\sqrt{3}}{4}\right)</m>.
@@ -2003,7 +2003,7 @@
               </p>
               <image pg-name="$gr"/>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-tangent-5a">
               <statement>
                 <p>
                   At <m>\left(\frac{7}{2},\frac{6+3\sqrt{3}}{2}\right)</m>.
@@ -2013,7 +2013,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-5b">
               <statement>
                 <p>
                   At <m>\left(\frac{4+3\sqrt{3}}{2},\frac{3}{2}\right)</m>.
@@ -2059,7 +2059,7 @@
               </p>
               <image pg-name="$gr"/>
             </introduction>
-            <task>
+            <task label="ex-deriv-implicit-tangent-6a">
               <statement>
                 <p>
                   At <m>(-1,1)</m>.
@@ -2069,7 +2069,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-6b">
               <statement>
                 <p>
                   At <m>\left(-1,\frac12(-1+\sqrt{5})\right)</m>.
@@ -2079,7 +2079,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-implicit-tangent-6c">
               <statement>
                 <p>
                   At <m>\left(-1,\frac12(-1-\sqrt{5})\right)</m>.

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -1706,47 +1706,51 @@
 
       <exercise label="ex-deriv-implicit-compute-14">
         <webwork xml:id="ex-deriv-implicit-compute-14">
-          <statement>
+          <introduction>
             <p>
               Show that <m>\lz{y}{x}</m> is the same for each of the following implicitly defined functions.
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>xy=1</m>
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>x^2y^2=1</m>
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\sin(xy) = 1</m>
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\ln(xy) =1</m>
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  <m>xy=1</m>
+                </p>
+                <p>
+                  <var form="essay"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>x^2y^2=1</m>
+                </p>
+                <p>
+                  <var form="essay"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\sin(xy) = 1</m>
+                </p>
+                <p>
+                  <var form="essay"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  <m>\ln(xy) =1</m>
+                </p>
+                <p>
+                  <var form="essay"/>
+                </p>
+              </statement>
+            </task>
         </webwork>
       </exercise>
 
@@ -1782,34 +1786,33 @@
               $gr->stamps(closed_circle(0.1,0.2811,'black'));
               $gr->lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom','large'));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
-                On the curve <m>x^{2/5}+y^{2/5} = 1</m>,
-                find the equation of the tangent line at:
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>(1,0)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[0]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>(0.1,0.2811)</m> (which does not <em>exactly</em>
-                      lie on the curve, but is very close)
-                    </p>
-                    <p>
-                      <var name="$eq[1]" width="30"/>
-                    </p>
-                  </li>
-                </ol>
+                On the curve <m>x^{2/5}+y^{2/5} = 1</m>.
               </p>
               <image pg-name="$gr"/>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  At <m>(1,0)</m>.
+                </p>
+                <p>
+                  <var name="$eq[0]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>(0.1,0.2811)</m> (which does not <em>exactly</em>
+                  lie on the curve, but is very close).
+                </p>
+                <p>
+                  <var name="$eq[1]" width="30"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1836,41 +1839,32 @@
               $gr->stamps(closed_circle(0.7746,0.8944,'black'));
               $gr->lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top','large'));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
-                On the curve <m>x^{4}+y^{4} = 1</m>,
-                find the equation of the tangent line at:
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>(1,0)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[0]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\left(\sqrt{0.6},\sqrt{0.8}\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[1]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      At <m>(0,1)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[2]" width="30"/>
-                    </p>
-                  </li>
-                </ol>
+                On the curve <m>x^{4}+y^{4} = 1</m>.
               </p>
               <image pg-name="$gr"/>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  At <m>(1,0)</m>.
+                </p>
+                <p>
+                  <var name="$eq[0]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(\sqrt{0.6},\sqrt{0.8}\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[1]" width="30"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1897,33 +1891,32 @@
               $gr->stamps(closed_circle(2,-3.224,'black'));
               $gr->lb(new Label(2,-3.224,'(2,-root(4,108))','black','center','bottom','large'));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
-                On the curve <m>(x^2+y^2-4)^3 = 108y^2</m>,
-                find the equation of the tangent line at:
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>(0,4)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[0]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\left(2,-\sqrt[4]{108}\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[1]" width="30"/>
-                    </p>
-                  </li>
-                </ol>
+                On the curve <m>(x^2+y^2-4)^3 = 108y^2</m>.
               </p>
               <image pg-name="$gr"/>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  At <m>(0,4)</m>.
+                </p>
+                <p>
+                  <var name="$eq[0]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(2,-\sqrt[4]{108}\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[1]" width="30"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1950,33 +1943,32 @@
               $gr->stamps(closed_circle(-0.75,1.299,'black'));
               $gr->lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','right','bottom','large'));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
-                On the curve <m>(x^2+y^2+x)^2 = x^2+y^2</m>,
-                find the equation of the tangent line at:
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>(0,1)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[0]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\left(-\frac{3}{4}, \frac{3\sqrt{3}}{4}\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[1]" width="30"/>
-                    </p>
-                  </li>
-                </ol>
+                On the curve <m>(x^2+y^2+x)^2 = x^2+y^2</m>.
               </p>
               <image pg-name="$gr"/>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  At <m>(0,1)</m>.
+                </p>
+                <p>
+                  <var name="$eq[0]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(-\frac{3}{4}, \frac{3\sqrt{3}}{4}\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[1]" width="30"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -2005,33 +1997,32 @@
               $gr->stamps(closed_circle(4.598,1.5,'black'));
               $gr->lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom','large'));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
-                On the curve <m>(x-2)^2+(y-3)^2=9</m>,
-                find the equation of the tangent line at:
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\left(\frac{7}{2},\frac{6+3\sqrt{3}}{2}\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[0]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\left(\frac{4+3\sqrt{3}}{2},\frac{3}{2}\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[1]" width="30"/>
-                    </p>
-                  </li>
-                </ol>
+                On the curve <m>(x-2)^2+(y-3)^2=9</m>.
               </p>
               <image pg-name="$gr"/>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(\frac{7}{2},\frac{6+3\sqrt{3}}{2}\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[0]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(\frac{4+3\sqrt{3}}{2},\frac{3}{2}\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[1]" width="30"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -2062,41 +2053,42 @@
               $gr->stamps(closed_circle(-1,(-1-sqrt(5))/2,'black'));
               $gr->lb(new Label(-1,(-1-sqrt(5))/2,'(-1,(-1-sqrt(5))/2)','black','left','top','large'));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
-                On the curve <m>x^2+y^3+2xy=0</m>,
-                find the equation of the tangent line at:
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>(-1,1)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[0]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\left(-1,\frac12(-1+\sqrt{5})\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[1]" width="30"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\left(-1,\frac12(-1-\sqrt{5})\right)</m>
-                    </p>
-                    <p>
-                      <var name="$eq[2]" width="30"/>
-                    </p>
-                  </li>
-                </ol>
+                On the curve <m>x^2+y^3+2xy=0</m>.
               </p>
               <image pg-name="$gr"/>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  At <m>(-1,1)</m>.
+                </p>
+                <p>
+                  <var name="$eq[0]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(-1,\frac12(-1+\sqrt{5})\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[1]" width="30"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  At <m>\left(-1,\frac12(-1-\sqrt{5})\right)</m>.
+                </p>
+                <p>
+                  <var name="$eq[2]" width="30"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1004,7 +1004,7 @@
               of producing and selling <m>c</m> cars.
             </p>
           </introduction>
-          <task>
+          <task label="ex-deriv-interpret-10a">
             <statement>
               <p>
                 What are the units of <m>P'(c)</m>?
@@ -1019,7 +1019,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-deriv-interpret-10b">
             <statement>
               <p>
                 What is likely true of <m>P(0)</m>?
@@ -1046,7 +1046,7 @@
               <m>h</m> hours after midnight on July 4 in Sidney, NE.
             </p>
           </introduction>
-          <task>
+          <task label="ex-deriv-interpret-11a">
             <statement>
               <p>
                 What are the units of <m>T'(h)</m>?
@@ -1061,7 +1061,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-deriv-interpret-11b">
             <statement>
               <p>
                 Is <m>T'(8)</m> likely greater than or less than 0?
@@ -1078,7 +1078,7 @@
               </p>
             </solution>
           </task>
-          <task>
+          <task label="ex-deriv-interpret-11c">
             <statement>
               <p>
                 Is <m>T(8)</m> likely greater than or less than 0?

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -998,113 +998,103 @@
 
       <exercise label="ex-deriv-interpret-10">
         <webwork xml:id="ex-deriv-interpret-10">
-          <statement>
+          <introduction>
             <p>
               <m>P</m> is the profit, in thousands of dollars,
               of producing and selling <m>c</m> cars.
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    What are the units of <m>P'(c)</m>?
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    What is likely true of <m>P(0)</m>?
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    thousands of dollars per car
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    It is likely that <m>P(0)\lt 0</m>.
-                    That is, negative profit for not producing any cars.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                What are the units of <m>P'(c)</m>?
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Thousands of dollars per car.
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                What is likely true of <m>P(0)</m>?
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                It is likely that <m>P(0)\lt 0</m>.
+                That is, negative profit for not producing any cars.
+              </p>
+            </solution>
+          </task>
         </webwork>
       </exercise>
 
       <exercise label="ex-deriv-interpret-11">
         <webwork xml:id="ex-deriv-interpret-11">
-          <statement>
+          <introduction>
             <p>
               <m>T</m> is the temperature in degrees Fahrenheit,
               <m>h</m> hours after midnight on July 4 in Sidney, NE.
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    What are the units of <m>T'(h)</m>?
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Is <m>T'(8)</m> likely greater than or less than 0?
-                    Why?
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Is <m>T(8)</m> likely greater than or less than 0?
-                    Why?
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    degrees Fahrenheit per hour
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    It is likely that <m>T'(8) \gt 0</m> since at 8 in the morning,
-                    the temperature is likely rising.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    It is very likely that <m>T(8) \gt 0</m>,
-                    as at 8 in the morning on July 4, we would expect the temperature to be well above 0.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                What are the units of <m>T'(h)</m>?
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Degrees Fahrenheit per hour.
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Is <m>T'(8)</m> likely greater than or less than 0?
+                Why?
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                It is likely that <m>T'(8) \gt 0</m> since at 8 in the morning,
+                the temperature is likely rising.
+              </p>
+            </solution>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Is <m>T(8)</m> likely greater than or less than 0?
+                Why?
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                It is very likely that <m>T(8) \gt 0</m>,
+                as at 8 in the morning on July 4, we would expect the temperature to be well above 0.
+              </p>
+            </solution>
+          </task>
         </webwork>
       </exercise>
 

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2087,61 +2087,63 @@
             @slopes=(-2,0,4);
             $showwork = '[@ explanation_box(message => "Show your work.") @]*';
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               The graph of <m>f(x)=x^2-1</m> is shown.
             </p>
             <image pg-name="$gr" width="47%"/>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(-1,0)</m>, <m>(0,-1)</m>, and <m>(2,3)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$approx[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$approx[1]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$approx[2]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Using the definition of the derivative, find <m>\fp(x)</m>.
-                  </p>
-                  <p>
-                    <var name="$derivative" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$showwork" data="pgml"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Use the derivative to find the slope of the tangent line at the points <m>(-1,0)</m>, <m>(0,-1)</m> and <m>(2,3)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$slopes[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$slopes[1]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$slopes[2]" width="10"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(-1,0)</m>, <m>(0,-1)</m>, and <m>(2,3)</m>.
+              </p>
+              <instruction>
+                Enter the answers in the respective order.
+              </instruction>
+              <p>
+                <var name="$approx[0]" width="10"/>
+              </p>
+              <p>
+                <var name="$approx[1]" width="10"/>
+              </p>
+              <p>
+                <var name="$approx[2]" width="10"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Using the definition of the derivative, find <m>\fp(x)</m>.
+              </p>
+              <p>
+                <var name="$derivative" width="10"/>
+              </p>
+              <p>
+                <var name="$showwork" data="pgml"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Use the derivative to find the slope of the tangent line at the points <m>(-1,0)</m>, <m>(0,-1)</m> and <m>(2,3)</m>.
+              </p>
+              <instruction>
+                Enter the answers in the respective order.
+              </instruction>
+              <p>
+                <var name="$slopes[0]" width="10"/>
+              </p>
+              <p>
+                <var name="$slopes[1]" width="10"/>
+              </p>
+              <p>
+                <var name="$slopes[2]" width="10"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 
@@ -2165,53 +2167,53 @@
             @slopes=(-1,'-1/4');
             $showwork = '[@ explanation_box(message => "Show your work.") @]*';
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               The graph of <m>f(x)=\frac{1}{x+1}</m> is shown.
             </p>
             <image pg-name="$gr" width="47%"/>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(0,1)</m> and <m>(1,0.5)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$approx[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$approx[1]" width="10"/>
-                  </p>
-                  <p>
-                    Using the definition of the derivative, find <m>\fp(x)</m>.
-                  </p>
-                  <p>
-                    <var name="$derivative" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$showwork" data="pgml"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Use the derivative to find the slope of the tangent line at the points <m>(0,1)</m> and <m>(1,0.5)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$slopes[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$slopes[1]" width="10"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(0,1)</m> and <m>(1,0.5)</m>.
+              </p>
+              <instruction>
+                Enter the answers in the respective order.
+              </instruction>
+              <p>
+                <var name="$approx[0]" width="10"/>
+              </p>
+              <p>
+                <var name="$approx[1]" width="10"/>
+              </p>
+              <p>
+                Using the definition of the derivative, find <m>\fp(x)</m>.
+              </p>
+              <p>
+                <var name="$derivative" width="10"/>
+              </p>
+              <p>
+                <var name="$showwork" data="pgml"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Use the derivative to find the slope of the tangent line at the points <m>(0,1)</m> and <m>(1,0.5)</m>.
+              </p>
+              <instruction>
+                Enter the answers in the respective order.
+              </instruction>
+              <p>
+                <var name="$slopes[0]" width="10"/>
+              </p>
+              <p>
+                <var name="$slopes[1]" width="10"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 
@@ -2336,65 +2338,73 @@
               $inc=Compute("(-inf,-1)U(1,inf)");
               $fla=Compute("{-1,1}");
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
               <instruction>
                 Answer using interval notation or set notation, as appropriate. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
                 If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      Where is <m>g(x)\gt0</m>?
-                    </p>
-                    <p>
-                      <var name="$pos" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x)\lt0</m>?
-                    </p>
-                    <p>
-                      <var name="$neg" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$zer" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) \lt 0</m>?
-                    </p>
-                    <p>
-                      <var name="$dec" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x)  \gt  0</m>?
-                    </p>
-                    <p>
-                      <var name="$inc" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$fla" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g(x)\gt0</m>?
+                </p>
+                <p>
+                  <var name="$pos" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g(x)\lt0</m>?
+                </p>
+                <p>
+                  <var name="$neg" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g(x) = 0</m>?
+                </p>
+                <p>
+                  <var name="$zer" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g'(x) \lt 0</m>?
+                </p>
+                <p>
+                  <var name="$dec" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g'(x)  \gt  0</m>?
+                </p>
+                <p>
+                  <var name="$inc" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g'(x) = 0</m>?
+                </p>
+                <p>
+                  <var name="$fla" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -2414,65 +2424,73 @@
               $inc=Compute("(-inf,-1)U(0,1)");
               $fla=Compute("{-1,0,1}");
             </pg-code>
-            <statement>
+            <introduction>
               <image pg-name="$gr"/>
               <instruction>
                 Answer using interval notation or set notation, as appropriate. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
                 If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      Where is <m>g(x)\gt0</m>?
-                    </p>
-                    <p>
-                      <var name="$pos" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x)\lt0</m>?
-                    </p>
-                    <p>
-                      <var name="$neg" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$zer" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) \lt 0</m>?
-                    </p>
-                    <p>
-                      <var name="$dec" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x)  \gt  0</m>?
-                    </p>
-                    <p>
-                      <var name="$inc" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$fla" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g(x)\gt0</m>?
+                </p>
+                <p>
+                  <var name="$pos" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g(x)\lt0</m>?
+                </p>
+                <p>
+                  <var name="$neg" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g(x) = 0</m>?
+                </p>
+                <p>
+                  <var name="$zer" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g'(x) \lt 0</m>?
+                </p>
+                <p>
+                  <var name="$dec" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g'(x)  \gt  0</m>?
+                </p>
+                <p>
+                  <var name="$inc" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  Where is <m>g'(x) = 0</m>?
+                </p>
+                <p>
+                  <var name="$fla" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -2640,7 +2658,7 @@
               List(Interval("[-sqrt($b),sqrt($b)]"))
             );
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Give maximal intervals on which each of the following functions are continuous.
             </p>
@@ -2648,43 +2666,47 @@
               If there is more than one interval for an answer,
               enter the intervals as a list separated by commas.
             </instruction>
-            <p>
-              <ol cols="2">
-                <li>
-                  <p>
-                    <m>\dfrac{1}{e^x+1}</m>
-                  </p>
-                  <p>
-                    <var name="$cont[0]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$f"/></m>
-                  </p>
-                  <p>
-                    <var name="$cont[1]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$g"/></m>
-                  </p>
-                  <p>
-                    <var name="$cont[2]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$h"/></m>
-                  </p>
-                  <p>
-                    <var name="$cont[3]" width="20"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                <m>\dfrac{1}{e^x+1}</m>
+              </p>
+              <p>
+                <var name="$cont[0]" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m><var name="$f"/></m>
+              </p>
+              <p>
+                <var name="$cont[1]" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m><var name="$g"/></m>
+              </p>
+              <p>
+                <var name="$cont[2]" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m><var name="$h"/></m>
+              </p>
+              <p>
+                <var name="$cont[3]" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 
@@ -2702,7 +2724,7 @@
             Context("Interval");
             $cont=Compute("(-inf,-3)U(-3,inf)");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Use the graph of <m>f(x)</m> provided to answer the following.
             </p>
@@ -2711,47 +2733,51 @@
               If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
               If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
             </instruction>
-            <p>
-              <ol cols="2">
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to-3^-} f(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[0]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to-3^+} f(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[1]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to-3} f(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[2]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Where is <m>f</m> continuous?
-                  </p>
-                  <instruction>
-                    Answer using interval notation. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
-                    If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
-                  </instruction>
-                  <p>
-                    <var name="$cont" width="15"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to-3^-} f(x)</m>
+              </p>
+              <p>
+                <var name="$L[0]" width="10"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to-3^+} f(x)</m>
+              </p>
+              <p>
+                <var name="$L[1]" width="10"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to-3} f(x)</m>
+              </p>
+              <p>
+                <var name="$L[2]" width="10"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                Where is <m>f</m> continuous?
+              </p>
+              <instruction>
+                Answer using interval notation. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
+                If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
+              </instruction>
+              <p>
+                <var name="$cont" width="15"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
     </subexercises>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2093,7 +2093,7 @@
             </p>
             <image pg-name="$gr" width="47%"/>
           </introduction>
-          <task>
+          <task label="ex-deriv-intro-graph-approx-1a">
             <statement>
               <p>
                 Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(-1,0)</m>, <m>(0,-1)</m>, and <m>(2,3)</m>.
@@ -2112,7 +2112,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-graph-approx-1b">
             <statement>
               <p>
                 Using the definition of the derivative, find <m>\fp(x)</m>.
@@ -2125,7 +2125,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-graph-approx-1c">
             <statement>
               <p>
                 Use the derivative to find the slope of the tangent line at the points <m>(-1,0)</m>, <m>(0,-1)</m> and <m>(2,3)</m>.
@@ -2173,7 +2173,7 @@
             </p>
             <image pg-name="$gr" width="47%"/>
           </introduction>
-          <task>
+          <task label="ex-deriv-intro-graph-approx-2a">
             <statement>
               <p>
                 Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(0,1)</m> and <m>(1,0.5)</m>.
@@ -2198,7 +2198,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-graph-approx-2b">
             <statement>
               <p>
                 Use the derivative to find the slope of the tangent line at the points <m>(0,1)</m> and <m>(1,0.5)</m>.
@@ -2345,7 +2345,7 @@
                 If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
               </instruction>
             </introduction>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-1a">
               <statement>
                 <p>
                   Where is <m>g(x)\gt0</m>?
@@ -2355,7 +2355,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-1b">
               <statement>
                 <p>
                   Where is <m>g(x)\lt0</m>?
@@ -2365,7 +2365,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-1c">
               <statement>
                 <p>
                   Where is <m>g(x) = 0</m>?
@@ -2375,7 +2375,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-1d">
               <statement>
                 <p>
                   Where is <m>g'(x) \lt 0</m>?
@@ -2385,7 +2385,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-1e">
               <statement>
                 <p>
                   Where is <m>g'(x)  \gt  0</m>?
@@ -2395,7 +2395,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-1f">
               <statement>
                 <p>
                   Where is <m>g'(x) = 0</m>?
@@ -2431,7 +2431,7 @@
                 If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
               </instruction>
             </introduction>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-2a">
               <statement>
                 <p>
                   Where is <m>g(x)\gt0</m>?
@@ -2441,7 +2441,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-2b">
               <statement>
                 <p>
                   Where is <m>g(x)\lt0</m>?
@@ -2451,7 +2451,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-2c">
               <statement>
                 <p>
                   Where is <m>g(x) = 0</m>?
@@ -2461,7 +2461,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-2d">
               <statement>
                 <p>
                   Where is <m>g'(x) \lt 0</m>?
@@ -2471,7 +2471,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-2e">
               <statement>
                 <p>
                   Where is <m>g'(x)  \gt  0</m>?
@@ -2481,7 +2481,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-deriv-intro-graph-interpret-2f">
               <statement>
                 <p>
                   Where is <m>g'(x) = 0</m>?
@@ -2667,7 +2667,7 @@
               enter the intervals as a list separated by commas.
             </instruction>
           </introduction>
-          <task>
+          <task label="ex-deriv-intro-review-3a">
             <statement>
               <p>
                 <m>\dfrac{1}{e^x+1}</m>
@@ -2677,7 +2677,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-review-3b">
             <statement>
               <p>
                 <m><var name="$f"/></m>
@@ -2687,7 +2687,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-review-3c">
             <statement>
               <p>
                 <m><var name="$g"/></m>
@@ -2697,7 +2697,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-review-3d">
             <statement>
               <p>
                 <m><var name="$h"/></m>
@@ -2734,7 +2734,7 @@
               If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
             </instruction>
           </introduction>
-          <task>
+          <task label="ex-deriv-intro-review-4a">
             <statement>
               <p>
                 <m>\lim\limits_{x\to-3^-} f(x)</m>
@@ -2744,7 +2744,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-review-4b">
             <statement>
               <p>
                 <m>\lim\limits_{x\to-3^+} f(x)</m>
@@ -2754,7 +2754,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-review-4c">
             <statement>
               <p>
                 <m>\lim\limits_{x\to-3} f(x)</m>
@@ -2764,7 +2764,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-deriv-intro-review-4d">
             <statement>
               <p>
                 Where is <m>f</m> continuous?

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -1473,7 +1473,7 @@
               <m><var name="$dx"/>/10</m> of a second and the measured time is:
             </p>
           </introduction>
-          <task>
+          <task label="ex-differentials-error-2a">
             <statement>
               <p>
                 <m><var name="$a"/></m> seconds?
@@ -1483,7 +1483,7 @@
               </p>
             </statement>
           </task>
-          <task>
+          <task label="ex-differentials-error-2b">
             <statement>
               <p>
                 <m><var name="$b"/></m> seconds?
@@ -1590,7 +1590,7 @@
                 \end{tikzpicture}
               </latex-image>
             </introduction>
-            <task>
+            <task label="ex-differentials-survey-1a">
               <statement>
                 <p>
                   What is the measured length <m>L</m> of the wall?
@@ -1600,7 +1600,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-differentials-survey-1b">
               <statement>
                 <p>
                   What is the propagated error?
@@ -1610,7 +1610,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-differentials-survey-1c">
               <statement>
                 <p>
                   What is the percent error?
@@ -1656,7 +1656,7 @@
                 </latex-image>
               </image>
             </introduction>
-            <task>
+            <task label="ex-differentials-survey-2a">
               <statement>
                 <p>
                   What is the measured length <m>L</m> of the wall?
@@ -1666,7 +1666,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-differentials-survey-2b">
               <statement>
                 <p>
                   What is the propagated error?
@@ -1676,7 +1676,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-differentials-survey-2c">
               <statement>
                 <p>
                   What is the percent error?
@@ -1722,7 +1722,7 @@
                 </latex-image>
               </image>
             </introduction>
-            <task>
+            <task label="ex-differentials-survey-3a">
               <statement>
                 <p>
                   What is the measured length <m>L</m> of the wall?
@@ -1732,7 +1732,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-differentials-survey-3b">
               <statement>
                 <p>
                   What is the propagated error?
@@ -1742,7 +1742,7 @@
                 </p>
               </statement>
             </task>
-            <task>
+            <task label="ex-differentials-survey-3c">
               <statement>
                 <p>
                   What is the percent error?

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -1464,33 +1464,35 @@
             $err_b = $df->eval(x=>$b) * $dx/10;
             $err_bU = NumberWithUnits("$err_b ft");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               The distance, in feet,
               a stone drops in <m>t</m> seconds is given by <m>d(t) = 16t^2</m>.
               The depth of a hole is to be approximated by dropping a rock and listening for it to hit the bottom.
               What is the propagated error if the time measurement is accurate to
               <m><var name="$dx"/>/10</m> of a second and the measured time is:
-              <ol>
-                <li>
-                  <p>
-                    <m><var name="$a"/></m> seconds?
-                  </p>
-                  <p>
-                    <var name="$err_a" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$b"/></m> seconds?
-                  </p>
-                  <p>
-                    <var name="$err_b" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                <m><var name="$a"/></m> seconds?
+              </p>
+              <p>
+                <var name="$err_a" width="20"/>
+              </p>
+            </statement>
+          </task>
+          <task>
+            <statement>
+              <p>
+                <m><var name="$b"/></m> seconds?
+              </p>
+              <p>
+                <var name="$err_b" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!-- Exercise 33: Propagated error in cross-sectional area of a log -->
@@ -1571,7 +1573,7 @@
               Context("Percent");
               $err_pct = Percent("$err/$l");
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 The length <m>L</m> of a long wall is to be approximated.
                 The angle <m>\theta</m>, as shown in the diagram
@@ -1587,35 +1589,37 @@
                   \draw [dashed] (1,1) -&#x2D; (-1,-1) node [xshift=10pt,yshift=5pt] { \(\theta\)} -&#x2D; node [pos=.5,below] { \(25'\)} (1,-1);
                 \end{tikzpicture}
               </latex-image>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      What is the measured length <m>L</m> of the wall?
-                    </p>
-                    <p>
-                      <var name="$lU" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the propagated error?
-                    </p>
-                    <p>
-                      <var name="$errU" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the percent error?
-                    </p>
-                    <p>
-                      <var name="$err_pct" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  What is the measured length <m>L</m> of the wall?
+                </p>
+                <p>
+                  <var name="$lU" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the propagated error?
+                </p>
+                <p>
+                  <var name="$errU" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the percent error?
+                </p>
+                <p>
+                  <var name="$err_pct" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 36: Length of the wall with a different angle and distance -->
@@ -1633,7 +1637,7 @@
               Context("Percent");
               $err_pct = Percent("$err/$l");
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 The length <m>L</m> of a long wall is to be approximated.
                 The angle <m>\theta</m>, as shown in the diagram
@@ -1651,35 +1655,37 @@
                   \end{tikzpicture}
                 </latex-image>
               </image>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      What is the measured length <m>L</m> of the wall?
-                    </p>
-                    <p>
-                      <var name="$lU" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the propagated error?
-                    </p>
-                    <p>
-                      <var name="$errU" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the percent error?
-                    </p>
-                    <p>
-                      <var name="$err_pct" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  What is the measured length <m>L</m> of the wall?
+                </p>
+                <p>
+                  <var name="$lU" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the propagated error?
+                </p>
+                <p>
+                  <var name="$errU" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the percent error?
+                </p>
+                <p>
+                  <var name="$err_pct" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 37: Length of the wall if an isosceles triangle -->
@@ -1697,7 +1703,7 @@
               Context("Percent");
               $err_pct = Percent("$err/$l");
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 The length <m>L</m> of a long wall is to be calculated
                 by measuring the angle <m>\theta</m> shown in the diagram
@@ -1715,35 +1721,37 @@
                   \end{tikzpicture}
                 </latex-image>
               </image>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      What is the measured length <m>L</m> of the wall?
-                    </p>
-                    <p>
-                      <var name="$lU" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the propagated error?
-                    </p>
-                    <p>
-                      <var name="$errU" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      What is the percent error?
-                    </p>
-                    <p>
-                      <var name="$err_pct" width="20"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+            <task>
+              <statement>
+                <p>
+                  What is the measured length <m>L</m> of the wall?
+                </p>
+                <p>
+                  <var name="$lU" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the propagated error?
+                </p>
+                <p>
+                  <var name="$errU" width="20"/>
+                </p>
+              </statement>
+            </task>
+            <task>
+              <statement>
+                <p>
+                  What is the percent error?
+                </p>
+                <p>
+                  <var name="$err_pct" width="20"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
         <!-- Exercise 37: Compare errors in wall measurements from previous exercises -->

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1345,50 +1345,52 @@
           <!-- <webwork xml:id="ex-directional-derivative-compute-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>f(x,y) = -x^2y+xy^2+xy</m>, <m>P= (2,1)</m>
                 </p>
-
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        In the direction of <m>\vec v = \la 3,4\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        In the direction toward the point <m>Q = (1,-1)</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <m>\nabla f = \la -2xy+y^2+y, -x^2+2xy+x\ra</m>;
-                  <m>\nabla f(2,1) = \la -2,2\ra</m>.
-                  Be sure to change all directions to unit vectors.
-                </p>
-
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>2/5</m> (<m>\vec u = \la 3/5,4/5\ra</m>)
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>-2/\sqrt{5}</m> (<m>\vec u = \la -1/\sqrt{5},-2\sqrt{5}\ra</m>)
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              </introduction>
+              <task>
+                <statement>
+                  <p>
+                    In the direction of <m>\vec v = \la 3,4\ra</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2/5</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    <m>\nabla f = \la -2xy+y^2+y, -x^2+2xy+x\ra</m>;
+                    <m>\nabla f(2,1) = \la -2,2\ra</m>.
+                    The unit vector in the direction of <m>\vec v</m> is <m>\vec u = \la 3/5,4/5\ra</m>.
+                    Therefore, <m>D_{\vec u}f(2,1) = -2(3/5)+2(4/5)=2/5</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    In the direction toward the point <m>Q = (1,-1)</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>-2/\sqrt{5}</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    <m>\nabla f = \la -2xy+y^2+y, -x^2+2xy+x\ra</m>;
+                    <m>\nabla f(2,1) = \la -2,2\ra</m>.
+                    The vector from <m>P</m> to <m>Q</m> is <m>\vec v = \la 1-2, -1-1\ra = \la -1,-2\ra</m>.
+                    The unit vector in the direction of <m>\vec v</m> is <m>\vec u = \la -1/\sqrt{5},-2/\sqrt{5}\ra</m>.
+                    Therefore, <m>D_{\vec{u}}f(2,1)=-2(-1/\sqrt{5})+2(-2/\sqrt{5})=-2/\sqrt{5}</m>.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1400,36 +1402,35 @@
                 $b=Compute("(4sqrt(3)-3)/(10 sqrt(2))");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   Consider <m>f(x,y) = \sin(x)\cos(y)</m>,
                   at <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>.
                 </p>
+              </introduction>
+              <task>
+                <statement>
+                  <p>
+                    In the direction of <m>\vec v=\la 1,1\ra</m>.
+                  </p>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        Find the directional derivative in the direction of <m>\vec v=\la 1,1\ra</m>.
-                      </p>
+                  <p>
+                    <var name="$a" width="15"/>
+                  </p>
+                </statement>
+              </task>
 
-                      <p>
-                        <var name="$a" width="15"/>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    In the direction toward the point <m>Q = (0,0)</m>.
+                  </p>
 
-                    <li>
-                      <p>
-                        Find the directional derivative in the direction toward the point <m>Q = (0,0)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$b" width="15"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$b" width="15"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1437,50 +1438,52 @@
           <!-- <webwork xml:id="ex-directional-derivative-compute-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>.
                 </p>
-
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        In the direction of <m>\vec v = \la 1,-1\ra</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        In the direction toward the point <m>Q = (-2,-2)</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <m>\nabla f = \la \frac{-2x}{(x^2+y^2+1)^2}, \frac{-2y}{(x^2+y^2+1)^2}\ra</m>;
-                  <m>\nabla f(1,1) = \la -2/9,-2/9\ra</m>.
-                  Be sure to change all directions to unit vectors.
-                </p>
-
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        0 (<m>\vec u = \la 1/\sqrt{2},-1/\sqrt{2}\ra</m>)
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>2\sqrt{2}/9</m> (<m>\vec u = \la -1/\sqrt{2},-1/\sqrt{2}\ra</m>)
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              </introduction>
+              <task>
+                <statement>
+                  <p>
+                    In the direction of <m>\vec v = \la 1,-1\ra</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>0</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    <m>\nabla f = \la \frac{-2x}{(x^2+y^2+1)^2}, \frac{-2y}{(x^2+y^2+1)^2}\ra</m>;
+                    <m>\nabla f(1,1) = \la -2/9,-2/9\ra</m>.
+                    The unit vector in the direction of <m>\vec v</m> is <m>\vec u = \la 1/\sqrt{2}, -1/\sqrt{2}\ra</m>.
+                    The directional derivative is <m>D_{\vec u}f(1,1) = -2/9(1\/sqrt{2})-2/9(-1/\sqrt{2})=0</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    In the direction toward the point <m>Q = (-2,-2)</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2\sqrt{2}/9</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    <m>\nabla f = \la \frac{-2x}{(x^2+y^2+1)^2}, \frac{-2y}{(x^2+y^2+1)^2}\ra</m>;
+                    <m>\nabla f(1,1) = \la -2/9,-2/9\ra</m>.
+                    The vector from <m>P</m> to <m>Q</m> is <m>\vec v = \la -2-1,-2-1\ra = \la -3, -3\ra</m>.
+                    The unit vector in the direction of <m>\vec v</m> is <m>\vec u = \la -1/\sqrt{2}, -1/\sqrt{2}\ra</m>.
+                    The directional derivative is <m>D_{\vec u}f(1,1) = -2/9(-1\/sqrt{2})-2/9(-1/\sqrt{2})=2\sqrt{2}/9</m>.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1492,35 +1495,33 @@
                 $b=Compute("27/sqrt(34)");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   Consider <m>f(x,y) = -4x+3y</m>, at <m>P = (5,2)</m>.
                 </p>
+              </introduction>
+              <task>
+                <statement>
+                  <p>
+                    In the direction of <m>\vec v=\la 3,1\ra</m>.
+                  </p>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        Find the directional derivative in the direction of <m>\vec v=\la 3,1\ra</m>.
-                      </p>
+                  <p>
+                    <var name="$a" width="15"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    In the direction toward the point <m>Q = (2,7)</m>.
+                  </p>
 
-                      <p>
-                        <var name="$a" width="15"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Find the directional derivative in the direction toward the point <m>Q = (2,7)</m>.
-                      </p>
-
-                      <p>
-                        <var name="$b" width="15"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$b" width="15"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1528,49 +1529,49 @@
           <!-- <webwork xml:id="ex-directional-derivative-compute-5">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\ds f(x,y) = x^2+2y^2-xy-7x</m>, <m>P = (4,1)</m>
                 </p>
-
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        In the direction of <m>\vec v = \la -2,5\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        In the direction toward the point <m>Q = (4,0)</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <m>\nabla f = \la 2x-y-7,4y-x\ra</m>;
-                  <m>\nabla f(4,1) = \la 0,0\ra</m>.
-                </p>
-
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        0
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        0
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              </introduction>
+              <task>
+                <statement>
+                  <p>
+                    In the direction of <m>\vec v = \la -2,5\ra</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>0</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    <m>\nabla f = \la 2x-y-7,4y-x\ra</m>;
+                    <m>\nabla f(4,1) = \la 0,0\ra</m>.
+                    Since the gradient is zero, so is the directional derivative.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    In the direction toward the point <m>Q = (4,0)</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>0</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    <m>\nabla f = \la 2x-y-7,4y-x\ra</m>;
+                    <m>\nabla f(4,1) = \la 0,0\ra</m>.
+                    Since the gradient is zero, so is the directional derivative.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1582,35 +1583,35 @@
                 $b=Compute("3");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   Consider <m>f(x,y) = x^2y^3-2x</m>, at <m>P = (1,1)</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        Find the directional derivative in the direction of <m>\vec v=\la 3,3\ra</m>.
-                      </p>
+              <task>
+                <statement>
+                  <p>
+                    Find the directional derivative in the direction of <m>\vec v=\la 3,3\ra</m>.
+                  </p>
 
-                      <p>
-                        <var name="$a" width="15"/>
-                      </p>
-                    </li>
+                  <p>
+                    <var name="$a" width="15"/>
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Find the directional derivative in the direction toward the point <m>Q = (1,2)</m>.
-                      </p>
+              <task>
+                <statement>
+                  <p>
+                    Find the directional derivative in the direction toward the point <m>Q = (1,2)</m>.
+                  </p>
 
-                      <p>
-                        <var name="$b" width="15"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$b" width="15"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1621,34 +1622,7 @@
           <p>
             In the following exercises,
             a function <m>f(x,y)</m> and a point <m>P</m> are given.
-          </p>
-
-          <p>
-            <ol marker="a">
-              <li>
-                <p>
-                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                </p>
-              </li>
-            </ol>
+            Investigate the directions of maximal increase and decrease, as indicated.
           </p>
 
           <p>
@@ -1661,44 +1635,82 @@
           <!-- <webwork xml:id="ex-directional-derivative-maximum-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>f(x,y) = -x^2y+xy^2+xy</m>, <m>P= (2,1)</m>
                 </p>
-              </statement>
-              <solution>
-                <p>
-                  <m>\nabla f = \la -2xy+y^2+y, -x^2+2xy+x\ra</m>
-                </p>
-
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\nabla f(2,1) = \la -2,2\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\norm{\nabla f(2,1)} = \norm{\la -2,2\ra} = \sqrt{8}</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\la 2,-2\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\la 1/\sqrt{2},1/\sqrt{2}\ra</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              </introduction>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\nabla f(2,1) = \la -2,2\ra</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The gradient of <m>f</m> is <m>\nabla f(x,y) = \la -2xy+y^2+y, -x^2+2xy+x\ra</m>.
+                    The direction of maximal increase is <m>\nabla f(2,1) = \la -2,2\ra</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\sqrt{8}</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The maximal value is the norm of the gradient at <m>P</m>,
+                    which is <m>\norm{\nabla f(2,1)} = \norm{\la -2,2\ra} = \sqrt{8}</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\la 2, -2\ra</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    This is the direction opposite the direction of maximal increase; therefore, <m>\la 2,-2\ra</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\vec u = \la 1/\sqrt{2},1/\sqrt{2}\ra</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    We want <m>\vec u = \la a, b\ra</m> such that <m>\nabla f(2,1)\cdot \vec u = -2a+2b=0</m>.
+                    One such unit vector is <m>\vec u = \la 1/\sqrt{2},1/\sqrt{2}\ra</m>.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1716,37 +1728,57 @@
                 $nochangeev=$nochange->cmp(parallel=>1);
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
-                  Given <m>f(x,y) = \sin(x)\cos(y)</m>,
+                  <m>f(x,y) = \sin(x)\cos(y)</m>,
                   <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>:
                 </p>
+              </introduction>
 
-                <instruction>
-                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$maxdir" evaluator="$maxdirev" width="30"/>
-                </p>
-                <instruction>
-                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                </instruction>
-                <p>
-                  <var name="$maxval" width="30"/>
-                </p>
-                <instruction>
-                  Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$mindir" evaluator="$mindirev" width="30"/>
-                </p>
-                <instruction>
-                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$nochange" evaluator="$nochangeev" width="30"/>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$maxdir" evaluator="$maxdirev" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                  </p>
+
+                  <p>
+                    <var name="$maxval" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$mindir" evaluator="$mindirev" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$nochange" evaluator="$nochangeev" width="30"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1754,44 +1786,83 @@
           <!-- <webwork xml:id="ex-directional-derivative-maximum-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>.
                 </p>
-              </statement>
-              <solution>
-                <p>
-                  <m>\nabla f = \la \frac{-2x}{(x^2+y^2+1)^2}, \frac{-2y}{(x^2+y^2+1)^2}\ra</m>
-                </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\nabla f(1,1) = \la -2/9,-2/9\ra</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\norm{\nabla f(1,1)} = \norm{\la -2/9,-2/9\ra}=2\sqrt{2}/9</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\la 2/9,2/9\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\la 1/\sqrt{2},-1/\sqrt{2}\ra</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\nabla f(1,1) = \la -2/9,-2/9\ra</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The gradient of <m>f</m> is <m>\nabla f = \la \frac{-2x}{(x^2+y^2+1)^2}, \frac{-2y}{(x^2+y^2+1)^2}\ra</m>.
+                    The direction of maximal increase is <m>\nabla f(1,1) = \la -2/9,-2/9\ra</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2\sqrt{2}/9</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The maximal value is the norm of the gradient at <m>P</m>,
+                    which is <m>\norm{\nabla f(1,1)} = \norm{\la -2/9,-2/9\ra}=2\sqrt{2}/9</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\la 2/9,2/9\ra</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    This is the direction opposite the direction of maximal increase; therefore, <m>\la 2/9,2/9\ra</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\vec u = \la 1/\sqrt{2},-1/\sqrt{2}\ra</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    We want <m>\vec u = \la a, b\ra</m> such that <m>\nabla f(1,1)\cdot \vec u = -\frac29 a-\frac29 b=0</m>.
+                    One such unit vector is <m>\vec u = \la 1/\sqrt{2},-1/\sqrt{2}\ra</m>.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1809,36 +1880,56 @@
                 $nochangeev=$nochange->cmp(parallel=>1);
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
-                  Given <m>f(x,y) = -4x+3y</m>, <m>P = (5,4)</m>:
+                  <m>f(x,y) = -4x+3y</m>, <m>P = (5,4)</m>
                 </p>
+              </introduction>
 
-                <instruction>
-                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$maxdir" evaluator="$maxdirev" width="30"/>
-                </p>
-                <instruction>
-                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                </instruction>
-                <p>
-                  <var name="$maxval" width="30"/>
-                </p>
-                <instruction>
-                  Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$mindir" evaluator="$mindirev" width="30"/>
-                </p>
-                <instruction>
-                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$nochange" evaluator="$nochangeev" width="30"/>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$maxdir" evaluator="$maxdirev" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                  </p>
+
+                  <p>
+                    <var name="$maxval" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$mindir" evaluator="$mindirev" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$nochange" evaluator="$nochangeev" width="30"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1846,44 +1937,83 @@
           <!-- <webwork xml:id="ex-directional-derivative-maximum-5">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\ds f(x,y) = x^2+2y^2-xy-7x</m>, <m>P = (4,1)</m>
                 </p>
-              </statement>
-              <solution>
-                <p>
-                  <m>\nabla f = \la 2x-y-7,4y-x\ra</m>
-                </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\nabla f(4,1) = \la 0,0\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        0
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\la 0,0\ra</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        All directions give a directional derivative of 0.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    No such direction
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The gradient of <m>f</m> is <m>\nabla f(x,y) = \la 2x-y-7,4y-x\ra</m>.
+                    At the point <m>P</m> we get <m>\nabla f(4,1) = \la 0,0\ra</m>,
+                    so <m>P</m> is a critical point; there is no such direction.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>0</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The maximal value is the norm of the gradient at <m>P</m>,
+                    which is <m>\norm{\nabla f(4,1)} = 0</m>.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    No such direction
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    There is no direction of maximal decrease, since <m>P</m> is a critical point.
+                  </p>
+                </solution>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    All directions
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    Since <m>\nabla f(4,1)=\la 0,0\ra</m>, this is true in all directions.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1901,35 +2031,56 @@
                 $nochangeev=$nochange->cmp(parallel=>1);
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   Given <m>f(x,y) = x^2y^3-2x</m>, <m>P = (1,1)</m>:
                 </p>
-                <instruction>
-                  Find the direction of maximal increase of <m>f</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$maxdir" evaluator="$maxdirev" width="30"/>
-                </p>
-                <instruction>
-                  What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
-                </instruction>
-                <p>
-                  <var name="$maxval" width="30"/>
-                </p>
-                <instruction>
-                  Find the direction of maximal decrease of <m>f</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$mindir" evaluator="$mindirev" width="30"/>
-                </p>
-                <instruction>
-                  Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$nochange" evaluator="$nochangeev" width="30"/>
-                </p>
-              </statement>
+              </introduction>
+
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal increase of <m>f</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$maxdir" evaluator="$maxdirev" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
+                  </p>
+
+                  <p>
+                    <var name="$maxval" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$mindir" evaluator="$mindirev" width="30"/>
+                  </p>
+                </statement>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$nochange" evaluator="$nochangeev" width="30"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1938,25 +2089,12 @@
 
         <introduction>
           <p>
-            In the following exercises, a function <m>w=F(x,y,z)</m>,
+            In the following exercises, a function <m>F(x,y,z)</m>,
             a vector <m>\vec v</m> and a point <m>P</m> are given.
           </p>
 
           <p>
-            <ol marker="a">
-              <li>
-                <p>
-                  Find <m>\nabla F(x,y,z)</m>.
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  Find <m>D_{\vec u}\,F</m> at <m>P</m>,
-                  where <m>\vec u</m> is the unit vector in the direction of <m>\vec v</m>.
-                </p>
-              </li>
-            </ol>
+            Compute the gradient of <m>F</m>, and the derivative of <m>F</m> in the direction of <m>\vec v</m> at <m>P</m>.
           </p>
         </introduction>
 
@@ -1964,29 +2102,44 @@
           <!-- <webwork xml:id="ex-directional-derivative-r3-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\ds F(x,y,z) = 3x^2z^3+4xy-3z^2</m>,
                   <m>\vec v = \la 1,1,1\ra</m>, <m>P = (3,2,1)</m>
                 </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\nabla F(x,y,z) = \la 6xz^3+4y, 4x, 9x^2z^2-6z\ra</m>
-                      </p>
-                    </li>
+              </introduction>
 
-                    <li>
-                      <p>
-                        <m>113/\sqrt{3}</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Compute the gradient of <m>F</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\nabla F(x,y,z) = \la 6xz^3+4y, 4x, 9x^2z^2-6z\ra</m>
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the derivative of <m>F</m> at <m>P</m> in the direction of <m>\vec v</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>113/\sqrt{3}</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The gradient of <m>F</m> at <m>P</m> is <m>\nabla F(3,2,1) = \la 26, 12, 75\ra</m>.
+                    A unit vector in the direction of <m>\vec v</m> is <m>\vec u = \la 1/\sqrt{3},1/\sqrt{3},1/\sqrt{3}\ra</m>.
+                    The directional derivative is <m>D_{\vec u}f(3,2,1) = \nabla F(3,2,1)\cdot \vec u = 113/\sqrt{3}</m>.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1999,25 +2152,36 @@
                 $directional=Compute("2/3");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
-                  Given <m>F(x,y,z) = \sin(x)\cos(y)e^z</m>,
-                  <m>\vec v = \la 2,2,1\ra</m>, <m>P = (0,0,0)</m>:
+                  <m>F(x,y,z) = \sin(x)\cos(y)e^z</m>,
+                  <m>\vec v = \la 2,2,1\ra</m>, <m>P = (0,0,0)</m>.
                 </p>
+              </introduction>
 
-                <instruction>
-                  Find <m>\nabla F(x,y,z)</m>.
-                </instruction>
-                <p>
-                  <var name="$gradient" width="50"/>
-                </p>
-                <instruction>
-                  Find <m>D_{\vec u}\,F</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$directional" width="20"/>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Find <m>\nabla F(x,y,z)</m>.
+                  </p>
+
+                  <p>
+                    <var name="$gradient" width="50"/>
+                  </p>
+                </statement>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    Find <m>D_{\vec u}\,F</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$directional" width="20"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -2025,29 +2189,43 @@
           <!-- <webwork xml:id="ex-directional-derivative-r3-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\ds F(x,y,z) = x^2y^2-y^2z^2</m>,
                   <m>\vec v = \la -1,7,3\ra</m>, <m>P = (1,0,-1)</m>
                 </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\nabla F(x,y,z) = \la 2xy^2, 2y(x^2-z^2), -2y^2z\ra</m>
-                      </p>
-                    </li>
+              </introduction>
 
-                    <li>
-                      <p>
-                        <m>0</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Compute the gradient of <m>F</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\nabla F(x,y,z) = \la 2xy^2, 2y(x^2-z^2), -2y^2z\ra</m>
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    Find the derivative of <m>F</m> at <m>P</m> in the direction of <m>\vec v</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>0</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The gradient of <m>F</m> at <m>P</m> is <m>\nabla F(1,0,-1) = \la 0,0,0\ra</m>.
+                    Therefore, the derivative of <m>F</m> at <m>P</m> in any direction is <m>0</m>.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2060,25 +2238,36 @@
                 $directional=Compute("0");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   Given <m>F(x,y,z) = \frac{2}{x^2+y^2+z^2}</m>,
                   <m>\vec v = \la 1,1,-2\ra</m>, <m>P = (1,1,1)</m>:
                 </p>
+              </introduction>
 
-                <instruction>
-                  Find <m>\nabla F(x,y,z)</m>.
-                </instruction>
-                <p>
-                  <var name="$gradient" width="50"/>
-                </p>
-                <instruction>
-                  Find <m>D_{\vec u}\,F</m> at <m>P</m>.
-                </instruction>
-                <p>
-                  <var name="$directional" width="20"/>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Find <m>\nabla F(x,y,z)</m>.
+                  </p>
+
+                  <p>
+                    <var name="$gradient" width="50"/>
+                  </p>
+                </statement>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    Find <m>D_{\vec u}\,F</m> at <m>P</m>.
+                  </p>
+
+                  <p>
+                    <var name="$directional" width="20"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1350,7 +1350,7 @@
                   <m>f(x,y) = -x^2y+xy^2+xy</m>, <m>P= (2,1)</m>
                 </p>
               </introduction>
-              <task>
+              <task label="ex-directional-derivative-compute-1a">
                 <statement>
                   <p>
                     In the direction of <m>\vec v = \la 3,4\ra</m>
@@ -1370,7 +1370,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-compute-1b">
                 <statement>
                   <p>
                     In the direction toward the point <m>Q = (1,-1)</m>.
@@ -1408,7 +1408,7 @@
                   at <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>.
                 </p>
               </introduction>
-              <task>
+              <task label="ex-directional-derivative-compute-2a">
                 <statement>
                   <p>
                     In the direction of <m>\vec v=\la 1,1\ra</m>.
@@ -1420,7 +1420,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-directional-derivative-compute-2b">
                 <statement>
                   <p>
                     In the direction toward the point <m>Q = (0,0)</m>.
@@ -1443,7 +1443,7 @@
                   <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>.
                 </p>
               </introduction>
-              <task>
+              <task label="ex-directional-derivative-compute-3a">
                 <statement>
                   <p>
                     In the direction of <m>\vec v = \la 1,-1\ra</m>.
@@ -1463,7 +1463,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-compute-3b">
                 <statement>
                   <p>
                     In the direction toward the point <m>Q = (-2,-2)</m>.
@@ -1500,7 +1500,7 @@
                   Consider <m>f(x,y) = -4x+3y</m>, at <m>P = (5,2)</m>.
                 </p>
               </introduction>
-              <task>
+              <task label="ex-directional-derivative-compute-4a">
                 <statement>
                   <p>
                     In the direction of <m>\vec v=\la 3,1\ra</m>.
@@ -1511,7 +1511,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-compute-4b">
                 <statement>
                   <p>
                     In the direction toward the point <m>Q = (2,7)</m>.
@@ -1534,7 +1534,7 @@
                   <m>\ds f(x,y) = x^2+2y^2-xy-7x</m>, <m>P = (4,1)</m>
                 </p>
               </introduction>
-              <task>
+              <task label="ex-directional-derivative-compute-5a">
                 <statement>
                   <p>
                     In the direction of <m>\vec v = \la -2,5\ra</m>
@@ -1553,7 +1553,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-compute-5b">
                 <statement>
                   <p>
                     In the direction toward the point <m>Q = (4,0)</m>.
@@ -1589,7 +1589,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-compute-6a">
                 <statement>
                   <p>
                     Find the directional derivative in the direction of <m>\vec v=\la 3,3\ra</m>.
@@ -1601,7 +1601,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-directional-derivative-compute-6b">
                 <statement>
                   <p>
                     Find the directional derivative in the direction toward the point <m>Q = (1,2)</m>.
@@ -1640,7 +1640,7 @@
                   <m>f(x,y) = -x^2y+xy^2+xy</m>, <m>P= (2,1)</m>
                 </p>
               </introduction>
-              <task>
+              <task label="ex-directional-derivative-maximum-1a">
                 <statement>
                   <p>
                     Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -1658,7 +1658,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-1b">
                 <statement>
                   <p>
                     What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
@@ -1676,7 +1676,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-1c">
                 <statement>
                   <p>
                     Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
@@ -1693,7 +1693,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-1d">
                 <statement>
                   <p>
                     Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
@@ -1735,7 +1735,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-maximum-2a">
                 <statement>
                   <p>
                     Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -1746,7 +1746,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-2b">
                 <statement>
                   <p>
                     What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
@@ -1757,7 +1757,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-2c">
                 <statement>
                   <p>
                     Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
@@ -1768,7 +1768,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-2d">
                 <statement>
                   <p>
                     Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
@@ -1792,7 +1792,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-maximum-3a">
                 <statement>
                   <p>
                     Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -1810,7 +1810,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-3b">
                 <statement>
                   <p>
                     What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
@@ -1828,7 +1828,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-3c">
                 <statement>
                   <p>
                     Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
@@ -1845,7 +1845,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-3d">
                 <statement>
                   <p>
                     Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
@@ -1886,7 +1886,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-maximum-4a">
                 <statement>
                   <p>
                     Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -1897,7 +1897,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-4b">
                 <statement>
                   <p>
                     What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
@@ -1908,7 +1908,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-4c">
                 <statement>
                   <p>
                     Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
@@ -1919,7 +1919,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-4d">
                 <statement>
                   <p>
                     Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
@@ -1943,7 +1943,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-maximum-5a">
                 <statement>
                   <p>
                     Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -1962,7 +1962,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-5b">
                 <statement>
                   <p>
                     What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
@@ -1980,7 +1980,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-5c">
                 <statement>
                   <p>
                     Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
@@ -1997,7 +1997,7 @@
                   </p>
                 </solution>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-5d">
                 <statement>
                   <p>
                     Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
@@ -2037,7 +2037,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-maximum-6a">
                 <statement>
                   <p>
                     Find the direction of maximal increase of <m>f</m> at <m>P</m>.
@@ -2048,7 +2048,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-6b">
                 <statement>
                   <p>
                     What is the maximal value of <m>D_{\vec u}\,f</m> at <m>P</m>?
@@ -2059,7 +2059,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-6c">
                 <statement>
                   <p>
                     Find the direction of maximal decrease in <m>f</m> at <m>P</m>.
@@ -2070,7 +2070,7 @@
                   </p>
                 </statement>
               </task>
-              <task>
+              <task label="ex-directional-derivative-maximum-6d">
                 <statement>
                   <p>
                     Give a direction <m>\vec u</m> such that <m>D_{\vec u}\,f=0</m> at <m>P</m>.
@@ -2109,7 +2109,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-r3-1a">
                 <statement>
                   <p>
                     Compute the gradient of <m>F</m>.
@@ -2121,7 +2121,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-directional-derivative-r3-1b">
                 <statement>
                   <p>
                     Find the derivative of <m>F</m> at <m>P</m> in the direction of <m>\vec v</m>.
@@ -2159,7 +2159,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-r3-2a">
                 <statement>
                   <p>
                     Find <m>\nabla F(x,y,z)</m>.
@@ -2171,7 +2171,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-directional-derivative-r3-2b">
                 <statement>
                   <p>
                     Find <m>D_{\vec u}\,F</m> at <m>P</m>.
@@ -2196,7 +2196,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-r3-3a">
                 <statement>
                   <p>
                     Compute the gradient of <m>F</m>.
@@ -2208,7 +2208,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-directional-derivative-r3-3b">
                 <statement>
                   <p>
                     Find the derivative of <m>F</m> at <m>P</m> in the direction of <m>\vec v</m>.
@@ -2245,7 +2245,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-directional-derivative-r3-4a">
                 <statement>
                   <p>
                     Find <m>\nabla F(x,y,z)</m>.
@@ -2257,7 +2257,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-directional-derivative-r3-4b">
                 <statement>
                   <p>
                     Find <m>D_{\vec u}\,F</m> at <m>P</m>.

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -2190,73 +2190,64 @@
           <!-- <webwork xml:id="ex-volume-disk-both-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by: <m>y=\sqrt{x}</m>,
                   <m>y=0</m> and <m>x=1</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi/2</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>5\pi/6</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=1</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>y</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>4\pi/5</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=1</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\pi/2</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>5\pi/6</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>4\pi/5</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi/15</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi/15</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2264,72 +2255,63 @@
           <!-- <webwork xml:id="ex-volume-disk-both-2">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by: <m>y=4-x^2</m> and <m>y=0</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>512\pi/15</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=4</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>256\pi/5</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=4</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=-1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>832\pi/15</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=-1</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=2</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>512\pi/15</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>256\pi/5</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>832\pi/15</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>128\pi/3</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=2</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>128\pi/3</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2337,73 +2319,64 @@
           <!-- <webwork xml:id="ex-volume-disk-both-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   The triangle with vertices <m>(1,1)</m>,
                   <m>(1,2)</m> and <m>(2,1)</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Roate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>4\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Roate about <m>y=2</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=2</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>y</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>4\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=1</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>4\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>2\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>4\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\pi/3</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi/3</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2411,60 +2384,50 @@
           <!-- <webwork xml:id="ex-volume-disk-both-4">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by <m>y=x^2-2x+2</m> and <m>y=2x-1</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>104\pi/15</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>64\pi/15</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=1</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>y=5</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>104\pi/15</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>64\pi/15</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>32\pi/5</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=5</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>32\pi/5</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2472,61 +2435,51 @@
           <!-- <webwork xml:id="ex-volume-disk-both-5">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by <m>y=1/\sqrt{x^2+1}</m>, <m>x=-1</m>,
                   <m>x=1</m> and the <m>x</m>-axis.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi^2/2</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi^2/2-4\pi\sinh^{-1}(1)</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=1</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>y=-1</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\pi^2/2</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\pi^2/2-4\pi\sinh^{-1}(1)</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\pi^2/2+4\pi\sinh^{-1}(1)</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=-1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi^2/2+4\pi\sinh^{-1}(1)</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2534,73 +2487,64 @@
           <!-- <webwork xml:id="ex-volume-disk-both-6">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by <m>y=2x</m>,
                   <m>y=x</m> and <m>x=2</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=4</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>y=4</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>y</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>16\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=2</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>8\pi</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>16\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi/3</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=2</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi/3</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -2197,7 +2197,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-disk-both-1a">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -2210,7 +2210,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-1b">
                 <statement>
                   <p>
                     Rotate about <m>y=1</m>.
@@ -2223,7 +2223,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-1c">
                 <statement>
                   <p>
                     Rotate about the <m>y</m> axis.
@@ -2236,7 +2236,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-1d">
                 <statement>
                   <p>
                     Rotate about <m>x=1</m>.
@@ -2261,7 +2261,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-disk-both-2a">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -2274,7 +2274,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-2b">
                 <statement>
                   <p>
                     Rotate about <m>y=4</m>.
@@ -2287,7 +2287,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-2c">
                 <statement>
                   <p>
                     Rotate about <m>y=-1</m>.
@@ -2300,7 +2300,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-2d">
                 <statement>
                   <p>
                     Rotate about <m>x=2</m>.
@@ -2326,7 +2326,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-disk-both-3a">
                 <statement>
                   <p>
                     Roate about the <m>x</m> axis.
@@ -2339,7 +2339,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-3b">
                 <statement>
                   <p>
                     Roate about <m>y=2</m>.
@@ -2352,7 +2352,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-3c">
                 <statement>
                   <p>
                     Rotate about the <m>y</m> axis.
@@ -2365,7 +2365,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-3d">
                 <statement>
                   <p>
                     Rotate about <m>x=1</m>.
@@ -2390,7 +2390,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-disk-both-4a">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -2403,7 +2403,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-4b">
                 <statement>
                   <p>
                     Rotate about <m>y=1</m>.
@@ -2416,7 +2416,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-4c">
                 <statement>
                   <p>
                     Rotate about <m>y=5</m>.
@@ -2442,7 +2442,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-disk-both-5a">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -2455,7 +2455,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-5b">
                 <statement>
                   <p>
                     Rotate about <m>y=1</m>.
@@ -2468,7 +2468,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-5c">
                 <statement>
                   <p>
                     Rotate about <m>y=-1</m>.
@@ -2494,7 +2494,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-disk-both-6a">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -2507,7 +2507,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-6b">
                 <statement>
                   <p>
                     Rotate about <m>y=4</m>.
@@ -2520,7 +2520,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-6c">
                 <statement>
                   <p>
                     Rotate about the <m>y</m> axis.
@@ -2533,7 +2533,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-disk-both-6d">
                 <statement>
                   <p>
                     Rotate about <m>x=2</m>.

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -1166,63 +1166,57 @@
           <!--<webwork xml:id="ex_double_int_polar_gaussian">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Consider <m>\ds \iint_R e^{-(x^2+y^2)}\, dA</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Why is this integral difficult to evaluate in rectangular coordinates,
-                        regardless of the region <m>R</m>?
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Why is this integral difficult to evaluate in rectangular coordinates,
+                    regardless of the region <m>R</m>?
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    This is impossible to integrate with rectangular coordinates as
+                    <m>e^{-(x^2+y^2)}</m> does not have an antiderivative in terms of elementary functions.
+                  </p>
+                </solution>
+              </task>
 
-                    <li>
-                      <p>
-                        Let <m>R</m> be the region bounded by the circle of radius <m>a</m> centered at the origin.
-                        Evaluate the double integral using polar coordinates.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Let <m>R</m> be the region bounded by the circle of radius <m>a</m> centered at the origin.
+                    Evaluate the double integral using polar coordinates.
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    <m>\ds \int_0^{2\pi}\int_0^a re^{r^2}\, dr\, d\theta = \pi(1-e^{-a^2})</m>.
+                  </p>
+                </solution>
+              </task>
 
-                    <li>
-                      <p>
-                        Take the limit of your answer from (b), as <m>a\to\infty</m>.
-                        What does this imply about the volume under the surface
-                        <m>z= e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane?
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        This is impossible to integrate with rectangular coordinates as
-                        <m>e^{-(x^2+y^2)}</m> does not have an antiderivative in terms of elementary functions.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\ds \int_0^{2\pi}\int_0^a re^{r^2}\, dr\, d\theta = \pi(1-e^{-a^2})</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\lim\limits_{a\to\infty} \pi(1-e^{-a^2})=\pi</m>.
-                        This implies that there is a finite volume under the surface
-                        <m>z=e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Take the limit of your answer from (b), as <m>a\to\infty</m>.
+                    What does this imply about the volume under the surface
+                    <m>z= e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane?
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    <m>\lim\limits_{a\to\infty} \pi(1-e^{-a^2})=\pi</m>.
+                    This implies that there is a finite volume under the surface
+                    <m>z=e^{-(x^2+y^2)}</m> over the entire <m>xy</m>-plane.
+                  </p>
+                </solution>
+              </task>
           <!--</webwork>-->
         </exercise>
 

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -1172,7 +1172,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex_double_int_polar_gaussian-a">
                 <statement>
                   <p>
                     Why is this integral difficult to evaluate in rectangular coordinates,
@@ -1187,7 +1187,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex_double_int_polar_gaussian-b">
                 <statement>
                   <p>
                     Let <m>R</m> be the region bounded by the circle of radius <m>a</m> centered at the origin.
@@ -1201,7 +1201,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex_double_int_polar_gaussian-c">
                 <statement>
                   <p>
                     Take the limit of your answer from (b), as <m>a\to\infty</m>.

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -848,40 +848,31 @@
           <!--<webwork xml:id="ex-iterated-integrals-evaluate-1">
               <pg-code>
               </pg-code> -->
+            <task>
               <statement>
                 <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\ds \int_2^{5} \big(6x^2+4xy-3y^2\big)\, dy</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\ds \int_{-3}^{-2} \int_2^{5} \big(6x^2+4xy-3y^2\big)\, dy\, dx</m>
-                      </p>
-                    </li>
-                  </ol>
+                  <m>\ds \int_2^{5} \big(6x^2+4xy-3y^2\big)\, dy</m>
                 </p>
               </statement>
               <answer>
                 <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>18x^2+42x-117</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>-108</m>
-                      </p>
-                    </li>
-                  </ol>
+                  <m>18x^2+42x-117</m>
                 </p>
               </answer>
+            </task>
+            
+            <task>
+              <statement>
+                <p>
+                  <m>\ds \int_{-3}^{-2} \int_2^{5} \big(6x^2+4xy-3y^2\big)\, dy\, dx</m>
+                </p>
+              </statement>
+              <answer>
+                <p>
+                  <m>-108</m>
+                </p>
+              </answer>
+            </task>
           <!--</webwork>-->
         </exercise>
         <!--TODO: the webwork code here does not display well in static-->
@@ -894,40 +885,32 @@
                 $a=Compute("2+pi^2cos(y)");
                 $b=Formula("pi^2+pi");
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\ds \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx=</m><var name="$a" width="20"/>
-                      </p>
-                    </li>
 
-                    <li>
-                      <p>
-                        <m>\ds \int_{0}^{\pi/2} \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx\,dy=</m><var name="$b" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <answer>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>2+\pi^2\cos(y)</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx=</m><var name="$a" width="20"/>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2+\pi^2\cos(y)</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>\pi^2+\pi</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </answer>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_{0}^{\pi/2} \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx\,dy=</m><var name="$b" width="20"/>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi^2+\pi</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -935,40 +918,31 @@
           <!--<webwork xml:id="ex-iterated-integrals-evaluate-3">
               <pg-code>
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\ds \int_1^x \big(x^2y - y+2\big)\, dy</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_1^x \big(x^2y - y+2\big)\, dy</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>x^4/2-x^2+2x-3/2</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>\ds \int_0^2\int_1^x \big(x^2y - y+2\big)\, dy\, dx</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <answer>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>x^4/2-x^2+2x-3/2</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>23/15</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </answer>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_0^2\int_1^x \big(x^2y - y+2\big)\, dy\, dx</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>23/15</m>
+                  </p>
+                </answer>
+              </task>
           <!--</webwork>-->
         </exercise>
 
@@ -981,82 +955,64 @@
                 $a=Compute("y^4/2-y^3+y^2/2");
                 $b=Formula("8/15");
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\ds \int_y^{y^2} (x-y)\,dx=</m><var name="$a" width="20"/>
-                      </p>
-                    </li>
 
-                    <li>
-                      <p>
-                        <m>\ds \int_{-1}^1\int_y^{y^2} (x-y)\,dx\,dy=</m><var name="$b" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <answer>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>y^4/2-y^3+y^2/2</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_y^{y^2} (x-y)\,dx=</m><var name="$a" width="20"/>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>y^4/2-y^3+y^2/2</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>8/15</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </answer>
-          <!-- </webwork> -->
-
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_{-1}^1\int_y^{y^2} (x-y)\,dx\,dy=</m><var name="$b" width="20"/>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8/15</m>
+                  </p>
+                </answer>
+              </task>
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-5">
           <!--<webwork xml:id="ex-iterated-integrals-evaluate-5">
               <pg-code>
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\ds \int_0^{y} \big(\cos(x) \sin(y) \big)\, dx</m>
-                      </p>
-                    </li>
 
-                    <li>
-                      <p>
-                        <m>\ds \int_0^\pi \int_0^{y} \big(\cos(x) \sin(y) \big)\, dx\, dy</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <answer>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\sin^2(y)</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_0^{y} \big(\cos(x) \sin(y) \big)\, dx</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\sin^2(y)</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>\pi/2</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </answer>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_0^\pi \int_0^{y} \big(\cos(x) \sin(y) \big)\, dx\, dy</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\pi/2</m>
+                  </p>
+                </answer>
+              </task>
           <!--</webwork>-->
         </exercise>
 
@@ -1069,31 +1025,32 @@
                 $a=Compute("x/(1+x^2)");
                 $b=Formula("1/2 ln(5/2)");
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>\ds \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy=</m><var name="$a" width="20"/>
-                      </p>
-                    </li>
 
-                    <li>
-                      <p>
-                        <m>\ds \int_1^2 \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy\,dx=</m><var name="$b" width="20"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <answer>
-                <p>
-                  <ol>
-                    <li><m>\frac{x}{1+x^2}</m></li>
-                    <li><m>\frac12 \ln\left(\frac52\right)</m></li>
-                  </ol>
-                </p>
-              </answer>
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy=</m><var name="$a" width="20"/>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\frac{x}{1+x^2}</m>
+                  </p>
+                </answer>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    <m>\ds \int_1^2 \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy\,dx=</m><var name="$b" width="20"/>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\frac12 \ln\left(\frac52\right)</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -848,7 +848,7 @@
           <!--<webwork xml:id="ex-iterated-integrals-evaluate-1">
               <pg-code>
               </pg-code> -->
-            <task>
+            <task label="ex-iterated-integrals-evaluate-1a">
               <statement>
                 <p>
                   <m>\ds \int_2^{5} \big(6x^2+4xy-3y^2\big)\, dy</m>
@@ -861,7 +861,7 @@
               </answer>
             </task>
             
-            <task>
+            <task label="ex-iterated-integrals-evaluate-1b">
               <statement>
                 <p>
                   <m>\ds \int_{-3}^{-2} \int_2^{5} \big(6x^2+4xy-3y^2\big)\, dy\, dx</m>
@@ -886,7 +886,7 @@
                 $b=Formula("pi^2+pi");
               </pg-code> -->
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-2a">
                 <statement>
                   <p>
                     <m>\ds \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx=</m><var name="$a" width="20"/>
@@ -899,7 +899,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-2b">
                 <statement>
                   <p>
                     <m>\ds \int_{0}^{\pi/2} \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx\,dy=</m><var name="$b" width="20"/>
@@ -918,7 +918,7 @@
           <!--<webwork xml:id="ex-iterated-integrals-evaluate-3">
               <pg-code>
               </pg-code> -->
-              <task>
+              <task label="ex-iterated-integrals-evaluate-3a">
                 <statement>
                   <p>
                     <m>\ds \int_1^x \big(x^2y - y+2\big)\, dy</m>
@@ -931,7 +931,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-3b">
                 <statement>
                   <p>
                     <m>\ds \int_0^2\int_1^x \big(x^2y - y+2\big)\, dy\, dx</m>
@@ -956,7 +956,7 @@
                 $b=Formula("8/15");
               </pg-code> -->
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-4a">
                 <statement>
                   <p>
                     <m>\ds \int_y^{y^2} (x-y)\,dx=</m><var name="$a" width="20"/>
@@ -969,7 +969,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-4b">
                 <statement>
                   <p>
                     <m>\ds \int_{-1}^1\int_y^{y^2} (x-y)\,dx\,dy=</m><var name="$b" width="20"/>
@@ -988,7 +988,7 @@
               <pg-code>
               </pg-code> -->
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-5a">
                 <statement>
                   <p>
                     <m>\ds \int_0^{y} \big(\cos(x) \sin(y) \big)\, dx</m>
@@ -1001,7 +1001,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-5b">
                 <statement>
                   <p>
                     <m>\ds \int_0^\pi \int_0^{y} \big(\cos(x) \sin(y) \big)\, dx\, dy</m>
@@ -1026,7 +1026,7 @@
                 $b=Formula("1/2 ln(5/2)");
               </pg-code> -->
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-6a">
                 <statement>
                   <p>
                     <m>\ds \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy=</m><var name="$a" width="20"/>
@@ -1039,7 +1039,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-iterated-integrals-evaluate-6b">
                 <statement>
                   <p>
                     <m>\ds \int_1^2 \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy\,dx=</m><var name="$b" width="20"/>

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -2377,7 +2377,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-limit-analytically-challenge-5a">
             <statement>
               <p>
                 Explain why <m>\lim\limits_{x\to2}f(x)=0</m>.
@@ -2393,7 +2393,7 @@
             </solution>
           </task>
 
-          <task>
+          <task label="ex-limit-analytically-challenge-5b">
             <statement>
               <p>
                 Explain why <m>\lim\limits_{x\to0}g(x)=1</m>.
@@ -2411,7 +2411,7 @@
             </solution>
           </task>
 
-          <task>
+          <task label="ex-limit-analytically-challenge-5c">
             <statement>
               <p>
                 Explain why <m>\lim\limits_{x\to2} g(f(x))</m> does not exist.
@@ -2429,7 +2429,7 @@
             </solution>
           </task>
 
-          <task>
+          <task label="ex-limit-analytically-challenge-5d">
             <statement>
               <p>
                 Explain why the previous statement does not violate the Composition Rule of <xref ref="thm_limit_algebra">Theorem</xref>.

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -2371,79 +2371,83 @@
 
       <exercise label="ex-limit-analytically-challenge-5">
         <webwork xml:id="ex-limit-analytically-challenge-5">
-          <statement>
+          <introduction>
             <p>
               Let <m>f(x)=0</m> and <m>g(x)=\frac{x}{x}</m>.
-              <ol>
-                <li>
-                  <p>
-                    Explain why <m>\lim\limits_{x\to2}f(x)=0</m>.
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Explain why <m>\lim\limits_{x\to0}g(x)=1</m>.
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Explain why <m>\lim\limits_{x\to2} g(f(x))</m> does not exist.
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Explain why the previous statement does not violate the Composition Rule of <xref ref="thm_limit_algebra">Theorem</xref>.
-                  </p>
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
-          <solution>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Apply Part 1 of <xref ref="thm_limit_algebra">Theorem</xref>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Apply <xref ref="thm_limit_allbut1">Theorem</xref>;
-                    <m>g(x)=\frac{x}{x}</m> is the same as <m>g(x)=1</m> everywhere except at <m>x=0</m>.
-                    Thus <m>\lim\limits_{x\to0}g(x)=\lim_{x\to0}1=1</m>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    The function <m>f</m> always gives output <m>0</m>,
-                    so <m>g(f(x))</m> is never defined as <m>g</m> is not defined for an input of <m>0</m>.
-                    Therefore the limit does not exist.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    The Composition Rule requires that
-                    <m>\lim\limits_{x\to0}g(x)</m> be equal to <m>g(0)</m>.
-                    They are not equal,
-                    so the conditions of the Composition Rule are not satisfied,
-                    and hence the rule is not violated.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </solution>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                Explain why <m>\lim\limits_{x\to2}f(x)=0</m>.
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Apply Part 1 of <xref ref="thm_limit_algebra">Theorem</xref>.
+              </p>
+            </solution>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Explain why <m>\lim\limits_{x\to0}g(x)=1</m>.
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                Apply <xref ref="thm_limit_allbut1">Theorem</xref>;
+                <m>g(x)=\frac{x}{x}</m> is the same as <m>g(x)=1</m> everywhere except at <m>x=0</m>.
+                Thus <m>\lim\limits_{x\to0}g(x)=\lim_{x\to0}1=1</m>.
+              </p>
+            </solution>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Explain why <m>\lim\limits_{x\to2} g(f(x))</m> does not exist.
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                The function <m>f</m> always gives output <m>0</m>,
+                so <m>g(f(x))</m> is never defined as <m>g</m> is not defined for an input of <m>0</m>.
+                Therefore the limit does not exist.
+              </p>
+            </solution>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Explain why the previous statement does not violate the Composition Rule of <xref ref="thm_limit_algebra">Theorem</xref>.
+              </p>
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+            <solution>
+              <p>
+                The Composition Rule requires that
+                <m>\lim\limits_{x\to0}g(x)</m> be equal to <m>g(0)</m>.
+                They are not equal,
+                so the conditions of the Composition Rule are not satisfied,
+                and hence the rule is not violated.
+              </p>
+            </solution>
+          </task>
         </webwork>
       </exercise>
     </subexercises>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1813,35 +1813,39 @@
               @answer=(PopUp(~~@choices,1),PopUp(~~@choices,1));
               $showwork = '[@ explanation_box(message => "If not, explain why not.") @]*';
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=\begin{cases}1\amp x=0\\\frac{\sin(x)}{x}\amp x\neq0\end{cases}</m>
-                <ol>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m>0</m>?
-                    </p>
-                    <p>
-                      <var name="$answer[0]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m>\pi</m>?
-                    </p>
-                    <p>
-                      <var name="$answer[1]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                </ol>
               </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m>0</m>?
+                </p>
+                <p>
+                  <var name="$answer[0]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m>\pi</m>?
+                </p>
+                <p>
+                  <var name="$answer[1]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1863,35 +1867,39 @@
               @answer=(PopUp(~~@choices,1),PopUp(~~@choices,$correct[1]));
               $showwork = '[@ explanation_box(message => "If not, explain why not.") @]*';
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=<var name="$f"/></m>
-                <ol>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m>0</m>?
-                    </p>
-                    <p>
-                      <var name="$answer[0]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m>1</m>?
-                    </p>
-                    <p>
-                      <var name="$answer[1]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                </ol>
               </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m>0</m>?
+                </p>
+                <p>
+                  <var name="$answer[0]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m>1</m>?
+                </p>
+                <p>
+                  <var name="$answer[1]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1910,35 +1918,39 @@
               @answer=(PopUp(~~@choices,1),PopUp(~~@choices,1));
               $showwork = '[@ explanation_box(message => "If not, explain why not.") @]*';
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=<var name="$f"/></m>
-                <ol>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m><var name="$a[0]"/></m>?
-                    </p>
-                    <p>
-                      <var name="$answer[0]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m><var name="$a[3]"/></m>?
-                    </p>
-                    <p>
-                      <var name="$answer[1]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                </ol>
               </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m><var name="$a[0]"/></m>?
+                </p>
+                <p>
+                  <var name="$answer[0]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m><var name="$a[3]"/></m>?
+                </p>
+                <p>
+                  <var name="$answer[1]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1958,35 +1970,39 @@
               @answer=(PopUp(~~@choices,1),PopUp(~~@choices,$correct[1]));
               $showwork = '[@ explanation_box(message => "If not, explain why not.") @]*';
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=<var name="$f"/></m>
-                <ol>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m><var name="$a[0]"/></m>?
-                    </p>
-                    <p>
-                      <var name="$answer[0]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Is <m>f</m> is continuous at <m><var name="$a[1]"/></m>?
-                    </p>
-                    <p>
-                      <var name="$answer[1]" form="popup"/>
-                    </p>
-                    <p>
-                      <var name="$showwork" data="pgml"/>
-                    </p>
-                  </li>
-                </ol>
               </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m><var name="$a[0]"/></m>?
+                </p>
+                <p>
+                  <var name="$answer[0]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  Is <m>f</m> is continuous at <m><var name="$a[1]"/></m>?
+                </p>
+                <p>
+                  <var name="$answer[1]" form="popup"/>
+                </p>
+                <p>
+                  <var name="$showwork" data="pgml"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -2776,7 +2792,7 @@
             $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
             $L[3]=$g->eval(x=>$a);
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Evaluate the given limits of the piecewise defined function.
             </p>
@@ -2787,43 +2803,51 @@
               If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
               If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
             </instruction>
-            <p>
-              <ol cols="2">
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[0]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[1]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[2]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>f(<var name="$a"/>)</m>
-                  </p>
-                  <p>
-                    <var name="$L[3]" width="10"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+              </p>
+              <p>
+                <var name="$L[0]" width="10"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+              </p>
+              <p>
+                <var name="$L[1]" width="10"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+              </p>
+              <p>
+                <var name="$L[2]" width="10"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>f(<var name="$a"/>)</m>
+              </p>
+              <p>
+                <var name="$L[3]" width="10"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 
@@ -2839,7 +2863,7 @@
             @tabin=($a-0.1,$a-0.01,$a-0.001,$a+0.001,$a+0.01,$a+0.1);
             @tabout=map{$f->eval(x=>$_)} @tabin;
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Numerically approximate the following limits.
             </p>
@@ -2847,27 +2871,29 @@
               If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
               If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
             </instruction>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to <var name="$a"/>^{+}}\left(<var name="$f"/>\right)</m>
-                  </p>
-                  <p>
-                    <var name="$l" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to <var name="$a"/>^{-}}\left(<var name="$f"/>\right)</m>
-                  </p>
-                  <p>
-                    <var name="$l" width="10"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to <var name="$a"/>^{+}}\left(<var name="$f"/>\right)</m>
+              </p>
+              <p>
+                <var name="$l" width="10"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to <var name="$a"/>^{-}}\left(<var name="$f"/>\right)</m>
+              </p>
+              <p>
+                <var name="$l" width="10"/>
+              </p>
+            </statement>
+          </task>
           <solution>
             <p>
               For a numerical approximation, make a table:

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1819,7 +1819,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-limit-continuity-point-1a">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m>0</m>?
@@ -1833,7 +1833,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-continuity-point-1b">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m>\pi</m>?
@@ -1873,7 +1873,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-limit-continuity-point-2a">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m>0</m>?
@@ -1887,7 +1887,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-continuity-point-2b">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m>1</m>?
@@ -1924,7 +1924,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-limit-continuity-point-3a">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m><var name="$a[0]"/></m>?
@@ -1938,7 +1938,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-continuity-point-3b">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m><var name="$a[3]"/></m>?
@@ -1976,7 +1976,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-limit-continuity-point-4a">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m><var name="$a[0]"/></m>?
@@ -1990,7 +1990,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-continuity-point-4b">
               <statement>
                 <p>
                   Is <m>f</m> is continuous at <m><var name="$a[1]"/></m>?
@@ -2805,7 +2805,7 @@
             </instruction>
           </introduction>
 
-          <task>
+          <task label="ex-limit-continuity-review-1a">
             <statement>
               <p>
                 <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -2816,7 +2816,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-continuity-review-1b">
             <statement>
               <p>
                 <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -2827,7 +2827,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-continuity-review-1c">
             <statement>
               <p>
                 <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -2838,7 +2838,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-continuity-review-1d">
             <statement>
               <p>
                 <m>f(<var name="$a"/>)</m>
@@ -2873,7 +2873,7 @@
             </instruction>
           </introduction>
 
-          <task>
+          <task label="ex-limit-continuity-review-2a">
             <statement>
               <p>
                 <m>\lim\limits_{x\to <var name="$a"/>^{+}}\left(<var name="$f"/>\right)</m>
@@ -2884,7 +2884,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-continuity-review-2b">
             <statement>
               <p>
                 <m>\lim\limits_{x\to <var name="$a"/>^{-}}\left(<var name="$f"/>\right)</m>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1273,7 +1273,7 @@
               $above=$a+$e;
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
@@ -1297,27 +1297,29 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" evaluator="$ev[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" evaluator="$ev[1]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" evaluator="$ev[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" evaluator="$ev[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1341,7 +1343,7 @@
               );
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
@@ -1367,59 +1369,73 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a[0]"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" evaluator="$ev[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a[0]"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" evaluator="$ev[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a[0]"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" evaluator="$ev[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a[1]"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" evaluator="$ev[3]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a[1]"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[4]" evaluator="$ev[4]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a[1]"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[5]" evaluator="$ev[5]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a[0]"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" evaluator="$ev[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a[0]"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" evaluator="$ev[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a[0]"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" evaluator="$ev[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a[1]"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" evaluator="$ev[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a[1]"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[4]" evaluator="$ev[4]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a[1]"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[5]" evaluator="$ev[5]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1436,7 +1452,7 @@
               $xmin=-11;$xmax=11;
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
@@ -1458,43 +1474,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to-\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0^{-}} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0^{+}} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to-\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0^{-}} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0^{+}} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1513,7 +1537,7 @@
               $samples = 1 + int(11/(2/$a))*80;
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
@@ -1533,43 +1557,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to-\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0^{-}} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0^{+}} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to-\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0^{-}} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0^{+}} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1586,7 +1618,7 @@
               $samples = 1 + int(14/(2*pi/$a))*80;
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
@@ -1608,27 +1640,29 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to-\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to-\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1649,7 +1683,7 @@
               }
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = <var name="$f"/></m> has the graph:
               </p>
@@ -1671,27 +1705,29 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to-\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\infty} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to-\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\infty} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -1718,7 +1754,7 @@
               $limit=($L[2]==Compute("DNE"))?"does not exist":"is `".$L[2]->TeX."`";
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                  <m>f(x)=<var name="$f"/></m>
               </p>
@@ -1726,35 +1762,41 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
             <solution>
               <p>
                 Tables will vary.
@@ -1833,7 +1875,7 @@
               $limit=($L[2]==Compute("DNE"))?"does not exist":"is `".$L[2]->TeX."`";
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=<var name="$f"/></m>
               </p>
@@ -1841,35 +1883,40 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
             <solution>
               <p>
                 Tables will vary.
@@ -1948,7 +1995,7 @@
               $limit=($L[2]==Compute("DNE"))?"does not exist":"is `".$L[2]->TeX."`";
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=<var name="$f"/></m>
               </p>
@@ -1956,35 +2003,40 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
             <solution>
               <p>
                 Tables will vary.
@@ -2063,7 +2115,7 @@
               $limit=($L[2]==Compute("DNE"))?"does not exist":"is `".$L[2]->TeX."`";
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x)=<var name="$f"/></m>
               </p>
@@ -2071,35 +2123,40 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
             <solution>
               <p>
                 Tables will vary.
@@ -2561,7 +2618,7 @@
             $L[5]=Fraction(($L[0])**($L[1]));
             Context()->strings->add('does not exist'=>{alias=>'DNE'});
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Let <m>\lim\limits_{x\to<var name="$a"/>} f(x) = <var name="$L[0]"/></m> and <m>\lim\limits_{x\to<var name="$a"/>} g(x) = <var name="$L[1]"/></m>.
               Evaluate the following limits.
@@ -2570,43 +2627,51 @@
               If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
               If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
             </instruction>
-            <p>
-              <ol cols="2">
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to<var name="$a"/>}(f+g)(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[2]" width="5"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to<var name="$a"/>}(fg)(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[3]" width="5"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to<var name="$a"/>}(f/g)(x)</m>
-                  </p>
-                  <p>
-                    <var name="$L[4]" width="5"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m>\lim\limits_{x\to<var name="$a"/>}f(x)^{g(x)}</m>
-                  </p>
-                  <p>
-                    <var name="$L[5]" width="5"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to<var name="$a"/>}(f+g)(x)</m>
+              </p>
+              <p>
+                <var name="$L[2]" width="5"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to<var name="$a"/>}(fg)(x)</m>
+              </p>
+              <p>
+                <var name="$L[3]" width="5"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to<var name="$a"/>}(f/g)(x)</m>
+              </p>
+              <p>
+                <var name="$L[4]" width="5"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to<var name="$a"/>}f(x)^{g(x)}</m>
+              </p>
+              <p>
+                <var name="$L[5]" width="5"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1299,7 +1299,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-1a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1310,7 +1310,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-1b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1371,7 +1371,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-2a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a[0]"/>^-} f(x)</m>
@@ -1382,7 +1382,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-2b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a[0]"/>^+} f(x)</m>
@@ -1393,7 +1393,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-2c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a[0]"/>} f(x)</m>
@@ -1404,7 +1404,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-2d">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a[1]"/>^-} f(x)</m>
@@ -1415,7 +1415,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-2e">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a[1]"/>^+} f(x)</m>
@@ -1426,7 +1426,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-2f">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a[1]"/>} f(x)</m>
@@ -1476,7 +1476,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-3a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to-\infty} f(x)</m>
@@ -1487,7 +1487,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-3b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\infty} f(x)</m>
@@ -1498,7 +1498,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-3c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0^{-}} f(x)</m>
@@ -1509,7 +1509,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-3d">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0^{+}} f(x)</m>
@@ -1559,7 +1559,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-4a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to-\infty} f(x)</m>
@@ -1570,7 +1570,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-4b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\infty} f(x)</m>
@@ -1581,7 +1581,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-4c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0^{-}} f(x)</m>
@@ -1592,7 +1592,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-4d">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0^{+}} f(x)</m>
@@ -1642,7 +1642,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-5a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to-\infty} f(x)</m>
@@ -1653,7 +1653,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-5b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\infty} f(x)</m>
@@ -1707,7 +1707,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-6a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to-\infty} f(x)</m>
@@ -1718,7 +1718,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-use-graph-6b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\infty} f(x)</m>
@@ -1764,7 +1764,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-1a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
@@ -1775,7 +1775,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-1b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
@@ -1786,7 +1786,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-1c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
@@ -1885,7 +1885,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-2a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
@@ -1896,7 +1896,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-2b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
@@ -1907,7 +1907,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-2c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
@@ -2005,7 +2005,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-3a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
@@ -2016,7 +2016,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-3b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
@@ -2027,7 +2027,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-3c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
@@ -2125,7 +2125,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-4a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{-}}f(x)</m>
@@ -2136,7 +2136,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-4b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>^{+}}f(x)</m>
@@ -2147,7 +2147,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-infinity-numerical-4c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to<var name="$a"/>}f(x)</m>
@@ -2629,7 +2629,7 @@
             </instruction>
           </introduction>
 
-          <task>
+          <task label="ex-limit-infinity-review-2a">
             <statement>
               <p>
                 <m>\lim\limits_{x\to<var name="$a"/>}(f+g)(x)</m>
@@ -2640,7 +2640,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-infinity-review-2b">
             <statement>
               <p>
                 <m>\lim\limits_{x\to<var name="$a"/>}(fg)(x)</m>
@@ -2651,7 +2651,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-infinity-review-2c">
             <statement>
               <p>
                 <m>\lim\limits_{x\to<var name="$a"/>}(f/g)(x)</m>
@@ -2662,7 +2662,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-limit-infinity-review-2d">
             <statement>
               <p>
                 <m>\lim\limits_{x\to<var name="$a"/>}f(x)^{g(x)}</m>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -833,7 +833,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-1a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -844,7 +844,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-1b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -855,7 +855,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-1c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -866,7 +866,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-1d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -877,7 +877,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-1e">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
@@ -888,7 +888,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-1f">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
@@ -942,7 +942,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-2a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -953,7 +953,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-2b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -964,7 +964,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-2c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -975,7 +975,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-2d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -986,7 +986,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-2e">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
@@ -997,7 +997,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-2f">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
@@ -1054,7 +1054,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-3a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1065,7 +1065,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-3b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1076,7 +1076,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-3c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1087,7 +1087,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-3d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1098,7 +1098,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-3e">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
@@ -1109,7 +1109,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-3f">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$c"/>^+} f(x)</m>
@@ -1160,7 +1160,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-4a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1171,7 +1171,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-4b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1182,7 +1182,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-4c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1193,7 +1193,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-4d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1243,7 +1243,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-5a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1254,7 +1254,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-5b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1265,7 +1265,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-5c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1276,7 +1276,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-5d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1330,7 +1330,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-6a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1341,7 +1341,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-6b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1352,7 +1352,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-6c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1363,7 +1363,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-6d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1408,7 +1408,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to -2^-} f(x)</m>
@@ -1419,7 +1419,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to -2^+} f(x)</m>
@@ -1430,7 +1430,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to -2} f(x)</m>
@@ -1441,7 +1441,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7d">
               <statement>
                 <p>
                   <m>f(-2)</m>
@@ -1452,7 +1452,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7e">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 2^-} f(x)</m>
@@ -1463,7 +1463,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7f">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 2^+} f(x)</m>
@@ -1474,7 +1474,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7g">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 2} f(x)</m>
@@ -1485,7 +1485,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-7h">
               <statement>
                 <p>
                   <m>f(2)</m>
@@ -1535,7 +1535,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-8a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to a^-} f(x)</m>
@@ -1546,7 +1546,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-8b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to a^+} f(x)</m>
@@ -1557,7 +1557,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-8c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to a} f(x)</m>
@@ -1568,7 +1568,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-use-graph-8d">
               <statement>
                 <p>
                   <m>f(a)</m>
@@ -1614,7 +1614,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-1a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1625,7 +1625,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-1b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1636,7 +1636,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-1c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1647,7 +1647,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-1d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1685,7 +1685,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-2a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1696,7 +1696,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-2b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1707,7 +1707,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-2c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1718,7 +1718,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-2d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1757,7 +1757,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1768,7 +1768,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1779,7 +1779,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1790,7 +1790,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1801,7 +1801,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3e">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
@@ -1812,7 +1812,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3f">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
@@ -1823,7 +1823,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3g">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$b"/>} f(x)</m>
@@ -1834,7 +1834,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-3h">
               <statement>
                 <p>
                   <m>f(<var name="$b"/>)</m>
@@ -1864,7 +1864,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-4a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\pi^-} f(x)</m>
@@ -1875,7 +1875,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-4b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\pi^+} f(x)</m>
@@ -1886,7 +1886,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-4c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to\pi} f(x)</m>
@@ -1897,7 +1897,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-4d">
               <statement>
                 <p>
                   <m>f(\pi)</m>
@@ -1928,7 +1928,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-5a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -1939,7 +1939,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-5b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -1950,7 +1950,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-5c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -1961,7 +1961,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-5d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -1998,7 +1998,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-6a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -2009,7 +2009,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-6b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -2020,7 +2020,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-6c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -2031,7 +2031,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-6d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -2068,7 +2068,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-7a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
@@ -2079,7 +2079,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-7b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
@@ -2090,7 +2090,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-7c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
@@ -2101,7 +2101,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-7d">
               <statement>
                 <p>
                   <m>f(<var name="$a"/>)</m>
@@ -2131,7 +2131,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-8a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to b^-} f(x)</m>
@@ -2142,7 +2142,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-8b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to b^+} f(x)</m>
@@ -2153,7 +2153,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-8c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to b} f(x)</m>
@@ -2164,7 +2164,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-8d">
               <statement>
                 <p>
                   <m>f(b)</m>
@@ -2193,7 +2193,7 @@
               </instruction>
             </introduction>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-9a">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0^-} f(x)</m>
@@ -2204,7 +2204,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-9b">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0^+} f(x)</m>
@@ -2215,7 +2215,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-9c">
               <statement>
                 <p>
                   <m>\lim\limits_{x\to 0} f(x)</m>
@@ -2226,7 +2226,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-limit-onesided-piecewise-evaluate-9d">
               <statement>
                 <p>
                   <m>f(0)</m>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -809,7 +809,7 @@
               @L=($y[1],$y[1],$y[1],$z);
               ($L[4],$L[5])=($b==0)?(Compute("DNE"),$y[0]):($y[2],Compute("DNE"));
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -831,59 +831,73 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[4]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[5]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[4]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[5]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -904,7 +918,7 @@
               @L=($y[1],$z,Compute("DNE"),$z);
               ($L[4],$L[5])=($b==0)?(Compute("DNE"),$y[0]):($y[2],Compute("DNE"));
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -926,59 +940,73 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[4]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[5]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[4]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[5]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1002,7 +1030,7 @@
               @L=(OneOf(Compute("DNE"),Compute("INF")),OneOf(Compute("DNE"),Compute("INF")),OneOf(Compute("DNE"),Compute("INF")),Compute("DNE"));
               ($L[4],$L[5])=($b==0)?(Compute("DNE"),Compute("DNE")):($y[2],$y[0]);
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1024,59 +1052,73 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[4]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$c"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[5]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[4]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$c"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[5]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1094,7 +1136,7 @@
               $xmin=min(0,@x)-1;$xmax=max(0,@x)+1;$ymin=min(0,@y,$z,$w)-1;$ymax=max(0,@y,$z,$w)+1;
               @L=($z,$y[1],Compute("DNE"),$w);
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1116,43 +1158,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1170,7 +1220,7 @@
               $xmin=min(0,@x)-1;$xmax=max(0,@x)+1;$ymin=min(0,@y,0)-1;$ymax=max(0,@y,0)+1;
               @L=($y[1],$y[1],$y[1],$y[1]);
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1191,43 +1241,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1248,7 +1306,7 @@
               $xmin=min(0,@x)-1;$xmax=max(0,@x)+1;$ymin=min(0,@y)-1;$ymax=max(0,@y)+1;
               @L=($y[1],$y[3],Compute("DNE"),$y[2]);
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1270,43 +1328,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1316,7 +1382,7 @@
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @L=(2,2,2,0,2,2,2,Compute("DNE"));
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1340,75 +1406,95 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to -2^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to -2^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to -2} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(-2)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 2^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[4]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 2^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[5]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 2} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[6]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(2)</m>
-                    </p>
-                    <p>
-                      <var name="$L[7]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to -2^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to -2^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to -2} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(-2)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 2^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[4]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 2^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[5]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 2} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[6]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(2)</m>
+                </p>
+                <p>
+                  <var name="$L[7]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1419,7 +1505,7 @@
               Context()->variables->are(a=>'Real');
               @L=(Formula("a-1"),Formula("a"),Compute("DNE"),Formula("a"));
             </pg-code>
-            <statement>
+            <introduction>
               <image>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1443,46 +1529,55 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
+
               <p>
                 Let <m>a</m> be an integer with <m>-3\leq a\leq3</m>.
               </p>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to a^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to a^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to a} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(a)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to a^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to a^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to a} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(a)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>
@@ -1509,7 +1604,7 @@
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
               $L[3]=$g->eval(x=>$a);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) =<var name="$g"/></m>
               </p>
@@ -1517,43 +1612,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1572,7 +1675,7 @@
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
               $L[3]=$g->eval(x=>$a);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) =<var name="$g"/></m>
               </p>
@@ -1580,43 +1683,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1636,7 +1747,7 @@
               $L[6]=($L[4]==$L[5])?$L[4]:Compute("DNE");
               $L[7]=$g->eval(x=>$b);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) =<var name="$g"/></m>
               </p>
@@ -1644,75 +1755,95 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[4]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[5]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$b"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[6]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$b"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[7]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[4]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[5]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$b"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[6]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$b"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[7]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1723,7 +1854,7 @@
               @f=(Formula("cos(x)"),Formula("sin(x)"));
               @L=(-1,0,Compute("DNE"),0);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = \begin{cases}<var name="$f[0]"/>\amp x\lt\pi\\ <var name="$f[1]"/>\amp x\geq\pi\end{cases}</m>
               </p>
@@ -1731,43 +1862,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\pi^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\pi^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to\pi} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(\pi)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\pi^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\pi^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to\pi} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(\pi)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1778,7 +1917,7 @@
               Context()->variables->add(a=>'Real');
               @L=(Formula("1-cos^2(a)"),Formula("sin^2(a)"),OneOf(Formula("1-cos^2(a)"),Formula("sin^2(a)")),Formula("sin^2(a)"));
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = \begin{cases}1-\cos^2(x)\amp x&lt;a\\\sin^2(x)\amp x\geq a\end{cases}</m>
                 where <m>a</m> is a real number.
@@ -1787,43 +1926,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to a^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to a^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to a} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(a)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1841,7 +1988,7 @@
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
               $L[3]=$g->eval(x=>$a);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) =<var name="$g"/></m>
               </p>
@@ -1849,43 +1996,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1903,7 +2058,7 @@
               $L[2]=($L[0]==$L[1])?$L[0]:Compute("DNE");
               $L[3]=$g->eval(x=>$a);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) =<var name="$g"/></m>
               </p>
@@ -1911,43 +2066,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(<var name="$a"/>)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(<var name="$a"/>)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -1958,7 +2121,7 @@
               Context()->variables->add(c=>'Real');
               $L=Formula("c");
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = \begin{cases}a(x-b)^2+c\amp x\lt b\\a(x-b)+c\amp x\geq b\end{cases}</m>
               </p>
@@ -1966,43 +2129,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to b^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to b^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to b} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(b)</m>
-                    </p>
-                    <p>
-                      <var name="$L" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to b^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to b^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to b} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(b)</m>
+                </p>
+                <p>
+                  <var name="$L" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
 
@@ -2012,7 +2183,7 @@
               Context()->strings->add('does not exist'=>{alias=>'DNE'});
               @L=(-1,1,Compute("DNE"),0);
             </pg-code>
-            <statement>
+            <introduction>
               <p>
                 <m>f(x) = \begin{cases}\frac{\abs{x}}{x}\amp x\neq0\\0\amp x=0\end{cases}</m>
               </p>
@@ -2020,43 +2191,51 @@
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
                 If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.
               </instruction>
-              <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0^-} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[0]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0^+} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[1]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>\lim\limits_{x\to 0} f(x)</m>
-                    </p>
-                    <p>
-                      <var name="$L[2]" width="10"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      <m>f(0)</m>
-                    </p>
-                    <p>
-                      <var name="$L[3]" width="10"/>
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
+            </introduction>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0^-} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[0]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0^+} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[1]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>\lim\limits_{x\to 0} f(x)</m>
+                </p>
+                <p>
+                  <var name="$L[2]" width="10"/>
+                </p>
+              </statement>
+            </task>
+
+            <task>
+              <statement>
+                <p>
+                  <m>f(0)</m>
+                </p>
+                <p>
+                  <var name="$L[3]" width="10"/>
+                </p>
+              </statement>
+            </task>
           </webwork>
         </exercise>
       </exercisegroup>

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -2420,70 +2420,64 @@
           <!--<webwork xml:id="ex-vector-lines-distance-formula-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Let lines <m>\vec\ell_1(t)</m> and <m>\vec\ell_2(t)</m> be parallel.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Show why the distance formula for distance between lines cannot be used as stated to find the distance between the lines.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Show why the distance formula for distance between lines cannot be used as stated to find the distance between the lines.
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    The distance formula cannot be used because since
+                    <m>\vec d_1</m> and <m>\vec d_2</m> are parallel,
+                    <m>\vec c</m> is <m>\vec 0</m> and we cannot divide by <m>\vnorm{0}</m>.
+                  </p>
+                </solution>
+              </task>
 
-                    <li>
-                      <p>
-                        Show why letting <m>\vec c=(\overrightarrow{P_1P_2}\times\vec d_2)\times\vec d_2</m> allows one to the use the formula.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Show why letting <m>\vec c=(\overrightarrow{P_1P_2}\times\vec d_2)\times\vec d_2</m> allows one to the use the formula.
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    Since <m>\vec d_1</m> and <m>\vec d_2</m> are parallel,
+                    <m>\overrightarrow{P_1P_2}</m> lies in the plane formed by the two lines.
+                    Thus <m>\overrightarrow{P_1P_2}\times\vec d_2</m> is orthogonal to this plane,
+                    and <m>\vec c=(\overrightarrow{P_1P_2}\times\vec d_2)\times \vec d_2</m> is parallel to the plane,
+                    but still orthogonal to both <m>\vec d_1</m> and <m>\vec d_2</m>.
+                    We desire the length of the projection of <m>\overrightarrow{P_1P_2}</m> onto <m>\vec c</m>,
+                    which is what the formula provides.
+                  </p>
+                </solution>
+              </task>
 
-                    <li>
-                      <p>
-                        Show how one can use the formula for the distance between a point and a line to find the distance between parallel lines.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        The distance formula cannot be used because since
-                        <m>\vec d_1</m> and <m>\vec d_2</m> are parallel,
-                        <m>\vec c</m> is <m>\vec 0</m> and we cannot divide by <m>\vnorm{0}</m>.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Since <m>\vec d_1</m> and <m>\vec d_2</m> are parallel,
-                        <m>\overrightarrow{P_1P_2}</m> lies in the plane formed by the two lines.
-                        Thus <m>\overrightarrow{P_1P_2}\times\vec d_2</m> is orthogonal to this plane,
-                        and <m>\vec c=(\overrightarrow{P_1P_2}\times\vec d_2)\times \vec d_2</m> is parallel to the plane,
-                        but still orthogonal to both <m>\vec d_1</m> and <m>\vec d_2</m>.
-                        We desire the length of the projection of <m>\overrightarrow{P_1P_2}</m> onto <m>\vec c</m>,
-                        which is what the formula provides.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Since the lines are parallel,
-                        one can measure the distance between the lines at any location on either line
-                        (just as to find the distance between straight railroad tracks,
-                        one can use a measuring tape anywhere along the track,
-                        not just at one specific place.)
-                        Let <m>P=P_1</m> and <m>Q=P_2</m> as given by the equations of the lines,
-                        and apply the formula for distance between a point and a line.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Show how one can use the formula for the distance between a point and a line to find the distance between parallel lines.
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    Since the lines are parallel,
+                    one can measure the distance between the lines at any location on either line
+                    (just as to find the distance between straight railroad tracks,
+                    one can use a measuring tape anywhere along the track,
+                    not just at one specific place.)
+                    Let <m>P=P_1</m> and <m>Q=P_2</m> as given by the equations of the lines,
+                    and apply the formula for distance between a point and a line.
+                  </p>
+                </solution>
+              </task>
           <!-- </webwork> -->
         </exercise>
       </exercisegroup>

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -2426,7 +2426,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-lines-distance-formula-3a">
                 <statement>
                   <p>
                     Show why the distance formula for distance between lines cannot be used as stated to find the distance between the lines.
@@ -2441,7 +2441,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex-vector-lines-distance-formula-3b">
                 <statement>
                   <p>
                     Show why letting <m>\vec c=(\overrightarrow{P_1P_2}\times\vec d_2)\times\vec d_2</m> allows one to the use the formula.
@@ -2460,7 +2460,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex-vector-lines-distance-formula-3c">
                 <statement>
                   <p>
                     Show how one can use the formula for the distance between a point and a line to find the distance between parallel lines.

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -924,7 +924,7 @@
                   <m>z=3x+4y</m>, <m>x=t^2</m>, <m>y=2t</m>; <m>t=1</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -940,7 +940,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!-- </webwork> -->
         </exercise>
 
@@ -995,7 +995,7 @@
                   <m>y=\sin(t) -3</m>; <m>t=\pi/4</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1011,7 +1011,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!-- </webwork> -->
         </exercise>
 
@@ -1066,7 +1066,7 @@
                   <m>y=3\sin(t)</m>; <m>t=\pi/4</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1083,7 +1083,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!-- </webwork> -->
         </exercise>
 

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -1624,7 +1624,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-1a">
                 <statement>
                   <p>
                     Along the path <m>y=0</m>.
@@ -1632,7 +1632,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-1b">
                 <statement>
                   <p>
                     Along the path <m>x=0</m>.
@@ -1705,7 +1705,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-3a">
                 <statement>
                   <p>
                     Along the path <m>y=mx</m>.
@@ -1713,7 +1713,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-3b">
                 <statement>
                   <p>
                     Along the path <m>x=0</m>.
@@ -1754,7 +1754,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-4a">
                 <statement>
                   <p>
                     Along the path <m>y=mx</m>.
@@ -1762,7 +1762,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-4b">
                 <statement>
                   <p>
                     Along the path <m>y=x^2</m>.
@@ -1813,7 +1813,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-5a">
                 <statement>
                   <p>
                     Along the path <m>y=2</m>.
@@ -1821,7 +1821,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-5b">
                 <statement>
                   <p>
                     Along the path <m>y=x+1</m>.
@@ -1873,7 +1873,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-6a">
                 <statement>
                   <p>
                     Along the path <m>x=\pi</m>.
@@ -1881,7 +1881,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-multi-limit-two-paths-6b">
                 <statement>
                   <p>
                     Along the path <m>y=x-\pi/2</m>.

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -1248,7 +1248,7 @@
                   <m>\ds S = \left\{(x,y)\,\left| \, \frac{(x-1)^2}{4}+\frac{(y-3)^2}{9}\leq 1\right.\right\}</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1274,7 +1274,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!--</webwork>-->
         </exercise>
 
@@ -1322,7 +1322,7 @@
                   The set <m>S</m> is: <var name="$bu" form="popup"/>.
                 </p> -->
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1343,7 +1343,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!-- </webwork> -->
         </exercise>
 
@@ -1356,7 +1356,7 @@
                   <m>\ds S = \left\{(x,y)\,| \, x^2+y^2=1\right\}</m>
                 </p>
               </statement>
-              <solution>
+            answer>
                 <p>
                   <ol>
                     <li>
@@ -1382,7 +1382,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              answer>
           <!--</webwork>-->
         </exercise>
 
@@ -1472,7 +1472,7 @@
                   <m>\ds f(x,y) = \sqrt{9-x^2-y^2}</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1494,7 +1494,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!--</webwork>-->
         </exercise>
 
@@ -1507,7 +1507,7 @@
                   <m>\ds f(x,y) = \sqrt{y-x^2}</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1529,7 +1529,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!--</webwork>-->
         </exercise>
 
@@ -1542,7 +1542,7 @@
                   <m>\ds f(x,y) = \frac{1}{\sqrt{y-x^2}}</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1564,7 +1564,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!--</webwork>-->
         </exercise>
 
@@ -1577,7 +1577,7 @@
                   <m>\ds f(x,y) = \frac{x^2-y^2}{x^2+y^2}</m>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
                   <ol>
                     <li>
@@ -1599,7 +1599,7 @@
                     </li>
                   </ol>
                 </p>
-              </solution>
+              </answer>
           <!--</webwork>-->
         </exercise>
 
@@ -1618,27 +1618,27 @@
           <!--<webwork xml:id="ex-multi-limit-two-paths-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\lim\limits_{(x,y)\to(0,0)} \frac{x^2-y^2}{x^2+y^2}</m>
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Along the path <m>y=0</m>.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=0</m>.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Along the path <m>x=0</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>x=0</m>.
+                  </p>
+                </statement>
+              </task>
               <solution>
                 <p>
                   <ol>
@@ -1673,13 +1673,7 @@
                 </p>
 
                 <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Along the path <m>y=mx</m>.
-                      </p>
-                    </li>
-                  </ol>
+                  Along the path <m>y=mx</m>.
                 </p>
               </statement>
               <solution>
@@ -1705,27 +1699,27 @@
           <!--<webwork xml:id="ex-multi-limit-two-paths-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\lim\limits_{(x,y)\to(0,0)} \frac{xy-y^2}{y^2+x}</m>
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Along the path <m>y=mx</m>.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=mx</m>.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Along the path <m>x=0</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>x=0</m>.
+                  </p>
+                </statement>
+              </task>
               <solution>
                 <p>
                   <ol>
@@ -1754,27 +1748,27 @@
           <!--<webwork xml:id="ex-multi-limit-two-paths-4">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\lim\limits_{(x,y)\to(0,0)} \frac{\sin(x^2)}{y}</m>
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Along the path <m>y=mx</m>.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=mx</m>.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Along the path <m>y=x^2</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=x^2</m>.
+                  </p>
+                </statement>
+              </task>
               <solution>
                 <p>
                   <ol>
@@ -1813,27 +1807,27 @@
           <!--<webwork xml:id="ex-multi-limit-two-paths-5">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\lim\limits_{(x,y)\to(1,2)} \frac{x+y-3}{x^2-1}</m>
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Along the path <m>y=2</m>.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=2</m>.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Along the path <m>y=x+1</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=x+1</m>.
+                  </p>
+                </statement>
+              </task>
               <solution>
                 <p>
                   <ol>
@@ -1873,27 +1867,27 @@
           <!--<webwork xml:id="ex-multi-limit-two-paths-6">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   <m>\lim\limits_{(x,y)\to(\pi,\pi/2)} \frac{\sin(x) }{\cos(y) }</m>
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Along the path <m>x=\pi</m>.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>x=\pi</m>.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Along the path <m>y=x-\pi/2</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+              <task>
+                <statement>
+                  <p>
+                    Along the path <m>y=x-\pi/2</m>.
+                  </p>
+                </statement>
+              </task>
               <solution>
                 <p>
                   <ol>

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -2079,35 +2079,35 @@
           <!-- <webwork xml:id="ex-parametric-surface-area-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Find the surface area of the sphere formed by rotating the circle
                   <m>x=2\cos(t)</m>,<m>y=2\sin(t)</m> about:
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        the <m>x</m>-axis and
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    The <m>x</m>-axis.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        the <m>y</m>-axis.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
+              <task>
+                <statement>
+                  <p>
+                    The <m>y</m>-axis.
+                  </p>
+                </statement>
+              </task>
+              <answer>
                 <p>
                   The answer is <m>16\pi</m> for both
                   (of course),
                   but the integrals are different.
                 </p>
-              </solution>
+              </answer>
           <!-- </webwork> -->
         </exercise>
 

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -2086,7 +2086,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-parametric-surface-area-1a">
                 <statement>
                   <p>
                     The <m>x</m>-axis.
@@ -2094,7 +2094,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-parametric-surface-area-1b">
                 <statement>
                   <p>
                     The <m>y</m>-axis.

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -1798,7 +1798,7 @@
           <!-- <webwork xml:id="ex-parametric-equations-compare-1">
               <pg-code>
               </pg-code> -->
-              <task>
+              <task label="ex-parametric-equations-compare-1a">
                 <statement>
                   <p>
                     <m>x=t</m> <m>y=t^2</m>, <m>-\infty\lt t\lt \infty</m>
@@ -1810,7 +1810,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-parametric-equations-compare-1b">
                 <statement>
                   <p>
                     <m>x=\sin(t)</m> <m>y=\sin^2(t)</m>,
@@ -1825,7 +1825,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-parametric-equations-compare-1c">
                 <statement>
                   <p>
                     <m>x=e^t</m> <m>y=e^{2t}</m>,
@@ -1840,7 +1840,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-parametric-equations-compare-1d">
                 <statement>
                   <p>
                     <m>x=-t</m> <m>y=t^2</m>, <m>-\infty\lt t\lt \infty</m>
@@ -1859,7 +1859,7 @@
           <!-- <webwork xml:id="ex-parametric-equations-compare-2">
               <pg-code>
               </pg-code> -->
-              <task>
+              <task label="ex-parametric-equations-compare-2a">
                 <statement>
                   <p>
                     <m>x=\cos(t)</m> <m>y=\sin(t)</m>, <m>0\leq t\leq 2\pi</m>
@@ -1871,7 +1871,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-parametric-equations-compare-2b">
                 <statement>
                   <p>
                     <m>x=\cos(t^2)</m> <m>y=\sin(t^2)</m>, <m>0\leq t\leq 2\pi</m>
@@ -1883,7 +1883,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-parametric-equations-compare-2c">
                 <statement>
                   <p>
                     <m>x=\cos(1/t)</m> <m>y=\sin(1/t)</m>, <m>0\lt t\lt 1</m>
@@ -1895,7 +1895,7 @@
                   </p>
                 </answer>
               </task>
-              <task>
+              <task label="ex-parametric-equations-compare-2d">
                 <statement>
                   <p>
                     <m>x=\cos(\cos(t) )</m> <m>y=\sin(\cos(t) )</m>, <m>0\leq t\leq 2\pi</m>

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -1798,70 +1798,60 @@
           <!-- <webwork xml:id="ex-parametric-equations-compare-1">
               <pg-code>
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>x=t</m> <m>y=t^2</m>, <m>-\infty\lt t\lt \infty</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=\sin(t)</m> <m>y=\sin^2(t)</m>,
-                        <m>-\infty\lt t\lt \infty</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=e^t</m> <m>y=e^{2t}</m>,
-                        <m>-\infty\lt t\lt \infty</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=-t</m> <m>y=t^2</m>, <m>-\infty\lt t\lt \infty</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Traces the parabola <m>y=x^2</m>, moves from left to right.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Traces the parabola <m>y=x^2</m>,
-                        but only from <m>-1\leq x\leq 1</m>;
-                        traces this portion back and forth infinitely.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Traces the parabola <m>y=x^2</m>,
-                        but only for <m>0\lt x</m>.
-                        Moves left to right.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Traces the parabola <m>y=x^2</m>, moves from right to left.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=t</m> <m>y=t^2</m>, <m>-\infty\lt t\lt \infty</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces the parabola <m>y=x^2</m>, moves from left to right.
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=\sin(t)</m> <m>y=\sin^2(t)</m>,
+                    <m>-\infty\lt t\lt \infty</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces the parabola <m>y=x^2</m>,
+                    but only from <m>-1\leq x\leq 1</m>;
+                    traces this portion back and forth infinitely.
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=e^t</m> <m>y=e^{2t}</m>,
+                    <m>-\infty\lt t\lt \infty</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces the parabola <m>y=x^2</m>,
+                    but only for <m>0\lt x</m>.
+                    Moves left to right.
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=-t</m> <m>y=t^2</m>, <m>-\infty\lt t\lt \infty</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces the parabola <m>y=x^2</m>, moves from right to left.
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1869,64 +1859,54 @@
           <!-- <webwork xml:id="ex-parametric-equations-compare-2">
               <pg-code>
               </pg-code> -->
-              <statement>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>x=\cos(t)</m> <m>y=\sin(t)</m>, <m>0\leq t\leq 2\pi</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=\cos(t^2)</m> <m>y=\sin(t^2)</m>, <m>0\leq t\leq 2\pi</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=\cos(1/t)</m> <m>y=\sin(1/t)</m>, <m>0\lt t\lt 1</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=\cos(\cos(t) )</m> <m>y=\sin(\cos(t) )</m>, <m>0\leq t\leq 2\pi</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Traces a circle of radius 1 counterclockwise once.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Traces a circle of radius 1 counterclockwise over 6 times.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Traces a circle of radius 1 clockwise infinite times.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        Traces an arc of a circle of radius 1, from an angle of -1 radians to 1 radian, twice.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=\cos(t)</m> <m>y=\sin(t)</m>, <m>0\leq t\leq 2\pi</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces a circle of radius 1 counterclockwise once.
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=\cos(t^2)</m> <m>y=\sin(t^2)</m>, <m>0\leq t\leq 2\pi</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces a circle of radius 1 counterclockwise over 6 times.
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=\cos(1/t)</m> <m>y=\sin(1/t)</m>, <m>0\lt t\lt 1</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces a circle of radius 1 clockwise infinite times.
+                  </p>
+                </answer>
+              </task>
+              <task>
+                <statement>
+                  <p>
+                    <m>x=\cos(\cos(t) )</m> <m>y=\sin(\cos(t) )</m>, <m>0\leq t\leq 2\pi</m>
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    Traces an arc of a circle of radius 1, from an angle of -1 radians to 1 radian, twice.
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -2197,23 +2197,14 @@
                   </ol>
                 </p>
               </statement>
-              <solution>
+              <answer>
                 <p>
-                  <m>A=(\sqrt{2},\sqrt{2})</m>
+                  <m>A=(\sqrt{2},\sqrt{2})</m>,
+                  <m>B=(\sqrt{2},-\sqrt{2})</m>,
+                  <m>C=P(\sqrt{5},-0.46)</m>,
+                  <m>D=P(\sqrt{5},2.68)</m>.
                 </p>
-
-                <p>
-                  <m>B=(\sqrt{2},-\sqrt{2})</m>
-                </p>
-
-                <p>
-                  <m>C=P(\sqrt{5},-0.46)</m>
-                </p>
-
-                <p>
-                  <m>D=P(\sqrt{5},2.68)</m>
-                </p>
-              </solution>
+              </answer>
           </webwork>
         </exercise>
 
@@ -2281,23 +2272,14 @@
                 </ol>
               </p>
             </statement>
-            <solution>
+            <answer>
               <p>
-                <m>A=(-3,0)</m>
+                <m>A=(-3,0)</m>,
+                <m>B=(-1/2,\sqrt{3}/2)</m>,
+                <m>C=P(4,\pi/2)</m>,
+                <m>D=P(2,-\pi/3)</m>.
               </p>
-
-              <p>
-                <m>B=(-1/2,\sqrt{3}/2)</m>
-              </p>
-
-              <p>
-                <m>C=P(4,\pi/2)</m>
-              </p>
-
-              <p>
-                <m>D=P(2,-\pi/3)</m>
-              </p>
-            </solution>
+            </answer>
           </webwork>
         </exercise>
 

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -784,40 +784,47 @@
             @den = map{($_->value)[1]}(@f);
             @sU = map{NumberWithUnits("$num[$_]/($den[$_] pi) cm/s")}(0,1,2);
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Water flows onto a flat surface at a rate of
               <m><var name="$rateU"/></m>
               forming a circular puddle <m><var name="$depthU"/></m> deep.
               How fast is the radius growing when the radius is:
-              <ol>
-                <li>
-                  <p>
-                    <m><var name="$rU[0]"/></m>
-                  </p>
-                  <p>
-                    <var name="$sU[0]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$rU[1]"/></m>
-                  </p>
-                  <p>
-                    <var name="$sU[1]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$rU[2]"/></m>
-                  </p>
-                  <p>
-                    <var name="$sU[2]" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+          
+          <task>
+            <statement>
+              <p>
+                <m><var name="$rU[0]"/></m>
+              </p>
+              <p>
+                <var name="$sU[0]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$rU[1]"/></m>
+              </p>
+              <p>
+                <var name="$sU[1]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$rU[2]"/></m>
+              </p>
+              <p>
+                <var name="$sU[2]" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 4: Spherical balloon radius increasing-->
@@ -837,39 +844,46 @@
             @den = map{($_->value)[1]}(@f);
             @sU = map{NumberWithUnits("$num[$_]/($den[$_] pi) cm/s")}(0,1,2);
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               A spherical balloon is inflated with air flowing at a rate of
               <m><var name="$rateU"/></m>.
               How fast is the radius of the balloon increasing when the radius is:
-              <ol>
-                <li>
-                  <p>
-                    <m><var name="$rU[0]"/></m>
-                  </p>
-                  <p>
-                    <var name="$sU[0]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$rU[1]"/></m>
-                  </p>
-                  <p>
-                    <var name="$sU[1]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$rU[2]"/></m>
-                  </p>
-                  <p>
-                    <var name="$sU[2]" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$rU[0]"/></m>
+              </p>
+              <p>
+                <var name="$sU[0]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$rU[1]"/></m>
+              </p>
+              <p>
+                <var name="$sU[1]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$rU[2]"/></m>
+              </p>
+              <p>
+                <var name="$sU[2]" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 5: Refer to Example 100-->
@@ -920,36 +934,40 @@
             $b = Compute("$f4 sqrt($f2)-$f5");
             $b = NumberWithUnits("$b mi/h");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Consider the traffic situation introduced in <xref ref="ex_rr3">Example</xref>.
               Calculate how fast the <q>other car</q> is traveling in each of the following situations.
-              <ol>
-                <li>
-                  <p>
-                    The officer is traveling due north at <m><var name="$speed"/>\,\text{mph}</m>
-                    and is <m><var name="$f"/></m> mile from the intersection,
-                    while the other car is <m>1</m> mile from the intersection
-                    traveling west and the radar reading is <m>-<var name="$rate"/>\,\text{mph}</m>?
-                  </p>
-                  <p>
-                    <var name="$a" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    The officer is traveling due north at <m><var name="$speed"/>\,\text{mph}</m>
-                    and is <m>1</m> mile from the intersection,
-                    while the other car is <m><var name="$f"/></m> mile from the
-                    intersection traveling west and the radar reading is <m>-<var name="$rate"/>\,\text{mph}</m>?
-                  </p>
-                  <p>
-                    <var name="$b" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                The officer is traveling due north at <m><var name="$speed"/>\,\text{mph}</m>
+                and is <m><var name="$f"/></m> mile from the intersection,
+                while the other car is <m>1</m> mile from the intersection
+                traveling west and the radar reading is <m>-<var name="$rate"/>\,\text{mph}</m>?
+              </p>
+              <p>
+                <var name="$a" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                The officer is traveling due north at <m><var name="$speed"/>\,\text{mph}</m>
+                and is <m>1</m> mile from the intersection,
+                while the other car is <m><var name="$f"/></m> mile from the
+                intersection traveling west and the radar reading is <m>-<var name="$rate"/>\,\text{mph}</m>?
+              </p>
+              <p>
+                <var name="$b" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 7: Anti-aircraft gun-->
@@ -966,7 +984,7 @@
             $c = Compute("$spd*5280/$elev"); <!--Simplify the formula and get this as the limit>-->
             $cU = NumberWithUnits("$c rad/hr");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               An F-22 aircraft is flying at <m><var name="$spd"/>\,\text{mph}</m>
               with an elevation of <m><var name="$elev"/>\,\text{ft}</m> on a
@@ -999,43 +1017,57 @@
             <p>
               How fast (in radians per second) must the gun be able to turn to accurately track the
               aircraft when the plane is:
-              <ol>
-                <li>
-                  <p>
-                    <m>1</m> mile away?
-                  </p>
-                  <p>
-                    <var name="$aU" width="10"/>
-                  </p>
-                  <instruction>
-                    Use <c>rad/s</c> for radians per second.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>1/5</m> mile away?
-                  </p>
-                  <p>
-                    <var name="$bU" width="10"/>
-                  </p>
-                  <instruction>
-                    Use <c>rad/s</c> for radians per second.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    Directly overhead?
-                  </p>
-                  <p>
-                    <var name="$cU" width="10"/>
-                  </p>
-                  <instruction>
-                    Use <c>rad/s</c> for radians per second.
-                  </instruction>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m>1</m> mile away?
+              </p>
+              <p>
+                <var name="$aU" width="10"/>
+              </p>
+              <instruction>
+                Use <c>rad/s</c> for radians per second.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <p>
+              <m>1/5</m> mile away?
+            </p>
+            <p>
+              <var name="$bU" width="10"/>
+            </p>
+            <instruction>
+              Use <c>rad/s</c> for radians per second.
+            </instruction>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Directly overhead?
+              </p>
+              <p>
+                <var name="$cU" width="10"/>
+              </p>
+              <instruction>
+                Use <c>rad/s</c> for radians per second.
+              </instruction>
+
+            </statement>
+          </task>
           <hint>
             <p>
               There are <m>5280</m> feet in one mile.
@@ -1056,7 +1088,7 @@
             @b = map{100*$speed*5280/3600/(100**2 + $_**2)}(@a);
             @bU = map{NumberWithUnits("$_ rad/s")}(@b);
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               An F-22 aircraft is flying at
               <var name="$speedU"/>
@@ -1068,43 +1100,50 @@
             <p>
               How fast must the gun be able to turn to accurately track the
               aircraft when the plane is:
-              <ol>
-                <li>
-                  <p>
-                    <m><var name="$aU[0]"/></m> away?
-                  </p>
-                  <instruction>
-                    Use <c>rad/s</c> for radians per second.
-                  </instruction>
-                  <p>
-                    <var name="$bU[0]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$aU[1]"/></m> away?
-                  </p>
-                  <instruction>
-                    Use <c>rad/s</c> for radians per second.
-                  </instruction>
-                  <p>
-                    <var name="$bU[1]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Directly overhead?
-                  </p>
-                  <instruction>
-                    Use <c>rad/s</c> for radians per second.
-                  </instruction>
-                  <p>
-                    <var name="$bU[2]" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$aU[0]"/></m> away?
+              </p>
+              <instruction>
+                Use <c>rad/s</c> for radians per second.
+              </instruction>
+              <p>
+                <var name="$bU[0]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$aU[1]"/></m> away?
+              </p>
+              <instruction>
+                Use <c>rad/s</c> for radians per second.
+              </instruction>
+              <p>
+                <var name="$bU[1]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Directly overhead?
+              </p>
+              <instruction>
+                Use <c>rad/s</c> for radians per second.
+              </instruction>
+              <p>
+                <var name="$bU[2]" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 9: Ladder sliding down a house-->
@@ -1121,7 +1160,7 @@
             $c = NumberWithUnits("$c ft/s");
             $d = Compute("inf");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               A <quantity><mag>24</mag><unit base="foot"/></quantity> ladder
               is leaning against a house while the base is pulled away at a
@@ -1148,56 +1187,64 @@
               At what rate is the top of the ladder sliding down the side of
               the house when the base is:
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>1</m> foot from the house?
-                  </p>
-                  <p>
-                    <var name="$a" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/s</c> for feet per second.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>10</m> feet from the house?
-                  </p>
-                  <p>
-                    <var name="$b" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/s</c> for feet per second.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>23</m> feet from the house?
-                  </p>
+          </introduction>
 
-                  <p>
-                    <var name="$c" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/s</c> for feet per second.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>24</m> feet from the house?
-                  </p>
-                  <p>
-                    <var name="$d" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/s</c> for feet per second.
-                  </instruction>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          <task>
+            <statement>
+              <p>
+                <m>1</m> foot from the house?
+              </p>
+              <p>
+                <var name="$a" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/s</c> for feet per second.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>10</m> feet from the house?
+              </p>
+              <p>
+                <var name="$b" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/s</c> for feet per second.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>23</m> feet from the house?
+              </p>
+
+              <p>
+                <var name="$c" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/s</c> for feet per second.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>24</m> feet from the house?
+              </p>
+              <p>
+                <var name="$d" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/s</c> for feet per second.
+              </instruction>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 10: Winch that boat in-->
@@ -1213,7 +1260,7 @@
             $c = Compute($f->eval(x=>1));
             $c = NumberWithUnits("$c ft/min");
           </pg-code>
-          <statement>
+          <introduciton>
             <p>
               A boat is being pulled into a dock at a constant rate of
               <quantity>
@@ -1241,54 +1288,61 @@
             <p>
               At what rate is the boat approaching the dock when the boat is:
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>50</m> feet out?
-                  </p>
-                  <p>
-                    <var name="$a" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/min</c> for feet per minute.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>15</m> feet out?
-                  </p>
-                  <p>
-                    <var name="$b" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/min</c> for feet per minute.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>1</m> foot from the dock?
-                  </p>
-                  <p>
-                    <var name="$c" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/min</c> for feet per minute.
-                  </instruction>
-                </li>
-                
-                <li>
-                  <p>
-                    What happens when the length of rope pulling in the boat is less than 10 feet long?
-                  </p>
-                  
-                  <p>
-                    <var form="essay"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+          </introduciton>
+
+          <task>
+            <statement>
+              <p>
+                <m>50</m> feet out?
+              </p>
+              <p>
+                <var name="$a" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/min</c> for feet per minute.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>15</m> feet out?
+              </p>
+              <p>
+                <var name="$b" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/min</c> for feet per minute.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>1</m> foot from the dock?
+              </p>
+              <p>
+                <var name="$c" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/min</c> for feet per minute.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                What happens when the length of rope pulling in the boat is less than 10 feet long?
+              </p>
+              
+              <p>
+                <var form="essay"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 11: Inverted cylindrical cone-->
@@ -1307,7 +1361,7 @@
             $T = pi/12 * $diameter**2 * $depth / $rate;
             $TU = NumberWithUnits("$T s");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               An inverted cylindrical cone,
               <m><var name="$depthU"/></m> deep and
@@ -1316,40 +1370,52 @@
               <m><var name="$rateU"/></m>.
               At what rate is the water rising in the tank when the depth of
               the water is:
-              <ol>
-                <li>
-                  <p>
-                    <m><var name="$a[0]"/></m> foot?
-                  </p>
-                  <p>
-                    <var name="$bU[0]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$a[1]"/></m> feet?
-                  </p>
-                  <p>
-                    <var name="$bU[1]" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    <m><var name="$a[2]"/></m> feet?
-                  </p>
-                  <p>
-                    <var name="$bU[2]" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-            <p>
-              How long will the tank take to fill when starting at empty?
-            </p>
-            <p>
-              <var name="$TU" width="20"/>
-            </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$a[0]"/></m> foot?
+              </p>
+              <p>
+                <var name="$bU[0]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$a[1]"/></m> feet?
+              </p>
+              <p>
+                <var name="$bU[1]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m><var name="$a[2]"/></m> feet?
+              </p>
+              <p>
+                <var name="$bU[2]" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                How long will the tank take to fill when starting at empty?
+              </p>
+              <p>
+                <var name="$TU" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 12: Rope, pulley, man standing next to the weight and walking away-->
@@ -1365,7 +1431,7 @@
             $c = Compute("sqrt(60^2-30^2)");
             $c = NumberWithUnits("$c ft");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               A rope, attached to a weight,
               goes up through a pulley at the ceiling and back down to a worker.
@@ -1399,43 +1465,51 @@
               </quantity>.
               How fast is the weight rising when the man has walked:
             </p>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>10</m> feet?
-                  </p>
-                  <p>
-                    <var name="$a" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/s</c> for feet per second.
-                  </instruction>
-                </li>
-                <li>
-                  <p>
-                    <m>40</m> feet?
-                  </p>
-                  <p>
-                    <var name="$b" width="20"/>
-                  </p>
-                  <instruction>
-                    Use <c>ft/s</c> for feet per second.
-                  </instruction>
-                </li>
-              </ol>
-            </p>
-            <p>
-              How far must the man walk to raise the weight all the way to
-              the pulley?
-            </p>
-            <p>
-              <var name="$c" width="20"/>
-            </p>
-            <instruction>
-                    Use <c>ft</c> for feet.
-                  </instruction>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                <m>10</m> feet?
+              </p>
+              <p>
+                <var name="$a" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/s</c> for feet per second.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                <m>40</m> feet?
+              </p>
+              <p>
+                <var name="$b" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft/s</c> for feet per second.
+              </instruction>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                How far must the man walk to raise the weight all the way to
+                the pulley?
+              </p>
+
+              <p>
+                <var name="$c" width="20"/>
+              </p>
+              <instruction>
+                Use <c>ft</c> for feet.
+              </instruction>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 13: Same setup, but starting further away-->
@@ -1463,51 +1537,61 @@
             $far = sqrt($length**2 - 30**2);
             $farU = NumberWithUnits("$far ft");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               Consider the situation described in
               <xref ref="exer_04_02_ex_12">Exercise</xref>.
               Suppose the man starts <m><var name="$bU"/></m> from the weight and begins
               to walk away at a rate of <m><var name="$speedU"/></m>.
-              <ol>
-                <li>
-                  <p>
-                    How long is the rope?
-                  </p>
-                  <p>
-                    <var name="$lengthU" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    How fast is the weight rising after the man has walked
-                    <m>10</m> feet?
-                  </p>
-                  <p>
-                    <var name="$newrateU" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    How fast is the weight rising after the man has walked
-                    <m>30</m> feet?
-                  </p>
-                  <p>
-                    <var name="$newnewrateU" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    How far must the man walk to raise the weight all the way
-                    to the pulley?
-                  </p>
-                  <p>
-                    <var name="$farU" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                How long is the rope?
+              </p>
+              <p>
+                <var name="$lengthU" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                How fast is the weight rising after the man has walked
+                <m>10</m> feet?
+              </p>
+              <p>
+                <var name="$newrateU" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                How fast is the weight rising after the man has walked
+                <m>30</m> feet?
+              </p>
+              <p>
+                <var name="$newnewrateU" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                How far must the man walk to raise the weight all the way
+                to the pulley?
+              </p>
+              <p>
+                <var name="$farU" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 14: Hot air balloon rising while being tracked-->
@@ -1524,7 +1608,7 @@
             $speed = 2*$distance*$rate*pi/180;
             $speedU = NumberWithUnits("$speed ft/s");
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               A hot air balloon lifts off from ground rising vertically.
               From <m><var name="$distance"/></m> feet away, a
@@ -1533,26 +1617,30 @@
               When her sightline with the balloon makes a
               <m>45^\circ</m> angle with the horizontal, she notes the angle
               is increasing at about <m><var name="$rate"/>^\circ</m> per minute.
-              <ol>
-                <li>
-                  <p>
-                    What is the elevation of the balloon?
-                  </p>
-                  <p>
-                    <var name="$elevU" width="20"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    How fast is it rising?
-                  </p>
-                  <p>
-                    <var name="$speedU" width="20"/>
-                  </p>
-                </li>
-              </ol>
             </p>
-          </statement>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                What is the elevation of the balloon?
+              </p>
+              <p>
+                <var name="$elevU" width="20"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                How fast is it rising?
+              </p>
+              <p>
+                <var name="$speedU" width="20"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
       <!--Exercise 15: Sand being dumped into a conical pile-->

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -793,7 +793,7 @@
             </p>
           </introduction>
           
-          <task>
+          <task label="ex-related-rates-puddle-a">
             <statement>
               <p>
                 <m><var name="$rU[0]"/></m>
@@ -804,7 +804,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-puddle-b">
             <statement>
               <p>
                 <m><var name="$rU[1]"/></m>
@@ -815,7 +815,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-puddle-c">
             <statement>
               <p>
                 <m><var name="$rU[2]"/></m>
@@ -852,7 +852,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-balloon-a">
             <statement>
               <p>
                 <m><var name="$rU[0]"/></m>
@@ -863,7 +863,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-balloon-b">
             <statement>
               <p>
                 <m><var name="$rU[1]"/></m>
@@ -874,7 +874,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-balloon-c">
             <statement>
               <p>
                 <m><var name="$rU[2]"/></m>
@@ -941,7 +941,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-radar-2a">
             <statement>
               <p>
                 The officer is traveling due north at <m><var name="$speed"/>\,\text{mph}</m>
@@ -955,7 +955,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-radar-2b">
             <statement>
               <p>
                 The officer is traveling due north at <m><var name="$speed"/>\,\text{mph}</m>
@@ -1020,7 +1020,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-aircraft-1a">
             <statement>
               <p>
                 <m>1</m> mile away?
@@ -1034,7 +1034,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-aircraft-1b">
             <p>
               <m>1/5</m> mile away?
             </p>
@@ -1046,7 +1046,7 @@
             </instruction>
           </task>
 
-          <task>
+          <task label="ex-related-rates-aircraft-1c">
             <statement>
               <p>
                 
@@ -1054,7 +1054,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-aircraft-1d">
             <statement>
               <p>
                 Directly overhead?
@@ -1103,7 +1103,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-aircraft-2a">
             <statement>
               <p>
                 <m><var name="$aU[0]"/></m> away?
@@ -1117,7 +1117,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-aircraft-2b">
             <statement>
               <p>
                 <m><var name="$aU[1]"/></m> away?
@@ -1131,7 +1131,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-aircraft-2c">
             <statement>
               <p>
                 Directly overhead?
@@ -1189,7 +1189,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-ladder-a">
             <statement>
               <p>
                 <m>1</m> foot from the house?
@@ -1203,7 +1203,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-ladder-b">
             <statement>
               <p>
                 <m>10</m> feet from the house?
@@ -1217,7 +1217,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-ladder-c">
             <statement>
               <p>
                 <m>23</m> feet from the house?
@@ -1232,7 +1232,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-ladder-d">
             <statement>
               <p>
                 <m>24</m> feet from the house?
@@ -1290,7 +1290,7 @@
             </p>
           </introduciton>
 
-          <task>
+          <task label="ex-related-rates-boat-a">
             <statement>
               <p>
                 <m>50</m> feet out?
@@ -1304,7 +1304,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-boat-b">
             <statement>
               <p>
                 <m>15</m> feet out?
@@ -1318,7 +1318,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-boat-c">
             <statement>
               <p>
                 <m>1</m> foot from the dock?
@@ -1332,7 +1332,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-boat-d">
             <statement>
               <p>
                 What happens when the length of rope pulling in the boat is less than 10 feet long?
@@ -1373,7 +1373,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-cone-a">
             <statement>
               <p>
                 <m><var name="$a[0]"/></m> foot?
@@ -1384,7 +1384,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-cone-b">
             <statement>
               <p>
                 <m><var name="$a[1]"/></m> feet?
@@ -1395,7 +1395,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-cone-c">
             <statement>
               <p>
                 <m><var name="$a[2]"/></m> feet?
@@ -1406,7 +1406,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-cone-d">
             <statement>
               <p>
                 How long will the tank take to fill when starting at empty?
@@ -1467,7 +1467,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-pulley-1a">
             <statement>
               <p>
                 <m>10</m> feet?
@@ -1481,7 +1481,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-pulley-1b">
             <statement>
               <p>
                 <m>40</m> feet?
@@ -1495,7 +1495,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-pulley-1c">
             <statement>
               <p>
                 How far must the man walk to raise the weight all the way to
@@ -1546,7 +1546,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-pulley-2a">
             <statement>
               <p>
                 How long is the rope?
@@ -1557,7 +1557,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-pulley-2b">
             <statement>
               <p>
                 How fast is the weight rising after the man has walked
@@ -1569,7 +1569,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-pulley-2c">
             <statement>
               <p>
                 How fast is the weight rising after the man has walked
@@ -1581,7 +1581,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-pulley-2d">
             <statement>
               <p>
                 How far must the man walk to raise the weight all the way
@@ -1620,7 +1620,7 @@
             </p>
           </introduction>
 
-          <task>
+          <task label="ex-related-rates-hot-air-a">
             <statement>
               <p>
                 What is the elevation of the balloon?
@@ -1631,7 +1631,7 @@
             </statement>
           </task>
 
-          <task>
+          <task label="ex-related-rates-hot-air-b">
             <statement>
               <p>
                 How fast is it rising?

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -1049,14 +1049,6 @@
           <task label="ex-related-rates-aircraft-1c">
             <statement>
               <p>
-                
-              </p>
-            </statement>
-          </task>
-
-          <task label="ex-related-rates-aircraft-1d">
-            <statement>
-              <p>
                 Directly overhead?
               </p>
               <p>

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -1035,15 +1035,17 @@
           </task>
 
           <task label="ex-related-rates-aircraft-1b">
-            <p>
-              <m>1/5</m> mile away?
-            </p>
-            <p>
-              <var name="$bU" width="10"/>
-            </p>
-            <instruction>
-              Use <c>rad/s</c> for radians per second.
-            </instruction>
+            <statement>
+              <p>
+                <m>1/5</m> mile away?
+              </p>
+              <p>
+                <var name="$bU" width="10"/>
+              </p>
+              <instruction>
+                Use <c>rad/s</c> for radians per second.
+              </instruction>
+            </statement>
           </task>
 
           <task label="ex-related-rates-aircraft-1c">
@@ -1057,7 +1059,6 @@
               <instruction>
                 Use <c>rad/s</c> for radians per second.
               </instruction>
-
             </statement>
           </task>
           <hint>

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -2361,45 +2361,33 @@
           <!--<webwork xml:id="ex-sequences-theory-2">
               <pg-code>
               </pg-code>-->
-              <statement>
+              <introduction>
                 <p>
                   Let <m>\{a_n\}</m> and <m>\{b_n\}</m> be sequences such that
                   <m>\lim\limits_{n\to\infty} a_n = L</m> and <m>\lim\limits_{n\to\infty} b_n = K</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Show that if <m>a_n\lt b_n</m> for all <m>n</m>, then <m>L\leq K</m>.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Show that if <m>a_n\lt b_n</m> for all <m>n</m>, then <m>L\leq K</m>.
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        Give an example where <m>L = K</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        Left to reader
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>a_n = 1/3^n</m> and <m>b_n = 1/2^n</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Give an example where <m>L = K</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>a_n = 1/3^n</m> and <m>b_n = 1/2^n</m>
+                  </p>
+                </answer>
+              </task>
           <!--</webwork>-->
         </exercise>
 

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -2368,7 +2368,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-sequences-theory-2a">
                 <statement>
                   <p>
                     Show that if <m>a_n\lt b_n</m> for all <m>n</m>, then <m>L\leq K</m>.
@@ -2376,7 +2376,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-sequences-theory-2b">
                 <statement>
                   <p>
                     Give an example where <m>L = K</m>.

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -2786,7 +2786,7 @@
         </exercise>
       </exercisegroup>
 
-      <exercise xml:id="x08_02_ex_24"  label="ex-series-harmonic-split">
+      <exercise xml:id="x08_02_ex_24" label="ex-series-harmonic-split">
         <!--<webwork xml:id="ex-series-harmonic-split">
             <pg-code>
             </pg-code>-->
@@ -2803,7 +2803,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-series-harmonic-split-a">
               <statement>
                 <p>
                   Show why <m>\ds \infser \frac{1}{2n-1} \gt \infser \frac{1}{2n}</m>.
@@ -2823,7 +2823,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-series-harmonic-split-b">
               <statement>
                 <p>
                   Show why <m>\ds\infser \frac{1}{2n-1}\lt 1+\infser \frac{1}{2n}</m>
@@ -2840,7 +2840,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-series-harmonic-split-c">
               <statement>
                 <p>
                   Explain why (a) and (b) demonstrate that the series of odd terms is convergent, if,
@@ -2865,7 +2865,7 @@
               </solution>
             </task>
 
-            <task>
+            <task label="ex-series-harmonic-split-d">
               <statement>
                 <p>
                   Explain why knowing the Harmonic Series is divergent determines that the even and odd series are also divergent.

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -2790,7 +2790,7 @@
         <!--<webwork xml:id="ex-series-harmonic-split">
             <pg-code>
             </pg-code>-->
-            <statement>
+            <introduction>
               <p>
                 Break the Harmonic Series into the sum of the odd and even terms:
                 <me>
@@ -2801,87 +2801,86 @@
               <p>
                 The goal is to show that each of the series on the right diverge.
               </p>
+            </introduction>
 
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      Show why <m>\ds \infser \frac{1}{2n-1} \gt \infser \frac{1}{2n}</m>.
+            <task>
+              <statement>
+                <p>
+                  Show why <m>\ds \infser \frac{1}{2n-1} \gt \infser \frac{1}{2n}</m>.
+                </p>
 
-                      (Compare each <m>n</m>th partial sum.)
-                    </p>
-                  </li>
+                <p>
+                  (Compare each <m>n</m>th partial sum.)
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  The <m>n</m>th partial sum of the odd series is <m>1+\frac13+\frac15+\cdots+\frac{1}{2n-1}</m>.
+                  The <m>n</m>th partial sum of the even series is <m>\frac12+\frac14 + \frac16 + \cdots +\frac1{2n}</m>.
+                  Each term of the even series is less than the corresponding term of the odd series,
+                  giving us our result.
+                </p>
+              </solution>
+            </task>
 
-                  <li>
-                    <p>
-                      Show why <m>\ds\infser \frac{1}{2n-1}\lt 1+\infser \frac{1}{2n}</m>
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Show why <m>\ds\infser \frac{1}{2n-1}\lt 1+\infser \frac{1}{2n}</m>
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  The <m>n</m>th partial sum of the odd series is <m>1+\frac13+\frac15+\cdots+\frac1{2n-1}</m>.
+                  The <m>n</m>th partial sum of 1 plus the even series is <m>1+\frac12+\frac14+\cdots + \frac{1}{2(n-1)}</m>.
+                  Each term of the even series is now greater than or equal to the corresponding term of the odd series,
+                  with equality only on the first term.
+                  This gives us the result.
+                </p>
+              </solution>
+            </task>
 
-                  <li>
-                    <p>
-                      Explain why (a) and (b) demonstrate that the series of odd terms is convergent, if,
-                      and only if, the series of even terms is also convergent.
-                      (That is, show both converge or both diverge.)
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Explain why (a) and (b) demonstrate that the series of odd terms is convergent, if,
+                  and only if, the series of even terms is also convergent.
+                  (That is, show both converge or both diverge.)
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  If the odd series converges,
+                  the work done in (a) shows the even series converges also.
+                  (The sequence of the <m>n</m>th partial sum of the even series is bounded and monotonically increasing.)
+                  Likewise, (b) shows that if the even series converges,
+                  the odd series will, too.
+                  Thus if either series converges, the other does.
+                </p>
 
-                  <li>
-                    <p>
-                      Explain why knowing the Harmonic Series is divergent determines that the even and odd series are also divergent.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
-            <solution>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      The <m>n</m>th partial sum of the odd series is <m>1+\frac13+\frac15+\cdots+\frac{1}{2n-1}</m>.
-                      The <m>n</m>th partial sum of the even series is <m>\frac12+\frac14 + \frac16 + \cdots +\frac1{2n}</m>.
-                      Each term of the even series is less than the corresponding term of the odd series,
-                      giving us our result.
-                    </p>
-                  </li>
+                <p>
+                  Similarly, (a) and (b) can be used to show that if either series diverges,
+                  the other does, too.
+                </p>
+              </solution>
+            </task>
 
-                  <li>
-                    <p>
-                      The <m>n</m>th partial sum of the odd series is <m>1+\frac13+\frac15+\cdots+\frac1{2n-1}</m>.
-                      The <m>n</m>th partial sum of 1 plus the even series is <m>1+\frac12+\frac14+\cdots + \frac{1}{2(n-1)}</m>.
-                      Each term of the even series is now greater than or equal to the corresponding term of the odd series,
-                      with equality only on the first term.
-                      This gives us the result.
-                    </p>
-                  </li>
-
-                  <li>
-                    <p>
-                      If the odd series converges,
-                      the work done in (a) shows the even series converges also.
-                      (The sequence of the <m>n</m>th partial sum of the even series is bounded and monotonically increasing.)
-                      Likewise, (b) shows that if the even series converges,
-                      the odd series will, too.
-                      Thus if either series converges, the other does.
-
-                      Similarly, (a) and (b) can be used to show that if either series diverges,
-                      the other does, too.
-                    </p>
-                  </li>
-
-                  <li>
-                    <p>
-                      If both the even and odd series converge,
-                      then their sum would be a convergent series.
-                      This would imply that the Harmonic Series, their sum, is convergent.
-                      It is not.
-                      Hence each series diverges.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </solution>
+            <task>
+              <statement>
+                <p>
+                  Explain why knowing the Harmonic Series is divergent determines that the even and odd series are also divergent.
+                </p>
+              </statement>
+              <solution>
+                <p>
+                  If both the even and odd series converge,
+                  then their sum would be a convergent series.
+                  This would imply that the Harmonic Series, their sum, is convergent.
+                  It is not.
+                  Hence each series diverges.
+                </p>
+              </solution>
+            </task>
         <!--</webwork>-->
       </exercise>
 

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -1789,73 +1789,64 @@
           <!-- <webwork xml:id="ex-volume-shells-both-axes-1">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by: <m>y=\sqrt{x}</m>,
                   <m>y=0</m> and <m>x=1</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about the <m>y</m> axis.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>4\pi/5</m>
+                    </p>
+                  </answer>
+                </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about <m>x=1</m>.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>8\pi/15</m>
+                    </p>
+                  </answer>
+                </task>
 
-                    <li>
-                      <p>
-                        <m>x=1</m>
-                      </p>
-                    </li>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about the <m>x</m> axis.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>\pi/2</m>
+                    </p>
+                  </answer>
+                </task>
 
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>y=1</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>4\pi/5</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi/15</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\pi/2</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>5\pi/6</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about <m>y=1</m>.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>5\pi/6</m>
+                    </p>
+                  </answer>
+                </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1863,72 +1854,63 @@
           <!-- <webwork xml:id="ex-volume-shells-both-axes-2">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by: <m>y=4-x^2</m> and <m>y=0</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=2</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>128\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        <m>x=2</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=-2</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>128\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>x=-2</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>512\pi/15</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>y=4</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>128\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>128\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>512\pi/15</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>256\pi/5</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=4</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>256\pi/5</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -1936,73 +1918,64 @@
           <!-- <webwork xml:id="ex-volume-shells-both-axes-3">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   The triangle with vertices <m>(1,1)</m>,
                   <m>(1,2)</m> and <m>(2,1)</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about the <m>y</m> axis.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>4\pi/3</m>
+                    </p>
+                  </answer>
+                </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about <m>x=1</m>.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>\pi/3</m>
+                    </p>
+                  </answer>
+                </task>
 
-                    <li>
-                      <p>
-                        <m>x=1</m>
-                      </p>
-                    </li>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about the <m>x</m> axis.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>4\pi/3</m>
+                    </p>
+                  </answer>
+                </task>
 
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>y=2</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>4\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>4\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>2\pi/3</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about <m>y=2</m>.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>2\pi/3</m>
+                    </p>
+                  </answer>
+                </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2010,60 +1983,50 @@
           <!-- <webwork xml:id="ex-volume-shells-both-axes-4">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by <m>y=x^2-2x+2</m> and <m>y=2x-1</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about the <m>y</m> axis.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>16\pi/3</m>
+                    </p>
+                  </answer>
+                </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about <m>x=1</m>.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>8\pi/3</m>
+                    </p>
+                  </answer>
+                </task>
 
-                    <li>
-                      <p>
-                        <m>x=1</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=-1</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>16\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+                <task>
+                  <statement>
+                    <p>
+                      Rotate about <m>x=-1</m>.
+                    </p>
+                  </statement>
+                  <answer>
+                    <p>
+                      <m>8\pi</m>
+                    </p>
+                  </answer>
+                </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2071,49 +2034,38 @@
           <!-- <webwork xml:id="ex-volume-shells-both-axes-5">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by <m>y=1/\sqrt{x^2+1}</m>,
-                  <m>x=1</m> and the <m>x</m> and <m>y</m>-axes.
+                  <m>x=1</m> and the <m>x</m> and <m>y</m> axes.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>y</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2\pi(\sqrt{2}-1)</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>x=1</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>2\pi(\sqrt{2}-1)</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>2\pi(1-\sqrt{2}+\sinh^{-1}(1))</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=1</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>2\pi(1-\sqrt{2}+\sinh^{-1}(1))</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 
@@ -2121,73 +2073,64 @@
           <!-- <webwork xml:id="ex-volume-shells-both-axes-6">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   Region bounded by <m>y=2x</m>,
                   <m>y=x</m> and <m>x=2</m>.
                 </p>
+              </introduction>
 
-                <p>
-                  Rotate about:
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>y</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>16\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol cols="2">
-                    <li>
-                      <p>
-                        the <m>y</m>-axis
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>x=2</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi/3</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        <m>x=2</m>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about the <m>x</m> axis.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi</m>
+                  </p>
+                </answer>
+              </task>
 
-                    <li>
-                      <p>
-                        the <m>x</m>-axis
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>y=4</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        <m>16\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi/3</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi</m>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>8\pi</m>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Rotate about <m>y=4</m>.
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>8\pi</m>
+                  </p>
+                </answer>
+              </task>
           <!-- </webwork> -->
         </exercise>
 

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -1796,7 +1796,7 @@
                 </p>
               </introduction>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-1a">
                   <statement>
                     <p>
                       Rotate about the <m>y</m> axis.
@@ -1809,7 +1809,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-1b">
                   <statement>
                     <p>
                       Rotate about <m>x=1</m>.
@@ -1822,7 +1822,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-1c">
                   <statement>
                     <p>
                       Rotate about the <m>x</m> axis.
@@ -1835,7 +1835,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-1d">
                   <statement>
                     <p>
                       Rotate about <m>y=1</m>.
@@ -1860,7 +1860,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-2a">
                 <statement>
                   <p>
                     Rotate about <m>x=2</m>.
@@ -1873,7 +1873,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-2b">
                 <statement>
                   <p>
                     Rotate about <m>x=-2</m>.
@@ -1886,7 +1886,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-2c">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -1899,7 +1899,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-2d">
                 <statement>
                   <p>
                     Rotate about <m>y=4</m>.
@@ -1925,7 +1925,7 @@
                 </p>
               </introduction>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-3a">
                   <statement>
                     <p>
                       Rotate about the <m>y</m> axis.
@@ -1938,7 +1938,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-3b">
                   <statement>
                     <p>
                       Rotate about <m>x=1</m>.
@@ -1951,7 +1951,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-3c">
                   <statement>
                     <p>
                       Rotate about the <m>x</m> axis.
@@ -1964,7 +1964,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-3d">
                   <statement>
                     <p>
                       Rotate about <m>y=2</m>.
@@ -1989,7 +1989,7 @@
                 </p>
               </introduction>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-4a">
                   <statement>
                     <p>
                       Rotate about the <m>y</m> axis.
@@ -2002,7 +2002,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-4b">
                   <statement>
                     <p>
                       Rotate about <m>x=1</m>.
@@ -2015,7 +2015,7 @@
                   </answer>
                 </task>
 
-                <task>
+                <task label="ex-volume-shells-both-axes-4c">
                   <statement>
                     <p>
                       Rotate about <m>x=-1</m>.
@@ -2041,7 +2041,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-5a">
                 <statement>
                   <p>
                     Rotate about the <m>y</m> axis.
@@ -2054,7 +2054,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-5b">
                 <statement>
                   <p>
                     Rotate about <m>x=1</m>.
@@ -2080,7 +2080,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-6a">
                 <statement>
                   <p>
                     Rotate about the <m>y</m> axis.
@@ -2093,7 +2093,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-6b">
                 <statement>
                   <p>
                     Rotate about <m>x=2</m>.
@@ -2106,7 +2106,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-6c">
                 <statement>
                   <p>
                     Rotate about the <m>x</m> axis.
@@ -2119,7 +2119,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-volume-shells-both-axes-6d">
                 <statement>
                   <p>
                     Rotate about <m>y=4</m>.

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -2564,43 +2564,34 @@
         </exercise>
 
         <exercise label="exset-stokes-divergence-understand-2">
-          <statement>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Green's Theorem can be used to find the area of a region enclosed by a curve by evaluating a line integral with the appropriate choice of vector field <m>\vec F</m>.
-                    What condition on <m>\vec F</m> makes this possible?
-                  </p>
-                </li>
+          <task>
+            <statement>
+              <p>
+                Green's Theorem can be used to find the area of a region enclosed by a curve by evaluating a line integral with the appropriate choice of vector field <m>\vec F</m>.
+                What condition on <m>\vec F</m> makes this possible?
+              </p>
+            </statement>
+            <answer>
+              <p>
+                <m>\curl\vec F = 1</m>.
+              </p>
+            </answer>
+          </task>
 
-                <li>
-                  <p>
-                    Likewise, Stokes' Theorem can be used to find the surface area of a region enclosed by a curve in space by evaluating a line integral with the appropriate choice of vector field <m>\vec F</m>.
-                    What condition on <m>\vec F</m> makes this possible?
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
-          <answer>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    <m>\curl\vec F = 1</m>.
-                  </p>
-                </li>
-
-                <li>
-                  <p>
-                    <m>\curl\vec F\cdot \vec n = 1</m>,
-                    where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m>.
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </answer>
+          <task>
+            <statement>
+              <p>
+                Likewise, Stokes' Theorem can be used to find the surface area of a region enclosed by a curve in space by evaluating a line integral with the appropriate choice of vector field <m>\vec F</m>.
+                What condition on <m>\vec F</m> makes this possible?
+              </p>
+            </statement>
+            <answer>
+              <p>
+                <m>\curl\vec F\cdot \vec n = 1</m>,
+                where <m>\vec n</m> is a unit vector normal to <m>\surfaceS</m>.
+              </p>
+            </answer>
+          </task>
         </exercise>
 
         <exercise label="exset-stokes-divergence-understand-3">

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -2564,7 +2564,7 @@
         </exercise>
 
         <exercise label="exset-stokes-divergence-understand-2">
-          <task>
+          <task label="exset-stokes-divergence-understand-2a">
             <statement>
               <p>
                 Green's Theorem can be used to find the area of a region enclosed by a curve by evaluating a line integral with the appropriate choice of vector field <m>\vec F</m>.
@@ -2578,7 +2578,7 @@
             </answer>
           </task>
 
-          <task>
+          <task label="exset-stokes-divergence-understand-2b">
             <statement>
               <p>
                 Likewise, Stokes' Theorem can be used to find the surface area of a region enclosed by a curve in space by evaluating a line integral with the appropriate choice of vector field <m>\vec F</m>.

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1668,7 +1668,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-between-points-1a">
                 <statement>
                   <p>
                     in component form. 
@@ -1680,7 +1680,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-vector-between-points-1b">
                 <statement>
                   <p>
                     using the standard unit vectors.
@@ -1714,7 +1714,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-between-points-2a">
                 <statement>
                   <p>
                     in component form.
@@ -1726,7 +1726,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-vector-between-points-2b">
                 <statement>
                   <p>
                     using the standard unit vectors.
@@ -1760,7 +1760,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-between-points-3a">
                 <statement>
                   <p>
                     in component form.
@@ -1772,7 +1772,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-vector-between-points-3b">
                 <statement>
                   <p>
                     using the standard unit vectors.
@@ -1806,7 +1806,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-between-points-4a">
                 <statement>
                   <p>
                     in component form.
@@ -1818,7 +1818,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-vector-between-points-4b">
                 <statement>
                   <p>
                     using the standard unit vectors.
@@ -1845,7 +1845,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-vector-arithmetic-1a">
               <statement>
                 <p>
                   Find <m>\vec u+\vec v</m>,
@@ -1861,7 +1861,7 @@
               </answer>
             </task>
 
-            <task>
+            <task label="ex-vector-arithmetic-1b">
               <statement>
                 <p>
                   Sketch the above vectors on the same axes,
@@ -1870,7 +1870,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-vector-arithmetic-1c">
               <statement>
                 <p>
                   Find <m>\vec x</m> where <m>\vec u+\vec x = 2\vec v-\vec x</m>.
@@ -1896,7 +1896,7 @@
               </p>
             </introduction>
 
-            <task>
+            <task label="ex-vector-arithmetic-2a">
               <statement>
                 <p>
                   Find <m>\vec u+\vec v</m>,
@@ -1912,7 +1912,7 @@
               </answer>
             </task>
 
-            <task>
+            <task label="ex-vector-arithmetic-2b">
               <statement>
                 <p>
                   Sketch the above vectors on the same axes,
@@ -1921,7 +1921,7 @@
               </statement>
             </task>
 
-            <task>
+            <task label="ex-vector-arithmetic-2c">
               <statement>
                 <p>
                   Find <m>\vec x</m> where <m>\vec u+\vec x = \vec v+2\vec x</m>.

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1661,29 +1661,36 @@
                 $stan=Vector("i+6j");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   If <m>P=(2,-1)</m> and <m>Q = (3,5)</m>,
                   write the vector <m>\overrightarrow{PQ}</m>:
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        in component form: <var name="$comp" width="10"/>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    in component form. 
+                  </p>
 
-                    <li>
-                      <p>
-                        using the standard unit vectors:
-                        <var name="$stan" width="10"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$comp" width="10"/>
+                  </p>
+                </statement>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    using the standard unit vectors.
+                  </p>
+
+                  <p>
+                    <var name="$stan" width="10"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1700,29 +1707,36 @@
                 $stan=Vector("4i-4j");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   If <m>P=(3,2)</m> and <m>Q = (7,-2)</m>,
                   write the vector <m>\overrightarrow{PQ}</m>:
                 </p>
+              </introduction>
+
+              <task>
+                <statement>
+                  <p>
+                    in component form.
+                  </p>
+
+                  <p>
+                    <var name="$comp" width="10"/>
+                  </p>
+                </statement>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    using the standard unit vectors.
+                  </p>
+                </statement>
 
                 <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        in component form: <var name="$comp" width="10"/>
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        using the standard unit vectors:
-                        <var name="$stan" width="10"/>
-                      </p>
-                    </li>
-                  </ol>
+                  <var name="$stan" width="10"/>
                 </p>
-              </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1739,29 +1753,36 @@
                 $stan=Vector("6i-j+6k");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   If <m>P=(0,3,-1)</m> and <m>Q = (6,2,5)</m>,
                   write the vector <m>\overrightarrow{PQ}</m>:
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        in component form: <var name="$comp" width="10"/>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    in component form.
+                  </p>
 
-                    <li>
-                      <p>
-                        using the standard unit vectors:
-                        <var name="$stan" width="10"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$comp" width="10"/>
+                  </p>
+                </statement>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    using the standard unit vectors.
+                  </p>
+
+                  <p>
+                    <var name="$stan" width="10"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1778,29 +1799,36 @@
                 $stan=Vector("2i+2j");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   If <m>P=(2,1,2)</m> and <m>Q = (4,3,2)</m>,
                   write the vector <m>\overrightarrow{PQ}</m>:
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        in component form: <var name="$comp" width="10"/>
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    in component form.
+                  </p>
 
-                    <li>
-                      <p>
-                        using the standard unit vectors:
-                        <var name="$stan" width="10"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$comp" width="10"/>
+                  </p>
+                </statement>
+              </task>
+
+              <task>
+                <statement>
+                  <p>
+                    using the standard unit vectors.
+                  </p>
+
+                  <p>
+                    <var name="$stan" width="10"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -1811,54 +1839,49 @@
             <pg-code>
             </pg-code>
              -->
-            <statement>
+            <introduction>
               <p>
                 Let <m>\vec u = \la 1,-2\ra</m> and <m>\vec v= \la 1,1\ra</m>.
               </p>
+            </introduction>
 
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      Find <m>\vec u+\vec v</m>,
-                      <m>\vec u-\vec v</m>, <m>2\vec u-3\vec v</m>.
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Find <m>\vec u+\vec v</m>,
+                  <m>\vec u-\vec v</m>, <m>2\vec u-3\vec v</m>.
+                </p>
+              </statement>
+              <answer>
+                <p>
+                  <m>\vec u+\vec v = \la 2,-1\ra</m>;
+                  <m>\vec u -\vec v = \la0,-3\ra</m>;
+                  <m>2\vec u-3\vec v = \la -1,-7\ra</m>.
+                </p>
+              </answer>
+            </task>
 
-                  <li>
-                    <p>
-                      Sketch the above vectors on the same axes,
-                      along with <m>\vec u</m> and <m>\vec v</m>.
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Sketch the above vectors on the same axes,
+                  along with <m>\vec u</m> and <m>\vec v</m>.
+                </p>
+              </statement>
+            </task>
 
-                  <li>
-                    <p>
-                      Find <m>\vec x</m> where <m>\vec u+\vec x = 2\vec v-\vec x</m>.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
-            <solution>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\vec u+\vec v = \la 2,-1\ra</m>;
-                      <m>\vec u -\vec v = \la0,-3\ra</m>;
-                      <m>2\vec u-3\vec v = \la -1,-7\ra</m>.
-                    </p>
-                  </li>
-
-                  <li>
-                    <p>
-                      <m>\vec x = \la 1/2,2\ra</m>.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </solution>
+            <task>
+              <statement>
+                <p>
+                  Find <m>\vec x</m> where <m>\vec u+\vec x = 2\vec v-\vec x</m>.
+                </p>
+              </statement>
+              <answer>
+                <p>
+                  <m>\vec x = \la 1/2,2\ra</m>.
+                </p>
+              </answer>
+            </task>
         <!-- </webwork> -->
       </exercise>
 
@@ -1867,54 +1890,49 @@
             <pg-code>
             </pg-code>
              -->
-            <statement>
+            <introduction>
               <p>
                 Let <m>\vec u = \la 1,1,-1\ra</m> and <m>\vec v= \la 2,1,2\ra</m>.
               </p>
+            </introduction>
 
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      Find <m>\vec u+\vec v</m>,
-                      <m>\vec u-\vec v</m>, <m>\pi\vec u-\sqrt{2}\vec v</m>.
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Find <m>\vec u+\vec v</m>,
+                  <m>\vec u-\vec v</m>, <m>\pi\vec u-\sqrt{2}\vec v</m>.
+                </p>
+              </statement>
+              <answer>
+                <p>
+                  <m>\vec u+\vec v = \la 3,2,1\ra</m>;
+                  <m>\vec u -\vec v = \la-1,0,-3\ra</m>;
+                  <m>\pi\vec u-\sqrt{2}\vec v = \la \pi-2\sqrt{2},\pi-\sqrt{2},-\pi-2\sqrt{2}\ra</m>.
+                </p>
+              </answer>
+            </task>
 
-                  <li>
-                    <p>
-                      Sketch the above vectors on the same axes,
-                      along with <m>\vec u</m> and <m>\vec v</m>.
-                    </p>
-                  </li>
+            <task>
+              <statement>
+                <p>
+                  Sketch the above vectors on the same axes,
+                  along with <m>\vec u</m> and <m>\vec v</m>.
+                </p>
+              </statement>
+            </task>
 
-                  <li>
-                    <p>
-                      Find <m>\vec x</m> where <m>\vec u+\vec x = \vec v+2\vec x</m>.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </statement>
-            <solution>
-              <p>
-                <ol>
-                  <li>
-                    <p>
-                      <m>\vec u+\vec v = \la 3,2,1\ra</m>;
-                      <m>\vec u -\vec v = \la-1,0,-3\ra</m>;
-                      <m>\pi\vec u-\sqrt{2}\vec v = \la \pi-2\sqrt{2},\pi-\sqrt{2},-\pi-2\sqrt{2}\ra</m>.
-                    </p>
-                  </li>
-
-                  <li>
-                    <p>
-                      <m>\vec x = \la-1,0,-3\ra</m>.
-                    </p>
-                  </li>
-                </ol>
-              </p>
-            </solution>
+            <task>
+              <statement>
+                <p>
+                  Find <m>\vec x</m> where <m>\vec u+\vec x = \vec v+2\vec x</m>.
+                </p>
+              </statement>
+              <answer>
+                <p>
+                  <m>\vec x = \la-1,0,-3\ra</m>.
+                </p>
+              </answer>
+            </task>
         <!-- </webwork> -->
       </exercise>
 

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -2251,70 +2251,75 @@
   <!--        <webwork xml:id="ex-vector-motion-projectile-2">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   David faces Goliath with only a stone in a 3 ft sling,
                   which he whirls above his head at 4 revolutions per second.
                   They stand 20 ft apart.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        At what <m>t</m>-values must David release the stone in his sling in order to hit Goliath?
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    At what <m>t</m>-values must David release the stone in his sling in order to hit Goliath?
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>t=\sin^{-1}(3/20)/(8\pi) + n/4 \approx 0.006 + n/4</m>,
+                    where <m>n</m> is an integer
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    The stone, while whirling,
+                    can be modeled by <m>\vrt = \la 3\cos(8\pi t),3\sin(8\pi t)\ra</m>.
+                  </p>
 
-                    <li>
-                      <p>
-                        What is the speed at which the stone is traveling when released?
-                      </p>
-                    </li>
+                  <p>
+                    He can releast the stone for <m>t</m>-values <m>t=\sin^{-1}(3/20)/(8\pi) + n/4 \approx 0.006 + n/4</m>,
+                    where <m>n</m> is an integer.
+                  </p>
+                </solution>
+              </task>
 
-                    <li>
-                      <p>
-                        Assume David releases the stone from a height of 6ft and Goliath's forehead is 9 ft above the ground.
-                        What angle of elevation must David apply to the stone to hit Goliath's head?
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  The stone, while whirling,
-                  can be modeled by <m>\vrt = \la 3\cos(8\pi t),3\sin(8\pi t)\ra</m>.
-                </p>
+              <task>
+                <statement>
+                  <p>
+                    What is the speed at which the stone is traveling when released?
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>\norm{\vrp(t)} = 24\pi\approx 51.4</m> ft/s
+                  </p>
+                </answer>
+              </task>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        For <m>t</m>-values <m>t=\sin^{-1}(3/20)/(8\pi) + n/4 \approx 0.006 + n/4</m>,
-                        where <m>n</m> is an integer.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        <m>\norm{\vrp(t)} = 24\pi\approx 51.4</m> ft/s
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        At <m>t=0.006</m>,
-                        the stone is approximately <m>19.77</m> ft from Goliath.
-                        Using the formula for projectile motion,
-                        we want the angle of elevation that lets a projectile starting at
-                        <m>\la 0,6\ra</m> with a initial velocity of <m>51.4</m> ft/s arrive at <m>\la 19.77,9\ra</m>.
-                        The desired angle is <m>0.27</m> radians, or <m>15.69^\circ</m>.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Assume David releases the stone from a height of 6ft and Goliath's forehead is 9 ft above the ground.
+                    What angle of elevation must David apply to the stone to hit Goliath's head?
+                  </p>
+                </statement>
+                <answer>
+                  <p>
+                    <m>0.27</m> radians, or <m>15.69^\circ</m>
+                  </p>
+                </answer>
+                <solution>
+                  <p>
+                    At <m>t=0.006</m>,
+                    the stone is approximately <m>19.77</m> ft from Goliath.
+                    Using the formula for projectile motion,
+                    we want the angle of elevation that lets a projectile starting at
+                    <m>\la 0,6\ra</m> with a initial velocity of <m>51.4</m> ft/s arrive at <m>\la 19.77,9\ra</m>.
+                    The desired angle is <m>0.27</m> radians, or <m>15.69^\circ</m>.
+                  </p>
+                </solution>
+              </task>
           <!--</webwork>-->
         </exercise>
 
@@ -2326,39 +2331,39 @@
                 $lead=NumberWithUnits("11.7 ft");
               </pg-code>
 
-              <statement>
+              <introduction>
                 <p>
                   A hunter aims at a deer which is <m>40</m> yards away.
                   Her crossbow is at a height of <m>5</m> ft,
                   and she aims for a spot on the deer <m>4</m> ft above the ground.
                   The crossbow fires her arrows at <m>300</m> ft/s.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        At what angle of elevation should she hold the crossbow to hit her target?
-                      </p>
+              <task>
+                <statement>
+                  <p>
+                    At what angle of elevation should she hold the crossbow to hit her target?
+                  </p>
 
-                      <p>
-                        <var name="$angle" width="15"/>
-                      </p>
-                    </li>
+                  <p>
+                    <var name="$angle" width="15"/>
+                  </p>
+                </statement>
+              </task>
 
-                    <li>
-                      <p>
-                        If the deer is moving perpendicularly to her line of sight at a rate of <m>20</m> mph,
-                        by approximately how much should she lead the deer in order to hit it in the desired location? (How far ahead of the deer should she aim?)
-                      </p>
+              <task>
+                <statement>
+                  <p>
+                    If the deer is moving perpendicularly to her line of sight at a rate of <m>20</m> mph,
+                    by approximately how much should she lead the deer in order to hit it in the desired location? (How far ahead of the deer should she aim?)
+                  </p>
 
-                      <p>
-                        <var name="$lead" width="15"/>
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
+                  <p>
+                    <var name="$lead" width="15"/>
+                  </p>
+                </statement>
+              </task>
           </webwork>
         </exercise>
 
@@ -2366,7 +2371,7 @@
   <!--        <webwork xml:id="ex-vector-motion-projectile-4">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   A baseball player hits a ball at 100 mph,
                   with an initial height of 3 ft and an angle of elevation of
@@ -2374,51 +2379,44 @@
                   The ball flies towards the famed <q>Green Monster,</q>
                   a wall 37 ft high located 310 ft from home plate.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        Show that as hit, the ball hits the wall.
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    Show that as hit, the ball hits the wall.
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    The position function of the ball is <m>\vrt = \la (146.67\cos(\theta) )t,-16t^2+(146.67\sin(\theta) )t+3\ra</m>,
+                    where <m>\theta</m> is the angle of elevation.
+                  </p>
 
-                    <li>
-                      <p>
-                        Show that if the angle of elevation is <m>21^\circ</m>,
-                        the ball clears the Green Monster.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  The position function of the ball is <m>\vrt = \la (146.67\cos(\theta) )t,-16t^2+(146.67\sin(\theta) )t+3\ra</m>,
-                  where <m>\theta</m> is the angle of elevation.
-                </p>
+                  <p>
+                    With <m>\theta=20^\circ</m>,
+                    the ball reaches 310 ft from home plate in 2.25 seconds;
+                    at this time, the height of the ball is 34.9 ft,
+                    not enough to clear the Green Monster.
+                  </p>
+                </solution>
+              </task>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        With <m>\theta=20^\circ</m>,
-                        the ball reaches 310 ft from home plate in 2.25 seconds;
-                        at this time, the height of the ball is 34.9 ft,
-                        not enough to clear the Green Monster.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        With <m>\theta=21^\circ</m>,
-                        the ball reaches 310 ft from home plate in 2.26 s,
-                        with a height of 40 ft, clearing the wall.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    Show that if the angle of elevation is <m>21^\circ</m>,
+                    the ball clears the Green Monster.
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    With <m>\theta=21^\circ</m>,
+                    the ball reaches 310 ft from home plate in 2.26 s,
+                    with a height of 40 ft, clearing the wall.
+                  </p>
+                </solution>
+              </task>
           <!--</webwork>-->
         </exercise>
 
@@ -2450,55 +2448,48 @@
   <!--        <webwork xml:id="ex-vector-motion-projectile-6">
               <pg-code>
               </pg-code> -->
-              <statement>
+              <introduction>
                 <p>
                   A football quarterback throws a pass from a height of 6 ft,
                   intending to hit his receiver 20 yds away at a height of 5 ft.
                 </p>
+              </introduction>
 
-                <p>
-                  <ol marker="a">
-                    <li>
-                      <p>
-                        If the ball is thrown at a rate of 50mph,
-                        what angle of elevation is needed to hit his intended target?
-                      </p>
-                    </li>
+              <task>
+                <statement>
+                  <p>
+                    If the ball is thrown at a rate of 50mph,
+                    what angle of elevation is needed to hit his intended target?
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    The position function of the ball is <m>\vrt = \la (v_0\cos(\theta) )t,-16t^2+(v_0\sin(\theta) )t+6\ra</m>,
+                    where <m>\theta</m> is the angle of elevation and <m>v_0</m> is the initial ball speed.
+                  </p>
 
-                    <li>
-                      <p>
-                        If the ball is thrown at with an angle of elevation of <m>8^\circ</m>,
-                        what initial ball speed is needed to hit his target?
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </statement>
-              <solution>
-                <p>
-                  The position function of the ball is <m>\vrt = \la (v_0\cos(\theta) )t,-16t^2+(v_0\sin(\theta) )t+6\ra</m>,
-                  where <m>\theta</m> is the angle of elevation and <m>v_0</m> is the initial ball speed.
-                </p>
+                  <p>
+                    With <m>v_0 = 73.33</m> ft/s, there are two angles of elevation possible.
+                    An angle of <m>\theta = 9.47^\circ</m> delivers the ball in 0.83 s,
+                    while an angle of <m>79.57^\circ</m> delivers the ball in <m>4.5</m> s.
+                  </p>
+                </solution>
+              </task>
 
-                <p>
-                  <ol>
-                    <li>
-                      <p>
-                        With <m>v_0 = 73.33</m> ft/s, there are two angles of elevation possible.
-                        An angle of <m>\theta = 9.47^\circ</m> delivers the ball in 0.83 s,
-                        while an angle of <m>79.57^\circ</m> delivers the ball in <m>4.5</m> s.
-                      </p>
-                    </li>
-
-                    <li>
-                      <p>
-                        With <m>\theta=8^\circ</m>,
-                        the initial speed must be 53.8 mph<m>\approx 78.9</m> ft/s.
-                      </p>
-                    </li>
-                  </ol>
-                </p>
-              </solution>
+              <task>
+                <statement>
+                  <p>
+                    If the ball is thrown at with an angle of elevation of <m>8^\circ</m>,
+                    what initial ball speed is needed to hit his target?
+                  </p>
+                </statement>
+                <solution>
+                  <p>
+                    With <m>\theta=8^\circ</m>,
+                    the initial speed must be 53.8 mph<m>\approx 78.9</m> ft/s.
+                  </p>
+                </solution>
+              </task>
           <!--</webwork>-->
         </exercise>
       </exercisegroup>

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -2259,7 +2259,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-motion-projectile-2a">
                 <statement>
                   <p>
                     At what <m>t</m>-values must David release the stone in his sling in order to hit Goliath?
@@ -2284,7 +2284,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex-vector-motion-projectile-2b">
                 <statement>
                   <p>
                     What is the speed at which the stone is traveling when released?
@@ -2297,7 +2297,7 @@
                 </answer>
               </task>
 
-              <task>
+              <task label="ex-vector-motion-projectile-2c">
                 <statement>
                   <p>
                     Assume David releases the stone from a height of 6ft and Goliath's forehead is 9 ft above the ground.
@@ -2340,7 +2340,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-motion-projectile-3a">
                 <statement>
                   <p>
                     At what angle of elevation should she hold the crossbow to hit her target?
@@ -2352,7 +2352,7 @@
                 </statement>
               </task>
 
-              <task>
+              <task label="ex-vector-motion-projectile-3b">
                 <statement>
                   <p>
                     If the deer is moving perpendicularly to her line of sight at a rate of <m>20</m> mph,
@@ -2381,7 +2381,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-motion-projectile-4a">
                 <statement>
                   <p>
                     Show that as hit, the ball hits the wall.
@@ -2402,7 +2402,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex-vector-motion-projectile-4b">
                 <statement>
                   <p>
                     Show that if the angle of elevation is <m>21^\circ</m>,
@@ -2455,7 +2455,7 @@
                 </p>
               </introduction>
 
-              <task>
+              <task label="ex-vector-motion-projectile-6a">
                 <statement>
                   <p>
                     If the ball is thrown at a rate of 50mph,
@@ -2476,7 +2476,7 @@
                 </solution>
               </task>
 
-              <task>
+              <task label="ex-vector-motion-projectile-6b">
                 <statement>
                   <p>
                     If the ball is thrown at with an angle of elevation of <m>8^\circ</m>,

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -971,144 +971,124 @@
     <subexercises>
       <title>Problems</title>
       <exercise label="ex-work-1">
-        <statement>
+        <introduction>
           <p>
             A <quantity><mag>100</mag><unit base="foot"/></quantity> rope, weighing
             <quantity><mag>0.1</mag><unit base="pound"/><per base="foot"/></quantity>,
             hangs over the edge of a tall building.
           </p>
+        </introduction>
 
-          <p>
-            <ol>
-              <li>
-                <p>
-                  How much work is done pulling the entire rope to the top of the building?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is done pulling the entire rope to the top of the building?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              500 ft<ndash/>lb
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  How much rope is pulled in when half of the total work is done?
-                </p>
-              </li>
-            </ol>
-          </p>
-        </statement>
-        <answer>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  500 ft<ndash/>lb
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  <m>100-50\sqrt{2} \approx 29.29</m> ft
-                </p>
-              </li>
-            </ol>
-          </p>
-        </answer>
+        <task>
+          <statement>
+            <p>
+              How much rope is pulled in when half of the total work is done?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              <m>100-50\sqrt{2} \approx 29.29</m> ft
+            </p>
+          </answer>
+        </task>
       </exercise>
 
       <exercise label="ex-work-2">
-        <statement>
+        <introduction>
           <p>
             A <quantity><mag>50</mag><unit base="meter"/></quantity> rope,
             with a mass density of <quantity><mag>0.2</mag><unit prefix="kilo" base="gram"/><per base="meter"/></quantity>,
             hangs over the edge of a tall building.
           </p>
+        </introduction>
 
-          <p>
-            <ol>
-              <li>
-                <p>
-                  How much work is done pulling the entire rope to the top of the building?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is done pulling the entire rope to the top of the building?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              2450 J
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  How much work is done pulling in the first 20 m?
-                </p>
-              </li>
-            </ol>
-          </p>
-        </statement>
-        <answer>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  2450 J
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  1568 J
-                </p>
-              </li>
-            </ol>
-          </p>
-        </answer>
+        <task>
+          <statement>
+            <p>
+              How much work is done pulling in the first 20 m?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              1568 J
+            </p>
+          </answer>
+        </task>
       </exercise>
 
       <exercise label="ex-work-3">
-        <statement>
+        <introduction>
           <p>
             A rope of length <m>\ell</m> <quantity><unit base="foot"/></quantity> hangs over the edge of tall cliff.
             (Assume the cliff is taller than the length of the rope.)
             The rope has a weight density of <m>d</m> <quantity><unit base="pound"/><per base="foot"/></quantity>.
           </p>
+        </introduction>
 
-          <p>
-            <ol>
-              <li>
-                <p>
-                  How much work is done pulling the entire rope to the top of the cliff?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is done pulling the entire rope to the top of the cliff?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              <m>\frac12\cdot d\cdot l^2</m> ft<ndash/>lb
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  What percentage of the total work is done pulling in the first half of the rope?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              What percentage of the total work is done pulling in the first half of the rope?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              75 %
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  How much rope is pulled in when half of the total work is done?
-                </p>
-              </li>
-            </ol>
-          </p>
-        </statement>
-        <answer>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  <m>\frac12\cdot d\cdot l^2</m> ft<ndash/>lb
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  75 %
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  <m>\ell(1-\sqrt{2}/2) \approx 0.2929\ell</m>
-                </p>
-              </li>
-            </ol>
-          </p>
-        </answer>
+        <task>
+          <statement>
+            <p>
+              How much rope is pulled in when half of the total work is done?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              <m>\ell(1-\sqrt{2}/2) \approx 0.2929\ell</m>
+            </p>
+          </answer>
+        </task>
       </exercise>
 
       <exercise label="ex-work-4">
@@ -1126,56 +1106,53 @@
       </exercise>
 
       <exercise label="ex-work-5">
-        <statement>
+        <introduction>
           <p>
-            A crane lifts a <quantity><mag>2000</mag><unit base="pound"/></quantity>  load vertically <quantity><mag>30</mag><unit base="foot"/></quantity> with a <quantity><mag>1</mag><unit base="inch"/></quantity>  cable weighing <quantity><mag>1.68</mag><unit base="pound"/><per base="foot"/></quantity>.
+            A crane lifts a <quantity><mag>2000</mag><unit base="pound"/></quantity>  
+            load vertically <quantity><mag>30</mag><unit base="foot"/></quantity> 
+            with a <quantity><mag>1</mag><unit base="inch"/></quantity>  cable weighing 
+            <quantity><mag>1.68</mag><unit base="pound"/><per base="foot"/></quantity>.
           </p>
+        </introduction>
 
-          <p>
-            <ol>
-              <li>
-                <p>
-                  How much work is done lifting the cable alone?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is done lifting the cable alone?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              756 ft<ndash/>lb
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  How much work is done lifting the load alone?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is done lifting the load alone?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              60,000 ft<ndash/>lb
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  Could one conclude that the work done lifting the cable is negligible compared to the work done lifting the load?
-                </p>
-              </li>
-            </ol>
-          </p>
-        </statement>
-        <answer>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  756 ft<ndash/>lb
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  60,000 ft<ndash/>lb
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  Yes, for the cable accounts for about 1% of the total work.
-                </p>
-              </li>
-            </ol>
-          </p>
-        </answer>
+        <task>
+          <statement>
+            <p>
+              Could one conclude that the work done lifting the cable is negligible compared to the work done lifting the load?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              Yes, for the cable accounts for about 1% of the total work.
+            </p>
+          </answer>
+        </task>
       </exercise>
 
       <exercise label="ex-work-6">
@@ -1348,59 +1325,53 @@
       </exercise>
 
       <exercise label="ex-work-17">
-        <statement>
+        <introduction>
           <p>
             A <quantity><mag>6</mag><unit base="foot"/></quantity> cylindrical tank with a radius of <quantity><mag>3</mag><unit base="foot"/></quantity> is filled with water,
             which has a weight density of <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
             The water is to be pumped to a point <quantity><mag>2</mag><unit base="foot"/></quantity> above the top of the tank.
           </p>
+        </introduction>
 
-          <p>
-            <ol>
-              <li>
-                <p>
-                  How much work is performed in pumping all the water from the tank?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is performed in pumping all the water from the tank?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              52,929.6 ft<ndash/>lb
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  How much work is performed in pumping <quantity><mag>3</mag><unit base="foot"/></quantity> of water from the tank?
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              How much work is performed in pumping <quantity><mag>3</mag><unit base="foot"/></quantity> of water from the tank?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              18,525.3 ft<ndash/>lb
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  At what point is 1/2 of the total work done?
-                </p>
-              </li>
-            </ol>
-          </p>
-        </statement>
-        <answer>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  52,929.6 ft<ndash/>lb
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  18,525.3 ft<ndash/>lb
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  When <quantity><mag>3.83</mag><unit base="foot"/></quantity> of water have been pumped from the tank,
-                  leaving about <quantity><mag>2.17</mag><unit base="foot"/></quantity> in the tank.
-                </p>
-              </li>
-            </ol>
-          </p>
-        </answer>
+        <task>
+          <statement>
+            <p>
+              At what point is 1/2 of the total work done?
+            </p>
+          </statement>
+          <answer>
+            <p>
+              When <quantity><mag>3.83</mag><unit base="foot"/></quantity> of water have been pumped from the tank,
+              leaving about <quantity><mag>2.17</mag><unit base="foot"/></quantity> in the tank.
+            </p>
+          </answer>
+        </task>
       </exercise>
 
       <exercise label="ex-work-18">
@@ -1471,62 +1442,57 @@
       </exercise>
 
       <exercise label="ex-work-20">
-        <statement>
+        <introduction>
           <p>
             A conical water tank is <quantity><mag>5</mag><unit base="meter"/></quantity> deep with a top radius of <quantity><mag>3</mag><unit base="meter"/></quantity>.
             (This is similar to <xref ref="ex_pump2">Example</xref>.)
             The tank is filled with pure water,
             with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
           </p>
+        </introduction>
 
-          <p>
-            <ol>
-              <li>
-                <p>
-                  Find the work performed in pumping all the water to the top of the tank.
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              Find the work performed in pumping all the water to the top of the tank.
+            </p>
+          </statement>
+          <answer>
+            <p>
+              approx. 577,000 J
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  Find the work performed in pumping the top <quantity><mag>2.5</mag><unit base="meter"/></quantity> of water to the top of the tank.
-                </p>
-              </li>
+        <task>
+          <statement>
+            <p>
+              Find the work performed in pumping the top 
+              <quantity><mag>2.5</mag><unit base="meter"/></quantity> of water to the top of the tank.
+            </p>
+          </statement>
+          <answer>
+            <p>
+              approx. 399,000 J
+            </p>
+          </answer>
+        </task>
 
-              <li>
-                <p>
-                  Find the work performed in pumping the top half of the water,
-                  by volume, to the top of the tank.
-                </p>
-              </li>
-            </ol>
-          </p>
-        </statement>
-        <answer>
-          <p>
-            <ol>
-              <li>
-                <p>
-                  approx. 577,000 J
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  approx. 399,000 J
-                </p>
-              </li>
-
-              <li>
-                <p>
-                  approx 110,000 J (By volume,
+        <task>
+          <statement>
+            <p>
+              Find the work performed in pumping the top half of the water,
+              by volume, to the top of the tank.
+            </p>
+          </statement>
+          <answer>
+            <p>
+              approx 110,000 J (By volume,
                   half of the water is between the base of the cone and a height of 3.9685 m.
                   If one rounds this to <quantity><mag>4</mag><unit base="meter"/></quantity>, the work is approx 104,000 J.)
-                </p>
-              </li>
-            </ol>
-          </p>
-        </answer>
+            </p>
+          </answer>
+        </task>
       </exercise>
 
       <exercise label="ex-work-21">

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -979,7 +979,7 @@
           </p>
         </introduction>
 
-        <task>
+        <task label="ex-work-1a">
           <statement>
             <p>
               How much work is done pulling the entire rope to the top of the building?
@@ -992,7 +992,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-1b">
           <statement>
             <p>
               How much rope is pulled in when half of the total work is done?
@@ -1015,7 +1015,7 @@
           </p>
         </introduction>
 
-        <task>
+        <task label="ex-work-2a">
           <statement>
             <p>
               How much work is done pulling the entire rope to the top of the building?
@@ -1028,7 +1028,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-2b">
           <statement>
             <p>
               How much work is done pulling in the first 20 m?
@@ -1051,7 +1051,7 @@
           </p>
         </introduction>
 
-        <task>
+        <task label="ex-work-3a">
           <statement>
             <p>
               How much work is done pulling the entire rope to the top of the cliff?
@@ -1064,7 +1064,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-3b">
           <statement>
             <p>
               What percentage of the total work is done pulling in the first half of the rope?
@@ -1077,7 +1077,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-3c">
           <statement>
             <p>
               How much rope is pulled in when half of the total work is done?
@@ -1115,7 +1115,7 @@
           </p>
         </introduction>
 
-        <task>
+        <task label="ex-work-5a">
           <statement>
             <p>
               How much work is done lifting the cable alone?
@@ -1128,7 +1128,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-5b">
           <statement>
             <p>
               How much work is done lifting the load alone?
@@ -1141,7 +1141,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-5c">
           <statement>
             <p>
               Could one conclude that the work done lifting the cable is negligible compared to the work done lifting the load?
@@ -1333,7 +1333,7 @@
           </p>
         </introduction>
 
-        <task>
+        <task label="ex-work-17a">
           <statement>
             <p>
               How much work is performed in pumping all the water from the tank?
@@ -1346,7 +1346,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-17b">
           <statement>
             <p>
               How much work is performed in pumping <quantity><mag>3</mag><unit base="foot"/></quantity> of water from the tank?
@@ -1359,7 +1359,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-17c">
           <statement>
             <p>
               At what point is 1/2 of the total work done?
@@ -1451,7 +1451,7 @@
           </p>
         </introduction>
 
-        <task>
+        <task label="ex-work-20a">
           <statement>
             <p>
               Find the work performed in pumping all the water to the top of the tank.
@@ -1464,7 +1464,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-20b">
           <statement>
             <p>
               Find the work performed in pumping the top 
@@ -1478,7 +1478,7 @@
           </answer>
         </task>
 
-        <task>
+        <task label="ex-work-20c">
           <statement>
             <p>
               Find the work performed in pumping the top half of the water,


### PR DESCRIPTION
Many exercises had parts that were marked up using ordered lists.
Current best practice is to structure these by `task`, instead.

This pull request does so. Turns out there were a **lot** of these, so this is a pretty big pull request.
I would appreciate it if someone has the time to review it, despite the size.

Note that I didn't deal with cases where the `ol` is in the introduction to an exercise group. In most of these cases, the exercise itself didn't have parts, although these are implied by the exercise group introduction. A `ol` still appears in the solution, if there is one.

(**NB**. Many of these 'solutions' are in fact just collections of answers. A later round of exercise revisions should probably address this.)