### PR TITLE
In Which the Book of APEX Calculus is Hereby Freed of All WeBWorK-Generated Graphs

### DIFF
--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -774,7 +774,6 @@
     </subexercises>
     <subexercises xml:id="problems-area-between">
       <title>Problems</title>
-    <!--TODO: the following problems need pg-graphs or tikz support in webwork-->
       <exercisegroup cols="2" xml:id="exset-area-between-graph">
 
         <introduction>
@@ -786,7 +785,7 @@
 
   <!-- Exercise 4 -->
         <exercise label="ex-area-between-graph-1">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-1">
+          <webwork xml:id="webwork-ex-area-between-graph-1">
               <pg-code>
                 $x0 = 0;
                 $x1 = Compute("2*pi");
@@ -796,7 +795,7 @@
                 $G = Formula("1/2*sin(x)+x");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between <m>y=\frac12 x +3</m> and <m>y=\frac12\cos(x)+1</m>,
@@ -832,9 +831,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_04.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- 4pi+pi^2 -->
               </statement>
               <answer>
@@ -842,11 +841,11 @@
                   <m>4\pi+\pi^2\approx 22.436</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 5 -->
         <exercise label="ex-area-between-graph-2">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-2">
+          <webwork xml:id="webwork-ex-area-between-graph-2">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("1");
@@ -856,7 +855,7 @@
                 $G = Formula("x^3/3+x^2/2-x");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between <m>y=-3x^3+3x+2</m> and <m>y=x^2+x-1</m>,
@@ -891,9 +890,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_05.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- 10/3 -->
               </statement>
               <answer>
@@ -901,11 +900,11 @@
                   <m>10/3</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 6 -->
         <exercise label="ex-area-between-graph-3">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-3">
+          <webwork xml:id="webwork-ex-area-between-graph-3">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi");
@@ -915,7 +914,7 @@
                 $G = Formula("x");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between <m>y=1</m> and <m>y=2</m>, for <m>0\leq x\leq \pi</m>.
@@ -951,9 +950,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_10.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- pi -->
               </statement>
               <answer>
@@ -961,11 +960,11 @@
                   <m>\pi</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 7 -->
         <exercise label="ex-area-between-graph-4">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-4">
+          <webwork xml:id="webwork-ex-area-between-graph-4">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi");
@@ -975,7 +974,7 @@
                 $G = Formula("-cos(x)");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between <m>y=\sin(x)+1</m> and <m>y=\sin(x)</m>,
@@ -1012,9 +1011,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_06.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- pi -->
               </statement>
               <answer>
@@ -1022,11 +1021,11 @@
                   <m>\pi</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 8 -->
         <exercise label="ex-area-between-graph-5">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-5">
+          <webwork xml:id="webwork-ex-area-between-graph-5">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("pi/4");
@@ -1037,7 +1036,7 @@
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
               </pg-code>
-               -->
+              
               <statement>
                 <p>
                   Between <m>y=\sin(4x)</m> and <m>y=\sec^2(x)</m>,
@@ -1074,9 +1073,9 @@
                 </image>
               <!-- figures/fig_07_01_ex_07.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- 1/2 -->
               </statement>
               <answer>
@@ -1084,11 +1083,11 @@
                   <m>1/2</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 9 -->
         <exercise label="ex-area-between-graph-6">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-6">
+          <webwork xml:id="webwork-ex-area-between-graph-6">
               <pg-code>
                 $x0 = Compute("pi/4");
                 $x1 = Compute("5*pi/4");
@@ -1098,7 +1097,7 @@
                 $G = Formula("sin(x)");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between <m>y=\sin(x)</m> and <m>y=\cos(x)</m>,
@@ -1134,9 +1133,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_08.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- 2sqrt(2) -->
               </statement>
               <answer>
@@ -1144,11 +1143,11 @@
                   <m>2\sqrt{2}</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 10 -->
         <exercise label="ex-area-between-graph-7">
-          <!-- <webwork xml:id="webwork-ex-area-between-graph-7">
+          <webwork xml:id="webwork-ex-area-between-graph-7">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
@@ -1158,7 +1157,7 @@
                 $G = Formula("2^x/ln(2)");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between <m>y=2^x</m> and <m>y=4^x</m>,
@@ -1191,9 +1190,9 @@
                   </image>
 
             <!-- figures/fig_07_01_ex_09.tex END -->
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
     <!-- 1/ln(4) -->
               </statement>
               <answer>
@@ -1201,7 +1200,7 @@
                   <m>1/\ln(4)</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
 
         <exercise label="ex-area-between-graph-8">
@@ -1503,13 +1502,13 @@
         </introduction>
   <!-- Exercise 18 -->
         <exercise label="ex-area-between-two-ways-1">
-          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-1">
+          <webwork xml:id="webwork-ex-area-between-two-ways-1">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
-                $x2 = Compute("3");-->
+                $x2 = Compute("3");
               <!-- f1(x) - g(x) on [x0,x1] and f2(x) - g(x) on [x1,x2] -->
-              <!-- $f1 = Formula("x^2+1");
+                $f1 = Formula("x^2+1");
                 $f2 = Formula("1/4*(x-3)^2+1");
                 $g = Formula("1");
                 $F1 = Formula("x^3/3+x");
@@ -1520,7 +1519,7 @@
                 $D2 = Formula("$F2-$G");
                 $area2 = $D2->eval(x=>$x2) - $D2->eval(x=>$x1);
                 $area = $area1 + $area2;
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Bounded by <m>y=x^2+1</m>, <m>y=\frac14(x-3)^2+1</m>, and <m>y=1</m>.
@@ -1553,9 +1552,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_18.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
      <!-- 1 -->
               </statement>
               <answer>
@@ -1563,17 +1562,17 @@
                   <m>1</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 19 -->
         <exercise label="ex-area-between-two-ways-2">
-          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-2">
+          <webwork xml:id="webwork-ex-area-between-two-ways-2">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1");
-                $x2 = Compute("2"); -->
+                $x2 = Compute("2");
               <!-- f1(x) - g(x) on [x0,x1] and f2(x) - g(x) on [x1,x2] -->
-                <!-- $f1 = Formula("sqrt(x)");
+                $f1 = Formula("sqrt(x)");
                 $f2 = Formula("-2x+3");
                 $g = Formula("-1/2*x");
                 $F1 = Formula("2/3*x^(3/2)");
@@ -1584,7 +1583,7 @@
                 $D2 = Formula("$F2-$G");
                 $area2 = $D2->eval(x=>$x2) - $D2->eval(x=>$x1);
                 $area = $area1 + $area2;
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Bounded by <m>y=\sqrt{x}</m>, <m>y=-2x+3</m>, and <m>y=-\frac12 x</m>.
@@ -1617,9 +1616,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_19.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
      <!-- 5/3 -->
               </statement>
               <answer>
@@ -1627,11 +1626,11 @@
                   <m>5/3</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 20 -->
         <exercise label="ex-area-between-two-ways-3">
-          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-3">
+          <webwork xml:id="webwork-ex-area-between-two-ways-3">
               <pg-code>
                 $x0 = Compute("-1");
                 $x1 = Compute("2");
@@ -1641,7 +1640,7 @@
                 $G = Formula("x^3/3");
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between the curves <m>y=x+2</m> and <m>y=x^2</m>.
@@ -1673,9 +1672,9 @@
                   </image>
 
             <!-- figures/fig_07_01_ex_20.tex END -->
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
      <!-- 9/2 -->
               </statement>
               <answer>
@@ -1683,17 +1682,17 @@
                   <m>9/2</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 21 -->
         <exercise label="ex-area-between-two-ways-4">
-          <!--<webwork xml:id="webwork-ex-area-between-two-ways-4">
+          <webwork xml:id="webwork-ex-area-between-two-ways-4">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1/2");
-                $x2 = Compute("2"); -->
+                $x2 = Compute("2");
               <!-- f1(x) - g(x) on [x0,x1] and f2(x) - g(x) on [x1,x2] -->
-               <!--  $f1 = Formula("sqrt(2*x)");
+                $f1 = Formula("sqrt(2*x)");
                 $f2 = Formula("-2*(x-1)");
                 $g = Formula("-sqrt(2*x)");
                 $F1 = Formula("sqrt(2)*2/3*x^(3/2)");
@@ -1704,7 +1703,7 @@
                 $D2 = Formula("$F2-$G");
                 $area2 = $D2->eval(x=>$x2) - $D2->eval(x=>$x1);
                 $area = $area1 + $area2;
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Between the curves <m>x=-\frac12 y+1</m> and <m>x=\frac12 y^2</m>.
@@ -1736,9 +1735,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_21.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
      <!-- 9/4 -->
               </statement>
               <answer>
@@ -1746,17 +1745,17 @@
                   <m>9/4</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 22 -->
         <exercise label="ex-area-between-two-ways-5">
-          <!-- <webwork xml:id="webwork-ex-area-between-two-ways-5">
+          <webwork xml:id="webwork-ex-area-between-two-ways-5">
               <pg-code>
                 $x0 = Compute("0");
                 $x1 = Compute("1/2");
-                $x2 = Compute("1"); -->
+                $x2 = Compute("1");
               <!-- f1(x) - g(x) on [x0,x1] and f1(x) - f2(x) on [x1,x2] -->
-               <!--  $f1 = Formula("x^(1/3)");
+                $f1 = Formula("x^(1/3)");
                 $f2 = Formula("sqrt(x-1/2)");
                 $g = Formula("0");
                 $F1 = Formula("3/4*x^(4/3)");
@@ -1767,7 +1766,7 @@
                 $D2 = Formula("$F1-$F2");
                 $area2 = $D2->eval(x=>$x2) - $D2->eval(x=>$x1);
                 $area = $area1 + $area2;
-              </pg-code> -->
+              </pg-code>
               <statement>
                 <p>
                   Bounded by <m>y=x^{1/3}</m>, <m>y=\sqrt{x-1/2}</m>,
@@ -1799,9 +1798,9 @@
                   </image>
               <!-- figures/fig_07_01_ex_22.tex END -->
 
-                <!-- <p>
+                <p>
                   <var name="$area" width="10"/>
-                </p> -->
+                </p>
      <!-- 1/12(9-2\sqrt{2})\approx 0.514 -->
               </statement>
               <answer>
@@ -1809,7 +1808,7 @@
                   <m>\frac{1}{12}(9-2\sqrt{2})\approx 0.514</m>
                 </p>
               </answer>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
 
         <exercise label="ex-area-between-two-ways-6">
@@ -1967,10 +1966,10 @@
       </exercisegroup>
   <!-- Exercise 27 -->
       <exercise xml:id="x07_01_ex_29" label="ex-area-between-trapezoidal-1">
-        <!-- <webwork xml:id="webwork-ex-area-between-trapezoidal-1">
-            <pg-code> -->
+        <webwork xml:id="webwork-ex-area-between-trapezoidal-1">
+            <pg-code>
             <!-- Trapezoidal Rule, n = 6 -->
-              <!-- $a = 0;
+              $a = 0;
               $b = 6;
               $n = 5;
               $delta_x = ($b - $a)/$n;
@@ -1985,7 +1984,7 @@
               $area_ft = $area * 100 * 100;
               $area = NumberWithUnits("$area cm^2");
               $area_ft = NumberWithUnits("$area_ft ft^2");
-            </pg-code> -->
+            </pg-code>
             <statement>
               <p>
                 Use the Trapezoidal Rule to approximate the area of the pictured lake whose lengths,
@@ -2013,26 +2012,19 @@
                 </image>
               <!-- figures/fig_07_01_ex_29.tex END -->
 
-              <!-- <p>
+              <p>
                 <var name="$area_ft" width="20"/>
-              </p> -->
+              </p>
    <!-- 262,800 ft^2 -->
             </statement>
-            <answer>
-            <!-- This solution uses n = 6, but I don't see why that would be true. -->
-            <p>
-              219,000 ft<m>^2</m>
-            </p>
-
-            </answer>
-        <!-- </webwork> -->
+        </webwork>
       </exercise>
 <!-- Exercise 28 -->
       <exercise xml:id="x07_01_ex_30" label="ex-area-between-trapezoidal-2">
-        <!-- <webwork xml:id="webwork-ex-area-between-trapezoidal-2">
-            <pg-code> -->
+        <webwork xml:id="webwork-ex-area-between-trapezoidal-2">
+            <pg-code>
             <!-- Simpson's Rule, n = 6 -->
-              <!-- $a = 0;
+              $a = 0;
               $b = 6;
               $n = 6;
               $delta_x = ($b - $a)/$n;
@@ -2047,7 +2039,7 @@
               $area_ft = $area * 100 * 200;
               $area = NumberWithUnits("$area cm^2");
               $area_ft = NumberWithUnits("$area_ft ft^2");
-            </pg-code> -->
+            </pg-code>
             <statement>
               <p>
                 Use Simpson's Rule to approximate the area of the pictured lake whose lengths,
@@ -2077,17 +2069,12 @@
                 </image>
             <!-- figures/fig_07_01_ex_30.tex END -->
 
-              <!-- <p>
+              <p>
                 <var name="$area_ft" width="20"/>
-              </p> -->
+              </p>
    <!-- 623,333 ft^2 -->
             </statement>
-            <answer>
-              <p>
-                <m>623,333 \,\text{ft}^2</m>
-              </p>
-            </answer>
-        <!-- </webwork> -->
+        </webwork>
       </exercise>
     </subexercises>
   </exercises>

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -802,6 +802,10 @@
                   for <m>0\leq x\leq 2\pi</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
                 <!-- START figures/fig_07_01_ex_04.tex -->
                   <image xml:id="img_07_01_ex_04">
                     <description></description>
@@ -813,13 +817,13 @@
                     axis on top,
                     xtick=\empty,
                     extra x ticks={3.14,6.28},
-                    extra x tick labels={$\pi$,$2\pi$},
+                    extra x tick labels={\(\pi\),\(2\pi\)},
                     ymin=-.2,ymax=6.5,
                     xmin=-1,xmax=7
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.9:6.5,samples=40] {.5*cos(deg(x))+1} node [shift={(-50pt,7pt)} ,black] { $y=\frac12\cos(x) +1$};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.9:6.5] {.5*x+3}node [shift={(-50pt,-5pt)} ,black] { $y=\frac12x+3$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.9:6.5,samples=40] {.5*cos(deg(x))+1} node [shift={(-50pt,7pt)} ,black] { \(y=\frac12\cos(x) +1\)};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.9:6.5] {.5*x+3}node [shift={(-50pt,-5pt)} ,black] { \(y=\frac12x+3\)};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:2*pi}];
 
@@ -831,9 +835,7 @@
                   </image>
               <!-- figures/fig_07_01_ex_04.tex END -->
 
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- 4pi+pi^2 -->
               </statement>
               <answer>
@@ -862,6 +864,10 @@
                   for <m>-1\leq x\leq 1</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
               <!-- START figures/fig_07_01_ex_05.tex -->
                   <image xml:id="img_07_01_ex_05">
                     <description></description>
@@ -877,8 +883,8 @@
                     xmin=-1.1,xmax=1.1
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-1.05:1.05] {x^2+x-1} node [shift={(-40pt,-65pt)},black] { $y=x^2+x-1$};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-1.05:1.05,samples=60] {-3*x^3+3*x+2} node [shift={(-140pt,30pt)},black] { $y=-3x^3+3x+2$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-1.05:1.05] {x^2+x-1} node [shift={(-40pt,-65pt)},black] { \(y=x^2+x-1\)};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-1.05:1.05,samples=60] {-3*x^3+3*x+2} node [shift={(-140pt,30pt)},black] { \(y=-3x^3+3x+2\)};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=-1:1}];
 
@@ -890,9 +896,7 @@
                   </image>
               <!-- figures/fig_07_01_ex_05.tex END -->
 
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- 10/3 -->
               </statement>
               <answer>
@@ -920,6 +924,10 @@
                   Between <m>y=1</m> and <m>y=2</m>, for <m>0\leq x\leq \pi</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
               <!-- START figures/fig_07_01_ex_10.tex -->
                   <image xml:id="img_07_01_ex_10">
                     <description></description>
@@ -931,14 +939,14 @@
                     axis on top,
                     xtick=\empty,
                     extra x ticks={3.14,1.57},
-                    extra x tick labels={$\pi$,$\pi/2$},
+                    extra x tick labels={\(\pi\),\(\pi/2\)},
                     ytick={-1,1,2,3},
                     ymin=-.5,ymax=2.4,
                     xmin=-.1,xmax=3.5
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-] {1} node [shift={(-100pt,-10pt)},black] { $y=1$};
-                    \addplot [name path=B,firstcurvestyle,-] {2} node [shift={(-100pt,10pt)},black] { $y=2$};
+                    \addplot [name path=A,firstcurvestyle,-] {1} node [shift={(-100pt,-10pt)},black] { \(y=1\)};
+                    \addplot [name path=B,firstcurvestyle,-] {2} node [shift={(-100pt,10pt)},black] { \(y=2\)};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi}];
 
@@ -950,9 +958,7 @@
                   </image>
               <!-- figures/fig_07_01_ex_10.tex END -->
 
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- pi -->
               </statement>
               <answer>
@@ -981,6 +987,10 @@
                   for <m>0\leq x\leq \pi</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
               <!-- START figures/fig_07_01_ex_06.tex -->
                   <image xml:id="img_07_01_ex_06">
                     <description></description>
@@ -992,14 +1002,14 @@
                     axis on top,
                     xtick=\empty,
                     extra x ticks={3.14,1.57},
-                    extra x tick labels={$\pi$,$\pi/2$},
+                    extra x tick labels={\(\pi\),\(\pi/2\)},
                     ytick={-1,1,2,3},
                     ymin=-.5,ymax=2.2,
                     xmin=-.1,xmax=3.5
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))} node [shift={(-80pt,45pt)} ,black] { $y=\sin(x) $};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))+1} node [shift={(-45pt,85pt)} ,black] { $y=\sin(x) +1$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))} node [shift={(-80pt,45pt)} ,black] { \(y=\sin(x) \)};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:3.5,samples=40] {sin(deg(x))+1} node [shift={(-45pt,85pt)} ,black] { \(y=\sin(x) +1\)};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi}];
 
@@ -1011,9 +1021,7 @@
                   </image>
               <!-- figures/fig_07_01_ex_06.tex END -->
 
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- pi -->
               </statement>
               <answer>
@@ -1043,6 +1051,10 @@
                   for <m>0\leq x\leq \pi/4</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
               <!-- START figures/fig_07_01_ex_07.tex -->
                 <image xml:id="img_07_01_ex_07">
                   <description></description>
@@ -1054,14 +1066,14 @@
                   axis on top,
                   xtick=\empty,
                   extra x ticks={0.785,0.392},
-                  extra x tick labels={$\pi/4$,$\pi/8$},
+                  extra x tick labels={\(\pi/4\),\(\pi/8\)},
                   ytick={-1,1,2,3},
                   ymin=-.5,ymax=2.2,
                   xmin=-.1,xmax=1
                   ]
 
-                  \addplot [name path=A,firstcurvestyle,-,domain=-.1:.9,samples=60] {sin(deg(4*x))} node [shift={(-65pt,40pt)} ,black] { $y=\sin(4x) $};
-                  \addplot [name path=B,firstcurvestyle,-,domain=-.1:.9,samples=60] {sec(deg(x))^2} node [shift={(-60pt,-40pt)} ,black] { $y=\sec^2(x)$};
+                  \addplot [name path=A,firstcurvestyle,-,domain=-.1:.9,samples=60] {sin(deg(4*x))} node [shift={(-65pt,40pt)} ,black] { \(y=\sin(4x) \)};
+                  \addplot [name path=B,firstcurvestyle,-,domain=-.1:.9,samples=60] {sec(deg(x))^2} node [shift={(-60pt,-40pt)} ,black] { \(y=\sec^2(x)\)};
 
                   \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:pi/4}];
 
@@ -1073,9 +1085,7 @@
                 </image>
               <!-- figures/fig_07_01_ex_07.tex END -->
 
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- 1/2 -->
               </statement>
               <answer>
@@ -1104,6 +1114,10 @@
                   for <m>\pi/4\leq x\leq 5\pi/4</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
               <!-- START figures/fig_07_01_ex_08.tex -->
                   <image xml:id="img_07_01_ex_08">
                     <description></description>
@@ -1115,13 +1129,13 @@
                     axis on top,
                     xtick=\empty,
                     extra x ticks={.785,1.57,2.36,3.14,3.92},
-                    extra x tick labels={$\pi/4$,$\pi/2$,$3\pi/4$,$\pi$,$5\pi/4$},
+                    extra x tick labels={\(\pi/4\),\(\pi/2\),\(3\pi/4\),\(\pi\),\(5\pi/4\)},
                     ymin=-1.1,ymax=1.1,
                     xmin=-.1,xmax=4.1
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:4.1,samples=40] {sin(deg(x))} node [shift={(-30pt,90pt)},black] { $y=\sin(x) $};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:4.1,samples=40] {cos(deg(x))} node [shift={(-125pt,-5pt)},black] { $y=\cos(x) $};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:4.1,samples=40] {sin(deg(x))} node [shift={(-30pt,90pt)},black] { \(y=\sin(x) \)};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:4.1,samples=40] {cos(deg(x))} node [shift={(-125pt,-5pt)},black] { \(y=\cos(x) \)};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=pi/4:5*pi/4}];
 
@@ -1133,9 +1147,7 @@
                   </image>
               <!-- figures/fig_07_01_ex_08.tex END -->
 
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- 2sqrt(2) -->
               </statement>
               <answer>
@@ -1164,6 +1176,10 @@
                   for <m>0\leq x\leq 1</m>.
                 </p>
 
+                <p>
+                  <var name="$area" width="10"/>
+                </p>
+
               <!-- START figures/fig_07_01_ex_09.tex -->
                   <image xml:id="img_07_01_ex_09">
                     <description></description>
@@ -1177,8 +1193,8 @@
                     xmin=-.1,xmax=1.1
                     ]
 
-                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:1.1] {2^x} node [shift={(-25pt,-20pt)},black] { $y=2^x$};
-                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:1.1] {4^x} node [shift={(-45pt,-30pt)},black] { $y=4^x$};
+                    \addplot [name path=A,firstcurvestyle,-,domain=-.1:1.1] {2^x} node [shift={(-25pt,-20pt)},black] { \(y=2^x\)};
+                    \addplot [name path=B,firstcurvestyle,-,domain=-.1:1.1] {4^x} node [shift={(-45pt,-30pt)},black] { \(y=4^x\)};
 
                     \addplot [firstcurvestyle,areastyle] fill between [of=A and B,soft clip={domain=0:1}];
 
@@ -1190,9 +1206,7 @@
                   </image>
 
             <!-- figures/fig_07_01_ex_09.tex END -->
-                <p>
-                  <var name="$area" width="10"/>
-                </p>
+
     <!-- 1/ln(4) -->
               </statement>
               <answer>
@@ -1222,12 +1236,12 @@
               ]
 
               \addplot [name path=A,firstcurvestyle,-,domain=0:1,samples=40] {1};
-              \addplot [name path=B,firstcurvestyle,-,domain=0:1,samples=40] ({x^2},{x+1}) node [pos=.85,above left,black] { $y=\sqrt{x}+1$};
+              \addplot [name path=B,firstcurvestyle,-,domain=0:1,samples=40] ({x^2},{x+1}) node [pos=.85,above left,black] { \(y=\sqrt{x}+1\)};
 
               \addplot [firstcurvestyle,areastyle] fill between [of=A and B];
 
               \addplot [name path=C,firstcurvestyle,-,domain=1:2,samples=2] {1};
-              \addplot [name path=D,firstcurvestyle,-,domain=0:1,samples=40] ({-x^2+2},{x+1}) node [pos=.9,above right,black] { $y=\sqrt{2-x}+1$};
+              \addplot [name path=D,firstcurvestyle,-,domain=0:1,samples=40] ({-x^2+2},{x+1}) node [pos=.9,above right,black] { \(y=\sqrt{2-x}+1\)};
 
               \addplot [firstcurvestyle,areastyle] fill between [of=C and D];
 
@@ -1540,9 +1554,9 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates {(0,1.)(0.1,1.01)(0.2,1.04)(0.3,1.09)(0.4,1.16)(0.5,1.25)(0.6,1.36)(0.7,1.49)(0.8,1.64)(0.9,1.81)(1.,2.)(1.1,1.903)(1.2,1.81)(1.3,1.723)(1.4,1.64)(1.5,1.563)(1.6,1.49)(1.7,1.423)(1.8,1.36)(1.9,1.303)(2.,1.25)(2.1,1.203)(2.2,1.16)(2.3,1.123)(2.4,1.09)(2.5,1.063)(2.6,1.04)(2.7,1.023)(2.8,1.01)(2.9,1.003)(3.,1.)(0,1)};
 
-                    \addplot [firstcurvestyle,-,domain=1:3] {.25*(x-3)^2+1} node [shift={(-20pt,40pt)},black] { $y=\frac14(x-3)^2+1$};
-                    \addplot [firstcurvestyle,-,domain=0:1] {x^2+1} node [shift={(-40pt,-15pt)},black] { $y=x^2+1$};
-                    \addplot [firstcurvestyle,-,domain=0:3] {1} node [pos=.5,below,black] { $y=1$} (axis cs:3,1);
+                    \addplot [firstcurvestyle,-,domain=1:3] {.25*(x-3)^2+1} node [shift={(-20pt,40pt)},black] { \(y=\frac14(x-3)^2+1\)};
+                    \addplot [firstcurvestyle,-,domain=0:1] {x^2+1} node [shift={(-40pt,-15pt)},black] { \(y=x^2+1\)};
+                    \addplot [firstcurvestyle,-,domain=0:3] {1} node [pos=.5,below,black] { \(y=1\)} (axis cs:3,1);
 
                     \end{axis}
 
@@ -1604,9 +1618,9 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates { (0,0)(0.02,0.1414)(0.04,0.2)(0.06,0.2449)(0.08,0.2828)(0.1,0.3162)(0.2,0.4472)(0.3,0.5477)(0.4,0.6325)(0.5,0.7071)(0.6,0.7746)(0.7,0.8367)(0.8,0.8944)(0.9,0.9487)(1.,1.)(2,-1)(0,0)};
 
-                    \addplot [firstcurvestyle,-,domain=0:1,samples=60] {sqrt(x)} node [shift={(-40pt,-10pt)} ,black] { $y=\sqrt{x}$};
-                    \addplot [firstcurvestyle,-,domain=0:2] {-.5*x} node [pos=.3,shift={(5pt,-25pt)},black] { $y=-\frac12x$};
-                    \addplot [firstcurvestyle,-,domain=1:2] {-2*x+3} node [pos=.5,shift={(25pt,25pt)},black] { $y=-2x+3$};
+                    \addplot [firstcurvestyle,-,domain=0:1,samples=60] {sqrt(x)} node [shift={(-40pt,-10pt)} ,black] { \(y=\sqrt{x}\)};
+                    \addplot [firstcurvestyle,-,domain=0:2] {-.5*x} node [pos=.3,shift={(5pt,-25pt)},black] { \(y=-\frac12x\)};
+                    \addplot [firstcurvestyle,-,domain=1:2] {-2*x+3} node [pos=.5,shift={(25pt,25pt)},black] { \(y=-2x+3\)};
 
                     \end{axis}
 
@@ -1661,8 +1675,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates { (-1.,1.)(-0.9,0.81)(-0.8,0.64)(-0.7,0.49)(-0.6,0.36)(-0.5,0.25)(-0.4,0.16)(-0.3,0.09)(-0.2,0.04)(-0.1,0.01)(0,0)(0.1,0.01)(0.2,0.04)(0.3,0.09)(0.4,0.16)(0.5,0.25)(0.6,0.36)(0.7,0.49)(0.8,0.64)(0.9,0.81)(1.,1.)(1.1,1.21)(1.2,1.44)(1.3,1.69)(1.4,1.96)(1.5,2.25)(1.6,2.56)(1.7,2.89)(1.8,3.24)(1.9,3.61)(2.,4.)(-1,1)};
 
-                    \addplot [firstcurvestyle,-,domain=-1:2] {x^2} node [shift={(0pt,-60pt)} ,black] { $y=x^2$};
-                    \addplot [firstcurvestyle,-,domain=-1:2] {x+2} node [pos=.5,shift={(10pt,35pt)},black] { $y=x+2$} (axis cs:-1,1);
+                    \addplot [firstcurvestyle,-,domain=-1:2] {x^2} node [shift={(0pt,-60pt)} ,black] { \(y=x^2\)};
+                    \addplot [firstcurvestyle,-,domain=-1:2] {x+2} node [pos=.5,shift={(10pt,35pt)},black] { \(y=x+2\)} (axis cs:-1,1);
 
                     \end{axis}
 
@@ -1724,8 +1738,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates {(2.,-2.)(1.805,-1.9)(1.62,-1.8)(1.445,-1.7)(1.28,-1.6)(1.125,-1.5)(0.98,-1.4)(0.845,-1.3)(0.72,-1.2)(0.605,-1.1)(0.5,-1.)(0.405,-0.9)(0.32,-0.8)(0.245,-0.7)(0.18,-0.6)(0.125,-0.5)(0.08,-0.4)(0.045,-0.3)(0.02,-0.2)(0.005,-0.1)(0,0)(0.005,0.1)(0.02,0.2)(0.045,0.3)(0.08,0.4)(0.125,0.5)(0.18,0.6)(0.245,0.7)(0.32,0.8)(0.405,0.9)(0.5,1.)(2,-2)};
 
-                    \addplot [firstcurvestyle,-,domain=-2:1] ({.5*x^2},x) node [shift={(5pt,-110pt)},black] { $x=\frac12y^2$};
-                    \addplot [firstcurvestyle,-,domain=-2:1] ({-.5*x+1},x) node [pos=.85,shift={(40pt,0pt)},black] { $x=-\frac12y+1$};
+                    \addplot [firstcurvestyle,-,domain=-2:1] ({.5*x^2},x) node [shift={(5pt,-110pt)},black] { \(x=\frac12y^2\)};
+                    \addplot [firstcurvestyle,-,domain=-2:1] ({-.5*x+1},x) node [pos=.85,shift={(40pt,0pt)},black] { \(x=-\frac12y+1\)};
 
                     \end{axis}
 
@@ -1787,8 +1801,8 @@
 
                     \addplot [firstcurvestyle,areastyle] coordinates { (0,0)(0.01,0.2154)(0.02,0.2714)(0.03,0.3107)(0.04,0.342)(0.05,0.3684)(0.06,0.3915)(0.07,0.4121)(0.08,0.4309)(0.09,0.4481)(0.1,0.4642)(0.12,0.4932)(0.14,0.5192)(0.16,0.5429)(0.18,0.5646)(0.2,0.5848)(0.22,0.6037)(0.24,0.6214)(0.26,0.6383)(0.28,0.6542)(0.3,0.6694)(0.4,0.7368)(0.5,0.7937)(0.6,0.8434)(0.7,0.8879)(0.8,0.9283)(0.9,0.9655)(1.,1.)(1.,0.7071)(0.9,0.6325)(0.8,0.5477)(0.7,0.4472)(0.6,0.3162)(0.59,0.3)(0.58,0.2828)(0.57,0.2646)(0.56,0.2449)(0.55,0.2236)(0.54,0.2)(0.53,0.1732)(0.52,0.1414)(0.51,0.1)(0.5,0)(0,0)};
 
-                    \addplot [firstcurvestyle,-,domain=0:1] (x^3,x) node [shift={(-40pt,0pt)},black] { $y=x^{1/3}$};
-                    \addplot [firstcurvestyle,-,domain=0:.7071] ({(x)^2+.5},x) node [shift={(-20pt,-50pt)},black] { $y=\sqrt{x-1/2}$};
+                    \addplot [firstcurvestyle,-,domain=0:1] (x^3,x) node [shift={(-40pt,0pt)},black] { \(y=x^{1/3}\)};
+                    \addplot [firstcurvestyle,-,domain=0:.7071] ({(x)^2+.5},x) node [shift={(-20pt,-50pt)},black] { \(y=\sqrt{x-1/2}\)};
 
                     \end{axis}
 

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -1444,12 +1444,12 @@
                             axis on top,
                             ytick={1,2,3},
                             ymin=-.5,
-                            ymax=3.5,
-                            xmin=-1,
-                            xmax=10.9
+                            ymax=5,
+                            xmin=-0.5,
+                            xmax=10.5
                           ]
                         \addplot+[-,domain=0:10] ({x}, {3});
-                        \draw (axis cs:5,3.4) node { \(f(x) = 3\)};
+                        \draw (axis cs:5,3.4) node[] { \(f(x) = 3\)};
                         \end{axis}
                       \end{tikzpicture}
                     </latex-image>

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -1041,24 +1041,11 @@
         <exercise label="ex-definite-integral-geometry-1">
           <webwork xml:id="webwork-ex-definite-integral-geometry-1">
             <pg-code>
-              $gr = init_graph(-1,-5,5,5,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "-2x+4 for x in &lt;0,4>" . " using color:blue and weight:1");
-              $gr->lb( new Label(1,2,'y = -2x + 4','black','left','bottom','large'));
-              $gr->lb( new Label(5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,5,'y','black','left','top','large'));
-              $gr->h_ticks(0,"black",2,4);
-              $gr->v_ticks(0,"black",-4,-2,2,4);
-              for my $i (2,4) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              for my $i (-4,-2,2,4) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (3,4,3,0,-4,9);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_05">
+              <!-- graph was not randomized -->
+                <image xml:id="img_05_02_ex_05">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1069,11 +1056,11 @@
                           xmax=4.5
                         ]
                         \addplot+ [-,domain=0:4] {-2*x+4};
-                        \draw (axis cs:2,2.5) node { $y = -2x+4$};
+                        \draw (axis cs:2,2.5) node { \(y = -2x+4\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1133,26 +1120,11 @@
         <exercise label="ex-definite-integral-geometry-2">
           <webwork xml:id="webwork-ex-definite-integral-geometry-2">
             <pg-code>
-              $gr = init_graph(-1,-3,6,3,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "-2 for x in &lt;0,2>" . " using color:blue and weight:1",
-                                 "2x-6 for x in &lt;2,3>" . " using color:blue and weight:1",
-                                 "x-3 for x in &lt;3,5>" . " using color:blue and weight:1");
-              $gr->lb( new Label(2.5,-1,'y = f(x)','black','left','top','large'));
-              $gr->lb( new Label(6,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,3,'y','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..5);
-              $gr->v_ticks(0,"black",-2,-1,1,2);
-              for my $i (1..5) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              for my $i (-2,-1,1,2) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (-4,-5,-3,1,-2,10);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_06">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_06">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1166,11 +1138,11 @@
                         \addplot+ [-,domain=0:2] {-2};
                         \addplot [firstcurvestyle,-,domain=2:3] {2*x-6};
                         \addplot [firstcurvestyle,-,domain=3:5] {x-3};
-                        \draw (axis cs:3.2,-1.5) node { $y = f(x)$};
+                        \draw (axis cs:3.2,-1.5) node { \(y = f(x)\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1230,25 +1202,11 @@
         <exercise label="ex-definite-integral-geometry-3">
           <webwork xml:id="webwork-ex-definite-integral-geometry-3">
             <pg-code>
-              $gr = init_graph(-1,-1,5,5,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "4x for x in &lt;0,1>" . " using color:blue and weight:1",
-                                 "-4*(x-2) for x in &lt;1,2>" . " using color:blue and weight:1",
-                                 "2*(x-2) for x in &lt;2,3>" . " using color:blue and weight:1",
-                                 "-2*(x-4) for x in &lt;3,4>" . " using color:blue and weight:1");
-              $gr->lb( new Label(3,2,'y = f(x)','black','center','bottom','large'));
-              $gr->lb( new Label(5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,5,'y','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..4);
-              $gr->v_ticks(0,"black",1..4);
-              foreach my $i (1..4) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (4,2,4,2,1,2);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_07">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_07">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1263,11 +1221,11 @@
                         \addplot [firstcurvestyle,-,domain=1:2] {-4*(x-2)};
                         \addplot [firstcurvestyle,-,domain=2:3] {2*(x-2)};
                         \addplot [firstcurvestyle,-,domain=3:4] {-2*(x-4)};
-                        \draw (axis cs:3,2.5) node { $y = f(x)$};
+                        \draw (axis cs:3,2.5) node { \(y = f(x)\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1327,25 +1285,12 @@
         <exercise label="ex-definite-integral-geometry-4">
           <webwork xml:id="webwork-ex-definite-integral-geometry-4">
             <pg-code>
-              $gr = init_graph(-1,-2,5,4,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "x-1 for x in &lt;0,4>" . " using color:blue and weight:1");
-              $gr->lb( new Label(3,2,'y = x - 1','black','right','bottom','large'));
-              $gr->lb( new Label(5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,4,'y','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..4);
-              $gr->v_ticks(0,"black",1..3);
-              foreach my $i (1..4) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              foreach my $i (1..3) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               Context("Fraction");
               @a = (Fraction(-1/2),Fraction(0),Fraction(3/2),Fraction(3/2),Fraction(9/2),Fraction(15/2));
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_08">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_08">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1358,11 +1303,11 @@
                           xmax=4.5
                         ]
                         \addplot+ [-,domain=0:4] {x-1};
-                        \draw (axis cs:2,2.5) node { $y = x-1$};
+                        \draw (axis cs:2,2.5) node { \(y = x-1\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1422,31 +1367,11 @@
         <exercise label="ex-definite-integral-geometry-5">
           <webwork xml:id="webwork-ex-definite-integral-geometry-5">
             <pg-code>
-              $gr = init_graph(-1,-0.5,5,3.1,axes=>[0,0],size=>[240,144]);
-              $xfunc = sub { my $t = shift();
-                              return 2+2*cos($t); };
-              $yfunc = sub { my $t = shift();
-                              return 2*sin($t); };
-              $fn = new Fun( $xfunc, $yfunc, $gr );
-              $fn->domain(0,pi);
-              $fn->color('blue');
-              $fn->weight(1);
-              $gr->lb( new Label(2.5,2,'f(x) = sqrt(4-(x-2)^2)','black','center','bottom','large'));
-              $gr->lb( new Label(5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,4,'y','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..4);
-              $gr->v_ticks(0,"black",1..3);
-              foreach my $i (1..4) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              foreach my $i (1..3) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (Formula("pi"),Formula("pi"),Formula("2 pi"),Formula("10 pi"));
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_09">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_09">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1459,11 +1384,11 @@
                           xmax=4.5
                         ]
                         \addplot+ [-,samples=40,domain=0:3.14159] ({2*cos(deg(x))+2}, {2*sin(deg(x))});
-                        \draw (axis cs:3,2.4) node { $f(x) = \sqrt{4-(x-2)^2}$};
+                        \draw (axis cs:3,2.4) node { \(f(x) = \sqrt{4-(x-2)^2}\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1507,25 +1432,12 @@
         <exercise label="ex-definite-integral-geometry-6">
           <webwork xml:id="webwork-ex-definite-integral-geometry-6">
             <pg-code>
-              $gr = init_graph(-1,-1,11,4,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "3 for x in &lt;0,10>" . " using color:blue and weight:1");
-              $gr->lb( new Label(5,3,'f(x) = 3','black','center','bottom','large'));
-              $gr->lb( new Label(10,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,4,'y','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..10);
-              $gr->v_ticks(0,"black",1..3);
-              foreach my $i (1..10) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              foreach my $i (1..3) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               Context()->variables->add(a=>'Real',b=>'Real');
               @a = (15,12,0,Formula("3(b-a)"));
             </pg-code>
             <statement>
-                <image pg-name="$gr"/>
-                  <!-- <image xml:id="img_05_02_ex_10">
+                <!-- webwork graph was not randomized -->
+                  <image xml:id="img_05_02_ex_10">
                     <latex-image>
                       \begin{tikzpicture}
                         \begin{axis}[
@@ -1537,11 +1449,11 @@
                             xmax=10.9
                           ]
                         \addplot+[-,domain=0:10] ({x}, {3});
-                        \draw (axis cs:5,3.4) node { $f(x) = 3$};
+                        \draw (axis cs:5,3.4) node { \(f(x) = 3\)};
                         \end{axis}
                       \end{tikzpicture}
                     </latex-image>
-                  </image> -->
+                  </image>
                 <p>
                   <ol cols="2">
                     <li>
@@ -1596,34 +1508,11 @@
         <exercise label="ex-definite-integral-area-1">
           <webwork xml:id="webwork-ex-definite-integral-area-1">
             <pg-code>
-              $gr = init_graph(-1,-125,3.5,75,axes=>[0,0],size=>[240,144]);
-              $gr->new_color("lightblue", 191,191,255);
-              add_functions($gr, "60*x*(1-x)*(x-2)*(x-2)*(x-3) for x in &lt;0,3> using color:blue and weight:1",
-                                 "0 for x in &lt;0,3>" . " using color:blue and weight:1");
-              $gr->fillRegion([0.5,-50,"lightblue"]);
-              $gr->fillRegion([1.5,10,"lightblue"]);
-              $gr->fillRegion([2.5,10,"lightblue"]);
-              add_functions($gr, "0 for x in &lt;0,3>" . " using color:black and weight:1");
-              $gr->lb( new Label(2.7,41,'y = f(x)','black','right','bottom','large'));
-              $gr->lb( new Label(3.5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,75,'y','black','left','top','large'));
-              # values centered at centroids
-              $gr->lb( new Label(0.42,-38,'59','black','center','middle','large'));
-              $gr->lb( new Label(1.4,7.6,'11','black','center','middle','large'));
-              $gr->lb( new Label(2.64,15.4,'21','black','center','middle','large'));
-              $gr->h_ticks(0,"black",1..3);
-              $gr->v_ticks(0,"black",-100,-50,50);
-              for my $i (1..3) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              for my $i (-100,-50,50) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (-59,-48,-27,-33);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_11">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_11">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1637,14 +1526,14 @@
                         ]
                         \addplot [firstcurvestyle,areastyle,domain=0:3,samples=40] {60*x*(1-x)*(x-2)*(x-2)*(x-3)} \closedcycle;
                         \addplot [firstcurvestyle,-,domain=0:3,samples=90] {60*x*(1-x)*(x-2)*(x-2)*(x-3)};
-                        \draw (axis cs:1.5,30) node { $y=f(x)$};
-                        \draw (axis cs:.45,-10) node { $59$};
-                        \draw (axis cs:1.4,10) node { $11$};
-                        \draw (axis cs:2.6,10) node { $21$};
+                        \draw (axis cs:1.5,30) node { \(y=f(x)\)};
+                        \draw (axis cs:.45,-10) node { \(59\)};
+                        \draw (axis cs:1.4,10) node { \(11\)};
+                        \draw (axis cs:2.6,10) node { \(21\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1688,32 +1577,11 @@
         <exercise label="ex-definite-integral-area-2">
           <webwork xml:id="webwork-ex-definite-integral-area-2">
             <pg-code>
-              $gr = init_graph(-1,-2,4.5,2,axes=>[0,0],size=>[240,144]);
-              $gr->new_color("lightblue", 191,191,255);
-              add_functions($gr, "sin(pi*x/2) for x in &lt;0,4>" . " using color:blue and weight:1",
-                                 "0 for x in &lt;0,4>" . " using color:blue and weight:1");
-              $gr->fillRegion([1,0.5,"lightblue"]);
-              $gr->fillRegion([3,-0.5,"lightblue"]);
-              add_functions($gr, "0 for x in &lt;0,4>" . " using color:black and weight:1");
-              $gr->lb( new Label(1,1,'f(x) = sin(pi x/2)','black','left','bottom','large'));
-              $gr->lb( new Label(4.5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,2,'y','black','left','top','large'));
-              # values centered at centroids
-              $gr->lb( new Label(1,0.39,'4/pi','black','center','middle','large'));
-              $gr->lb( new Label(3,-0.39,'4/pi','black','center','middle','large'));
-              $gr->h_ticks(0,"black",1..4);
-              $gr->v_ticks(0,"black",-1,1);
-              for my $i (1,2,4) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              for my $i (-1,1) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (Formula("4/pi"),Formula("-4/pi"),Formula("0"),Formula("2/pi"));
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_12">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_12">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1727,13 +1595,13 @@
                         ]
                         \addplot [firstcurvestyle,areastyle,domain=0:4] {sin(deg(3.14159*x/2))} \closedcycle;
                         \addplot [firstcurvestyle,-,domain=0:4,samples=50] {sin(deg(3.14159*x/2))};
-                        \draw (axis cs:3,0.75) node { $f(x)=\sin(\pi x/2)$};
-                        \draw (axis cs:1,.6) node { $4/\pi$};
-                        \draw (axis cs:3,-.6) node { $4/\pi$};
+                        \draw (axis cs:3,0.75) node { \(f(x)=\sin(\pi x/2)\)};
+                        \draw (axis cs:1,.6) node { \(4/\pi\)};
+                        \draw (axis cs:3,-.6) node { \(4/\pi\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1777,42 +1645,11 @@
         <exercise label="ex-definite-integral-area-3">
           <webwork xml:id="webwork-ex-definite-integral-area-3">
             <pg-code>
-              $gr = init_graph(-2.5,-6,2.5,12,axes=>[0,0],size=>[240,144]);
-              $gr->new_color("lightblue", 191,191,255);
-              add_functions($gr, "3*x^2-3 for x in &lt;-2,2>" . " using color:blue and weight:1",
-                                 "0 for x in &lt;-2,2>" . " using color:blue and weight:1");
-              $gr->moveTo(-2,0);
-              $gr->lineTo(-2,10,"blue",1);
-              $gr->moveTo(2,0);
-              $gr->lineTo(2,10,"blue",1);
-              $gr->fillRegion([-1.5,1,"lightblue"]);
-              $gr->fillRegion([0,-1,"lightblue"]);
-              $gr->fillRegion([1.5,1,"lightblue"]);
-              $gr->moveTo(-2,0);
-              $gr->lineTo(-2,10,"white",1);
-              $gr->moveTo(2,0);
-              $gr->lineTo(2,10,"white",1);
-              add_functions($gr, "0 for x in &lt;-2,2>" . " using color:black and weight:1");
-              $gr->lb( new Label(0,10,'f(x) = 3x^2 - 3','black','left','top','large'));
-              $gr->lb( new Label(2.5,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,12,'y','black','left','top','large'));
-              # values centered at centroids
-              $gr->lb( new Label(-1.69,2.85,'4','black','center','middle','large'));
-              $gr->lb( new Label(0.1875,-1.2,'4','black','left','middle','large'));
-              $gr->lb( new Label(1.69,2.85,'4','black','center','middle','large'));
-              $gr->h_ticks(0,"black",1..4);
-              $gr->v_ticks(0,"black",-1,1);
-              for my $i (-2,-1,1,2) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              for my $i (-5,5,10) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               @a = (4,4,-4,-2);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_13">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_13">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1826,14 +1663,14 @@
                         ]
                         \addplot [firstcurvestyle,areastyle,domain=-2:2] {3*x^2-3} \closedcycle;
                         \addplot [firstcurvestyle,-,domain=-2:2,samples=40] {3*x^2-3};
-                        \draw (axis cs:1.5,10) node { $f(x)=3x^2-3$};
-                        \draw (axis cs:-1.5,1) node { $4$};
-                        \draw (axis cs:1.5,1) node { $4$};
-                        \draw (axis cs:.3,-1) node { $-4$};
+                        \draw (axis cs:1.5,10) node { \(f(x)=3x^2-3\)};
+                        \draw (axis cs:-1.5,1) node { \(4\)};
+                        \draw (axis cs:1.5,1) node { \(4\)};
+                        \draw (axis cs:.3,-1) node { \(-4\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1877,40 +1714,12 @@
         <exercise label="ex-definite-integral-area-4">
           <webwork xml:id="webwork-ex-definite-integral-area-4">
             <pg-code>
-              $gr = init_graph(-0.2,-1,2.1,5,axes=>[0,0],size=>[240,144]);
-              $gr->new_color("lightblue", 191,191,255);
-              add_functions($gr, "x^2 for x in &lt;0,2>" . " using color:blue and weight:1",
-                                 "0 for x in &lt;0,2>" . " using color:blue and weight:1");
-              $gr->moveTo(2,0);
-              $gr->lineTo(2,5,"blue",1);
-              $gr->fillRegion([-1.5,1,"lightblue"]);
-              $gr->fillRegion([0,-1,"lightblue"]);
-              $gr->fillRegion([1.5,1,"lightblue"]);
-              $gr->moveTo(2,0);
-              $gr->lineTo(2,5,"white",1);
-              $gr->moveTo(1,0);
-              $gr->lineTo(1,1,"blue",2,dashed);
-              add_functions($gr, "0 for x in &lt;0,2>" . " using color:black and weight:1");
-              $gr->lb( new Label(1,3,'f(x) = x^2','black','center','middle','large'));
-              $gr->lb( new Label(2.1,0,'x','black','right','bottom','large'));
-              $gr->lb( new Label(0,5,'y','black','left','top','large'));
-              # values centered at centroids
-              $gr->lb( new Label(1.61,1.33,'7/3','black','center','middle','large'));
-              $gr->lb( new Label(0.75,0.3,'1/3','black','center','middle','large'));
-              $gr->h_ticks(0,"black",1,2);
-              $gr->v_ticks(0,"black",1..4);
-              for my $i (1,2) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              for my $i (1..4) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               Context("Fraction");
               @a = (Fraction("40/3"),Fraction("26/3"),Fraction("8/3"),Fraction("38/3"));
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_14">
+              <!-- webwork graph was not randomized -->
+                <image xml:id="img_05_02_ex_14">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -1925,13 +1734,13 @@
                         \addplot [firstcurvestyle,areastyle,domain=0:2] {x^2} \closedcycle;
                         \addplot [firstcurvestyle,-,domain=0:2] {x^2};
                         \draw [thick,firstcolor,dashed] (axis cs:1,0) -&#x2D; (axis cs:1,1);
-                        \draw (axis cs:1,3) node { $f(x)=x^2$};
-                        \draw (axis cs:.7,.2) node { $1/3$};
-                        \draw (axis cs:1.5,.2) node { $7/3$};
+                        \draw (axis cs:1,3) node { \(f(x)=x^2\)};
+                        \draw (axis cs:.7,.2) node { \(1/3\)};
+                        \draw (axis cs:1.5,.2) node { \(7/3\)};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol cols="2">
                   <li>
@@ -1984,25 +1793,13 @@
         <exercise label="ex-definite-integral-velocity-1">
           <webwork xml:id="webwork-ex-definite-integral-velocity-1">
             <pg-code>
-              $gr = init_graph(-0.2,-1.1,3.1,2.5,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "-x+2 for x in &lt;0,3>" . " using color:blue and weight:1");
-              $gr->lb( new Label(3.1,0,'t (s)','black','right','bottom','large'));
-              $gr->lb( new Label(0,2.5,'y (ft/s)','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..3);
-              $gr->v_ticks(0,"black",-1,1,2);
-              foreach my $i (1..3) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              foreach my $i (-1,1,2) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               $mv = NumberWithUnits("2 ft/s");
               $md = NumberWithUnits("2 ft");
               $td = NumberWithUnits("1.5 ft");
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_15">
+              <!-- no randomization, no foul -->
+                <image xml:id="img_05_02_ex_15">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -2012,14 +1809,14 @@
                           ymax=2.2,
                           xmin=-.2,
                           xmax=3.1,
-                          xlabel={$t$ (s)},
-                          ylabel={$y$ (ft/s)}
+                          xlabel={\(t\) (s)},
+                          ylabel={\(y\) (ft/s)}
                         ]
                         \addplot+ [-,domain=0:3] {-x+2};
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol>
                   <li>
@@ -2055,28 +1852,13 @@
         <exercise label="ex-definite-integral-velocity-2">
           <webwork xml:id="webwork-ex-definite-integral-velocity-2">
             <pg-code>
-              $gr = init_graph(-0.2,-0.5,5.2,3.5,axes=>[0,0],size=>[240,144]);
-              add_functions($gr, "3 for x in &lt;0,1>" . " using color:blue and weight:1",
-                                 "-3(x-2) for x in &lt;1,2>" . " using color:blue and weight:1",
-                                 "2(x-2) for x in &lt;2,3>" . " using color:blue and weight:1",
-                                 "2 for x in &lt;3,5>" . " using color:blue and weight:1");
-              $gr->lb( new Label(5.2,0,'t (s)','black','right','bottom','large'));
-              $gr->lb( new Label(0,3.5,'y (ft/s)','black','left','top','large'));
-              $gr->h_ticks(0,"black",1..5);
-              $gr->v_ticks(0,"black",1..3);
-              foreach my $i (1..5) {
-                $gr->lb( new Label($i,0,$i,'black','center','top','large'));
-              }
-              foreach my $i (1..3) {
-                $gr->lb( new Label(0,$i,$i,'black','right','middle','large'));
-              }
               $mv = NumberWithUnits("3 ft/s");
               $md = NumberWithUnits("9.5 ft");
               $td = NumberWithUnits("9.5 ft");
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
-                <!-- <image xml:id="img_05_02_ex_16">
+              <!-- no randomization in graph -->
+                <image xml:id="img_05_02_ex_16">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}
@@ -2087,8 +1869,8 @@
                           ymax=3.2,
                           xmin=-.2,
                           xmax=5.3,
-                          xlabel={$t$ (s)},
-                          ylabel={$y$ (ft/s)}
+                          xlabel={\(t\) (s)},
+                          ylabel={\(y\) (ft/s)}
                         ]
                         \addplot+ [-,domain=0:1] {3};
                         \addplot [firstcurvestyle,-,domain=1:2] {-3*(x-2)};
@@ -2097,7 +1879,7 @@
                       \end{axis}
                     \end{tikzpicture}
                   </latex-image>
-                </image> -->
+                </image>
               <p>
                 <ol>
                   <li>

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -1862,7 +1862,7 @@
                       \begin{axis}[
                           xtick={1,2,3},
                           ymin=-1.1,
-                          ymax=2.2,
+                          ymax=3,
                           xmin=-.2,
                           xmax=3.1,
                           xlabel={\(t\) (s)},
@@ -1924,7 +1924,7 @@
                           axis on top,
                           xtick={1,2,3,4,5},
                           ymin=-.5,
-                          ymax=3.2,
+                          ymax=4,
                           xmin=-.2,
                           xmax=5.3,
                           xlabel={\(t\) (s)},

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -1766,21 +1766,6 @@
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               @eq=(Formula("y=0"),Formula("y=-1.859(x-0.1)+0.2811"));
-              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              Context("Numeric");
-              Context()->variables->are(t=>'Real');
-              $x=Formula("cos^5(t)");
-              $y=Formula("sin^5(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(0.1,0.2811,'black'));
-              $gr->lb(new Label(0.1,0.2811,'(0.1,0.2811)','black','left','bottom','large'));
             </pg-code>
             <statement>
               <p>
@@ -1808,7 +1793,21 @@
                   </li>
                 </ol>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_06_02_ex_23">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                    \begin{axis}[
+                      ymin=-1.1,ymax=1.1,%
+                      xmin=-1.1,xmax=1.1,%
+                    ]
+
+                    \addplot [firstcurvestyle,-,domain=0:360,samples=40] ({(cos(x))^5},{(sin(x))^5});
+                    \filldraw [] (axis cs:.1,.28) node [above right] {\((0.1,0.281)\)} circle (1pt);
+                    \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
             </statement>
           </webwork>
         </exercise>
@@ -1820,21 +1819,6 @@
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               @eq=(Formula("x=1"),Formula("y=-3sqrt(3)/8(x-sqrt(0.6))+sqrt(0.8)"),Formula("y=1"));
-              $gr=init_graph(-1.2,-1.2,1.2,1.2,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              Context("Numeric");
-              Context()->variables->are(t=>'Real');
-              $x=Formula("(abs(cos(t)))^(1/2)*sgn(cos(t))");
-              $y=Formula("(abs(sin(t)))^(1/2)*sgn(sin(t))");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(0.7746,0.8944,'black'));
-              $gr->lb(new Label(0.7746,0.8944,'(sqrt(0.6),sqrt(0.8))','black','right','top','large'));
             </pg-code>
             <statement>
               <p>
@@ -1869,7 +1853,22 @@
                   </li>
                 </ol>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_06_ex_24">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-1.1,ymax=1.1,%
+                    xmin=-1.1,xmax=1.1,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-] coordinates {(1.,0) (0.98901,0.45597) (0.9558,0.63776) (0.89945,0.76667) (0.818,0.86206) (0.70711,0.9306) (0.55589,0.97522) (0.32331,0.99726) (-0.32331,0.99726) (-0.55589,0.97522) (-0.70711,0.9306) (-0.818,0.86206) (-0.89945,0.76667) (-0.9558,0.63776) (-0.98901,0.45597) (-1.,0) (-1.,0) (-0.98901,-0.45597) (-0.9558,-0.63776) (-0.89945,-0.76667) (-0.818,-0.86206)(-0.70711,-0.9306) (-0.55589,-0.97522) (-0.32331,-0.99726)(0.32331,-0.99726) (0.55589,-0.97522) (0.70711,-0.9306)(0.818,-0.86206) (0.89945,-0.76667) (0.9558,-0.63776)(0.98901,-0.45597) (1.,0) };
+                  \filldraw [] (axis cs:.775,.894) node [below left] {\((\sqrt{0.6},\sqrt{0.8})\)} circle (1pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
             </statement>
           </webwork>
         </exercise>
@@ -1881,21 +1880,6 @@
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               @eq=(Formula("y=4"),Formula("y=3/108^(1/4)(x-2)-108^(1/4)"));
-              $gr=init_graph(-4.2,-4.2,4.2,4.2,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-4,-3,-2,-1,1,2,3,4){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-4,-3,-2,-1,1,2,3,4){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              Context("Numeric");
-              Context()->variables->are(t=>'Real');
-              $x=Formula("sqrt((216 sin^2(t) + sqrt((216 sin^2(t))^2 - (36 sin^2(t))^3))^(1/3) + (216 sin^2(t) - sqrt((216 sin^2(t))^2 - (36sin^2(t))^3))^(1/3) + 4) cos(t)");
-              $y=Formula("sqrt((216 sin^2(t) + sqrt((216 sin^2(t))^2 - (36 sin^2(t))^3))^(1/3) + (216 sin^2(t) - sqrt((216 sin^2(t))^2 - (36sin^2(t))^3))^(1/3) + 4) sin(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(2,-3.224,'black'));
-              $gr->lb(new Label(2,-3.224,'(2,-root(4,108))','black','center','bottom','large'));
             </pg-code>
             <statement>
               <p>
@@ -1922,7 +1906,27 @@
                   </li>
                 </ol>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_06_ex_25">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-4.5,ymax=4.5,%
+                    xmin=-4.5,xmax=4.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-] coordinates {(-0.22282,-3.9915) (-0.57143,-3.9441) (-1.,-3.8244) (-1.2959,-3.7041)(-1.5714,-3.551) (-1.8453,-3.3571) (-2.0412,-3.1841) (-2.2149,-3.)(-2.3706,-2.7991) (-2.4727,-2.6429) (-2.5832,-2.4403)(-2.7019,-2.1552) (-2.783,-1.8571) (-2.8275,-1.4582)(-2.8002,-1.0859) (-2.7143,-0.74808) (-2.5958,-0.5)(-2.4708,-0.31491) (-2.3571,-0.19279) (-2.2143,-0.081938)(-2.0659,-0.005515) (-2.2078,0.077938) (-2.4036,0.23922)
+                  (-2.5608,0.4392) (-2.6877,0.68771) (-2.786,1.) (-2.8262,1.3571)(-2.8065,1.7143) (-2.7075,2.136) (-2.5114,2.5714) (-2.2471,2.9614)(-2.0396,3.1825) (-1.6513,3.5) (-1.2857,3.7088) (-1.0714,3.8007)(-0.78571,3.8938) (-0.52476,3.9533) (-0.28571,3.9855)
+                  (-0.070563,3.9991) (0.27289,3.9872) (0.64411,3.9298) (1.082,3.7963)(1.4286,3.6354) (1.7143,3.4554) (1.9675,3.2532) (2.1511,3.0714)(2.3284,2.8571) (2.4288,2.7143) (2.5351,2.5351) (2.6283,2.3426)(2.7079,2.1365) (2.7939,1.7939) (2.8255,1.3969) (2.8017,1.0874)(2.7481,0.85714) (2.6429,0.58296) (2.552,0.42857) (2.438,0.27631)
+                  (2.3214,0.16103) (2.1786,0.06028) (2.1143,-0.028574)(2.2857,-0.13046) (2.4439,-0.28571) (2.5958,-0.5) (2.7143,-0.74808)(2.8002,-1.0859) (2.827,-1.4286) (2.7984,-1.773) (2.7079,-2.1365)(2.6052,-2.3948) (2.4292,-2.7137) (2.2453,-2.9596) (2.,-3.2231)(1.7143,-3.4554) (1.4682,-3.611) (1.1839,-3.7553) (0.86968,-3.8697)
+                  (0.57143,-3.9441) (0.33765,-3.9805) (0.072336,-3.9991) (-0.22282,-3.9915)};
+                  
+                  \filldraw [] (axis cs:2,-3.22) node [shift={(15pt,-7pt)}] {\((2,-\sqrt[4]{108})\)} circle (1pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
             </statement>
           </webwork>
         </exercise>
@@ -1934,21 +1938,6 @@
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               @eq=(Formula("y=-x+1"),Formula("y=3sqrt(3)/4"));
-              $gr=init_graph(-2.5,-1.5,0.5,1.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-2,-1){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-1,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              Context("Numeric");
-              Context()->variables->are(t=>'Real');
-              $x=Formula("(1 - cos(t))*cos(t)");
-              $y=Formula("(1 - cos(t))*sin(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(-0.75,1.299,'black'));
-              $gr->lb(new Label(-0.75,1.299,'(-3/4,3sqrt(3)/4)','black','right','bottom','large'));
             </pg-code>
             <statement>
               <p>
@@ -1975,7 +1964,24 @@
                   </li>
                 </ol>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_06_ex_26">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-1.5,ymax=1.5,%
+                    xmin=-2.5,xmax=0.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-] coordinates {(-2.,0) (-1.9547,-0.34466) (-1.8227,-0.66341) (-1.616,-0.93301)(-1.3529,-1.1352) (-1.056,-1.2584) (-0.75,-1.299) (-0.459,-1.2611)(-0.2038,-1.1558) (0,-1.) (0.14349,-0.8138) (0.22504,-0.6183)(0.25,-0.43301) (0.22961,-0.27364) (0.17922,-0.15038)(0.11603,-0.066987) (0.05667,-0.020626) (0.014961,-0.0026381) (0,0)
+                  (0.014961,0.0026381) (0.05667,0.020626) (0.11603,0.066987)(0.17922,0.15038) (0.22961,0.27364) (0.25,0.43301) (0.22504,0.6183)(0.14349,0.8138) (0,1.) (-0.2038,1.1558) (-0.459,1.2611)(-0.75,1.299) (-1.056,1.2584) (-1.3529,1.1352) (-1.616,0.93301)(-1.8227,0.66341) (-1.9547,0.34466) (-2.,0)};
+                  
+                  \filldraw [] (axis cs:-.75,1.3) node [shift={(0pt,-10pt)}] {\(\left(-\frac{3}{4},\frac{3\sqrt{3}}{4}\right)\)} circle (1pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
             </statement>
           </webwork>
         </exercise>
@@ -1987,23 +1993,6 @@
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               @eq=(Formula("y=-1/sqrt(3)(x-7/2)+(6+3sqrt(3))/2"),Formula("y=sqrt(3)(x-(4+3sqrt(3)))/2+3/2"));
-              $gr=init_graph(-2,-2,6.5,6.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(2,4,6){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(2,4,6){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              Context("Numeric");
-              Context()->variables->are(t=>'Real');
-              $x=Formula("3*cos(t)+2");
-              $y=Formula("3*sin(t)+3");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(0,6.2831852);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(3.5,5.598,'black'));
-              $gr->lb(new Label(3.5,5.598,'(7/2,(6+3sqrt(3))/2)','black','center','top','large'));
-              $gr->stamps(closed_circle(4.598,1.5,'black'));
-              $gr->lb(new Label(4.598,1.5,'((4+3sqrt(3))/2,3/2)','black','right','bottom','large'));
             </pg-code>
             <statement>
               <p>
@@ -2030,7 +2019,23 @@
                   </li>
                 </ol>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_06_ex_27">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-.5,ymax=6.5,%
+                    xmin=-1.5,xmax=6.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-,domain=0:360] ({(2+3*cos(x))},{(3+3*sin(x))});
+                  \filldraw [] (axis cs:4.6,1.5) node [left] {\(\left(\frac{4+3\sqrt{3}}{2},1.5\right)\)} circle (1pt);
+                  \filldraw [] (axis cs:3.5,5.6) node [below left] {\(\left(3.5,\frac{6+3\sqrt{3}}{2}\right)\)} circle (1pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
             </statement>
           </webwork>
         </exercise>
@@ -2042,25 +2047,6 @@
               Context()->variables->add(y=>'Real');
               parser::Assignment->Allow;
               @eq=(Formula("y=1"),Formula("y=-2/sqrt(5)(x+1)+1/2(-1+sqrt(5))"),Formula("y=2/sqrt(5)(x+1)+1/2(-1-sqrt(5))"));
-              $gr=init_graph(-2.5,-2.5,2.5,2.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-2,-1,1,2){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,0,$i,'black','center','top','large'));};
-              for my$i(-2,-1,1,2){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(0,$i,$i,'black','right','middle','large'));};
-              Context("Numeric");
-              Context()->variables->are(t=>'Real');
-              $x=Formula("(-sin(2t)-cos^2(t))/sin^3(t) cos(t)");
-              $y=Formula("(-sin(2t)-cos^2(t))/sin^3(t) sin(t)");
-              $f=new Fun($x->perlFunction,$y->perlFunction,$gr);
-              $f->domain(pi/4,7*pi/8);
-              $f->steps(100);
-              $f->weight(2);
-              $f->color('blue');
-              $gr->stamps(closed_circle(-1,1,'black'));
-              $gr->lb(new Label(-1,1,'(-1,1)','black','right','bottom','large'));
-              $gr->stamps(closed_circle(-1,(-1+sqrt(5))/2,'black'));
-              $gr->lb(new Label(-1,(-1+sqrt(5))/2,'(-1,(-1+sqrt(5))/2)','black','left','middle','large'));
-              $gr->stamps(closed_circle(-1,(-1-sqrt(5))/2,'black'));
-              $gr->lb(new Label(-1,(-1-sqrt(5))/2,'(-1,(-1-sqrt(5))/2)','black','left','top','large'));
             </pg-code>
             <statement>
               <p>
@@ -2095,7 +2081,22 @@
                   </li>
                 </ol>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_06_ex_28">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-.5,ymax=6.5,%
+                    xmin=-1.5,xmax=6.5,%
+                  ]
+                  \addplot [firstcurvestyle,-,domain=45:157.5] ({((-sin(2*x)-(cos(x))^2)*cos(x)/((sin(x))^3))},{((-sin(2*x)-(cos(x))^2)/((sin(x))^2))});
+                  \filldraw [] (axis cs:4.6,1.5) node [left] {\(\left(\frac{4+3\sqrt{3}}{2},1.5\right)\)} circle (1pt);
+                  \filldraw [] (axis cs:3.5,5.6) node [below left] {\(\left(3.5,\frac{6+3\sqrt{3}}{2}\right)\)} circle (1pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
             </statement>
           </webwork>
         </exercise>

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -1793,7 +1793,7 @@
                   </li>
                 </ol>
               </p>
-              <image xml:id="img_06_02_ex_23">
+              <image xml:id="img_06_02_ex_27">
                 <description></description>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1802,7 +1802,7 @@
                       xmin=-1.1,xmax=1.1,%
                     ]
 
-                    \addplot [firstcurvestyle,-,domain=0:360,samples=40] ({(cos(x))^5},{(sin(x))^5});
+                    \addplot [firstcurvestyle,-,domain=0:360,samples=100] ({(cos(x))^5},{(sin(x))^5});
                     \filldraw [] (axis cs:.1,.28) node [above right] {\((0.1,0.281)\)} circle (1pt);
                     \end{axis}
                   \end{tikzpicture}
@@ -1853,7 +1853,7 @@
                   </li>
                 </ol>
               </p>
-              <image xml:id="img_02_06_ex_24">
+              <image xml:id="img_02_06_ex_28">
                 <description></description>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1906,7 +1906,7 @@
                   </li>
                 </ol>
               </p>
-              <image xml:id="img_02_06_ex_25">
+              <image xml:id="img_02_06_ex_29">
                 <description></description>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1921,7 +1921,7 @@
                   (2.3214,0.16103) (2.1786,0.06028) (2.1143,-0.028574)(2.2857,-0.13046) (2.4439,-0.28571) (2.5958,-0.5) (2.7143,-0.74808)(2.8002,-1.0859) (2.827,-1.4286) (2.7984,-1.773) (2.7079,-2.1365)(2.6052,-2.3948) (2.4292,-2.7137) (2.2453,-2.9596) (2.,-3.2231)(1.7143,-3.4554) (1.4682,-3.611) (1.1839,-3.7553) (0.86968,-3.8697)
                   (0.57143,-3.9441) (0.33765,-3.9805) (0.072336,-3.9991) (-0.22282,-3.9915)};
                   
-                  \filldraw [] (axis cs:2,-3.22) node [shift={(15pt,-7pt)}] {\((2,-\sqrt[4]{108})\)} circle (1pt);
+                  \filldraw [] (axis cs:2,-3.22) node [shift={(15pt,-10pt)}] {\((2,-\sqrt[4]{108})\)} circle (1pt);
                   
                   \end{axis}
                   \end{tikzpicture}
@@ -1964,7 +1964,7 @@
                   </li>
                 </ol>
               </p>
-              <image xml:id="img_02_06_ex_26">
+              <image xml:id="img_02_06_ex_30">
                 <description></description>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1973,10 +1973,10 @@
                     xmin=-2.5,xmax=0.5,%
                   ]
                   
-                  \addplot [firstcurvestyle,-] coordinates {(-2.,0) (-1.9547,-0.34466) (-1.8227,-0.66341) (-1.616,-0.93301)(-1.3529,-1.1352) (-1.056,-1.2584) (-0.75,-1.299) (-0.459,-1.2611)(-0.2038,-1.1558) (0,-1.) (0.14349,-0.8138) (0.22504,-0.6183)(0.25,-0.43301) (0.22961,-0.27364) (0.17922,-0.15038)(0.11603,-0.066987) (0.05667,-0.020626) (0.014961,-0.0026381) (0,0)
+                  \addplot [firstcurvestyle,-,samples=150] coordinates {(-2.,0) (-1.9547,-0.34466) (-1.8227,-0.66341) (-1.616,-0.93301)(-1.3529,-1.1352) (-1.056,-1.2584) (-0.75,-1.299) (-0.459,-1.2611)(-0.2038,-1.1558) (0,-1.) (0.14349,-0.8138) (0.22504,-0.6183)(0.25,-0.43301) (0.22961,-0.27364) (0.17922,-0.15038)(0.11603,-0.066987) (0.05667,-0.020626) (0.014961,-0.0026381) (0,0)
                   (0.014961,0.0026381) (0.05667,0.020626) (0.11603,0.066987)(0.17922,0.15038) (0.22961,0.27364) (0.25,0.43301) (0.22504,0.6183)(0.14349,0.8138) (0,1.) (-0.2038,1.1558) (-0.459,1.2611)(-0.75,1.299) (-1.056,1.2584) (-1.3529,1.1352) (-1.616,0.93301)(-1.8227,0.66341) (-1.9547,0.34466) (-2.,0)};
                   
-                  \filldraw [] (axis cs:-.75,1.3) node [shift={(0pt,-10pt)}] {\(\left(-\frac{3}{4},\frac{3\sqrt{3}}{4}\right)\)} circle (1pt);
+                  \filldraw [] (axis cs:-.75,1.3) node [shift={(0pt,-12pt)}] {\(\left(-\frac{3}{4},\frac{3\sqrt{3}}{4}\right)\)} circle (1pt);
                   
                   \end{axis}
                   \end{tikzpicture}
@@ -2019,7 +2019,7 @@
                   </li>
                 </ol>
               </p>
-              <image xml:id="img_02_06_ex_27">
+              <image xml:id="img_02_06_ex_31">
                 <description></description>
                 <latex-image>
                   \begin{tikzpicture}
@@ -2028,7 +2028,7 @@
                     xmin=-1.5,xmax=6.5,%
                   ]
                   
-                  \addplot [firstcurvestyle,-,domain=0:360] ({(2+3*cos(x))},{(3+3*sin(x))});
+                  \addplot [firstcurvestyle,-,samples=100,domain=0:360] ({(2+3*cos(x))},{(3+3*sin(x))});
                   \filldraw [] (axis cs:4.6,1.5) node [left] {\(\left(\frac{4+3\sqrt{3}}{2},1.5\right)\)} circle (1pt);
                   \filldraw [] (axis cs:3.5,5.6) node [below left] {\(\left(3.5,\frac{6+3\sqrt{3}}{2}\right)\)} circle (1pt);
                   
@@ -2081,17 +2081,20 @@
                   </li>
                 </ol>
               </p>
-              <image xml:id="img_02_06_ex_28">
+              <image xml:id="img_02_06_ex_32">
                 <description></description>
                 <latex-image>
                   \begin{tikzpicture}
                   \begin{axis}[
-                    ymin=-.5,ymax=6.5,%
-                    xmin=-1.5,xmax=6.5,%
+                  ymin=-2.5,ymax=2.5,%
+                  xmin=-2.5,xmax=2.5,%
                   ]
-                  \addplot [firstcurvestyle,-,domain=45:157.5] ({((-sin(2*x)-(cos(x))^2)*cos(x)/((sin(x))^3))},{((-sin(2*x)-(cos(x))^2)/((sin(x))^2))});
-                  \filldraw [] (axis cs:4.6,1.5) node [left] {\(\left(\frac{4+3\sqrt{3}}{2},1.5\right)\)} circle (1pt);
-                  \filldraw [] (axis cs:3.5,5.6) node [below left] {\(\left(3.5,\frac{6+3\sqrt{3}}{2}\right)\)} circle (1pt);
+                  \addplot [firstcurvestyle,-,samples=100,domain=45:157.5] ({((-sin(2*x)-(cos(x))^2)*cos(x)/((sin(x))^3))},{((-sin(2*x)-(cos(x))^2)/((sin(x))^2))});
+                  \filldraw [] (axis cs:-1,1) node [above] {\((-1,1)\)} circle (1pt);
+                  \filldraw [thin,->,>=latex] (axis cs:1.25,-1.5) node [fill=white] {\(\left(-1,\frac{-1-\sqrt{5}}2\right)\)} -- (axis cs: -.9,-1.62);
+                  \filldraw [] (axis cs: -1,-1.62)  circle (1pt);
+                  \filldraw [->,thin,>=latex] (axis cs:1.25,0.5) node [ fill=white] {\(\left(-1,\frac{-1+\sqrt{5}}2\right)\)} -- (axis cs: -.9,0.62);
+                  \filldraw [] (axis cs:-1,0.62)  circle (1pt);
                   
                   \end{axis}
                   \end{tikzpicture}

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1123,7 +1123,7 @@
               $k=non_zero_random(-2,2,1);
               $a=non_zero_random(-1,1,0.05);
               if($envir{problemSeed}==1){$a=0.25;$h=1;$k=2;};
-              $f=Formula("$a (x-$h)^2+$k");
+              $f=Formula("$a*(x-$h)^2+$k");
               $fp=$f->D('x');
               if ($a>0) {
                 $fleft  = $h - sqrt(5/$a - $k);
@@ -1144,31 +1144,30 @@
               $fright=min($fright,4);
               $fpleft=max($fpleft,-4);
               $fpright=min($fpright,4);
-              $gr=init_graph(-4,-5,4,5,axes=>[0,0],size=>[400,240]);
-              $gr->lb('reset');
-              for my$i(-3,-2,-1,1,2,3){
-                $gr->moveTo($i,-0.05);
-                $gr->lineTo($i,0.05,black,1);
-                $gr->lb(new Label($i,-0.1,$i,'black','center','top','large'));
-              };
-              for my$i(-4..-1,1..4){
-                $gr->moveTo(-0.05,$i);
-                $gr->lineTo(0.05,$i,black,1);
-                $gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));
-              };
-              $gr->new_color("lightblue", 174,180,244);
-              $gr->new_color("darkred", 159,64,16);
-              add_functions($gr, "$fp for x in &lt;$fpleft,$fpright> using color:lightblue and weight:3");
-              $gr->lb(new Label($fpright-1,$fp->eval(x=>$fpright-1),'f','lightblue',@fppos,'large'));
-              add_functions($gr, "$f for x in &lt;$fleft,$fright> using color:darkred and weight:2");
-              $gr->lb(new Label($h,$k,'g','darkred',@fpos,'large'));
               $radio=RadioButtons([
                 math_ev3(f).' is the derivative of '.math_ev3(g).'.',
                 math_ev3(g).' is the derivative of '.math_ev3(f).'.'
               ],0);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_02_ex_15">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=-5.1,ymax=5.1,%
+                        xmin=-4.3,xmax=4.3,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-,domain=$fpleft:$fpright] {$fp};
+                  \addplot [secondcurvestyle,-,domain=$fleft:$fright] {$f};
+                  \addlegendentry{\(f(x)\)};
+                  \addlegendentry{\(g(x)\)};
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <p>
                 <var name="$radio" form="buttons"/>
               </p>
@@ -1182,7 +1181,7 @@
               ($r,$s,$t)=num_sort((-3..3)[NchooseK(7,3)]);
               $a=non_zero_random(-1,1,0.05);
               if($envir{problemSeed}==1){$a=1;$r=0;$s=1;$t=2;};
-              $f=Formula("$a(x-$r)(x-$s)(x-$t)");
+              $f=Formula("$a*(x-$r)*(x-$s)*(x-$t)");
               $fp=$f->D('x');
               @cp=(
                 ($r+$s+$t - sqrt(($r+$s+$t)**2 - 3*($r*$s+$r*$t+$s*$t)))/3,
@@ -1197,38 +1196,31 @@
               $ymin=min(-5,map{Round($_)-1}(@cv));
               $ymax=max(5,map{Round($_)+1}(@cv));
               $infl=($r+$s+$t)/3;
-              $gr=init_graph($xmin,$ymin,$xmax,$ymax,axes=>[0,0],size=>[400,240]);
-              $gr->lb('reset');
-              $gr->new_color("lightblue", 174,180,244);
-              $gr->new_color("darkred", 159,64,16);
-              for my$i(($xmin+1)..-1,1..($xmax-1)){
-                $gr->moveTo($i,-0.05);
-                $gr->lineTo($i,0.05,black,1);
-                $gr->lb(new Label($i,0,$i,'black','center','top','large'));
-              };
-              for my$i(($ymin+1)..-1,1..($ymax-1)){
-                $gr->moveTo(-0.05,$i);
-                $gr->lineTo(0.05,$i,black,1);
-                $gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));
-              };
-              if ($a>0) {
-                @fpos=('right','bottom');
-                @fppos=('center','top');
-              } else {
-                @fpos=('left','bottom');
-                @fppos=('center','bottom');
-              }
-              add_functions($gr, "$f for x in &lt;$xmin,$xmax> using color:lightblue and weight:3");
-              $gr->lb(new Label($t,0,'f','lightblue',@fpos,'large'));
-              add_functions($gr, "$fp for x in &lt;$xmin,$xmax> using color:darkred and weight:2");
-              $gr->lb(new Label($infl,$fp->eval(x=>$infl),'g','darkred',@fppos,'large'));
+              $inflval=$fp->eval(x=>$infl);
               $radio=RadioButtons([
                 math_ev3(f).' is the derivative of '.math_ev3(g).'.',
                 math_ev3(g).' is the derivative of '.math_ev3(f).'.'
               ],1);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_02_ex_16">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=$ymin,ymax=$ymax,%
+                    xmin=$xmin,xmax=$xmax,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-,domain=$xmin:$xmax] {$a*(x-$r)*(x-$s)*(x-$t)};
+                  \addplot [secondcurvestyle,-,domain=$xmin:$xmax] {$a*(3*x^2-2*($r+$s+$t)*x+$r*$s+$r*$t+$s*$t)};
+                  \addlegendentry{\(f(x)\)};
+                  \addlegendentry{\(g(x)\)};
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <p>
                 <var name="$radio" form="buttons"/>
               </p>
@@ -1239,25 +1231,32 @@
         <exercise label="ex-deriv-interpret-graph-3">
           <webwork xml:id="webwork-ex-deriv-interpret-graph-3">
             <pg-code>
-              $gr=init_graph(-5,-5,5,5,axes=>[0,0],size=>[400,240],grid=>[10,10]);
-              $gr->lb('reset');
-              $gr->new_color("lightblue", 174,180,244);
-              $gr->new_color("darkred", 159,64,16);
-              for my$i(-4..-1,1..4){$gr->moveTo($i,-0.05);$gr->lineTo($i,0.05,black,1);$gr->lb(new Label($i,-0.1,$i,'black','center','top','large'));};
-              for my$i(-4..-1,1..4){$gr->moveTo(-0.05,$i);$gr->lineTo(0.05,$i,black,1);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));};
-              add_functions($gr, "1/x for x in &lt;-5,-0.2> using color:lightblue and weight:3");
-              add_functions($gr, "1/x for x in &lt;0.2,5> using color:lightblue and weight:3");
-              $gr->lb(new Label(1,1.2,'f','lightblue','left','bottom','large'));
-              add_functions($gr, "-1/x^2 for x in &lt;-5,-0.45> using color:darkred and weight:2");
-              add_functions($gr, "-1/x^2 for x in &lt;0.45,5> using color:darkred and weight:2");
-              $gr->lb(new Label(1,-1.2,'g','darkred','left','top','large'));
               $radio=RadioButtons([
                 math_ev3(f).' is the derivative of '.math_ev3(g).'.',
                 math_ev3(g).' is the derivative of '.math_ev3(f).'.'
               ],1);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_02_ex_17">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=-5.5,ymax=5.5,%
+                        xmin=-5.5,xmax=5.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-,domain=-5.5:-.182,samples=40] {1/x};
+                  \addplot [secondcurvestyle,-,domain=-5.5:-.426,samples=40] {-1/x^2};
+                  \addplot [firstcurvestyle,-,domain=.182:5.5,samples=40] {1/x};
+                  \addplot [secondcurvestyle,-,domain=.426:5.5,samples=40] {-1/x^2};
+                  \addlegendentry{\(f(x)\)};
+                  \addlegendentry{\(g(x)\)};
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <p>
                 <var name="$radio" form="buttons"/>
               </p>
@@ -1271,35 +1270,34 @@
               $h=random(-2,2,1);
               $p=random(2,4,1);
               if($envir{problemSeed}==1){$h=1;$p=2;};
-              $f=Formula("cos(pi/$p (x-$h))");
+              $f=Formula("cos((pi/$p)*(x-$h))");
               $fp=$f->D('x');
               $ymin=-max(int(pi/$p),1)-1;
               $ymax=max(int(pi/$p),1)+1;
-              $gr=init_graph(-4,$ymin,4,$ymax,axes=>[0,0],size=>[400,240]);
-              $gr->lb('reset');
-              $gr->new_color("lightblue", 174,180,244);
-              $gr->new_color("darkred", 159,64,16);
-              for my$i(-3..-1,1..3){
-                $gr->moveTo($i,-0.05);
-                $gr->lineTo($i,0.05,black,1);
-                $gr->lb(new Label($i,-0.1,$i,'black','center','top','large'));
-              };
-              for my$i($ymin+1..-1,1..$ymax-1){
-                $gr->moveTo(-0.05,$i);
-                $gr->lineTo(0.05,$i,black,1);
-                $gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));
-              };
-              add_functions($gr, "$f for x in &lt;-4,4> using color:lightblue and weight:3");
-              $gr->lb(new Label($h,1,'f','lightblue','center','bottom','large'));
-              add_functions($gr, "$fp for x in &lt;-4,4> using color:darkred and weight:2");
-              $gr->lb(new Label($h-3*$p/2,-pi/$p,'g','darkred','center','top','large'));
               $radio=RadioButtons([
                 math_ev3(f).' is the derivative of '.math_ev3(g).'.',
                 math_ev3(g).' is the derivative of '.math_ev3(f).'.'
               ],1);
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_02_ex_18">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=$ymin,ymax=$ymax,%
+                        xmin=-4,xmax=4,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,-,domain=-4:4,samples=100] {cos(deg((3.14/$p)*(x-$h)))};
+                  \addplot [secondcurvestyle,-,domain=-4:4,samples=40] {-(3.14/$p)*sin(deg((3.14/$p)*(x-$h)))};
+                  \addlegendentry{\(f(x)\)};
+                  \addlegendentry{\(g(x)\)};
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <p>
                 <var name="$radio" form="buttons"/>
               </p>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1116,15 +1116,15 @@
               $f=Formula("$a*(x-$h)^2+$k");
               $fp=$f->D('x');
               if ($a>0) {
-                $fleft  = $h - sqrt(5/$a - $k);
-                $fright = $h + sqrt(5/$a - $k);
+                $fleft  = $h - sqrt(5/$a - $k/$a);
+                $fright = $h + sqrt(5/$a - $k/$a);
                 @fpos = ('center','top');
                 $fpleft = $h-5/2/$a;
                 $fpright = $h+5/2/$a;
                 @fppos = ('left','top');
               } else {
-                $fleft  = $h - sqrt(-5/$a - $k);
-                $fright = $h + sqrt(-5/$a - $k);
+                $fleft  = $h - sqrt(-5/$a - $k/$a);
+                $fright = $h + sqrt(-5/$a - $k/$a);
                 @fpos = ('center','bottom');
                 $fpleft = $h+5/2/$a;
                 $fpright = $h-5/2/$a;
@@ -1173,16 +1173,13 @@
               if($envir{problemSeed}==1){$a=1;$r=0;$s=1;$t=2;};
               $f=Formula("$a*(x-$r)*(x-$s)*(x-$t)");
               $fp=$f->D('x');
-              @cp=(
-                ($r+$s+$t - sqrt(($r+$s+$t)**2 - 3*($r*$s+$r*$t+$s*$t)))/3,
-                ($r+$s+$t + sqrt(($r+$s+$t)**2 - 3*($r*$s+$r*$t+$s*$t)))/3
-              );
+              $xmin=$r-2;
+              $xmax=$t+2;
+              @cp=($xmin,$xmax);
               @cv;
               for $i (@cp) {
                 push(@cv, $f->eval(x=>$i));
               };
-              $xmin=$r-2;
-              $xmax=$t+2;
               $ymin=min(-5,map{Round($_)-1}(@cv));
               $ymax=max(5,map{Round($_)+1}(@cv));
               $infl=($r+$s+$t)/3;
@@ -1202,7 +1199,7 @@
                     xmin=$xmin,xmax=$xmax,%
                   ]
                   
-                  \addplot [firstcurvestyle,-,domain=$xmin:$xmax] {$a*(x-$r)*(x-$s)*(x-$t)};
+                  \addplot [firstcurvestyle,-,domain=$xmin:$xmax,samples=100] {$a*(x-$r)*(x-$s)*(x-$t)};
                   \addplot [secondcurvestyle,-,domain=$xmin:$xmax] {$a*(3*x^2-2*($r+$s+$t)*x+$r*$s+$r*$t+$s*$t)};
                   \addlegendentry{\(f(x)\)};
                   \addlegendentry{\(g(x)\)};

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2280,7 +2280,7 @@
 
         <exercise label="ex-deriv-intro-sketch-3">
           <statement>
-            <image xml:id="img_02_01_ex_28" width="50%">
+            <image xml:id="img_02_01_ex_28">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -2300,7 +2300,7 @@
 
         <exercise label="ex-deriv-intro-sketch-4">
           <statement>
-            <image xml:id="img_02_01_ex_29" width="50%">
+            <image xml:id="img_02_01_ex_29">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
@@ -2734,17 +2734,17 @@
             <p>
               Use the graph of <m>f(x)</m> provided to answer the following.
             </p>
-            <image xml:id="img_02_01_ex_40">
+            <image xml:id="img_02_01_ex_40" width="47%">
               <description></description>
               <latex-image>
                 \begin{tikzpicture}
                 \begin{axis}[
-                      ymin=-1.1,ymax=3.1,%
+                      ymin=-1.1,ymax=3.3,%
                       xmin=-5.1,xmax=0.5,%
                 ]
                 
-                \addplot [firstcurvestyle,domain=-5:-3] {(x+3)^2+1};
-                \addplot [firstcurvestyle,domain=-3:0.5] {-(x+3)^2+3};
+                \addplot [firstcurvestyle,-,domain=-4.5:-3] {(x+3)^2+1};
+                \addplot [firstcurvestyle,-,domain=-3:-1] {-(x+3)^2+3};
                 \filldraw [fill=white] (axis cs:-3,1) circle (1.5pt);
                 \filldraw [fill=white] (axis cs:-3,3) circle (1.5pt);
                 \filldraw [fill=black] (axis cs:-3,2) circle (1.5pt);

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2069,149 +2069,159 @@
       <exercise label="ex-deriv-intro-graph-approx-1">
         <webwork xml:id="webwork-ex-deriv-intro-graph-approx-1">
           <pg-code>
-            $gr = init_graph(-3,-2,3,4,axes=>[0,0],grid=>[6,6],size=>[400,240]);
-            $gr->lb('reset');
-            for my $i (-2,-1,1,2) {
-              $gr->lb(new Label($i,0,$i,'black','center','top','large'));
-            }
-            for my $i (-1,1,2,3) {
-              $gr->lb(new Label(0,$i,$i,'black','right','middle','large'));
-            }
-            add_functions($gr, "x^2-1 for x in &lt;-3,3> using color:blue and weight:2");
-            @approx=(
+              @approx=(
               Compute("-2")->with(tolType=>'absolute',tolerance=>0.4),
               Compute("0")->with(tolType=>'absolute',tolerance=>0.1),
               Compute("4")->with(tolType=>'absolute',tolerance=>2)
             );
+            $approx_list=List($approx[0],$approx[1],$approx[2]);
             $derivative=Formula("2x");
-            @slopes=(-2,0,4);
+            $slopes=List(-2,0,4);
             $showwork = '[@ explanation_box(message => "Show your work.") @]*';
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               The graph of <m>f(x)=x^2-1</m> is shown.
             </p>
-            <image pg-name="$gr" width="47%"/>
-            <p>
-              <ol>
-                <li>
-                  <p>
-                    Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(-1,0)</m>, <m>(0,-1)</m>, and <m>(2,3)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$approx[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$approx[1]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$approx[2]" width="10"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Using the definition of the derivative, find <m>\fp(x)</m>.
-                  </p>
-                  <p>
-                    <var name="$derivative" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$showwork" data="pgml"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Use the derivative to find the slope of the tangent line at the points <m>(-1,0)</m>, <m>(0,-1)</m> and <m>(2,3)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$slopes[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$slopes[1]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$slopes[2]" width="10"/>
-                  </p>
-                </li>
-              </ol>
-            </p>
-          </statement>
+            <image xml:id="img_02_01_ex_24" width="47%">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+                \begin{axis}[
+                      ytick={-1,1,2,3},
+                      ymin=-1.3,ymax=3.5,%
+                      xmin=-2.1,xmax=2.1,%
+                      grid=major
+                ]
+                
+                \addplot [firstcurvestyle,domain=-2.1:2.1] {x^2-1};
+                
+                \end{axis}
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+
+          </introduction>
+          <task>
+            <statement>
+              <p>
+                Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(-1,0)</m>, <m>(0,-1)</m>, and <m>(2,3)</m>.
+              </p>
+
+              <instruction>
+                Enter your answers as a comma-separated list of values.
+              </instruction>
+
+              <p>
+                <var name="$approx_list" width="10"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Using the definition of the derivative, find <m>\fp(x)</m>.
+              </p>
+              <p>
+                <var name="$derivative" width="10"/>
+              </p>
+              <p>
+                <var name="$showwork" data="pgml"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Use the derivative to find the slope of the tangent line at the points <m>(-1,0)</m>, <m>(0,-1)</m> and <m>(2,3)</m>.
+              </p>
+              <instruction>
+                Enter your answers as a comma-separated list of values.
+              </instruction>
+              <p>
+                <var name="$slopes" width="10"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 
       <exercise label="ex-deriv-intro-graph-approx-2">
         <webwork xml:id="webwork-ex-deriv-intro-graph-approx-2">
           <pg-code>
-            $gr = init_graph(-1,-1,3,6,axes=>[0,0],grid=>[4,7],size=>[400,240]);
-            $gr->lb('reset');
-            for my $i (1,2) {
-              $gr->lb(new Label($i,0,$i,'black','center','top','large'));
-            }
-            for my $i (1..5) {
-              $gr->lb(new Label(0,$i,$i,'black','right','middle','large'));
-            }
-            add_functions($gr, "1/(x+1) for x in &lt;-0.85,3> using color:blue and weight:2");
             @approx=(
               Compute("-1")->with(tolType=>'absolute',tolerance=>0.2),
               Compute("-1/4")->with(tolType=>'absolute',tolerance=>0.1)
             );
+            $approx_list=List($approx[0],$approx[1]);
             $derivative=Formula("-1/(x+1)^2");
-            @slopes=(-1,'-1/4');
+            $slopes=List(-1,'-1/4');
             $showwork = '[@ explanation_box(message => "Show your work.") @]*';
           </pg-code>
-          <statement>
+          <introduction>
             <p>
               The graph of <m>f(x)=\frac{1}{x+1}</m> is shown.
             </p>
-            <image pg-name="$gr" width="47%"/>
+            <image xml:id="img_02_01_ex_25" width="47%">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+                \begin{axis}[
+                      ytick={1,2,3,4,5},
+                      ymin=-.5,ymax=5.5,%
+                      xmin=-1.1,xmax=3.1,%
+                      grid=major
+                ]
+                
+                \addplot [firstcurvestyle,domain=-.9:3.1,samples=50] {1/(x+1)};
+                
+                \end{axis}
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </introduction>
+
+          <task>
+            <statement>
+              <p>
+                Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(0,1)</m> and <m>(1,0.5)</m>.
+              </p>
+              <instruction>
+                Enter your answers as a comma-separated list of values.
+              </instruction>
+              <p>
+                <var name="$approx_list" width="10"/>
+              </p>
+            </statement>
+          </task>
+
+          <task>
             <p>
-              <ol>
-                <li>
-                  <p>
-                    Use the graph to approximate the slope of the tangent line to <m>f</m> at <m>(0,1)</m> and <m>(1,0.5)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$approx[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$approx[1]" width="10"/>
-                  </p>
-                  <p>
-                    Using the definition of the derivative, find <m>\fp(x)</m>.
-                  </p>
-                  <p>
-                    <var name="$derivative" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$showwork" data="pgml"/>
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Use the derivative to find the slope of the tangent line at the points <m>(0,1)</m> and <m>(1,0.5)</m>.
-                  </p>
-                  <instruction>
-                    Enter the answers in the respective order.
-                  </instruction>
-                  <p>
-                    <var name="$slopes[0]" width="10"/>
-                  </p>
-                  <p>
-                    <var name="$slopes[1]" width="10"/>
-                  </p>
-                </li>
-              </ol>
+              Using the definition of the derivative, find <m>\fp(x)</m>.
             </p>
-          </statement>
+            <p>
+              <var name="$derivative" width="10"/>
+            </p>
+            <p>
+              <var name="$showwork" data="pgml"/>
+            </p>
+          </task>
+
+          <task>
+            <statement>
+              <p>
+                Use the derivative to find the slope of the tangent line at the points <m>(0,1)</m> and <m>(1,0.5)</m>.
+              </p>
+              <instruction>
+                Enter your answers as a comma-separated list of values.
+              </instruction>
+              <p>
+                <var name="$slopes" width="10"/>
+              </p>
+            </statement>
+          </task>
         </webwork>
       </exercise>
 
@@ -2313,21 +2323,44 @@
       <exercisegroup cols="2" xml:id="exset-deriv-intro-graph-interpret">
         <introduction>
           <p>
-            Use the graph of the function to answer questions about it.
+            Use the graph of the function to answer the following questions.
+            <ol cols="2">
+              <li>
+                <p>
+                  Where is <m>g(x)\gt 0</m>?
+                </p>
+              </li>
+              <li>
+                <p>
+                  Where is <m>g(x)\lt 0</m>?
+                </p>
+              </li>
+              <li>
+                <p>
+                  Where is <m>g(x) = 0</m>?
+                </p>
+              </li>
+              <li>
+                <p>
+                  Where is <m>g'(x) \lt 0</m>?
+                </p>
+              </li>
+              <li>
+                <p>
+                  Where is <m>g'(x)  \gt  0</m>?
+                </p>
+              </li>
+              <li>
+                <p>
+                  Where is <m>g'(x) = 0</m>?
+                </p>
+              </li>
+            </ol>
           </p>
         </introduction>
         <exercise label="ex-deriv-intro-graph-interpret-1">
           <webwork xml:id="webwork-ex-deriv-intro-graph-interpret-1">
             <pg-code>
-              $gr = init_graph(-3,-5,3,5,axes=>[0,0],size=>[400,240]);
-              add_functions($gr, "-3*(x+1)^2+3 for x in &lt;-2.75,-1> using color:blue and weight:2");
-              add_functions($gr, "3*(x-1)^2-3 for x in &lt;1,2.75> using color:blue and weight:2");
-              add_functions($gr, "-3*sin(x*pi/2) for x in &lt;-1,1> using color:blue and weight:2");
-              $gr -> lb('reset');
-              $gr->h_ticks(0,"black",(-3..3));
-              $gr->v_ticks(0,"black",(-4..4));
-              for my$i(-2,-1,1,2){$gr->lb(new Label($i,0,$i,'black','center','top','large'));};
-              for my$i(-4..-1,1..4){$gr->lb(new Label(0,$i,$i,'black','right','middle','large'));};
               Context("Interval");
               $pos=Compute("(-2,0)U(2,inf)");
               $neg=Compute("(-inf,-2)U(0,2)");
@@ -2337,62 +2370,61 @@
               $fla=Compute("{-1,1}");
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_01_ex_30">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                  xtick={-2,-1,1,2},
+                  ymin=-5.5,ymax=5.5,%
+                  xmin=-3.1,xmax=3.1,%
+                  ]
+            
+                  \addplot [firstcurvestyle,domain=-3.1:3.1,samples=40] {(x-2)*x*(x+2)};
+                        
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Answer using interval notation or set notation, as appropriate. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
                 If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
               </instruction>
+              <instruction>
+                Enter the set on which <m>g(x) \gt 0</m> using interval notation.
+              </instruction>
               <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      Where is <m>g(x)\gt0</m>?
-                    </p>
-                    <p>
-                      <var name="$pos" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x)\lt0</m>?
-                    </p>
-                    <p>
-                      <var name="$neg" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$zer" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) \lt 0</m>?
-                    </p>
-                    <p>
-                      <var name="$dec" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x)  \gt  0</m>?
-                    </p>
-                    <p>
-                      <var name="$inc" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$fla" width="20"/>
-                    </p>
-                  </li>
-                </ol>
+                <var name="$pos" width="20"/>
+              </p>
+              <instruction>
+                Enter the set on which <m>g(x) \lt 0</m> using interval notation.
+              </instruction>
+              <p>
+                <var name="$neg" width="20"/>
+              </p>
+              <instruction>
+                Enter the set of points where <m>g(x) = 0</m> using the syntax <c>{a,b}</c>.
+              </instruction>
+              <p>
+                <var name="$zer" width="20"/>
+              </p>
+              <instruction>
+                Enter the set on which <m>g'(x) \lt 0</m> using interval notation.
+              </instruction>
+              <p>
+                <var name="$dec" width="20"/>
+              </p>
+              <instruction>
+                Enter the set on which <m>g'(x) \gt 0</m> using interval notation.
+              </instruction>
+              <p>
+                <var name="$inc" width="20"/>
+              </p>
+              <instruction>
+                Enter the set of points where <m>g(x) \gt 0</m> using the syntax <c>{a,b}</c>.
+              </instruction>
+              <p>
+                <var name="$fla" width="20"/>
               </p>
             </statement>
           </webwork>
@@ -2401,76 +2433,74 @@
         <exercise label="ex-deriv-intro-graph-interpret-2">
           <webwork xml:id="webwork-ex-deriv-intro-graph-interpret-2">
             <pg-code>
-              $gr = init_graph(-3,-10,3,5,axes=>[0,0],grid=>[6,15],size=>[400,240]);
-              add_functions($gr, "-2x^4+4*x^2+3*1.5^4-6*1.5^2 for x in &lt;-2,2> using color:blue and weight:2");
-              $gr -> lb('reset');
-              for my$i(-2,-1,1,2){$gr->lb(new Label($i,0,$i,'black','center','top','large'));};
-              for my$i(-9..-1,1..4){$gr->lb(new Label(0,$i,$i,'black','right','middle','large'));};
               Context("Interval");
-              $pos=Compute("(-1.5,1.5)");
-              $neg=Compute("(-inf,-1.5)U(1.5,inf)");
-              $zer=Compute("{-1.5,1.5}");
+              $pos=Compute("(-2,2)");
+              $neg=Compute("(-inf,-2)U(2,inf)");
+              $zer=Compute("{-2,2}");
               $dec=Compute("(-1,0)U(1,inf)");
               $inc=Compute("(-inf,-1)U(0,1)");
               $fla=Compute("{-1,0,1}");
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_02_01_ex_31">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                  xtick={-2,-1,1,2},
+                  ymin=-1,ymax=5,%
+                  xmin=-2.8,xmax=2.8,%
+                  ]
+            
+                  \addplot [firstcurvestyle,domain=-2.6:2.6,samples=50] {(-2)*(x^4/4-x^2/2)+4};
+           
+                   \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Answer using interval notation or set notation, as appropriate. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
                 If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
               </instruction>
+              <instruction>
+                Answer using interval notation or set notation, as appropriate. If you need to write <m>\infty</m>, you may type <c>inf</c> or <c>infinity</c>.
+                If you need the union symbol, <m>\cup</m>, you may type the capital letter <c>U</c>.
+              </instruction>
+              <instruction>
+                Enter the set on which <m>g(x) \gt 0</m> using interval notation.
+              </instruction>
               <p>
-                <ol cols="2">
-                  <li>
-                    <p>
-                      Where is <m>g(x)\gt0</m>?
-                    </p>
-                    <p>
-                      <var name="$pos" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x)\lt0</m>?
-                    </p>
-                    <p>
-                      <var name="$neg" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$zer" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) \lt 0</m>?
-                    </p>
-                    <p>
-                      <var name="$dec" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x)  \gt  0</m>?
-                    </p>
-                    <p>
-                      <var name="$inc" width="20"/>
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Where is <m>g'(x) = 0</m>?
-                    </p>
-                    <p>
-                      <var name="$fla" width="20"/>
-                    </p>
-                  </li>
-                </ol>
+                <var name="$pos" width="20"/>
+              </p>
+              <instruction>
+                Enter the set on which <m>g(x) \lt 0</m> using interval notation.
+              </instruction>
+              <p>
+                <var name="$neg" width="20"/>
+              </p>
+              <instruction>
+                Enter the set of points where <m>g(x) = 0</m> using the syntax <c>{a,b}</c>.
+              </instruction>
+              <p>
+                <var name="$zer" width="20"/>
+              </p>
+              <instruction>
+                Enter the set on which <m>g'(x) \lt 0</m> using interval notation.
+              </instruction>
+              <p>
+                <var name="$dec" width="20"/>
+              </p>
+              <instruction>
+                Enter the set on which <m>g'(x) \gt 0</m> using interval notation.
+              </instruction>
+              <p>
+                <var name="$inc" width="20"/>
+              </p>
+              <instruction>
+                Enter the set of points where <m>g(x) \gt 0</m> using the syntax <c>{a,b}</c>.
+              </instruction>
+              <p>
+                <var name="$fla" width="20"/>
               </p>
             </statement>
           </webwork>
@@ -2691,13 +2721,6 @@
       <exercise label="ex-deriv-intro-review-4">
         <webwork xml:id="webwork-ex-deriv-intro-review-4">
           <pg-code>
-            $gr = init_graph(-5,-1,1,4,axes=>[0,0],grid=>[6,5],size=>[400,240]);
-            add_functions($gr, "(x+3)^2 +1 for x in &lt;-5,-3) using color:blue and weight:2");
-            add_functions($gr, "-(x+3)^2 +3 for x in (-3,-1> using color:blue and weight:2");
-            $gr->stamps(closed_circle(-3,2,'blue'));
-            $gr -> lb('reset');
-            for my$i(-4..-1){$gr->lb(new Label($i,0,$i,'black','center','top','large'));};
-            for my$i(1..3){$gr->lb(new Label(0,$i,$i,'black','right','middle','large'));};
             @L=(1,3,Compute("DNE"));
             Context("Interval");
             $cont=Compute("(-inf,-3)U(-3,inf)");
@@ -2706,7 +2729,25 @@
             <p>
               Use the graph of <m>f(x)</m> provided to answer the following.
             </p>
-            <image pg-name="$gr" width="47%"/>
+            <image xml:id="img_02_01_ex_40">
+              <description></description>
+              <latex-image>
+                \begin{tikzpicture}
+                \begin{axis}[
+                      ymin=-1.1,ymax=3.1,%
+                      xmin=-5.1,xmax=0.5,%
+                ]
+                
+                \addplot [firstcurvestyle,domain=-5:-3] {(x+3)^2+1};
+                \addplot [firstcurvestyle,domain=-3:0.5] {-(x+3)^2+3};
+                \filldraw [fill=white] (axis cs:-3,1) circle (1.5pt);
+                \filldraw [fill=white] (axis cs:-3,3) circle (1.5pt);
+                \filldraw [fill=black] (axis cs:-3,2) circle (1.5pt);
+                
+                \end{axis}
+                \end{tikzpicture}
+              </latex-image>
+            </image>
             <instruction>
               If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
               If the limit does not exist, you may type <c>does not exist</c>, or just <c>DNE</c>.

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2377,11 +2377,11 @@
                   \begin{tikzpicture}
                   \begin{axis}[
                   xtick={-2,-1,1,2},
-                  ymin=-5.5,ymax=5.5,%
-                  xmin=-3.1,xmax=3.1,%
+                  ymin=-5.6,ymax=5.6,%
+                  xmin=-3,xmax=3,%
                   ]
             
-                  \addplot [firstcurvestyle,domain=-3.1:3.1,samples=40] {(x-2)*x*(x+2)};
+                  \addplot [firstcurvestyle,domain=-2.5:2.5,samples=40] {(x-2)*x*(x+2)};
                         
                   \end{axis}
                   \end{tikzpicture}
@@ -2410,19 +2410,19 @@
                 <var name="$zer" width="20"/>
               </p>
               <instruction>
-                Enter the set on which <m>g'(x) \lt 0</m> using interval notation.
+                Enter the set on which <m>g^\prime(x) \lt 0</m> using interval notation.
               </instruction>
               <p>
                 <var name="$dec" width="20"/>
               </p>
               <instruction>
-                Enter the set on which <m>g'(x) \gt 0</m> using interval notation.
+                Enter the set on which <m>g^\prime(x) \gt 0</m> using interval notation.
               </instruction>
               <p>
                 <var name="$inc" width="20"/>
               </p>
               <instruction>
-                Enter the set of points where <m>g(x) \gt 0</m> using the syntax <c>{a,b}</c>.
+                Enter the set of points where <m>g^\prime(x) = 0</m> using the syntax <c>{a,b}</c>.
               </instruction>
               <p>
                 <var name="$fla" width="20"/>
@@ -2449,11 +2449,11 @@
                   \begin{tikzpicture}
                   \begin{axis}[
                   xtick={-2,-1,1,2},
-                  ymin=-1,ymax=5,%
+                  ymin=-3,ymax=6,%
                   xmin=-2.8,xmax=2.8,%
                   ]
             
-                  \addplot [firstcurvestyle,domain=-2.6:2.6,samples=50] {(-2)*(x^4/4-x^2/2)+4};
+                  \addplot [firstcurvestyle,domain=-2.2:2.2,samples=50] {(-2)*(x^4/4-x^2/2)+4};
            
                    \end{axis}
                   \end{tikzpicture}
@@ -2486,19 +2486,19 @@
                 <var name="$zer" width="20"/>
               </p>
               <instruction>
-                Enter the set on which <m>g'(x) \lt 0</m> using interval notation.
+                Enter the set on which <m>g^\prime(x) \lt 0</m> using interval notation.
               </instruction>
               <p>
                 <var name="$dec" width="20"/>
               </p>
               <instruction>
-                Enter the set on which <m>g'(x) \gt 0</m> using interval notation.
+                Enter the set on which <m>g^\prime(x) \gt 0</m> using interval notation.
               </instruction>
               <p>
                 <var name="$inc" width="20"/>
               </p>
               <instruction>
-                Enter the set of points where <m>g(x) \gt 0</m> using the syntax <c>{a,b}</c>.
+                Enter the set of points where <m>g^\prime(x) = 0</m> using the syntax <c>{a,b}</c>.
               </instruction>
               <p>
                 <var name="$fla" width="20"/>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -2197,15 +2197,17 @@
           </task>
 
           <task label="ex-deriv-intro-graph-approx-2b">
-            <p>
-              Using the definition of the derivative, find <m>\fp(x)</m>.
-            </p>
-            <p>
-              <var name="$derivative" width="10"/>
-            </p>
-            <p>
-              <var name="$showwork" data="pgml"/>
-            </p>
+            <statement>
+              <p>
+                Using the definition of the derivative, find <m>\fp(x)</m>.
+              </p>
+              <p>
+                <var name="$derivative" width="10"/>
+              </p>
+              <p>
+                <var name="$showwork" data="pgml"/>
+              </p>
+            </statement>
           </task>
 
           <task label="ex-deriv-intro-graph-approx-2c">

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -1582,7 +1582,6 @@
                 accurate to <m>1^\circ</m>.
                 Assume that the triangle formed is a right triangle.
               </p>
-              <!-- <image pg-name="$gr" width="40%"/> -->
               <latex-image>
                 \begin{tikzpicture}
                   \draw [ultra thick] (1,-1) -&#x2D; node [pos=.5,right] { \(l=\mathord{?}\)} (1,1);
@@ -1646,7 +1645,6 @@
                 accurate to <m>1^\circ</m>.
                 Assume that the triangle formed is a right triangle.
               </p>
-              <!-- <image pg-name="$gr" width="40%"/> -->
               <image xml:id="img-ex-diff-approx1" width="60%">
                 <latex-image>
                   \begin{tikzpicture}
@@ -1712,7 +1710,6 @@
                 The measured angle is <m><var name="$theta"/>^\circ</m>,
                 accurate to <m>1^\circ</m>.
               </p>
-              <!-- <image pg-name="$gr" width="40%"/> -->
               <image xml:id="img-ex-diff-approx2" width="60%">
                 <latex-image>
                   \begin{tikzpicture}
@@ -1792,22 +1789,6 @@
               $errU = NumberWithUnits("$err ft");
               Context("Percent");
               $err_pct = Percent("$err/$l");
-              <!-- $gr = init_graph(-1,-1,51,51, size=>[240,240]);
-              $gr->moveTo(0,25);
-              $gr->lineTo(50,0,'black',1,'dashed');
-              $gr->lineTo(50,50,'black',3);
-              $gr->lineTo(0,25,'black',1,'dashed');
-              $gr->moveTo(2,25);
-              $gr->lineTo(50,25,'black',1);
-              $gr->lb( new Label(25,25,$d."'",'black','center','top','large'));
-              $gr->lb( new Label(50,25,' L','black','left','middle','large'));
-              $xfunc = sub { my $t = shift();
-                return 6*cos($t); };
-              $yfunc = sub { my $t = shift();
-                return 25 + 6*sin($t); };
-              $fn = new Fun( $xfunc, $yfunc, $gr );
-              $fn->domain(atan(-0.5),atan(0.5));
-              $fn->color('black'); -->
             </pg-code>
             <statement>
               <p>
@@ -1815,7 +1796,6 @@
                 This time, assume the angle measurement of
                 <m>143^\circ</m> is exact but the measured <m>50'</m> from the wall is accurate to <m>6''</m>.
               </p>
-              <!-- <image pg-name="$gr" width="40%"/> -->
               <image xml:id="img-ex-diff-approx3" width="60%">
                 <latex-image>
                   \begin{tikzpicture}

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1077,30 +1077,6 @@
         <exercise label="ex-graph-extreme-values-identify-points-1">
           <webwork xml:id="webwork-ex-graph-extreme-values-identify-points-1">
             <pg-code>
-              $gr=init_graph(-0.5,-2.5,6.5,3.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(2,4,6){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-2,2){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              @x=(0.1,1,2,3,4,5,6);
-              @y=(-2,3,1,2,1,-1,2.5);
-              for my $i(0..2){
-                $left[$i]=Formula("(x-$x[2*$i+1])^2/($x[2*$i]-$x[2*$i+1])^2*($y[2*$i]-$y[2*$i+1])+$y[2*$i+1]");
-                $right[$i]=Formula("(x-$x[2*$i+1])^2/($x[2*$i+2]-$x[2*$i+1])^2*($y[2*$i+2]-$y[2*$i+1])+$y[2*$i+1]");
-                add_functions($gr,"$left[$i] for x in &lt;$x[2*$i],$x[2*$i+1]> using color:blue and weight:2");
-                add_functions($gr,"$right[$i] for x in &lt;$x[2*$i+1],$x[2*$i+2]> using color:blue and weight:2");
-              };
-              for my $i (0) {$gr->stamps(open_circle($x[$i],$y[$i],'blue'));
-                $gr->lb(new Label($x[$i],$y[$i],$ALPHABET[$i],'black','left','top','large'));
-              };
-              for my $i (3) {$gr->stamps(open_circle($x[$i],$y[$i],'blue'));
-                $gr->lb(new Label($x[$i],$y[$i],$ALPHABET[$i],'black','left','bottom','large'));
-              };
-              for my $i (1,4,6) {$gr->stamps(closed_circle($x[$i],$y[$i],'blue'));
-                $gr->lb(new Label($x[$i],$y[$i],$ALPHABET[$i],'black','left','bottom','large'));
-              };
-              for my $i (2,5) {$gr->stamps(closed_circle($x[$i],$y[$i],'blue'));
-                $gr->lb(new Label($x[$i],$y[$i],$ALPHABET[$i],'black','left','top','large'));
-              };
               for my $A ('A'..'G') {Context()->strings->add($A=>{})};
               $absmax = List("B");
               $absmin = List("None");
@@ -1108,7 +1084,30 @@
               $relmin = List("C","F");
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_06">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=-2.5,ymax=3.5,%
+                        xmin=-.5,xmax=6.5,%
+                  ]
+                  
+                  \draw [firstcurvestyle] (axis cs:.1,-2) parabola [bend at end] (axis cs:1,3) parabola (axis cs:2,1) parabola [bend at end] (axis cs:3,2) parabola (axis cs:4,1) parabola [bend at end] (axis cs:5,-1) parabola (axis cs:6,2.5);
+                  
+                  \draw [firstcolor] (axis cs: .1,-2) node [black,right] {\(A\)} circle (1.5pt) 
+                                          (axis cs:3,2) node [above,black] {\(D\)} circle (1.5pt);
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,3) node [above,black] {\(B\)} circle (1.5pt) 
+                                (axis cs:2,1) node [below,black] {\(C\)} circle (1.5pt)
+                                (axis cs:4,1) node [right,black] {\(E\)} circle (1.5pt)
+                                (axis cs:5,-1) node [below,black] {\(F\)} circle (1.5pt)
+                                (axis cs:6,2.5) node [left,black] {\(G\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter the <em>absolute maxima</em> points here, using commas to separate them if there is more than one. If there are none, enter <c>NONE</c>.
               </instruction>
@@ -1140,23 +1139,6 @@
         <exercise label="ex-graph-extreme-values-identify-points-2">
           <webwork xml:id="webwork-ex-graph-extreme-values-identify-points-2">
             <pg-code>
-              $gr=init_graph(-0.5,-2.5,5.5,2.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(2,4){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-2,2){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              @x=(1,2,3,4,5);
-              @y=(-2,1,2,1,-1);
-              $f[0]=Formula("(x-$x[0])^2/($x[1]-$x[0])^2*($y[1]-$y[0])+$y[0]");
-              $f[1]=Formula("(x-$x[1])/($x[2]-$x[1])*($y[2]-$y[1])+$y[1]");
-              $f[2]=Formula("(x-$x[3])^2/($x[2]-$x[3])^2*($y[2]-$y[3])+$y[3]");
-              $f[3]=Formula("(x-$x[3])/($x[4]-$x[3])*($y[4]-$y[3])+$y[3]");
-              for my $i(0..3) {add_functions($gr,"$f[$i] for x in &lt;$x[$i],$x[$i+1]> using color:blue and weight:2");};
-              for my $i (0,1,2) {$gr->stamps(closed_circle($x[$i],$y[$i],'blue'));
-                $gr->lb(new Label($x[$i],$y[$i],$ALPHABET[$i],'black','right','bottom','large'));
-              };
-              for my $i (3,4) {$gr->stamps(closed_circle($x[$i],$y[$i],'blue'));
-                $gr->lb(new Label($x[$i],$y[$i],$ALPHABET[$i],'black','left','bottom','large'));
-              };
               for my $A ('A'..'E') {Context()->strings->add($A=>{})};
               $absmax = List("C");
               $absmin = List("A");
@@ -1164,7 +1146,30 @@
               $relmin = List("A");
             </pg-code>
             <statement>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_07">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=-2.5,ymax=2.5,%
+                        xmin=-.5,xmax=5.5,%
+                  ]
+                  
+                  \draw [firstcurvestyle] (axis cs:1,-2)	parabola 	(axis cs:2,1) 
+                                                                  -- 	(axis cs:3,2) 
+                                                            parabola [bend at end] (axis cs:4,1) 
+                                                            -- (axis cs:5,-1);
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,-2) node [above,black] {\(A\)} circle (1.5pt) 
+                                (axis cs:2,1) node [left,black] {\(B\)} circle (1.5pt)
+                                (axis cs:3,2) node [above,black] {\(C\)} circle (1.5pt)
+                                (axis cs:4,1) node [right,black] {\(D\)} circle (1.5pt)
+                                (axis cs:5,-1) node [below,black] {\(E\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter the absolute maxima points here, using commas to separate them if there is more than one. If there are none, enter <c>NONE</c>.
               </instruction>
@@ -1204,14 +1209,7 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-1">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-1">
             <pg-code>
-              $gr=init_graph(-5.5,-0.5,5.5,2.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-5,5){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(1,2){$gr->moveTo(-0.19,$i);$gr->lineTo(0.19,$i,'black',2);$gr->lb(new Label(-0.2,$i,$i,'black','right','middle','large'));};
               $f=Formula("2/(x^2+1)");
-              add_functions($gr,"$f for x in &lt;-5,5> using color:blue and weight:2");
-              $gr->stamps(closed_circle(0,2,'blue'));
-              $gr->lb(new Label(0,2,'(0,2)','black','left','bottom','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1219,7 +1217,23 @@
               <p>
                 <m>f(x) = <var name="$f"/></m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_08">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=-.5,ymax=2.5,%
+                        xmin=-5.5,xmax=5.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle] {2/((x^2+1))};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,2) node [above right,black] {\((0,2)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(0)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1233,16 +1247,7 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-2">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-2">
             <pg-code>
-              $gr=init_graph(-4,-1,4,6.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-2,2){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(2,4,6){$gr->moveTo(-0.19,$i);$gr->lineTo(0.19,$i,'black',2);$gr->lb(new Label(-0.2,$i,$i,'black','right','middle','large'));};
               $f=Formula("x^2*sqrt(6-x^2)");
-              add_functions($gr,"$f for x in &lt;-2.449489,2.449489> using color:blue and weight:2");
-              $gr->stamps(closed_circle(0,0,'blue'));
-              $gr->lb(new Label(0,0,'(0,0)','black','left','top','large'));
-              $gr->stamps(closed_circle(2,5.656854,'blue'));
-              $gr->lb(new Label(2,4*sqrt(2),'(2,4sqrt(2))','black','center','bottom','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1250,7 +1255,24 @@
               <p>
                 <m>f(x) = <var name="$f"/></m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_09">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                        ymin=-.9,ymax=6.5,%
+                        xmin=-3.5,xmax=3.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=-2.44948:2.449489743,samples=100] {x^2*sqrt(6-x^2)};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 2,5.66) node [left,black] {\((2,4\sqrt{2})\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(0)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1270,16 +1292,7 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-3">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-3">
             <pg-code>
-              $gr=init_graph(-0.5,-1.4,6.5,1.4,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(2,4,6){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(-1,1){$gr->moveTo(-0.19,$i);$gr->lineTo(0.19,$i,'black',2);$gr->lb(new Label(-0.2,$i,$i,'black','right','middle','large'));};
               $f=Formula("sin(x)");
-              add_functions($gr,"$f for x in &lt;0,6.2831852> using color:blue and weight:2");
-              $gr->stamps(closed_circle(1.570796,1,'blue'));
-              $gr->lb(new Label(pi/2,1,'(pi/2,1)','black','left','bottom','large'));
-              $gr->stamps(closed_circle(4.712389,-1,'blue'));
-              $gr->lb(new Label(3*pi/2,-1,'(3pi/2,-1)','black','right','top','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1287,7 +1300,24 @@
               <p>
                 <m>f(x) = <var name="$f"/></m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_10">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-1.5,ymax=1.5,%
+                    xmin=-.5,xmax=6.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=0:6.28] {sin(deg(x))};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1.57,1) node [above,black] {\((\pi/2,1)\)} circle (1.5pt);
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 4.71,-1) node [below,black] {\((3\pi/2,-1)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(\pi/2)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1307,18 +1337,7 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-4">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-4">
             <pg-code>
-              $gr=init_graph(-2.5,-2,4.5,11,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-2,2,4){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(5,10){$gr->moveTo(-0.09,$i);$gr->lineTo(0.09,$i,'black',2);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));};
               $f=Formula("x^2*sqrt(4-x)");
-              add_functions($gr,"$f for x in &lt;-2,3.999999> using color:blue and weight:2");
-              $gr->stamps(closed_circle(0,0,'blue'));
-              $gr->lb(new Label(0,0,'(0,0)','black','left','top','large'));
-              $gr->stamps(closed_circle(16/5,512*sqrt(5)/125,'blue'));
-              $gr->lb(new Label(16/5,512*sqrt(5)/125,'(16/5,512sqrt(5)/125)','black','right','bottom','large'));
-              $gr->stamps(closed_circle(4,0,'blue'));
-              $gr->lb(new Label(4,0,'(4,0)','black','right','bottom','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1326,7 +1345,25 @@
               <p>
                 <m>f(x) = <var name="$f"/></m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_11">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-1.5,ymax=11,%
+                    xmin=-2.5,xmax=4.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=-2:4] {x^2*sqrt(4-x)};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 3.2,9.16) node [above,black] {\(\left(\frac{16}{5},\frac{512}{25\sqrt{5}}\right)\)} circle (1.5pt);
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 4,0) node [above left,black] {\((4,0)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(0)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1352,19 +1389,8 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-5">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-5">
             <pg-code>
-              $gr=init_graph(-1,-0.5,11,6.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(5,10){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(2,4,6){$gr->moveTo(-0.09,$i);$gr->lineTo(0.09,$i,'black',2);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));};
               Context()->flags->set(reduceConstants=>0);
               $f=Formula("1+(x-2)^(2/3)/x");
-              $g=Formula("1+(2-x)^(2/3)/x");
-              add_functions($gr,"$g for x in &lt;0.1,2> using color:blue and weight:2");
-              add_functions($gr,"$f for x in &lt;2,11> using color:blue and weight:2");
-              $gr->stamps(closed_circle(2,1,'blue'));
-              $gr->lb(new Label(2,1,'(2,1)','black','left','top','large'));
-              $gr->stamps(closed_circle(6,1+2**(1/3)/3,'blue'));
-              $gr->lb(new Label(6,1+2**(1/3)/3,'(6,1+cbrt(2)/3)','black','center','top','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1372,7 +1398,25 @@
               <p>
                 <m>f(x) = <var name="$f"/></m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_12">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-.5,ymax=6.5,%
+                    xmin=-1,xmax=11,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=.2:11,samples=100] {(((x-2)^2)^(1/3))/x+1};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 2,1) node [below,black] {\((2,1)\)} circle (1.5pt);
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 6,1.42) node [above,black] {\(\left(6,1+\frac{\sqrt[3]{2}}{3}\right)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(2)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1392,21 +1436,9 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-6">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-6">
             <pg-code>
-              $gr=init_graph(-2.5,-0.5,2.5,3.5,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-2,2){$gr->moveTo($i,-0.04);$gr->lineTo($i,0.04,'black',2);$gr->lb(new Label($i,-0.05,$i,'black','center','top','large'));};
-              for my$i(1,2,3){$gr->moveTo(-0.09,$i);$gr->lineTo(0.09,$i,'black',2);$gr->lb(new Label(-0.1,$i,$i,'black','right','middle','large'));};
               Context()->flags->set(reduceConstants=>0);
               parser::Root->Enable;
               $f=Formula("root(3,x^4-2x^2+1)");
-              $g=Formula("-root(3,-(x^4-2x^2+1))");
-              add_functions($gr,"$f for x in &lt;-2.5,-1> using color:blue and weight:2");
-              add_functions($gr,"$g for x in &lt;-1,1> using color:blue and weight:2");
-              add_functions($gr,"$f for x in &lt;1,2.5> using color:blue and weight:2");
-              $gr->stamps(closed_circle(-1,0,'blue'));
-              $gr->lb(new Label(-1,0,'(-1,0)','black','left','top','large'));
-              $gr->stamps(closed_circle(1,0,'blue'));
-              $gr->lb(new Label(1,0,'(1,0)','black','left','top','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1414,7 +1446,28 @@
               <p>
                 <m>f(x) = <var name="$f"/></m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_13">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                  xtick={-2,-1,1,2},
+                  ymin=-.5,ymax=3.5,%
+                  xmin=-2.5,xmax=2.5,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=-2:-1,samples=25] {(x^4-2*x^2+1)^(1/3)};
+                  \addplot [firstcurvestyle,domain=-1:1,samples=50] {(x^4-2*x^2+1)^(1/3)};
+                  \addplot [firstcurvestyle,domain=1:2,samples=25] {(x^4-2*x^2+1)^(1/3)};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,0) node [above right,black] {\((1,0)\)} circle (1.5pt);
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: -1,0) node [above left,black] {\((-1,0)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(-1)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1434,16 +1487,6 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-7">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-7">
             <pg-code>
-              $gr=init_graph(-1.1,-0.6,1.1,1.1,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.02);$gr->lineTo($i,0.02,'black',2);$gr->lb(new Label($i,-0.03,$i,'black','center','top','large'));};
-              for my$i(-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              $f=Formula("x^2");
-              $g=Formula("x^5");
-              add_functions($gr,"$f for x in &lt;-1,0> using color:blue and weight:2");
-              add_functions($gr,"$g for x in &lt;0,1> using color:blue and weight:2");
-              $gr->stamps(closed_circle(0,0,'blue'));
-              $gr->lb(new Label(0,0,'(0,0)','black','left','top','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1451,7 +1494,24 @@
               <p>
                 <m>f(x) = \begin{cases}x^2,\amp x\leq0\\x^5,\amp x\gt0\end{cases}</m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_14">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-.5,ymax=1.1,%
+                    xmin=-1.1,xmax=1.1,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=-1:0] {x^2};
+                  \addplot [firstcurvestyle,domain=0:1] {x^5};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(0)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>
@@ -1465,16 +1525,6 @@
         <exercise label="ex-graph-extreme-values-evaluate-fprime-8">
           <webwork xml:id="webwork-ex-graph-extreme-values-evaluate-fprime-8">
             <pg-code>
-              $gr=init_graph(-1.1,-0.6,1.1,1.1,axes=>[0,0],size=>[282,282]);
-              $gr->lb('reset');
-              for my$i(-1,-0.5,0.5,1){$gr->moveTo($i,-0.02);$gr->lineTo($i,0.02,'black',2);$gr->lb(new Label($i,-0.03,$i,'black','center','top','large'));};
-              for my$i(-0.5,0.5,1){$gr->moveTo(-0.04,$i);$gr->lineTo(0.04,$i,'black',2);$gr->lb(new Label(-0.05,$i,$i,'black','right','middle','large'));};
-              $f=Formula("x^2");
-              $g=Formula("x");
-              add_functions($gr,"$f for x in &lt;-1,0> using color:blue and weight:2");
-              add_functions($gr,"$g for x in &lt;0,1> using color:blue and weight:2");
-              $gr->stamps(closed_circle(0,0,'blue'));
-              $gr->lb(new Label(0,0,'(0,0)','black','left','top','large'));
               $zero=Real(0);
               $dne = String("DNE");
             </pg-code>
@@ -1482,7 +1532,24 @@
               <p>
                 <m>f(x) = \begin{cases}x^2,\amp x\leq0\\x,\amp x\gt0\end{cases}</m>
               </p>
-              <image pg-name="$gr"/>
+              <image xml:id="img_03_01_ex_15">
+                <description></description>
+                <latex-image>
+                  \begin{tikzpicture}
+                  \begin{axis}[
+                    ymin=-.5,ymax=1.1,%
+                    xmin=-1.1,xmax=1.1,%
+                  ]
+                  
+                  \addplot [firstcurvestyle,domain=-1:0] {x^2};
+                  \addplot [firstcurvestyle,domain=0:1] {x};
+                  
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
+                  
+                  \end{axis}
+                  \end{tikzpicture}
+                </latex-image>
+              </image>
               <instruction>
                 Enter <m>f^{\prime}(0)</m>. If the derivative does not exist at the indicated point, enter <c>DNE</c> for <q>does not exist</q>.
               </instruction>

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1095,7 +1095,7 @@
                   
                   \draw [firstcolor] (axis cs:.1,-2) parabola [bend at end] (axis cs:1,3) parabola (axis cs:2,1) parabola [bend at end] (axis cs:3,2) parabola (axis cs:4,1) parabola [bend at end] (axis cs:5,-1) parabola (axis cs:6,2.5);
                   
-                  \draw [firstcolor] (axis cs: .1,-2) node [black,right] {\(A\)} circle (1.5pt) 
+                  \draw [firstcolor,fill=white] (axis cs: .1,-2) node [black,right] {\(A\)} circle (1.5pt) 
                                           (axis cs:3,2) node [above,black] {\(D\)} circle (1.5pt);
                   
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,3) node [above,black] {\(B\)} circle (1.5pt) 
@@ -1226,7 +1226,7 @@
                         xmin=-5.5,xmax=5.5,%
                   ]
                   
-                  \addplot [firstcurvestyle] {2/((x^2+1))};
+                  \addplot [firstcurvestyle,samples=100] {2/((x^2+1))};
                   
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,2) node [above right,black] {\((0,2)\)} circle (1.5pt);
                   
@@ -1350,11 +1350,11 @@
                 <latex-image>
                   \begin{tikzpicture}
                   \begin{axis}[
-                    ymin=-1.5,ymax=11,%
+                    ymin=-1.8,ymax=11,%
                     xmin=-2.5,xmax=4.5,%
                   ]
                   
-                  \addplot [firstcurvestyle,domain=-2:4] {x^2*sqrt(4-x)};
+                  \addplot [firstcurvestyle,domain=-2:4.2,samples=100] {x^2*sqrt(4-x)};
                   
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 3.2,9.16) node [above,black] {\(\left(\frac{16}{5},\frac{512}{25\sqrt{5}}\right)\)} circle (1.5pt);
@@ -1503,8 +1503,8 @@
                     xmin=-1.1,xmax=1.1,%
                   ]
                   
-                  \addplot [firstcurvestyle,domain=-1:0] {x^2};
-                  \addplot [firstcurvestyle,domain=0:1] {x^5};
+                  \addplot [firstcurvestyle,{Kite}-,domain=-1:0] {x^2};
+                  \addplot [firstcurvestyle,-{Kite},domain=0:1] {x^5};
                   
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
                   
@@ -1541,8 +1541,8 @@
                     xmin=-1.1,xmax=1.1,%
                   ]
                   
-                  \addplot [firstcurvestyle,domain=-1:0] {x^2};
-                  \addplot [firstcurvestyle,domain=0:1] {x};
+                  \addplot [firstcurvestyle,{Kite}-,domain=-1:0] {x^2};
+                  \addplot [firstcurvestyle,-{Kite},domain=0:1] {x};
                   
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
                   

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -1093,7 +1093,7 @@
                         xmin=-.5,xmax=6.5,%
                   ]
                   
-                  \draw [firstcurvestyle] (axis cs:.1,-2) parabola [bend at end] (axis cs:1,3) parabola (axis cs:2,1) parabola [bend at end] (axis cs:3,2) parabola (axis cs:4,1) parabola [bend at end] (axis cs:5,-1) parabola (axis cs:6,2.5);
+                  \draw [firstcolor] (axis cs:.1,-2) parabola [bend at end] (axis cs:1,3) parabola (axis cs:2,1) parabola [bend at end] (axis cs:3,2) parabola (axis cs:4,1) parabola [bend at end] (axis cs:5,-1) parabola (axis cs:6,2.5);
                   
                   \draw [firstcolor] (axis cs: .1,-2) node [black,right] {\(A\)} circle (1.5pt) 
                                           (axis cs:3,2) node [above,black] {\(D\)} circle (1.5pt);
@@ -1155,7 +1155,7 @@
                         xmin=-.5,xmax=5.5,%
                   ]
                   
-                  \draw [firstcurvestyle] (axis cs:1,-2)	parabola 	(axis cs:2,1) 
+                  \draw [firstcolor] (axis cs:1,-2)	parabola 	(axis cs:2,1) 
                                                                   -- 	(axis cs:3,2) 
                                                             parabola [bend at end] (axis cs:4,1) 
                                                             -- (axis cs:5,-1);

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -875,43 +875,40 @@
             </task>
           <!--</webwork>-->
         </exercise>
-        <!--TODO: the webwork code here does not display well in static-->
+        
         <exercise label="ex-iterated-integrals-evaluate-2">
-          <!-- <webwork xml:id="webwork-ex-iterated-integrals-evaluate-2">
+          <webwork xml:id="webwork-ex-iterated-integrals-evaluate-2">
 
               <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $a=Compute("2+pi^2cos(y)");
                 $b=Formula("pi^2+pi");
-              </pg-code> -->
+              </pg-code>
 
               <task label="ex-iterated-integrals-evaluate-2a">
                 <statement>
                   <p>
-                    <m>\ds \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx=</m><var name="$a" width="20"/>
+                    <m>\ds \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx</m>
+                  </p>
+
+                  <p>
+                    <var name="$a" width="20"/>
                   </p>
                 </statement>
-                <answer>
-                  <p>
-                    <m>2+\pi^2\cos(y)</m>
-                  </p>
-                </answer>
               </task>
 
               <task label="ex-iterated-integrals-evaluate-2b">
                 <statement>
                   <p>
-                    <m>\ds \int_{0}^{\pi/2} \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx\,dy=</m><var name="$b" width="20"/>
+                    <m>\ds \int_{0}^{\pi/2} \int_0^{\pi} (2x\cos(y) + \sin(x) )\,dx\,dy</m>
+                  </p>
+                  <p>
+                    <var name="$b" width="20"/>
                   </p>
                 </statement>
-                <answer>
-                  <p>
-                    <m>\pi^2+\pi</m>
-                  </p>
-                </answer>
               </task>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-3">
@@ -947,40 +944,37 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-4">
-          <!-- <webwork xml:id="webwork-ex-iterated-integrals-evaluate-4">
+          <webwork xml:id="webwork-ex-iterated-integrals-evaluate-4">
 
               <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $a=Compute("y^4/2-y^3+y^2/2");
                 $b=Formula("8/15");
-              </pg-code> -->
+              </pg-code>
 
               <task label="ex-iterated-integrals-evaluate-4a">
                 <statement>
                   <p>
-                    <m>\ds \int_y^{y^2} (x-y)\,dx=</m><var name="$a" width="20"/>
+                    <m>\ds \int_y^{y^2} (x-y)\,dx</m>
+                  </p>
+                  <p>
+                    <var name="$a" width="20"/>
                   </p>
                 </statement>
-                <answer>
-                  <p>
-                    <m>y^4/2-y^3+y^2/2</m>
-                  </p>
-                </answer>
               </task>
 
               <task label="ex-iterated-integrals-evaluate-4b">
                 <statement>
                   <p>
-                    <m>\ds \int_{-1}^1\int_y^{y^2} (x-y)\,dx\,dy=</m><var name="$b" width="20"/>
+                    <m>\ds \int_{-1}^1\int_y^{y^2} (x-y)\,dx\,dy</m>
+                  </p>
+                  <p>
+                    <var name="$b" width="20"/>
                   </p>
                 </statement>
-                <answer>
-                  <p>
-                    <m>8/15</m>
-                  </p>
-                </answer>
               </task>
+          </webwork>
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-5">
@@ -1017,41 +1011,37 @@
         </exercise>
 
         <exercise label="ex-iterated-integrals-evaluate-6">
-          <!-- <webwork xml:id="webwork-ex-iterated-integrals-evaluate-6">
+          <webwork xml:id="webwork-ex-iterated-integrals-evaluate-6">
 
               <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
                 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
                 $a=Compute("x/(1+x^2)");
                 $b=Formula("1/2 ln(5/2)");
-              </pg-code> -->
+              </pg-code>
 
               <task label="ex-iterated-integrals-evaluate-6a">
                 <statement>
                   <p>
-                    <m>\ds \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy=</m><var name="$a" width="20"/>
+                    <m>\ds \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy</m>
+                  </p>
+                  <p>
+                    <var name="$a" width="20"/>
                   </p>
                 </statement>
-                <answer>
-                  <p>
-                    <m>\frac{x}{1+x^2}</m>
-                  </p>
-                </answer>
               </task>
 
               <task label="ex-iterated-integrals-evaluate-6b">
                 <statement>
                   <p>
-                    <m>\ds \int_1^2 \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy\,dx=</m><var name="$b" width="20"/>
+                    <m>\ds \int_1^2 \int_0^{x} \left(\frac{1}{1+x^2}\right)\,dy\,dx</m>
+                  </p>
+                  <p>
+                    <var name="$b" width="20"/>
                   </p>
                 </statement>
-                <answer>
-                  <p>
-                    <m>\frac12 \ln\left(\frac52\right)</m>
-                  </p>
-                </answer>
               </task>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
 
       </exercisegroup>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1468,7 +1468,6 @@
                   \end{tikzpicture}
                 </latex-image>
               </image>
-              <image pg-name="$graph"/>
               <p>
                 <var name="$answer" form="popup"/>
               </p>

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -3237,7 +3237,7 @@
         </introduction>
   <!-- Exercise 24 -->
         <exercise label="ex-numerical-integration-area-1">
-          <!-- <webwork xml:id="webwork-ex-numerical-integration-area-1">
+          <webwork xml:id="webwork-ex-numerical-integration-area-1">
               <pg-code>
                 $a = 0;
                 $b = 6;
@@ -3255,7 +3255,7 @@
                 $area = NumberWithUnits("$area cm^2");
                 $area_ft = NumberWithUnits("$area_ft ft^2");
               </pg-code>
-            -->
+           
               <statement>
                 <!-- START figures/fig_05_05_ex_01.tex -->
                   <image xml:id="img_05_05_ex_01" width="47%">
@@ -3291,16 +3291,22 @@
                     </latex-image>
                   </image>
                 <!-- figures/fig_05_05_ex_01.tex END -->
+                <instruction>
+                  Enter your answer using the metric measurements.
+                </instruction>
                 <p>
-                  Scenario (a): <fillin/><!--var name="$area" width="20"/>-->
+                  <var name="$area" width="20"/>
                 </p>
                 <!-- 30.8667 cm^2 -->
+                <instruction>
+                  Enter your answer using the imperial measurements.
+                </instruction>
                 <p>
-                  Scenario (b): <fillin/><!--<var name="$area_ft" width="20"/>-->
+                  <var name="$area_ft" width="20"/>
                 </p>
                 <!-- 308667 ft^2 -->
               </statement>
-          <!-- </webwork> -->
+          </webwork>
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-numerical-integration-area-2">

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -3258,7 +3258,7 @@
            
               <statement>
                 <!-- START figures/fig_05_05_ex_01.tex -->
-                  <image xml:id="img_05_05_ex_01" width="47%">
+                  <image xml:id="img_05_05_ex_01">
                     <description></description>
                     <latex-image>
 
@@ -3310,7 +3310,7 @@
         </exercise>
   <!-- Exercise 25 -->
         <exercise label="ex-numerical-integration-area-2">
-          <!--<webwork xml:id="webwork-ex-numerical-integration-area-2">
+          <webwork xml:id="webwork-ex-numerical-integration-area-2">
               <pg-code>
                 $a = 0;
                 $b = 6;
@@ -3328,10 +3328,10 @@
                 $area = NumberWithUnits("$area cm^2");
                 $area_ft = NumberWithUnits("$area_ft ft^2");
               </pg-code>
-            -->
+           
               <statement>
                 <!-- START figures/fig_05_05_ex_02.tex -->
-                  <image xml:id="img_05_05_ex_02" width="47%">
+                  <image xml:id="img_05_05_ex_02">
                     <description></description>
                     <latex-image>
 
@@ -3364,12 +3364,18 @@
                     </latex-image>
                   </image>
                 <!-- figures/fig_05_05_ex_02.tex END -->
+                <instruction>
+                  Enter your answer using the metric measurements.
+                </instruction>
                 <p>
-                  Scenario (a): <fillin/><!--<var name="$area" width="20"/>-->
+                  <var name="$area" width="20"/>
                 </p>
                 <!-- 25.0667 cm^2 -->
+                <instruction>
+                  Enter your answer using the imperial measurements.
+                </instruction>
                 <p>
-                  Scenario (b): <fillin/><!--<var name="$area_ft" width="20"/>-->
+                  <var name="$area_ft" width="20"/>
                 </p>
                 <!-- 250667 ft^2 -->
               </statement>

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -2042,7 +2042,7 @@
                   <latex-image>
                     \begin{tikzpicture}
                     \draw [dashed,gray] (-3.1,0) -- (0,0);
-                    \draw[thick,->,>=stealth] (0,0) node [below] {$O$} -- (3.5,0) ;
+                    \draw[thick,->,>=stealth] (0,0) node [below] {\(O\)} -- (3.5,0) ;
                     \filldraw (0,0) circle (1.5pt);
                     \foreach \x in {1,2,3}
                     {\draw (0,0) circle (\x cm);

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -2021,45 +2021,15 @@
         <exercise label="ex-polar-coordinates-two-ways-2">
           <webwork xml:id="webwork-ex-polar-coordinates-two-ways-2">
               <pg-code>
-                $gr = init_graph(-3.5,-3.5,3.5,3.5,size=>[400,400]);
-                $gr->moveTo(0,0); $gr->arrowTo(3.4,0,'black',1);
                 Context()->variables->are(t=>"Real");
-                $x = Formula("cos(t)");
-                $y = Formula("sin(t)");
-                $c[0] = new Fun( $x->perlFunction, $y->perlFunction, $gr );
-                $c[0]->domain(0,6.28318);
-                $c[0]->steps(90);
-                $c[0]->weight(1);
-                $c[0]->color('black');
-                $c[1] = new Fun( (2*$x)->perlFunction, (2*$y)->perlFunction, $gr );
-                $c[1]->domain(0,6.28318);
-                $c[1]->steps(90);
-                $c[1]->weight(1);
-                $c[1]->color('black');
-                $c[2] = new Fun( (3*$x)->perlFunction, (3*$y)->perlFunction, $gr );
-                $c[2]->domain(0,6.28318);
-                $c[2]->steps(90);
-                $c[2]->weight(1);
-                $c[2]->color('black');
-                for my$i(2,3,4,6,8,9,10,12,14,15,16,18,20,21,22)
-                  {$gr->moveTo(0,0); $gr->lineTo(3*cos($i*pi/12),3*sin($i*pi/12),'gray',1,'dashed');};
-                for my$i(1,2,3)
-                  {$gr->lb( new Label($i+0.04,0,$i,'black','left','top'));};
-                $gr->lb( new Label(0,0,'O','black','center','top'));
-                $gr->lb( new Label(2*cos(pi()/6),2*sin(pi()/6)-0.04,'A','black','center','top'));
-                $gr->lb( new Label(cos(-pi()/3),sin(-pi()/3)-0.04,'B','black','center','top'));
-                $gr->lb( new Label(2*cos(3*pi()/4),2*sin(3*pi()/4)-0.04,'C','black','center','top'));
-                $gr->lb( new Label(2.5*cos(pi()),2.5*sin(pi())-0.04,'D','black','center','top'));
-                $gr->stamps( closed_circle(2*cos(pi()/6),2*sin(pi()/6),'black') );
-                $gr->stamps( closed_circle(cos(-pi()/3),sin(-pi()/3),'black') );
-                $gr->stamps( closed_circle(2*cos(3*pi()/4),2*sin(3*pi()/4),'black') );
-                $gr->stamps( closed_circle(2.5*cos(pi()),2.5*sin(pi()),'black') );
-
-                @r=(2,1,2,2.5);
-                @s=map{-$_}(@r);
-                Context()->flags->set(reduceConstants=>0);
-                @t=(Formula("pi/6"),Formula("-pi/3"),Formula("(3pi)/4"),Formula("pi"));
-                @u=(Formula("(-5pi)/6"),Formula("(2pi)/3"),Formula("(-pi)/4"),Formula("0"));
+                @A=(Compute("(2,pi/6)"),Compute("(-2,-(5*pi)/6)"));
+                $Alist=List($A[0],$A[1]);
+                @B=(Compute("(1,-pi/3)"),Compute("(-1,(2*pi)/3)"));
+                $Blist=List($B[0],$B[1]);
+                @C=(Compute("(2,(3*pi)/4)"),Compute("(-2,-pi/4)"));
+                $Clist=List($C[0],$C[1]);
+                @D=(Compute("(5/2,pi)"),Compute("(5/2,-pi)"));
+                $Dlist=List($D[0],$D[1]);
               </pg-code>
               <statement>
                 <p>
@@ -2067,69 +2037,57 @@
                   where <m>-\pi\lt \theta\leq \pi</m>.
                 </p>
 
-                <image pg-name="$gr" width="47%"/>
+                <image xml:id="img_polar-two-ways-2">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+                    \draw [dashed,gray] (-3.1,0) -- (0,0);
+                    \draw[thick,->,>=stealth] (0,0) node [below] {$O$} -- (3.5,0) ;
+                    \filldraw (0,0) circle (1.5pt);
+                    \foreach \x in {1,2,3}
+                    {\draw (0,0) circle (\x cm);
+                    \draw (\x,0) node [below right] {\x};
+                    }
+                    \foreach \x in {30,45,60,90,120,135,150}
+                    {\draw [rotate=\x,dashed,gray] (-3.1,0) -- (3.1,0);
+                    }
+                    \filldraw (xyz polar cs: angle=30,radius=2) circle (2pt) node [above] {\(A\)}
+                          (xyz polar cs: angle=-60,radius=1)circle (2pt) node [below] {\(B\)}
+                          (xyz polar cs: angle=135,radius=2)circle (2pt) node [right] {\(C\)}
+                          (xyz polar cs: angle=180,radius=2.5)circle (2pt) node [below] {\(D\)};
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
 
-                <tabular>
-                  <col right="minor"/>
-                  <col halign="center"/>
-                  <col right="minor" halign="center"/>
-                  <col halign="center"/>
-                  <col halign="center"/>
-                  <row bottom="medium">
-                    <cell>Point</cell>
-                    <cell><m>(positive) r_1</m></cell>
-                    <cell><m>\theta_1</m></cell>
-                    <cell><m>r_2</m></cell>
-                    <cell><m>(negative) \theta_2</m></cell>
-                  </row>
-                  <row>
-                    <cell><m>A</m></cell>
-                    <cell><var name="$r[0]" width="5"/></cell>
-                    <cell><var name="$t[0]" width="5"/></cell>
-                    <cell><var name="$s[0]" width="5"/></cell>
-                    <cell><var name="$u[0]" width="5"/></cell>
-                  </row>
-                  <row>
-                    <cell><m>B</m></cell>
-                    <cell><var name="$r[1]" width="5"/></cell>
-                    <cell><var name="$t[1]" width="5"/></cell>
-                    <cell><var name="$s[1]" width="5"/></cell>
-                    <cell><var name="$u[1]" width="5"/></cell>
-                  </row>
-                  <row>
-                    <cell><m>C</m></cell>
-                    <cell><var name="$r[2]" width="5"/></cell>
-                    <cell><var name="$t[2]" width="5"/></cell>
-                    <cell><var name="$s[2]" width="5"/></cell>
-                    <cell><var name="$u[2]" width="5"/></cell>
-                  </row>
-                  <row>
-                    <cell><m>D</m></cell>
-                    <cell><var name="$r[3]" width="5"/></cell>
-                    <cell><var name="$t[3]" width="5"/></cell>
-                    <cell><var name="$s[3]" width="5"/></cell>
-                    <cell><var name="$u[3]" width="5"/></cell>
-                  </row>
-                </tabular>
+                <instruction>
+                  Enter two sets of coordinates for the point <m>A</m>. Separate your answers by a comma.
+                </instruction>
+                <p>
+                  <var name="$Alist" width="30"/>
+                </p>
 
+                <instruction>
+                  Enter two sets of coordinates for the point <m>B</m>. Separate your answers by a comma.
+                </instruction>
+                <p>
+                  <var name="$Blist" width="30"/>
+                </p>
+
+                <instruction>
+                  Enter two sets of coordinates for the point <m>C</m>. Separate your answers by a comma.
+                </instruction>
+                <p>
+                  <var name="$Clist" width="30"/>
+                </p>
+
+                <instruction>
+                  Enter two sets of coordinates for the point <m>D</m>. Separate your answers by a comma.
+                </instruction>
+                <p>
+                  <var name="$Dlist" width="30"/>
+                </p>
               </statement>
-              <solution>
-                <p>
-                  <m>A=P(2,\pi/6)</m> and <m>P(-2,-5\pi/6)</m>;
-                </p>
-
-                <p>
-                  <m>B=P(1,-\pi/3)</m> and <m>P(-1,2\pi/3)</m>;
-                </p>
-
-                <p>
-                  <m>C=P(2,3\pi/4)</m> and <m>P(-2,-\pi/4)</m>;
-                </p>
-
-                <p>
-                  <m>D=P(2.5,\pi)</m> and <m>P(2.5,-\pi)</m>;
-                </p>
-              </solution>
+              <!-- The previous provided "solution" was really just the answers -->
           </webwork>
         </exercise>
 

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -2037,7 +2037,7 @@
                   where <m>-\pi\lt \theta\leq \pi</m>.
                 </p>
 
-                <image xml:id="img_polar-two-ways-2">
+                <image xml:id="img_polar-two-ways-2" width="47%">
                   <description></description>
                   <latex-image>
                     \begin{tikzpicture}

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -1979,7 +1979,7 @@
                           xmin=-.08,xmax=1.1%
                     ]
                     
-                    \addplot [firstcurvestyle,areastyle,domain=15:60,samples=20] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)}) -- (axis cs:0,0);
+                    \addplot [firstcurvestyle,-,areastyle,domain=15:60,samples=20] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)}) -- (axis cs:0,0);
                     \addplot [white,fill=white, smooth,domain=0:30,samples=20] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
                     \addplot [firstcurvestyle,-, domain=0:60,samples=60] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)});
                     \addplot [secondcurvestyle,-,domain=-30:30,samples=60] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
@@ -2015,8 +2015,8 @@
                       xmin=-2.2,xmax=1.2%
                     ]
                     
-                    \addplot [firstcurvestyle,areastyle,domain=60:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
-                    \addplot [firstcurvestyle,areastyle,domain=0:60,samples=40] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
+                    \addplot [firstcurvestyle,-,areastyle,domain=60:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
+                    \addplot [firstcurvestyle,-,areastyle,domain=0:60,samples=40] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
                     \addplot [firstcurvestyle,-,domain=0:180,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
                     \addplot [secondcurvestyle,-,domain=0:360,samples=60] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
                     

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -1828,10 +1828,10 @@
           <!-- <webwork xml:id="webwork-ex-polar-calculus-area-6">
               <pg-code>
               </pg-code> -->
-              <!-- can't use &#xe7; in a WW. It leads to ç, which is not in the base64 charset -->
+              
               <statement>
                 <p>
-                  Enclosed by the inner loop of the limacon <m>\ds r=1+2\cos(\theta)</m>
+                  Enclosed by the inner loop of the lima&#xe7;on <m>\ds r=1+2\cos(\theta)</m>
                 </p>
               </statement>
               <solution>
@@ -1848,10 +1848,10 @@
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("2pi+3sqrt(3)/2");
               </pg-code>
-            <!-- can't use &#xe7; in a WW. It leads to ç, which is not in the base64 charset -->
+            
               <statement>
                 <p>
-                  Find the area enclosed by the outer loop of the limacon <m>r=1+2\cos(\theta)</m>
+                  Find the area enclosed by the outer loop of the lima&#xe7;on <m>r=1+2\cos(\theta)</m>
                   (including area enclosed by the inner loop).
                 </p>
 
@@ -1868,10 +1868,10 @@
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("pi+3sqrt(3)");
               </pg-code>
-            <!-- can't use &#xe7; in a WW. It leads to ç, which is not in the base64 charset -->
+            
               <statement>
                 <p>
-                  Find the area enclosed between the inner and outer loop of the limacon <m>r=1+2\cos(\theta)</m>.
+                  Find the area enclosed between the inner and outer loop of the lima&#xe7;on <m>r=1+2\cos(\theta)</m>.
                 </p>
 
                 <p>
@@ -1886,27 +1886,6 @@
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("1");
-                $gr = init_graph(-1.5,-1.5,2.5,2.5,size=>[400,400]);
-                $gr->moveTo(-1.5,0); $gr->arrowTo(2.4,0,'black',1);
-                $gr->moveTo(0,-1.5); $gr->arrowTo(0,2.4,'black',1);
-                Context()->variables->are(t=>"Real");
-                $x[0] = Formula("2*cos(t)*cos(t)");
-                $y[0] = Formula("2*cos(t)*sin(t)");
-                $c[0] = new Fun( $x[0]->perlFunction, $y[0]->perlFunction, $gr );
-                $c[0]->domain(0,6.28318);
-                $c[0]->steps(90);
-                $c[0]->weight(1);
-                $c[0]->color('black');
-                $x[1] = Formula("2*sin(t)*cos(t)");
-                $y[1] = Formula("2*sin(t)*sin(t)");
-                $c[1] = new Fun( $x[1]->perlFunction, $y[1]->perlFunction, $gr );
-                $c[1]->domain(0,6.28318);
-                $c[1]->steps(90);
-                $c[1]->weight(1);
-                $c[1]->color('black');
-                for my$i(-1,1,2){$gr->lb( new Label($i,-0.1,$i,'black','center','top'));};
-                for my$i(-1,1,2){$gr->lb( new Label(-0.1,$i,$i,'black','right','middle'));};
-                $gr->fillRegion([1.5,0.5,"blue"]);
               </pg-code>
               <statement>
                 <p>
@@ -1914,7 +1893,24 @@
                   <m>r=2\sin(\theta)</m>, and the <m>x</m>-axis, as shown:
                 </p>
 
-                <image pg-name="$gr"/>
+                <image xml:id="img_09_05_ex_25">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+                    \begin{axis}[
+                          ymin=-1.1,ymax=2.1,%
+                          xmin=-1.4,xmax=2.4%
+                    ]
+                    
+                    \addplot [firstcurvestyle,areastyle,domain=0:45,samples=20] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)}) -- (axis cs:0,0);
+                    \addplot [fill=white, smooth,domain=0:50,samples=20] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
+                    \addplot [firstcurvestyle,domain=0:180,samples=60] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)});
+                    \addplot [secondcurvestyle,domain=0:180,samples=40] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
+                    
+                    \end{axis}
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
 
                 <p>
                   The area is <var name="$area" width="15"/>.
@@ -1928,27 +1924,6 @@
               <pg-code>
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("1/32(4pi-3sqrt(3))");
-                $gr = init_graph(-0.1,-0.1,1.5,1.5,size=>[400,400]);
-                $gr->moveTo(-0.1,0); $gr->arrowTo(1.4,0,'black',1);
-                $gr->moveTo(0,-0.1); $gr->arrowTo(0,1.4,'black',1);
-                Context()->variables->are(t=>"Real");
-                $x[0] = Formula("cos(t)*cos(t)");
-                $y[0] = Formula("cos(t)*sin(t)");
-                $c[0] = new Fun( $x[0]->perlFunction, $y[0]->perlFunction, $gr );
-                $c[0]->domain(0,1.570796);
-                $c[0]->steps(90);
-                $c[0]->weight(1);
-                $c[0]->color('black');
-                $x[1] = Formula("sin(2t)*cos(t)");
-                $y[1] = Formula("sin(2t)*sin(t)");
-                $c[1] = new Fun( $x[1]->perlFunction, $y[1]->perlFunction, $gr );
-                $c[1]->domain(0,1.570796);
-                $c[1]->steps(90);
-                $c[1]->weight(1);
-                $c[1]->color('black');
-                for my$i(1){$gr->lb( new Label($i,-0.025,$i,'black','center','top'));};
-                for my$i(1){$gr->lb( new Label(-0.025,$i,$i,'black','right','middle'));};
-                $gr->fillRegion([0.3,0.3,"blue"]);
               </pg-code>
               <statement>
                 <p>
@@ -1956,7 +1931,26 @@
                   as shown:
                 </p>
 
-                <image pg-name="$gr"/>
+                <image xml:id="img_09_05_ex_24">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+                    \begin{axis}[
+                          xtick={1},
+                          ytick={1},
+                          ymin=-.1,ymax=1.1,%
+                          xmin=-.1,xmax=1.34%
+                    ]
+                    
+                    \addplot [firstcurvestyle,areastyle,domain=90:30,samples=20] ({cos(x)*cos(x)},{sin(x)*cos(x)}) -- (axis cs:0,0);
+                    \addplot [firstcurvestyle,areastyle,domain=0:30,samples=20] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)}) -- (axis cs:0,0);
+                    \addplot [firstcurvestyle smooth,domain=0:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
+                    \addplot [secondcurvestyle, smooth,domain=0:90,samples=40] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)});
+                    
+                    \end{axis}
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
 
                 <p>
                   The area is <var name="$area" width="15"/>.
@@ -1964,18 +1958,36 @@
               </statement>
           </webwork>
         </exercise>
-
-        <!-- TODO: there is no graph! So no area "as shown" -->
+        
         <exercise label="ex-polar-calculus-area-11">
           <!-- <webwork xml:id="webwork-ex-polar-calculus-area-11">
               <pg-code>
               </pg-code> -->
               <statement>
                 <p>
-                  Enclosed by <m>r=\cos(3 \theta)</m> and <m>r=\sin(3\theta)</m>.
-                  <!-- as shown: -->
+                  Enclosed by <m>r=\cos(3 \theta)</m> and <m>r=\sin(3\theta)</m>, as shown:
                 </p>
-              <!-- START\1END -->
+              
+                <image xml:id="img_09_05_ex_26">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+                    \begin{axis}[
+                          xtick={1},
+                          ytick={.5},
+                          ymin=-.25,ymax=.7,%
+                          xmin=-.08,xmax=1.1%
+                    ]
+                    
+                    \addplot [firstcurvestyle,areastyle,domain=15:60,samples=20] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)}) -- (axis cs:0,0);
+                    \addplot [white,fill=white, smooth,domain=0:30,samples=20] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
+                    \addplot [firstcurvestyle, domain=0:60,samples=60] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)});
+                    \addplot [secondcurvestyle,domain=-30:30,samples=60] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
+                    
+                    \end{axis}
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
               </statement>
               <solution>
                 <p>
@@ -1985,17 +1997,33 @@
           <!-- </webwork> -->
         </exercise>
 
-        <!-- TODO: there is no graph! So no area "as shown" -->
         <exercise label="ex-polar-calculus-area-12">
           <!-- <webwork xml:id="webwork-ex-polar-calculus-area-12">
               <pg-code>
               </pg-code> -->
               <statement>
                 <p>
-                  Enclosed by <m>r=\cos(\theta)</m> and <m>r=1-\cos(\theta)</m>.
-                  <!-- as shown: -->
+                  Enclosed by <m>r=\cos(\theta)</m> and <m>r=1-\cos(\theta)</m>, as shown:
                 </p>
-              <!-- START\1END -->
+
+                <image xml:id="img_09_05_ex_27">
+                  <description></description>
+                  <latex-image>
+                    \begin{tikzpicture}
+                    \begin{axis}[
+                      ymin=-1.4,ymax=1.4,%
+                      xmin=-2.2,xmax=1.2%
+                    ]
+                    
+                    \addplot [firstcurvestyle,areastyle,domain=60:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
+                    \addplot [firstcurvestyle,areastyle,domain=0:60,samples=40] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
+                    \addplot [firstcurvestyle,domain=0:180,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
+                    \addplot [secondcurvestyle,domain=0:360,samples=60] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
+                    
+                    \end{axis}
+                    \end{tikzpicture}
+                  </latex-image>
+                </image>
               </statement>
               <solution>
                 <p>

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -1904,8 +1904,8 @@
                     
                     \addplot [firstcurvestyle,areastyle,domain=0:45,samples=20] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)}) -- (axis cs:0,0);
                     \addplot [fill=white, smooth,domain=0:50,samples=20] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
-                    \addplot [firstcurvestyle,domain=0:180,samples=60] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)});
-                    \addplot [secondcurvestyle,domain=0:180,samples=40] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
+                    \addplot [firstcurvestyle,-,domain=0:180,samples=60] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)});
+                    \addplot [secondcurvestyle,-,domain=0:180,samples=40] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
                     
                     \end{axis}
                     \end{tikzpicture}
@@ -1944,8 +1944,8 @@
                     
                     \addplot [firstcurvestyle,areastyle,domain=90:30,samples=20] ({cos(x)*cos(x)},{sin(x)*cos(x)}) -- (axis cs:0,0);
                     \addplot [firstcurvestyle,areastyle,domain=0:30,samples=20] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)}) -- (axis cs:0,0);
-                    \addplot [firstcurvestyle smooth,domain=0:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
-                    \addplot [secondcurvestyle, smooth,domain=0:90,samples=40] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)});
+                    \addplot [firstcurvestyle,-,domain=0:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
+                    \addplot [secondcurvestyle,-,domain=0:90,samples=40] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)});
                     
                     \end{axis}
                     \end{tikzpicture}
@@ -1981,8 +1981,8 @@
                     
                     \addplot [firstcurvestyle,areastyle,domain=15:60,samples=20] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)}) -- (axis cs:0,0);
                     \addplot [white,fill=white, smooth,domain=0:30,samples=20] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
-                    \addplot [firstcurvestyle, domain=0:60,samples=60] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)});
-                    \addplot [secondcurvestyle,domain=-30:30,samples=60] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
+                    \addplot [firstcurvestyle,-, domain=0:60,samples=60] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)});
+                    \addplot [secondcurvestyle,-,domain=-30:30,samples=60] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
                     
                     \end{axis}
                     \end{tikzpicture}
@@ -2017,8 +2017,8 @@
                     
                     \addplot [firstcurvestyle,areastyle,domain=60:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
                     \addplot [firstcurvestyle,areastyle,domain=0:60,samples=40] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
-                    \addplot [firstcurvestyle,domain=0:180,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
-                    \addplot [secondcurvestyle,domain=0:360,samples=60] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
+                    \addplot [firstcurvestyle,-,domain=0:180,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
+                    \addplot [secondcurvestyle,-,domain=0:360,samples=60] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
                     
                     \end{axis}
                     \end{tikzpicture}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pretextbook == 1.5.3
+pretext == 1.7.4


### PR DESCRIPTION
Two main items in this pull request:

1. I tracked down all remaining occurrences of `<image pg-name="$gr"/>` (the webwork-generated graphs) and replaced them with TikZ graphs.
2. I found (I think) all places where the WeBWorK code had been commented out because we wanted to keep a TikZ graph in place, made the graph webwork-compatible, and uncommented the webwork code.

Fortunately, not too many of the graphs were in problems with randomization, so my job was a lot easier.
It was also fortunate that I still have Greg's original LaTeX on my computer, so I was able to track down the original TikZ and update it for use with PreTeXt and WeBWorK.

I feel a little bit bad about deleting hundreds of lines of WeBWorK code from @Alex-Jordan to make the old graphs, but I daresay the new ones are nicer. ;-)

Everything compiles, and I've adjusted a bunch that initially didn't look quite right, or had y values that ran off the bottom of the graph. (For some reason, even though you can't see the graph below the value of ymin, the cropping utility is leaving whitespace down to whatever the absolute minimum on the graph is.)

Note that I merged in the changes from the `ol-to-tasks` work before making the pull request, because otherwise there would be quite a few merge conflicts. I've resolved those for us ahead of time.