### PR TITLE
Update project.ptx to use intended defaults

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -1,35 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    This file provides the overall configuration for your PreTeXt
-    project. To edit the content of your document, open `source/main.ptx`
-    (default location).
--->
 <project ptx-version="2" source="ptx" asy-method="local">
   <targets>
-    <target name="html" format="html" source="apex.ptx" publication="publication.ptx" output-dir="output/html">
+    <target name="html" format="html" source="apex.ptx" publication="publication.ptx">
       <stringparams key="html.annotation" value="hypothesis"/>
     </target>
-    <target name="html-novideo" format="html" source="apex.ptx" publication="publication-novid.ptx" output-dir="output/html-novideo">
+    <target name="html-novideo" format="html" source="apex.ptx" publication="publication-novid.ptx">
       <stringparams key="html.annotation" value="hypothesis"/>
     </target>
-    <target name="html-standard" format="html" source="apex-UL-standard.ptx" publication="publication-standard.ptx" output-dir="output/html-standard">
+    <target name="html-standard" format="html" source="apex-UL-standard.ptx" publication="publication-standard.ptx">
       <stringparams key="html.annotation" value="hypothesis"/>
     </target>
-    <target name="html-accelerated" format="html" source="apex-UL-accelerated.ptx" publication="publication-accelerated.ptx" output-dir="output/html-accelerated">
+    <target name="html-accelerated" format="html" source="apex-UL-accelerated.ptx" publication="publication-accelerated.ptx">
       <stringparams key="html.annotation" value="hypothesis"/>
     </target>
-    <target name="runestone" format="html" source="apex.ptx" publication="publication-runestone.ptx" output-dir="published/APEX">
+    <target name="runestone" format="html" source="apex.ptx" publication="publication-runestone.ptx" output-dir="../published/APEX">
       <stringparams key="html.annotation" value="hypothesis"/>
     </target>
-    <target name="latex" format="latex" source="apex.ptx" publication="publication.ptx" output-dir="output/latex" xsl="style/apex-latex-style.xsl"/>
-    <target name="latex-novideo" format="latex" source="apex.ptx" publication="publication-novid.ptx" output-dir="output/latex-novideo" xsl="style/apex-latex-style.xsl"/>
-    <target name="latex-print" format="latex" source="apex.ptx" publication="publication-print.ptx" output-dir="output/latex-print" xsl="style/apex-latex-print-style.xsl"/>
-    <target name="latex-color-print" format="latex" source="apex.ptx" publication="publication-color-print.ptx" output-dir="output/latex-color-print" xsl="style/apex-latex-print-color.xsl"/>
-    <target name="latex-color-print-novideo" format="latex" source="apex.ptx" publication="publication-color-print-novideo.ptx" output-dir="output/latex-color-print-novideo" xsl="style/apex-latex-print-color.xsl"/>
-    <target name="latex-print-novideo" format="latex" source="apex.ptx" publication="publication-novid-print.ptx" output-dir="output/latex-print-novideo" xsl="style/apex-latex-print-style.xsl"/>
-    <target name="latex-standard" format="latex" source="apex-UL-standard.ptx" publication="publication-standard.ptx" output-dir="output/latex-standard" xsl="style/apex-latex-style.xsl"/>
-    <target name="latex-standard-print" format="latex" source="apex-UL-standard.ptx" publication="publication-standard-print.ptx" output-dir="output/latex-standard-print" xsl="style/apex-latex-print-style.xsl"/>
-    <target name="latex-accelerated" format="latex" source="apex-UL-accelerated.ptx" publication="publication-accelerated.ptx" output-dir="output/latex-accelerated" xsl="style/apex-latex-style.xsl"/>
-    <target name="latex-accelerated-print" format="latex" source="apex-UL-accelerated.ptx" publication="publication-accelerated-print.ptx" output-dir="output/latex-accelerated-print" xsl="style/apex-latex-print-style.xsl"/>
+    <target name="latex" format="latex" source="apex.ptx" publication="publication.ptx" xsl="style/apex-latex-style.xsl"/>
+    <target name="latex-novideo" format="latex" source="apex.ptx" publication="publication-novid.ptx" xsl="style/apex-latex-style.xsl"/>
+    <target name="latex-print" format="latex" source="apex.ptx" publication="publication-print.ptx" xsl="style/apex-latex-print-style.xsl"/>
+    <target name="latex-color-print" format="latex" source="apex.ptx" publication="publication-color-print.ptx" xsl="style/apex-latex-print-color.xsl"/>
+    <target name="latex-color-print-novideo" format="latex" source="apex.ptx" publication="publication-color-print-novideo.ptx" xsl="style/apex-latex-print-color.xsl"/>
+    <target name="latex-print-novideo" format="latex" source="apex.ptx" publication="publication-novid-print.ptx" xsl="style/apex-latex-print-style.xsl"/>
+    <target name="latex-standard" format="latex" source="apex-UL-standard.ptx" publication="publication-standard.ptx" xsl="style/apex-latex-style.xsl"/>
+    <target name="latex-standard-print" format="latex" source="apex-UL-standard.ptx" publication="publication-standard-print.ptx" xsl="style/apex-latex-print-style.xsl"/>
+    <target name="latex-accelerated" format="latex" source="apex-UL-accelerated.ptx" publication="publication-accelerated.ptx" xsl="style/apex-latex-style.xsl"/>
+    <target name="latex-accelerated-print" format="latex" source="apex-UL-accelerated.ptx" publication="publication-accelerated-print.ptx" xsl="style/apex-latex-print-style.xsl"/>
   </targets>
 </project>


### PR DESCRIPTION
Right now targets are building in `output/output/TARGETNAME` (using the default `output/` project output directory, and an `output/TARGETNAME` target output directory). I assume the intention is to build in `output/TARGETNAME`, which is the default, so I've removed the unnecessary configurations.

I've also fixed the Runestone target to build into `published/APEX` rather than `output/published/APEX`.