### PR TITLE
Numberline fix

### DIFF
--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -29,7 +29,8 @@
       <caption>The area of the shaded region is <m>F(x) = \int_a^x f(t)\, dt</m></caption>
       <image xml:id="img_ftc0" width="47%">
         <shortdescription>
-          A concave-down graph in the first quadrant, with the area underneath shaded from a to x.          </shortdescription>
+          A concave-down graph in the first quadrant, with the area underneath shaded from a to x.
+        </shortdescription>
         <description>
           <p>
             The <m>t</m> and the <m>y</m> axes are uncalibrated. 

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -1195,7 +1195,7 @@
       <m>\Delta\theta</m> and <m>\Delta\varphi</m> goes to zero,
       the number of wedges increases to infinity and the volume of <m>D</m> is more accurately approximated, giving
       <me>
-        dV = d\rho\ \times\ \rho\, d\varphi\ \times\ \rho\sin(\varphi)d\theta = \rho^2\sin(\varphi)\, d\rho\, d\theta\, d\varphi
+        dV = d\rho\ \times\ \rho\, d\varphi\ \times\ \rho\cos(\varphi)d\theta = \rho^2\cos(\varphi)\, d\rho\, d\theta\, d\varphi
       </me>.
     </p>
 

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -1956,8 +1956,8 @@
                 <image xml:id="img_05_02_ex_13">
                   <shortdescription>
                     Graph of function for this exercise that represents a parabola.
-                    </shortdescription>
-                    <description>
+                  </shortdescription>
+                  <description>
                     <p>
                     The <m>y</m> axis is drawn from <m>-5</m> to <m>10</m> and the <m>x</m> axis 
                     is drawn from <m>-2</m> to <m>2</m>.
@@ -1973,8 +1973,8 @@
                     From <m>x=-1</m> to  <m>x=1</m>, the area from above the parabola to the <m>x</m> axis 
                     is shaded and labeled as <m>-4</m>.
                     </p>
-                    </description>
-                                      <latex-image>
+                  </description>
+                  <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
                           axis on top,

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -85,7 +85,12 @@
           </shortdescription>
           <description>
             <p>
-              Delving into the small rectangle from the prior graph, we get a magnified view around the point <m>x=\pi/3</m> for <m>f(x) = \sin(x)</m> and its tangent line. This zoomed-in perspective demonstrates the precision with which the tangent line estimates <m>\sin(1.1)</m> at <m>x=1.1</m>. We can see how points on the tangent line lie quite close to the graph of <m>f(x)</m>, illustrating the fact that the tangent line gives a good approximation to the original graph, near the point where it meets the graph.
+              Zooming in on the small rectangle from the prior graph, 
+              we get a magnified view around the point <m>x=\pi/3</m> for <m>f(x) = \sin(x)</m> and its tangent line. 
+              This zoomed-in perspective demonstrates the precision with which the tangent line estimates <m>\sin(1.1)</m> at <m>x=1.1</m>. 
+              We can see how points on the tangent line lie quite close to the graph of <m>f(x)</m>, 
+              illustrating the fact that the tangent line gives a good approximation to the original graph, 
+              near the point where it meets the graph.
             </p>
           </description>        
           <latex-image>
@@ -1603,8 +1608,11 @@
                 </shortdescription>              
                 <description>
                   <p>
-                      The diagram presents a right-angled triangle, utilized to navigate an approximation problem concerning the length, <m>l</m>, of a long wall. 
-                      The angle labeled as <m>\theta</m> is opposite the wall, and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>. The opposite side, representing the wall's length, is denoted by the variable <m>l</m>. The triangle's hypotenuse is not specified in the given representation.
+                    The diagram presents a right-angled triangle utilized to navigate an approximation problem concerning the length, <m>l</m>, of a long wall. 
+                    The angle labeled as <m>\theta</m> is opposite the wall,
+                    and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>. 
+                    The opposite side, representing the wall's length, is denoted by the variable <m>l</m>. 
+                    The triangle's hypotenuse is not specified in the given representation.
                   </p>
                 </description>
               
@@ -1678,7 +1686,12 @@
                 </shortdescription>              
                 <description>
                   <p>
-                    The diagram showcases a right-angled triangle, which aids in determining an approximation for the length, <m>l</m>, of a lengthy wall. The angle labeled as <m>\theta</m> is opposite the wall, and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>. The opposite side, representing the wall's length, is denoted by the variable <m>l</m>. The triangle's hypotenuse is not specified in the given representation.
+                    The diagram showcases a right-angled triangle, 
+                    which aids in determining an approximation for the length, <m>l</m>, of a long wall. 
+                    The angle labeled as <m>\theta</m> is opposite the wall, 
+                    and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>. 
+                    The opposite side, representing the wall's length, is denoted by the variable <m>l</m>. 
+                    The triangle's hypotenuse is not specified in the given representation.
                   </p>
                 </description>
                 <latex-image>
@@ -1752,8 +1765,9 @@
                 <description>
                   <p>
                     The diagram illustrates an isosceles triangle to facilitate a calculation related to determining the length, <m>l</m>, of a long wall. 
-                    The triangle's height, perpendicular to the base representing the wall, is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>. 
-                    Positioned at the apex of the triangle, an angle is labeled as <m>\theta</m>.
+                    The triangle's height, perpendicular to the base representing the wall, 
+                    is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>. 
+                    The angle opposite the wall is labeled as <m>\theta</m>.
                   </p>
                 </description>
               
@@ -1844,6 +1858,17 @@
                 <m>143^\circ</m> is exact but the measured <m>50'</m> from the wall is accurate to <m>6''</m>.
               </p>
               <image xml:id="img-ex-diff-approx3" width="60%">
+                <shortdescription>
+                  An isosceles triangle used for calculating a wall's length, l.
+                </shortdescription>              
+                <description>
+                  <p>
+                    The diagram illustrates an isosceles triangle to facilitate a calculation related to determining the length, <m>l</m>, of a long wall. 
+                    The triangle's height, perpendicular to the base representing the wall, 
+                    is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>. 
+                    The angle opposite the wall is labeled as <m>\theta</m>.
+                  </p>
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
                   \draw [ultra thick] (1,-1) -- node [pos=.5,right] {\scriptsize \(l=\)?}(1,1);

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -606,25 +606,7 @@
           <caption>A number line determining the concavity of <m>f</m> in <xref ref="ex_conc1">Example</xref></caption>
           <!-- START figures/fig_concline1.tex -->
 
-          <tabular halign="center">
-            <row bottom="major">
-              <cell colspan="3" right="minor">
-                <line><m>\fpp\lt 0</m></line>
-                <line><m>f</m> is concave down</line>
-              </cell>
-              <cell colspan="3" right="minor">
-                <line><m>\fpp\gt 0</m></line>
-                <line><m>f</m> is concave up</line>
-              </cell>
-            </row>
-            <row>
-              <cell colspan="2"></cell>
-              <cell colspan="2"><m>0</m></cell>
-              <cell colspan="2"></cell>
-              <cell></cell>
-            </row>
-          </tabular>
-          <!-- <image xml:id="img_concline1"  width="47%">
+          <image xml:id="img_concline1"  width="47%">
             <shortdescription>
               A number line indicating the concavity of a function based on the second derivative.
             </shortdescription>
@@ -652,7 +634,7 @@
                 \end{axis}
               \end{tikzpicture}
             </latex-image>
-          </image> -->
+          </image>
           <!-- figures/fig_concline1.tex END -->
         </figure>
 
@@ -785,47 +767,45 @@
         <figure xml:id="fig_concline2">
           <caption>Number line for <m>f</m> in <xref ref="ex_conc2">Example</xref></caption>
           
-          <tabular halign="center">
-            <row bottom="major">
-              <cell colspan="2" right="minor">
-                <line><m>\fpp\lt 0</m></line>
-                <line><m>f</m> conc</line>
-                <line>down</line>
-              </cell>
-              <cell colspan="2" right="minor">
-                <line><m>\fpp\gt 0</m></line>
-                <line><m>f</m> conc</line>
-                <line>up</line>
-              </cell>
-              <cell colspan="2" right="minor">
-                <line><m>\fpp\lt 0</m></line>
-                <line><m>f</m> conc</line>
-                <line>down</line>
-              </cell>
-              <cell colspan="2">
-                <line><m>\fpp\gt 0</m></line>
-                <line><m>f</m> conc</line>
-                <line>up</line>
-              </cell>
-            </row>
-            <row>
-              <cell></cell>
-              <cell colspan="2"><m>-1</m></cell>
-              <cell colspan="2"><m>0</m></cell>
-              <cell colspan="2"><m>1</m></cell>
-              <cell></cell>
-            </row>
-          </tabular>
           <!-- START figures/fig_concline2.tex -->
-          <!-- <image xml:id="img_concline2" width="80%">
+          <image xml:id="img_concline2" width="50%">
             <shortdescription>
               A number line indicating intervals of concavity for a function.
             </shortdescription>
             <description>
               <p>
                 The image shows a number line that is used to determine the concavity of the function <m>f</m>.
-                The line is divided into four intervals by the critical points <m>-1, 0</m> and <m>1</m>. For <m>x</m> values less than <m>-1</m>, the function is concave down as indicated by <m>\fpp\lt 0</m>.
-                Between <m>-1</m> and <m>0</m>, the function is concave up <m>\fpp\gt 0</m>, and it becomes concave down again between <m>0</m> and <m>1</m>. For <m>x</m> values greater than 1, the function is concave up.
+                The line is divided into four intervals by the points <m>-1, 0</m> and <m>1</m>,
+                each of which is an inflection point.
+              </p>
+
+              <p>
+                The intervals are marked as follows:
+                <ul>
+                  <li>
+                    <p>
+                      For <m>x\lt -1</m>, <m>\fpp\lt 0</m>, and <m>f</m> is concave down.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>-1\lt x\lt 0</m>, <m>\fpp\gt 0</m>, and <m>f</m> is concave up.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>0\lt x\lt 1</m>, <m>\fpp\lt 0</m>, and <m>f</m> is concave down.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>x\gt 1</m>, <m>\fpp\gt 0</m>, and <m>f</m> is concave up.
+                    </p>
+                  </li>
+                </ul>
               </p>
             </description>
             <latex-image>
@@ -847,7 +827,7 @@
                 \end{axis}
               \end{tikzpicture}
             </latex-image>
-          </image> -->
+          </image>
           <!-- figures/fig_concline2.tex END -->
         </figure>
 

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -389,21 +389,15 @@
       <figure xml:id="fig_incrline1">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr1">Example</xref></caption>
         
-        <tabular halign="center">
-          <row bottom="major">
-            <cell colspan="2" right="minor"></cell>
-            <cell colspan="2" right="minor"></cell>
-            <cell colspan="2"></cell>
-          </row>
-          <row>
-            <cell></cell>
-            <cell colspan="2"><m>-1</m></cell>
-            <cell colspan="2"><m>1/3</m></cell>
-            <cell></cell>
-          </row>
-        </tabular>
-        <!-- <image xml:id="img_incrline1" width="47%">
-          <description></description>
+        <image xml:id="img_incrline1" width="47%">
+          <shortdescription>Number line showing the critical points of f</shortdescription>
+          <description>
+            <p>
+              A number line is shown with two marked points.
+              The points are labeled with the values <m>-1</m> and <m>1/3</m>,
+              which are the critical points of the function <m>f(x)=x^3+x^2-x+1</m>.
+            </p>
+          </description>
           <latex-image>
             \begin{tikzpicture}
               \begin{axis}[
@@ -418,7 +412,7 @@
               \end{axis}
             \end{tikzpicture}
           </latex-image>
-        </image> -->
+        </image>
       </figure>
 
       <p>
@@ -474,31 +468,47 @@
       <figure xml:id="fig_incrline1a">
         <caption>Completed number line for <m>f</m> in <xref ref="ex_incr1">Example</xref></caption>
         
-        <tabular halign="center">
-          <row bottom="major">
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt 0</m></line>
-              <line><m>f</m> incr</line>
-            </cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt 0</m></line>
-              <line><m>f</m> decr</line>
-            </cell>
-            <cell colspan="2">
-              <line><m>\fp\gt 0</m></line>
-              <line><m>f</m> incr</line>
-            </cell>
-          </row>
-          <row>
-            <cell></cell>
-            <cell colspan="2"><m>-1</m></cell>
-            <cell colspan="2"><m>1/3</m></cell>
-            <cell></cell>
-          </row>
-        </tabular>
         <!-- START figures/fig_incrline1.tex -->
-        <!-- <image xml:id="img_incrline1a" width="47%">
-          <description></description>
+        <image xml:id="img_incrline1a" width="47%">
+          <description>
+            <p>
+              A number line is shown with two marked points.
+              The points are labeled with the values <m>-1</m> and <m>1/3</m>,
+              which are the critical points of the function <m>f(x)=x^3+x^2-x+1</m>.
+            </p>
+
+            <p>
+              The marked points divide the number line into three intervals.
+              Above each interval, there is text indicating the sign of <m>f'</m>,
+              and whether the function <m>f</m> is increasing or decreasing.
+            </p>
+
+            <p>
+              The number line indicates the following:
+              <ul>
+                <li>
+                  <p>
+                    For <m>x\lt -1</m>, <m>\fp(x)\gt 0</m>,
+                    and <m>f</m> is increasing.
+                  </p>
+                </li>
+                
+                <li>
+                  <p>
+                    For <m>-1\lt x\lt 1/3</m>, <m>\fp(x)\lt 0</m>,
+                    and <m>f</m> is decreasing.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>x\gt 1/3</m>, <m>\fp(x)\gt 0</m>,
+                    and <m>f</m> is increasing.
+                  </p>
+                </li>
+              </ul>
+            </p>
+          </description>
           <latex-image>
             \begin{tikzpicture}
               \begin{axis}[
@@ -510,13 +520,13 @@
                 ]
                 \addplot[guideline] coordinates {(-1,0) (-1,2)};
                 \addplot[guideline] coordinates {(0.3333,0) (0.3333,2)};
-                \addplot[mark=none] coordinates {(-1.6666,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
-                \addplot[mark=none] coordinates {(-0.3333,1)} node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-                \addplot[mark=none] coordinates {(1,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
+                \addplot[mark=none] coordinates {(-1.6666,1)} node {\parbox{3em}{\centering $\fp&gt;0$\\$f$ incr }};
+                \addplot[mark=none] coordinates {(-0.3333,1)} node {\parbox{3em}{\centering $\fp\lt0$\\$f$ decr }};
+                \addplot[mark=none] coordinates {(1,1)} node {\parbox{3em}{\centering $\fp&gt;0$\\$f$ incr }};
               \end{axis}
             \end{tikzpicture}
           </latex-image>
-        </image> -->
+        </image>
         <!-- figures/fig_incrline1.tex END -->
       </figure>
 
@@ -849,74 +859,79 @@
       <figure xml:id="fig_incrline2">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr2"/></caption>
         
-        <tabular halign="center">
-          <row>
-            <cell></cell>
-            <cell colspan="2">
-              <line>rel</line>
-              <line>max</line>
-            </cell>
-            <cell colspan="2">
-              VA
-            </cell>
-            <cell colspan="2">
-              <line>rel</line>
-              <line>min</line>
-            </cell>
-            <cell></cell>
-          </row>
-          <row bottom="major">
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt 0</m></line>
-              <line><m>f</m> incr</line>
-            </cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt 0</m></line>
-              <line><m>f</m> decr</line>
-            </cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt 0</m></line>
-              <line><m>f</m> decr</line>
-            </cell>
-            <cell colspan="2">
-              <line><m>\fp\gt 0</m></line>
-              <line><m>f</m> incr</line>
-            </cell>
-          </row>
-          <row>
-            <cell></cell>
-            <cell colspan="2"><m>-1</m></cell>
-            <cell colspan="2"><m>1</m></cell>
-            <cell colspan="2"><m>3</m></cell>
-            <cell></cell>
-          </row>
-        </tabular>
         <!-- START figures/fig_incrline2.tex -->
-        <!-- <image xml:id="img_incrline2" width="47%">
-          <description></description>
+        <image xml:id="img_incrline2" width="47%">
+          <shortdescription>Number line for this example, showing critical points of f and intervals of increase and decrease</shortdescription>
+          <description>
+            <p>
+              On a number line, three points are marked.
+              The first point is labeled below with <m>-1</m>, and above with <q>rel max</q>.
+              This indicates that <m>f</m> has a relative maximum at the critical point <m>x=-1</m>.
+            </p>
+
+            <p>
+              The next point is labeled below with <m>1</m> and above with <q>VA</q>,
+              indicating that <m>f</m> has a vertical asymptote at <m>x=1</m>.
+            </p>
+
+            <p>
+              The last point is labeled below with <m>3</m> and above with <q>rel min</q>,
+              indicating that <m>f</m> has a relative minimum at the critical point <m>x=3</m>.
+            </p>
+
+            <p>
+              In between these points there is text indicating the sign of <m>\fp(x)</m>,
+              and whether <m>f</m> is increasing or decreasing, as follows:
+              <ul>
+                <li>
+                  <p>
+                    For <m>x\lt -1</m>, <m>f'\gt 0</m> and <m>f</m> is increasing
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>-1\lt x\lt 1</m>, <m>\fp\lt 0</m> and <m>f</m> is decreasing
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>1\lt x\lt 3</m>, <m>\fp\lt 0</m> and <m>f</m> is decreasing
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>x\gt 3</m>, <m>\fp\gt 0</m> and <m>f</m> is increasing
+                  </p>
+                </li>
+              </ul>
+            </p>
+          </description>
           <latex-image>
             \begin{tikzpicture}
               \begin{axis}[
                   numberline,
                   xmin=-3,
-                  xmax=5,
+                  xmax=4.9,
                   extra x ticks={-1, 1, 3},
                   extra x tick labels={$-1$,$1$, $3$},
                 ]
                 \addplot[guideline] coordinates {(-1,0) (-1,2)};
                 \addplot[guideline] coordinates {(1,0) (1,2)};
                 \addplot[guideline] coordinates {(3,0) (3,2)};
-                \addplot[mark=none] coordinates {(-2,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
-                \addplot[mark=none] coordinates {(0,1)} node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-                \addplot[mark=none] coordinates {(2,1)} node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-                \addplot[mark=none] coordinates {(4,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
-                \addplot[mark=none] coordinates {(-1,2)} node[above] {\parbox{3em}{\centering \small  rel\\max}};
-                \addplot[mark=none] coordinates {(1,2)} node[above] {\parbox{3em}{\centering \small  VA}};
-                \addplot[mark=none] coordinates {(3,2)} node[above] {\parbox{3em}{\centering \small  rel\\min}};
+                \addplot[mark=none] coordinates {(-2,1)} node {\parbox{3em}{\centering $\fp&gt;0$\\$f$ incr }};
+                \addplot[mark=none] coordinates {(0,1)} node {\parbox{3em}{\centering $\fp\lt0$\\$f$ decr }};
+                \addplot[mark=none] coordinates {(2,1)} node {\parbox{3em}{\centering $\fp\lt0$\\$f$ decr }};
+                \addplot[mark=none] coordinates {(4,1)} node {\parbox{3em}{\centering $\fp&gt;0$\\$f$ incr }};
+                \addplot[mark=none] coordinates {(-1,2)} node[above] {\parbox{3em}{\centering  rel\\max}};
+                \addplot[mark=none] coordinates {(1,2)} node[above] {\parbox{3em}{\centering  VA}};
+                \addplot[mark=none] coordinates {(3,2)} node[above] {\parbox{3em}{\centering  rel\\min}};
               \end{axis}
             \end{tikzpicture}
           </latex-image>
-        </image> -->
+        </image>
         <!-- figures/fig_incrline2.tex END -->
       </figure>
 
@@ -1075,52 +1090,56 @@
       <figure xml:id="fig_incrline3">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr3">Example</xref></caption>
         
-        <tabular halign="center">
-          <row>
-            <cell></cell>
-            <cell colspan="2">
-              <line>rel</line>
-              <line>min</line>
-            </cell>
-            <cell colspan="2">
-              <line>rel</line>
-              <line>max</line>
-            </cell>
-            <cell colspan="2">
-              <line>rel</line>
-              <line>min</line>
-            </cell>
-            <cell></cell>
-          </row>
-          <row bottom="major">
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt 0</m></line>
-              <line><m>f</m> decr</line>
-            </cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt 0</m></line>
-              <line><m>f</m> incr</line>
-            </cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt 0</m></line>
-              <line><m>f</m> decr</line>
-            </cell>
-            <cell colspan="2">
-              <line><m>\fp\gt 0</m></line>
-              <line><m>f</m> incr</line>
-            </cell>
-          </row>
-          <row>
-            <cell></cell>
-            <cell colspan="2"><m>-1</m></cell>
-            <cell colspan="2"><m>0</m></cell>
-            <cell colspan="2"><m>1</m></cell>
-            <cell></cell>
-          </row>
-        </tabular>
         <!-- START figures/fig_incrline3.tex -->
-        <!-- <image xml:id="img_incrline3" width="47%">
-          <description></description>
+        <image xml:id="img_incrline3" width="47%">
+          <shortdescription>Number line showing critical points and intervals of increase and decrease</shortdescription>
+          <description>
+            <p>
+              On a number line, three points are marked.
+              The first point is labeled below with <m>-1</m>, and above with <q>rel min</q>,
+              indicating that <m>f</m> has a relative minimum at the critical point <m>x=-1</m>.
+            </p>
+
+            <p>
+              The next point is labeled below with <m>0</m> and above with <q>rel max</q>,
+              indicating that <m>f</m> has a relative maximum at the critical point <m>x=0</m>.
+            </p>
+
+            <p>
+              The last point is labeled below with <m>1</m> and above with <q>rel min</q>,
+              indicating that <m>f</m> has a relative minimum at the critical point <m>x=1</m>.
+            </p>
+
+            <p>
+              In between these points there is text indicating the sign of <m>\fp(x)</m>,
+              and whether <m>f</m> is increasing or decreasing, as follows:
+              <ul>
+                <li>
+                  <p>
+                    For <m>x\lt -1</m>, <m>f'\tt 0</m> and <m>f</m> is decreasing
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>-1\lt x\lt 0</m>, <m>\fp\gt 0</m> and <m>f</m> is increasing
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>0\lt x\lt 1</m>, <m>\fp\lt 0</m> and <m>f</m> is decreasing
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>x\gt 1</m>, <m>\fp\gt 0</m> and <m>f</m> is increasing
+                  </p>
+                </li>
+              </ul>
+            </p>
+          </description>
           <latex-image>
             \begin{tikzpicture}
               \begin{axis}[
@@ -1133,17 +1152,17 @@
                 \addplot[guideline] coordinates {(-1,0) (-1,2)};
                 \addplot[guideline] coordinates {(0,0) (0,2)};
                 \addplot[guideline] coordinates {(1,0) (1,2)};
-                \addplot[mark=none] coordinates {(-1.5,1)} node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-                \addplot[mark=none] coordinates {(-0.5,1)} node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
-                \addplot[mark=none] coordinates {(0.5,1)}  node {\parbox{3em}{\centering \small $\fp\lt0$\\$f$ decr }};
-                \addplot[mark=none] coordinates {(1.5,1)}  node {\parbox{3em}{\centering \small $\fp&gt;0$\\$f$ incr }};
-                \addplot[mark=none] coordinates {(-1,2)} node[above] {\parbox{3em}{\centering \small rel\\min}};
-                \addplot[mark=none] coordinates {(0,2)} node[above] {\parbox{3em}{\centering \small rel\\max}};
-                \addplot[mark=none] coordinates {(1,2)} node[above] {\parbox{3em}{\centering \small rel\\min}};
+                \addplot[mark=none] coordinates {(-1.5,1)} node {\parbox{3em}{\centering $\fp\lt0$\\$f$ decr }};
+                \addplot[mark=none] coordinates {(-0.5,1)} node {\parbox{3em}{\centering $\fp&gt;0$\\$f$ incr }};
+                \addplot[mark=none] coordinates {(0.5,1)}  node {\parbox{3em}{\centering $\fp\lt0$\\$f$ decr }};
+                \addplot[mark=none] coordinates {(1.5,1)}  node {\parbox{3em}{\centering $\fp&gt;0$\\$f$ incr }};
+                \addplot[mark=none] coordinates {(-1,2)} node[above] {\parbox{3em}{\centering rel\\min}};
+                \addplot[mark=none] coordinates {(0,2)} node[above] {\parbox{3em}{\centering rel\\max}};
+                \addplot[mark=none] coordinates {(1,2)} node[above] {\parbox{3em}{\centering rel\\min}};
               \end{axis}
             \end{tikzpicture}
           </latex-image>
-        </image> -->
+        </image>
         <!-- figures/fig_incrline3.tex END -->
       </figure>
 

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -202,47 +202,87 @@
         </ol>
       </p>
 
-     <figure xml:id="fig_sketchline1">
+      <figure xml:id="fig_sketchline1">
         <caption>Number line for <m>f</m> in <xref ref="ex_sketch1"/></caption>
 
-        <tabular halign="center">
-          <row bottom="major">
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>f</m> incr;</line>
-              <line><m>\fpp\lt0</m>,</line>
-              <line><m>f</m> c. down</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt0</m>,</line>
-              <line><m>f</m> decr;</line>
-              <line><m>\fpp\lt0</m>,</line>
-              <line><m>f</m> c. down</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt0</m>,</line>
-              <line><m>f</m> decr;</line>
-              <line><m>\fpp\gt0</m>,</line>
-              <line><m>f</m> c. up</line></cell>
-            <cell colspan="2">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>f</m> incr;</line>
-              <line><m>\fpp\gt0</m>,</line>
-              <line><m>f</m> c. up</line></cell>
-          </row>
-          <row>
-            <cell></cell>
-            <cell colspan="2">
-              <line><m>\frac{1}{9}\left(10-\sqrt{37}\right)</m></line>
-              <line><m>\approx0.435</m></line></cell>
-            <cell colspan="2">
-              <line><m>\frac{10}{9}</m></line>
-              <line><m>\approx1.111</m></line></cell>
-            <cell colspan="2">
-              <line><m>\frac{1}{9}\left(10+\sqrt{37}\right)</m></line>
-              <line><m>\approx1.787</m></line></cell>
-            <cell></cell>
-          </row>
-        </tabular>
+        <image xml:id="img_sketchline1" width="75%">
+          <shortdescription>Number line showing intervals where f is increasing/decreasing and concave up/down</shortdescription>
+          <description>
+            <p>
+              A number line is shown, on which three points are marked.
+              The first point is marked as <m>\frac19(10-\sqrt{37})</m>, or approximately <m>0.435</m>;
+              it is a critical point of <m>f</m>, and a relative maximum.
+            </p>
 
+            <p>
+              The second point is marked as <m>\frac{10}{9}</m>, or approximately <m>1.111</m>;
+              it is an inflection point of <m>f</m>.
+            </p>
+
+            <p>
+              The last point is marked as <m>\frac19(10+\sqrt{37})</m>, or approximately <m>1.787</m>;
+              it is a critical point of <m>f</m>, and a relative minimum.
+            </p>
+
+            <p>
+              These points divide the number line into four intervals.
+              Above each interval, the signs of both <m>\fp</m> and <m>\fpp</m> are given,
+              along with whether <m>f</m> is increasing or decreasing, and concave up or down.
+            </p>
+
+            <p>
+              This information is as follows:
+              <ul>
+                <li>
+                  <p>
+                    For <m>x\lt 0.435</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                    and <m>\fpp\lt 0</m>, so <m>f</m> is concave down.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>0.435\lt x\lt 1.111</m>, <m>\fp\lt 0</m>, so <m>f</m> is decreasing,
+                    and <m>\fpp\lt 0</m>, so <m>f</m> is concave down.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>1.111\lt x\lt 1.787</m>, <m>\fp\lt 0</m>, so <m>f</m> is decreasing,
+                    and <m>\fpp\gt 0</m>, so <m>f</m> is concave up.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>x\gt 1.787</m>, <m>\ft\gt 0</m>, so <m>f</m> is increasing,
+                    and <m>\fpp\gt 0</m>, so <m>f</m> is concave up.
+                  </p>
+                </li>
+              </ul>
+            </p>
+          </description>
+          <latex-image>
+            \begin{tikzpicture}
+              \begin{axis}[numberline,
+                          xmin=0,xmax=2.222,
+                          xtick={10},
+                          minor xtick={{}},
+                          extra x ticks={0.435, 1.111, 1.787},
+                          extra x tick labels={\parbox{6em}{\centering \scriptsize $\frac{1}{9}\left(10-\sqrt{37}\right)$ $\approx0.435$},
+                            \parbox{2em}{\scriptsize $\frac{10}{9}\approx1.111$}, \parbox{6em}{\centering \scriptsize $\frac{1}{9}\left(10+\sqrt{37}\right)$ $\approx1.787$}},]
+                  \addplot[guideline] coordinates {(0.435,0) (0.435,2)};
+                  \addplot[guideline] coordinates {(1.111,0) (1.111,2)};
+                  \addplot[guideline] coordinates {(1.787,0) (1.787,2)};
+                  \addplot[mark=none] coordinates {(0.18,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt 0$,\\ $f$ incr\\$\fpp\lt 0$,\\ $f$ c.\ down }};
+                  \addplot[mark=none] coordinates {(0.77,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\lt 0$,\\ $f$ decr\\$\fpp\lt 0$,\\ $f$ c.\ down }};
+                  \addplot[mark=none] coordinates {(1.45,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\lt 0$,\\ $f$ decr\\$\fpp\gt 0$,\\ $f$ c.\ up }};
+                  \addplot[mark=none] coordinates {(2.1,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt 0$,\\ $f$ incr\\$\fpp\gt 0$,\\ $f$ c.\ up }};
+              \end{axis}
+            \end{tikzpicture}
+          </latex-image>
+        </image>
       </figure>
 
       <figure xml:id="fig_sketch1">
@@ -438,38 +478,68 @@
 
       <figure xml:id="fig_sketchline2">
         <caption>Number line for <m>f</m> in <xref ref="ex_sketch2">Example</xref></caption>
+        <image xml:id="img_sketchline2" width="67%">
+          <shortdescription>Number line showing intervals where f is increasing/decreasing and concave up/down</shortdescription>
+          <description>
+            <p>
+              On a number line there are three marked points: <m>-2</m>, <m>\frac12</m>, and <m>3</m>.
+              At <m>x=-2</m> and <m>x=3</m>, the graph of <m>f</m> has a vertical asymptote.
+              The point <m>x=\frac12</m> is a critical point of <m>f</m>, and a relative maximum.
+            </p>
 
-        <tabular halign="center">
-          <row bottom="major">
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt 0</m>,</line>
-              <line><m>f</m> incr;</line>
-              <line><m>\fpp\gt 0</m>,</line>
-              <line><m>f</m> c. up</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>f</m> incr;</line>
-              <line><m>\fpp\lt0</m>,</line>
-              <line><m>f</m> c. down</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt0</m>,</line>
-              <line><m>f</m> decr;</line>
-              <line><m>\fpp\lt0</m>,</line>
-              <line><m>f</m> c. down</line></cell>
-            <cell colspan="2">
-              <line><m>\fp\lt0</m>,</line>
-              <line><m>f</m> decr;</line>
-              <line><m>\fpp\gt0</m>,</line>
-              <line><m>f</m> c. up</line></cell>
-          </row>
-          <row>
-            <cell></cell>
-            <cell colspan="2"><m>-2</m></cell>
-            <cell colspan="2"><m>\frac{1}{2}</m></cell>
-            <cell colspan="2"><m>3</m></cell>
-            <cell></cell>
-          </row>
-        </tabular>
+            <p>
+              These three points divide the number line into four intervals.
+              Above each interval, the following information is indicated:
+              <ul>
+                <li>
+                  <p>
+                    For <m>x\lt -2</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                    and <m>\fpp\gt 0</m>, so <m>f</m> is concave up.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>-2\lt x\lt \frac12</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                    and <m>\fpp\lt 0</m>, so <m>f</m> is concave down.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>\frac12\lt x\lt 3</m>, <m>\fp\lt 0</m>, so <m>f</m> is decreasing,
+                    and <m>\fpp\lt 0</m>, so <m>f</m> is concave down.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    For <m>x\gt 3</m>, <m>\fp\lt 0</m>, so <m>f</m> is decreasing,
+                    and <m>\fpp\gt 0</m>, so <m>f</m> is concave up.
+                  </p>
+                </li>
+              </ul>
+            </p>
+          </description>
+          <latex-image>
+            \begin{tikzpicture}
+              \begin{axis}[numberline,
+                          xmin=0,xmax=2.222,
+                          minor xtick={{}},
+                          xtick={10},
+                          extra x ticks={0.435, 1.111, 1.787},
+                          extra x tick labels={\scriptsize $-2$, \scriptsize $\frac{1}{2}$, \scriptsize $3$},]
+                  \addplot[guideline] coordinates {(0.435,0) (0.435,2)};
+                  \addplot[guideline] coordinates {(1.111,0) (1.111,2)};
+                  \addplot[guideline] coordinates {(1.787,0) (1.787,2)};
+                  \addplot[mark=none] coordinates {(0.18,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt 0$,\\ $f$ incr\\$\fpp\gt 0$,\\ $f$ c.\ up }};
+                  \addplot[mark=none] coordinates {(0.77,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt 0$,\\ $f$ incr\\$\fpp\lt 0$,\\ $f$ c.\ down }};
+                  \addplot[mark=none] coordinates {(1.45,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\lt 0$,\\ $f$ decr\\$\fpp\lt 0$,\\ $f$ c.\ down }};
+                  \addplot[mark=none] coordinates {(2.1,1.5)} node {\parbox{8em}{\centering \scriptsize  $\fp\lt 0$,\\ $f$ incr\\$\fpp\lt 0$,\\ $f$ c.\ down }};
+              \end{axis}
+            \end{tikzpicture}
+          </latex-image>
+        </image>
       </figure>
 
       <figure xml:id="fig_sketch2">
@@ -661,54 +731,100 @@
 
       <figure xml:id="fig_sketchline3">
         <caption>Number line for <m>f</m> in Example <xref ref="ex_sketch3">Example</xref></caption>
+          <image xml:id="img_sketchline3" width="90%">
+            <shortdescription>Number line showing intervals where f is increasing/decreasing and concave up/down</shortdescription>
+            <description>
+              <p>
+                A number line is shown, on which five points are marked.
+                The points are labeled, from left to right, as <m>-5.579</m>,
+                <m>-4</m>, <m>-1.305</m>, <m>0</m>, and <m>1.064</m>.
+                The points <m>x=-4</m> and <m>x=0</m> are the critical points of <m>f</m>.
+              </p>
 
-        <tabular halign="center">
-          <row bottom="major">
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>\fpp\gt0</m>;</line>
-              <line><m>f</m> incr,</line>
-              <line><m>f</m> c. up</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>\fpp\lt0</m>;</line>
-              <line><m>f</m> incr,</line>
-              <line><m>f</m> c. down</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt0</m>,</line>
-              <line><m>\fpp\lt0</m>;</line>
-              <line><m>f</m> decr,</line>
-              <line><m>f</m> c. down</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\lt0</m>,</line>
-              <line><m>\fpp\gt0</m>;</line>
-              <line><m>f</m> decr,</line>
-              <line><m>f</m> c. up</line></cell>
-            <cell colspan="2" right="minor">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>\fpp\gt0</m>;</line>
-              <line><m>f</m> incr,</line>
-              <line><m>f</m> c. up</line></cell>
-            <cell colspan="2">
-              <line><m>\fp\gt0</m>,</line>
-              <line><m>\fpp\lt0</m>;</line>
-              <line><m>f</m> incr,</line>
-              <line><m>f</m> c. down</line></cell>
-          </row>
-          <row>
-            <cell/>
-            <cell colspan="2"><m>-5.579</m></cell>
-            <cell colspan="2"><m>-4</m></cell>
-            <cell colspan="2"><m>-1.305</m></cell>
-            <cell colspan="2"><m>0</m></cell>
-            <cell colspan="2"><m>1.064</m></cell>
-            <cell/>
-          </row>
-        </tabular>
-      </figure>
+              <p>
+                The three decimal values are the possible inflection points of <m>f</m>,
+                which had to be approximated using software.
+                These points divide the number line into six intervals;
+                above each interval, the following information is indicated:
+              </p>
+
+              <p>
+                <ul>
+                  <li>
+                    <p>
+                      For <m>x\lt -5.579</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                      and <m>\fpp \gt 0</m>, so <m>f</m> is concave up.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>-5.579\lt x\lt -4</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                      and <m>\fpp \lt 0</m>, so <m>f</m> is concave down.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>-4\lt x\lt -1.305</m>, <m>\fp\lt 0</m>, so <m>f</m> is decreasing,
+                      and <m>\fpp \lt 0</m>, so <m>f</m> is concave down.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>-1.305\lt x\lt 0</m>, <m>\fp\lt 0</m>, so <m>f</m> is decreasing,
+                      and <m>\fpp \gt 0</m>, so <m>f</m> is concave up.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>0\lt x\lt 1.064</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                      and <m>\fpp \gt 0</m>, so <m>f</m> is concave up.
+                    </p>
+                  </li>
+
+                  <li>
+                    <p>
+                      For <m>x\gt 1.064</m>, <m>\fp\gt 0</m>, so <m>f</m> is increasing,
+                      and <m>\fpp \lt 0</m>, so <m>f</m> is concave down.
+                    </p>
+                  </li>
+                </ul>
+              </p>
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+                \begin{axis}[axis y line=none,
+                			x=18pt,
+                			y=20pt,
+			                xtick={10},
+			                xlabel={},
+                      ymax=2.5,
+                            xmin=-7,xmax=6,
+                            minor xtick={{}},
+                            extra x ticks={-5,-2.8,-0.6,1.3,3.2},
+                            extra x tick labels={\scriptsize $-5.579$,\scriptsize  $-4$,\scriptsize  $-1.305$,\scriptsize  $0$,\scriptsize  $1.064$},]
+                    \addplot[guideline] coordinates {(-5,0) (-5,2)};
+                    \addplot[guideline] coordinates {(-2.8,0) (-2.8,2)};
+                    \addplot[guideline] coordinates {(-0.6,0) (-0.6,2)};
+                    \addplot[guideline] coordinates {(1.3,0) (1.3,2)};
+                    \addplot[guideline] coordinates {(3.2,0) (3.2,2)};
+                    \addplot[mark=none] coordinates {(-6,1.2)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt0$,\\ $f$ incr\\$\fpp\gt0$,\\ $f$ c.\ up }};
+                    \addplot[mark=none] coordinates {(-3.9,1.2)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt0$,\\ $f$ incr\\$\fpp\lt0$,\\ $f$ c.\ down }};
+                    \addplot[mark=none] coordinates {(-1.7,1.2)} node {\parbox{8em}{\centering \scriptsize  $\fp\lt0$,\\ $f$ decr\\$\fpp\lt0$,\\ $f$ c.\ down }};
+                    \addplot[mark=none] coordinates {(0.4,1.2)} node {\parbox{8em}{\centering \scriptsize  $\fp\lt0$,\\ $f$ decr\\$\fpp\gt0$,\\ $f$ c.\ up }};
+                    \addplot[mark=none] coordinates {(2.3,1.2)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt0$,\\ $f$ incr\\$\fpp\gt0$,\\ $f$ c.\ up }};
+                    \addplot[mark=none] coordinates {(4.4,1.2)} node {\parbox{8em}{\centering \scriptsize  $\fp\gt0$,\\ $f$ incr\\$\fpp\lt0$,\\ $f$ c.\ down }};
+                \end{axis}
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
         
 
-        <figure xml:id="fig_sketch3">
+      <figure xml:id="fig_sketch3">
         <caption>Sketching <m>f</m> in <xref ref="ex_sketch3">Example</xref></caption>
         <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
           <figure xml:id="fig_sketch3a">

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -671,6 +671,7 @@
         <sidebyside widths="32% 32% 32%" margins="0%">
           <!-- START figures/fig_squeeze1a.tex -->
           <figure xml:id="fig_squeeze1a">
+            <caption/>
             <image xml:id="img_squeeze1a">
               <description>
                 <p>
@@ -702,6 +703,7 @@
           <!-- figures/fig_squeeze1a.tex END -->
           <!-- START figures/fig_squeeze1b.tex -->
           <figure xml:id="fig_squeeze1b">
+            <caption/>
             <image xml:id="img_squeeze1b">
               <description>
                 <p>
@@ -733,6 +735,7 @@
           <!-- figures/fig_squeeze1b.tex END -->
           <!-- START figures/fig_squeeze1c.tex -->
           <figure xml:id="fig_squeeze1c">
+            <caption/>
             <image xml:id="img_squeeze1c">
               <description>
                 <p>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -861,19 +861,19 @@
             <shortdescription>
               Graph of sin(x) over x, showing that a function can cross a horizontal asymptote infinitely many times.
             </shortdescription>
+            <latex-image>
+              \begin{tikzpicture}[declare function = {func(\x) = (\x != 0) * (sin(x*180/pi)/x) + (\x == 0) * (1);}]
+                \begin{axis}[
+                    xmin=-21,
+                    xmax=21,
+                    ymin=-.3,
+                    ymax=1.1
+                  ]
+                  \addplot+[domain=-20:20,samples=100] {func(x)};
+                \end{axis}
+              \end{tikzpicture}
+            </latex-image>
           </image>
-          <latex-image>
-            \begin{tikzpicture}[declare function = {func(\x) = (\x != 0) * (sin(x*180/pi)/x) + (\x == 0) * (1);}]
-              \begin{axis}[
-                  xmin=-21,
-                  xmax=21,
-                  ymin=-.3,
-                  ymax=1.1
-                ]
-                \addplot+[domain=-20:20,samples=100] {func(x)};
-              \end{axis}
-            \end{tikzpicture}
-          </latex-image>
           <!-- figures/fig_hzasy4.tex END -->
         </figure>
       </sidebyside>


### PR DESCRIPTION
In the curve sketching chapter, there are several places where a number line is used to mark critical numbers, points of increase/decrease, etc.

We have gone back and forth a couple of times between implementing these as TikZ images, or as a `tabluar`.

The `tabular` isn't really any more accessible, since we are using table alignment to get a particular visual effect.
The TikZ images look better, so it makes more sense to use those, and include a description for accessibility.

That is the major change here.

There is one typo fix: Brad passed along a note that there is one place in the `cylindrical-spherical` section where we forgot to change an instance of `\sin(\phi)` to `\cos(\phi)`.

The remaining changes are just whitespace adjustments.