### PR TITLE
Add image descriptions for sequences and series chapter

### DIFF
--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -197,7 +197,7 @@
           from <xref ref="ex_simple_de">Example</xref></caption>
           <image xml:id="img_general_particular" width="47%">
             <shortdescription>
-              Graph of the members of the general solution to the equation y’ =2y, including a particular solution.
+              Graph of the members of the general solution to the equation y' =2y, including a particular solution.
             </shortdescription>
             <description>
               <p>
@@ -433,7 +433,7 @@
       <caption>Graphically finding an approximate solution to <m>\cos(x) = x</m></caption>
       <image xml:id="fig_de_intersection" width="47%">
         <shortdescription>
-          Graphically finding an approximate solution to  cos(x) =x.
+          Graphically finding an approximate solution to  cos(x)=x.
         </shortdescription>
         <description>
           <p>
@@ -556,7 +556,7 @@
           <caption>Slope field for <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref></caption>
           <image xml:id="img_slopefield1" width="47%">
             <shortdescription>
-              Graph of slope field of y’ = y+x.
+              Graph of slope field of y' = y+x.
             </shortdescription>
             <description>
               <p>
@@ -632,7 +632,7 @@
           <caption>Solution to the initial value problem <m>\yp = x+y</m>, with <m>y(1)=-1</m> from <xref ref="ex_IVP_graphical">Example</xref></caption>
           <image xml:id="img_slopefield1solution" width="47%">
             <shortdescription>
-              Graph of slope field of y’ = y+x with initial value y(1) = -1.
+              Graph of slope field of y' = y+x with initial value y(1) = -1.
             </shortdescription>
             <description>
               <p>
@@ -1079,7 +1079,7 @@
           and <xref ref="ex_euler2"></xref>, along with the analytical solution</caption>
           <image xml:id="img-euler2" width="47%">
             <shortdescription>
-              Euler&#39;s Method approximation to y&#39;=x+y with y(1)=-1 along with the analytical solution.
+              Euler's Method approximation to y'=x+y with y(1)=-1 along with the analytical solution.
             </shortdescription>
             <description>
               <p>
@@ -1223,7 +1223,7 @@
           along with the analytical solution</caption>
           <image xml:id="img_euler3" width="47%">
             <shortdescription>
-              Euler’s Method approximation to y’ = y(1-y) with y(0) = 0.25 along with its analytical solution.
+              Euler's Method approximation to y' = y(1-y) with y(0) = 0.25 along with its analytical solution.
             </shortdescription>
             <description>
               <p>

--- a/ptx/sec_alt_series.ptx
+++ b/ptx/sec_alt_series.ptx
@@ -110,7 +110,22 @@
     <caption>Illustrating convergence with the Alternating Series Test</caption>
   <!-- START figures/fig_alt_series_converge.tex -->
     <image xml:id="img_alt_series_converge_a" width="47%">
-      <description></description>
+      <shortdescription>Scatter plots of a positive, decreasing sequence and its alternating sequence of partial sums.</shortdescription>
+      <description>
+        <p>
+          On one set of coordinate axes, two scatter plots are shown.
+          The first is the plot of a positive, decreasing sequence <m>a_n</m>;
+          the second is the plot of the sequence of partial sums for the corresponding alternating sequence <m>(-1)^na_n</m>.
+        </p>
+
+        <p>
+          The scatter plots illustrate why an alternating series converges:
+          as <m>n</m> increases, the partial sums oscillate back and forth across a horizontal line marked <m>L</m>
+          (the limiting value).
+          Since <m>a_n</m> is a decreasing sequence, the oscillations get smaller as <m>n</m> increases,
+          and the points in the scatter plot for <m>S_n</m> get closer and closer to the line <m>y=L</m>.
+        </p>
+      </description>
       <latex-image>
 
       \begin{tikzpicture}
@@ -150,7 +165,34 @@
     <caption>A visual representation of adding terms of an alternating series. The arrows represent the length and direction of each term of the sequence.</caption>
   <!-- START figures/fig_ftc1.tex -->
     <image xml:id="img_alt_series_converge_b" width="67%">
-      <description></description>
+      <shortdescription>An illustration of the partial sums in an alternating series, using line segments to demonstrate convergence.</shortdescription>
+      <description>
+        <p>
+          On a set of coordinate axes, a sequence of horizontal line segments is shown.
+          At the top of the image is a line segment indicating in increase from <m>0</m> to <m>a_1</m>.
+          An arrow pointing to the right is at the end of the segment.
+        </p>
+
+        <p>
+          Below this segment is a shorter segment with an arrow pointing to the left.
+          The right end of this segment aligns with the right end of the first segment,
+          indicating that we obtain <m>a_1-a_2</m> by starting at <m>a_1</m> and then moving to the left by a distance <m>a_2</m>.
+        </p>
+
+        <p>
+          The third segment is below the second. Its left end aligns with the left end of the second segment,
+          and it points to the right, indicating the act of adding <m>a_3</m> to the partial sum.
+          The length of this segment is shorter than that of the second, indicating the fact that the sequence <m>a_n</m> is decreasing.
+        </p>
+
+        <p>
+          As we move down, additional segments are drawn, alternating between pointing left and right,
+          and getting shorter with each step. Below the segments is a horizontal axis, on which the values
+          <m>S_1, S_2, \ldots</m> of the partial sums are shown, as well as the limit <m>L</m>.
+          The illustration overall is intended to convey the idea that the line segments will shrink toward the limiting value <m>L</m>
+          as <m>n</m> increases.
+        </p>
+      </description>
       <latex-image>
 
       \begin{tikzpicture}

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -76,7 +76,15 @@
           <caption/>
           <!-- START figures/fig_integral_test_a.tex -->
           <image xml:id="img_integral_test_a">
-            <description></description>
+            <shortdescription>First of two graphs illustrating why the integral test works.</shortdescription>
+            <description>
+              <p>
+                The graph of a positive, decreasing function <m>y=a(x)</m> is shown.
+                Also shown are the first four rectangles in a Riemann sum with partition points at each integer,
+                and using left endpoints. Since <m>a(x)</m> is decreasing, this is an overestimate,
+                which is illustrated by the fact that the rectangles all reach above the graph.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -110,7 +118,15 @@
           <caption/>
           <!-- START figures/fig_integral_test_b.tex -->
           <image xml:id="img_integral_test_b">
-            <description></description>
+            <shortdescription>Second of two graphs illustrating why the integral test works.</shortdescription>
+            <description>
+              <p>
+                The graph of a positive, decreasing function <m>y=a(x)</m> is shown.
+                Also shown are the first four rectangles in a Riemann sum with partition points at each integer,
+                and using right endpoints. Since <m>a(x)</m> is decreasing, this is an underestimate,
+                which is illustrated by the fact that the rectangles all lie below the graph.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -267,7 +283,19 @@
           <caption>Plotting the sequence and series in <xref ref="ex_itest1">Example</xref></caption>
           <!-- START figures/fig_itest1.tex -->
           <image xml:id="img_itest1" width="47%">
-            <description></description>
+            <shortdescription>Scatter plots of the sequence used in this example, and the corresponding sequence of partial sums.</shortdescription>
+            <description>
+              <p>
+                A scatter plot of the sequence <m>a_n=\ln(n)/n^2</m> is shown.
+                Aside from an initial point <m>(1,0)</m>, this is a decreasing sequence,
+                descending from the point <m>(2,\ln(2)/4)</m> toward the <m>n</m> axis.
+              </p>
+
+              <p>
+                The scatter plot for the sequence <m>S_n</m> of partial sums is also shown;
+                this is an increasing sequence, which appears to be bounded above by some value less than 1.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -125,7 +125,16 @@
               <caption>Plotting the sequence in <xref ref="item_ex_seq1_1"/></caption>
         <!-- START figures/fig_seq1a.tex -->
               <image xml:id="img_seq1a" width="47%">
-                <description></description>
+                <shortdescription>Plot of the first four terms of the sequence in part 1 of this example.</shortdescription>
+                <description>
+                  <p>
+                    A pair of coordinate axes are given, with the horizontal axis labeled <m>n</m> (rather than <m>x</m>),
+                    and the origin at the bottom-left of the image.
+                    The first four terms of the sequence <m>3^n/n!</m> are plotted,
+                    at coordinates <m>(1,3)</m>,<m>(2,4.5)</m>,<m>(3,4.5)</m>, and <m>(4,3.375)</m>.
+                    The four points lie in an inverted U shape.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -168,7 +177,17 @@
               <caption>Plotting the sequence in <xref ref="item_ex_seq1_2"/></caption>
         <!-- START figures/fig_seq1b.tex -->
               <image xml:id="img_seq1b" width="47%">
-                <description></description>
+                <shortdescription>A plot of the first four terms of the sequence in part 2 of this example.</shortdescription>
+                <description>
+                  <p>
+                    A pair of coordinate axes are shown, with the horizontal axis labeled <m>n</m>,
+                    and the origin at the bottom-left of the image.
+                    The first four terms of the sequence <m>4+(-1)^n</m> are plotted,
+                    illustrating the oscillatory nature of this sequence:
+                    the four points make a sort of zig-zag configuration, with the <m>y</m> value
+                    going back and forth between 3 and 5.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -215,7 +234,18 @@
               <caption>Plotting the sequence in <xref ref="item_ex_seq1_3"/></caption>
         <!-- START figures/fig_seq1c.tex -->
               <image xml:id="img_seq1c" width="47%">
-                <description></description>
+                <shortdescription>A plot of the first four terms of the sequence in part 3 of this example.</shortdescription>
+                <description>
+                  <p>
+                    Another set of coordinate axes are shown; in this case, the horizontal axis (labeled <m>n</m>)
+                    is about two thirds of the way from the bottom of the image.
+                    The first five terms of the sequence <m>(-1)^{n(n+1)/2}/n^2</m> are shown.
+                    Since the triangular numbers <m>n(n+1)/2</m> follow an <q>odd, odd, even, even</q> pattern,
+                    the points plotted for the first two terms have negative <m>y</m> value,
+                    the next two have positive <m>y</m> value, and the fifth term is again negative.
+                    As <m>n</m> increases, the points get closer and closer to the <m>n</m> axis.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -556,7 +586,20 @@
               <caption>Scatter plot for the sequence in <xref ref="item_ex_seq4_1"/></caption>
               <!-- START figures/fig_seq4a.tex -->
               <image xml:id="img_seq4a" width="47%">
-                <description></description>
+                <shortdescription>A scatter plot showing a representative sample of points from the first sequence in this example.</shortdescription>
+                <description>
+                  <p>
+                    A pair of coordinate axes are shown, with the horizontal axis (labeled <m>n</m>) in the center of the image.
+                    The range for <m>n</m> is from 0 to 100, and every fourth point in the sequence has been plotted.
+                    The scatter plot for the sequence <m>a_n = \frac{3n^2-2n+1}{n^2-1000}</m> follows the graph of
+                    <m>f(x)=\frac{3x^2-3x+1}{x^2-1000}</m>.
+                    The graph of this function has a vertical asymptote at <m>x=\sqrt{1000}\approx 31.6</m>.
+                    Since this is not an integer value, <m>a_n</m> is defined for each <m>n</m>,
+                    but we can see that the largest negative value of <m>a_n</m> occurs when <m>n=31</m>
+                    (to the left of the asymptote), and the largest positive value of <m>a_n</m> occurs when <m>n=32</m>
+                    (to the right of the asymptote). As <m>n</m> gets large, the <m>y</m> coordinate of each point gets closer to 3.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -571,7 +614,7 @@
 
                 \addplot [only marks,firstcolor,mark size={.75pt},domain=1:100,samples=21] {(3*x^2 - 2*x + 1)/(x^2 - 1000)};
 
-                \draw (axis cs:60,-8) node { $\ds a_n = \frac{3x^2 - 2x + 1}{x^2 - 1000}$};
+                \draw (axis cs:60,-8) node { $\ds a_n = \frac{3n^2 - 2n + 1}{n^2 - 1000}$};
 
                 \end{axis}
                 \end{tikzpicture}
@@ -610,7 +653,14 @@
               <caption>Scatter plot for the sequence in <xref ref="item_ex_seq4_2"/></caption>
               <!-- START figures/fig_seq4b.tex -->
               <image xml:id="img_seq4b" width="47%">
-                <description></description>
+                <shortdescription>A scatter plot showing a representative sample of points from the second sequence in this example.</shortdescription>
+                <description>
+                  <p>
+                    The scatter plot for this example shows the first 100 terms in the sequence <m>a_n=\cos(n)</m>.
+                    The plot shows a collection of points whose <m>y</m> values seem to be randomly scattered
+                    between <m>-1</m> and <m>1</m>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -648,13 +698,13 @@
               we invoke the definition of the limit of a sequence.
               By looking at the plot in <xref ref="fig_seq4c">Figure</xref>,
               we would like to conclude that the sequence converges to <m>L=0</m>.
-              Let <m>\epsilon>0</m> be given.
+              Let <m>\epsilon\gt 0</m> be given.
               We can find a natural number <m>m</m> such that <m>1/m \lt  \varepsilon</m>.
-              Let <m>n>m</m>, and consider <m>\abs{a_n - L}</m>:
+              Let <m>n\gt m</m>, and consider <m>\abs{a_n - L}</m>:
               <md>
                 <mrow>\abs{a_n - L} \amp = \left\lvert\frac{(-1)^n}{n} - 0\right\rvert</mrow>
                 <mrow>\amp = \frac1n</mrow>
-                <mrow>\amp \lt  \frac1m \text{ (since \(n>m\)) }</mrow>
+                <mrow>\amp \lt  \frac1m \text{ (since \(n\gt m\)) }</mrow>
                 <mrow>\amp \lt  \varepsilon</mrow>
               </md>.
               We have shown that by picking <m>m</m> large enough,
@@ -667,7 +717,23 @@
               <caption>Scatter plot for the sequence in <xref ref="item_ex_seq4_3"/></caption>
               <!-- START figures/fig_seq4c.tex -->
               <image xml:id="img_seq4c" width="47%">
-                <description></description>
+                <shortdescription>A scatter plot showing a representative sample of points from the third sequence in this example.</shortdescription>
+                <description>
+                  <p>
+                    The scatter plot for the sequence <m>a_n = (-1)^n/n</m> shows a pair of coordinate axes,
+                    with the horizontal axis labeled <m>n</m>, and positioned in the center of the plot.
+                  </p>
+
+                  <p>
+                    When <m>n</m> is even, the points <m>(n,a_n)</m> follow the graph <m>y=1/x</m>,
+                    and get closer and closer to the <m>n</m> axis as <m>n</m> increases.
+                  </p>
+
+                  <p>
+                    When <m>n</m> is odd, the points <m>(n,a_n)</m> follow the graph <m>y=-1/x</m>,
+                    and approach the <m>n</m> axis from below.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -788,7 +854,16 @@
               <caption>A plot of a sequence in <xref ref="ex_seq5">Example</xref>, part 2</caption>
           <!-- START figures/fig_seq5.tex -->
               <image xml:id="img_seq5" width="47%">
-                <description></description>
+                <shortdescription>Scatter plot illustrating the first 20 points in the sequence from the second part of this example.</shortdescription>
+                <description>
+                  <p>
+                    The scatter plot for <m>a_n=(-1)^n(n+1)/n</m> splits into two parts.
+                    When <m>n</m> is even, the points <m>(n,a_n)</m> follow the graph <m>y=1+1/x</m>,
+                    and approach the line <m>y=1</m> from above as <m>n</m> gets large.
+                    When <m>n</m> is odd, the points <m>(n,a_n)</m> follow the graph <m>y=-1-1/x</m>,
+                    and approach the line <m>y=-1</m> from below as <m>n</m> gets large.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1055,7 +1130,19 @@
             <caption/>
             <!-- START figures/fig_seq3a.tex -->
             <image xml:id="img_seq3a">
-              <description></description>
+              <shortdescription>A scatter plot of the first 10 terms in the first sequence for this example.</shortdescription>
+              <description>
+                <p>
+                  The points <m>(n,a_n)</m> are plotted, for <m>n</m> ranging from 1 to 10.
+                  These points follow the graph <m>y=1/x</m>, begining at <m>(1,1)</m>,
+                  and descending toward the <m>n</m> axis as <m>n</m> gets large.
+                </p>
+
+                <p>
+                  We can see that the value of <m>a_n</m> remains positive, but will continue to decrease as <m>n</m> increases.
+                  This illustrates the fact that the sequence is bounded between 0 and 1.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1087,7 +1174,15 @@
             <caption/>
             <!-- START figures/fig_seq3b.tex -->
             <image xml:id="img_seq3b">
-              <description></description>
+              <shortdescription>The scatter plot for the second sequence in this example, which shows exponential growth.</shortdescription>
+              <description>
+                <p>
+                  This time, the points <m>(n,2^n)</m> are plotted, for values of <m>n</m> between 1 and 8.
+                  These points follow the exponential graph <m>y=2^x</m>;
+                  we can see that the <m>y</m> value will continue to increase without bound,
+                  illustrating the fact that this sequence is not bounded.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1386,7 +1481,13 @@
               <caption/>
             <!-- START figures/fig_seq7a.tex -->
               <image xml:id="img_seq7a">
-                <description></description>
+                <shortdescription>Plot of the first sequence in this example. It is decreasing and bounded below.</shortdescription>
+                <description>
+                  <p>
+                    The scatter plot for <m>a_n = (n+1)/n</m> shows a sequence that is decreasing,
+                    and bounded below by <m>y=1</m>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1415,7 +1516,15 @@
               <caption/>
             <!-- START figures/fig_seq7b.tex -->
               <image xml:id="img_seq7b">
-                <description></description>
+                <shortdescription>Scatter plot for the second sequence in this example. It is increasing but not bounded.</shortdescription>
+                <description>
+                  <p>
+                    The points in the scatter plot for this example get larger as <m>n</m> increases,
+                    illustrating the fact that this is an increasing sequence.
+                    In fact, for large <m>n</m> we can see that <m>a_n \approx n</m>,
+                    and the points in the plot do appear to follow close to the line <m>y=x</m>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1445,7 +1554,19 @@
               <caption/>
             <!-- START figures/fig_seq7c.tex -->
               <image xml:id="img_seq7c">
-                <description></description>
+                <shortdescription>Scatter plot for the third sequence in this example. It is not monotonic.</shortdescription>
+                <description>
+                  <p>
+                    The plot for <m>a_n = \frac{n^2-9}{n^2-10n+26}</m> shows a sequence that is initially increasing,
+                    but begins to decrease after <m>n=5</m>.
+                  </p>
+
+                  <p>
+                    Although this sequence is not monotonic, it is <em>eventually</em> monotonic,
+                    and bounded below,
+                    which (as we will soon see) is sufficient for the determination of a limit.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1475,7 +1596,19 @@
               <!-- Either all get captions, or none. The labels in each image make it clear enough?-->
             <!-- START figures/fig_seq7d.tex -->
               <image xml:id="img_seq7d">
-                <description></description>
+                <shortdescription>Scatter plot for the last sequence in this example. It is not monotonic.</shortdescription>
+                <description>
+                  <p>
+                    The plot for <m>a_n =n^2/n!</m> shows a sequence that is initially increasing,
+                    but begins to decrease after <m>n=2</m>.
+                  </p>
+
+                  <p>
+                    Although this sequence is not monotonic, it is <em>eventually</em> monotonic,
+                    and bounded below,
+                    which (as we will soon see) is sufficient for the determination of a limit.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -210,7 +210,14 @@
                     <caption/>
               <!-- START figures/fig_series1a.tex -->
                     <image xml:id="img_series1a">
-                      <description></description>
+                      <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the first part of this example.</shortdescription>
+                      <description>
+                        <p>
+                          The scatter plot shows the first 10 terms in the sequence <m>a_n=n^2</m>, which follow the graph <m>y=x^2</m>.
+                          On the same plot, the first 10 terms in the sequence of partial sums <m>S_n</m> are shown.
+                          As one might expect, the value of <m>S_n</m> grows much more rapidly than that of <m>a_n</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -246,7 +253,19 @@
                     <caption/>
               <!-- START figures/fig_series1b.tex -->
                     <image xml:id="img_series1b">
-                      <description></description>
+                      <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the second part of this example.</shortdescription>
+                      <description>
+                        <p>
+                          This scatter plot shows the terms in the sequence <m>b_n</m>, along with the corresponding partial sums.
+                          Since the value of <m>b_n</m> alternates between <m>-1</m> and <m>1</m>,
+                          we see one sequence of dots along the line <m>y=1</m>, and another along the line <m>y=-1</m>.
+                        </p>
+
+                        <p>
+                          When <m>n</m> is even, <m>S_n=0</m>, so we also see a sequence of dots along the <m>n</m> axis.
+                          When <m>n</m> is odd, <m>S_n=a_n</m>, so the dots for <m>b_n</m> and <m>S_n</m> overlap.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -508,7 +527,18 @@
                 <caption>Scatter plots for the series in <xref ref="item_ex_ser2_1"/></caption>
             <!-- START figures/fig_series2a.tex -->
                 <image xml:id="img_series2a" width="47%">
-                  <description></description>
+                  <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the first part of this example.</shortdescription>
+                  <description>
+                    <p>
+                      Scatter plots for both <m>a_n = (3/4)^n</m> and <m>S_n</m> are shown together in the same image.
+                      The point for <m>a_2</m> is not visible, as it is covered up by <m>S_2</m>, which has the same value.
+                    </p>
+
+                    <p>
+                      The points in the plot for <m>a_n</m> illustrate a sequence that decreases toward 0,
+                      while the points in the plot for <m>S_n</m> show that the partial sums are increasing toward a value slightly larger than 2.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -558,7 +588,18 @@
                 <caption>Scatter plots for the series in <xref ref="item_ex_ser2_2"/></caption>
           <!-- START figures/fig_series2b.tex -->
                 <image xml:id="img_series2b" width="47%">
-                  <description></description>
+                  <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the second part of this example.</shortdescription>
+                  <description>
+                    <p>
+                      Scatter plots for <m>a_n = (-1/2)^n</m> and the corresponding partial sums are shown together in the same image.
+                      The numbers <m>a_n</m> alternate in sign between positive and negative values, but get closer to 0 as <m>n</m> increases.
+                    </p>
+
+                    <p>
+                      The <m>y</m> coordinates for the points in the scatter plot for <m>S_n</m> also oscillate,
+                      but the oscillations get steadily smaller, and appear to settle down toward a common <m>y</m> value.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -608,7 +649,13 @@
                 <caption>Scatter plots for the series in <xref ref="item_ex_ser2_3"/></caption>
           <!-- START figures/fig_series2c.tex -->
                 <image xml:id="img_series2c" width="47%">
-                  <description></description>
+                  <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the third part of this example.</shortdescription>
+                  <description>
+                    <p>
+                      Scatter plots for the sequence <m>a_n=3^n</m> and the corresponding partial sums are shown together in the same image.
+                      Both plots follow curves that appear to be exponential in nature, with the points for <m>S_n</m> slightly above those for <m>a_n</m>.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -881,7 +928,20 @@
           <caption>Scatter plots relating to the series of <xref ref="ex_series3">Example</xref></caption>
           <!-- START figures/fig_series3.tex -->
           <image xml:id="img_series3" width="47%">
-            <description></description>
+            <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for this example.</shortdescription>
+            <description>
+              <p>
+                A scatter plot for the sequence <m>a_n = \frac1n-\frac{1}{n+1}=\frac{1}{n(n+1)}</m> is shown.
+                These points begin at <m>(1,1/2)</m> and then descend toward the <m>n</m> axis.
+              </p>
+
+              <p>
+                Also shown is the scatter plot for the sequence <m>S_n</m> of partial sums of this series.
+                These terms are shown to be given by <m>S_n = 1-\frac{1}{n+1}</m>,
+                and we see that the points on the scatter plot begin at <m>(1,1/2)</m>
+                and then rise toward the line <m>y=1</m>.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -895,7 +955,7 @@
             ]
 
             \addplot [only marks,firstcolor,mark size={1.5pt},domain=1:10,samples=10] {1/x-1/(x+1)};
-            \addplot [only marks,secondcolor,mark size={1.5pt},domain=1:10,samples=10] {1-1/x};
+            \addplot [only marks,secondcolor,mark size={1.5pt},domain=1:10,samples=10] {1-1/(x+1)};
 
             \end{axis}
 
@@ -1042,7 +1102,16 @@
               <caption/>
         <!-- START figures/fig_series4a.tex -->
               <image xml:id="img_series4a">
-                <description></description>
+                <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the first part of this example.</shortdescription>
+                <description>
+                  <p>
+                    The scatter plots given appear very similar to the previous example.
+                    Again, points plotted for the terms in the sequence <m>a_n</m>, 
+                    which begin at <m>(1,2/3)</m>, descend toward the <m>n</m> axis,
+                    while the points for the sequence of partial sums ascend from the same point,
+                    in this case getting closer and closer to the line <m>y=3/2</m>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1081,7 +1150,17 @@
               <caption/>
         <!-- START figures/fig_series4b.tex -->
               <image xml:id="img_series4b">
-                <description></description>
+                <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the second part of this example.</shortdescription>
+                <description>
+                  <p>
+                    Scatter plots are shown for both <m>a_n = \ln(1+1/n)</m> and <m>S_n = \ln(n+1)</m>,
+                    for <m>n=10,20,\ldots, 100</m>.
+                    The points for the sequence <m>a_n</m> are all very close to the <m>n</m> axis.
+                    The points for the sequence <m>S_n</m> of partial sums follow the graph <m>y=\ln(x+1)</m>;
+                    although this may appear to be bounded, we know that the value of the logarithm 
+                    will eventually approach infinity, even if it does so very slowly.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1282,7 +1361,19 @@
                     <caption/>
               <!-- START figures/fig_series5a.tex -->
                     <image xml:id="img_series5a">
-                      <description></description>
+                      <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the first part of this example.</shortdescription>
+                      <description>
+                        <p>
+                          The points in the scatter plot for the sequence <m>a_n</m>
+                          appear to alternate betwee positive and negative <m>y</m> values,
+                          and they converge toward the <m>n</m> axis from both sides.
+                        </p>
+
+                        <p>
+                          The points in the scatter plot for the sequence of partial sums <m>S_n</m>
+                          also appear to oscillate, although they all have negative <m>y</m> coordinates.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -1321,7 +1412,14 @@
                     <caption/>
               <!-- START figures/fig_series5b.tex -->
                     <image xml:id="img_series5b">
-                      <description></description>
+                      <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for the first part of this example.</shortdescription>
+                      <description>
+                        <p>
+                          Scatter plots are shown for the sequence <m>a_n = 1000/n!</m>, and the corresponding partial sums.
+                          The value of <m>a_n</m> approaches zero quite rapidly,
+                          and as a result, we also see that the points in the plot for <m>S_n</m> quickly converge toward the limiting value.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -38,7 +38,17 @@
 <!-- START figures/fig_taypolyintroa.tex -->
         <caption>A graph of <m>f(x)</m> and its tangent line at <m>0</m></caption>
         <image xml:id="img_taypolyintroa_1">
-          <description></description>
+          <shortdescription>The graph of a generic function is shown, along with the tangent line to the graph at x=0.</shortdescription>
+          <description>
+            <p>
+              The image shows the graph of a function <m>f(x)</m> and its tangent line at <m>(0,f(0))</m>.
+              The precise features of the graph of <m>f(x)</m> are unimportant for this illustration.
+              What is relevant is that points on the tangent line, which is the graph of a linear function labeled as <m>p_1(x)</m>,
+              are close to the corresponding points on the graph of <m>f(x)</m>, near the point <m>(0,f(0))</m>.
+              In other words, the image illustrates the fact that when <m>x</m> is close to zero,
+              the value of <m>p_1(x)</m> is close to the value of <m>f(x)</m>.
+            </p>
+          </description>
           <latex-image>
 
           \begin{tikzpicture}
@@ -174,7 +184,41 @@
       <caption>Plotting <m>f</m>, <m>p_2</m> and <m>p_4</m></caption>
       <!-- START figures/fig_taypolyintrob.tex -->
       <image xml:id="img_taypolyintrob" width="47%">
-        <description></description>
+        <shortdescription>The graph of a function and two polynomials that approximate the function near x=0.</shortdescription>
+        <description>
+          <p>
+            The graph of a function <m>f(x)</m> is shown. It is the same function as the first image in this section,
+            but again, the precise details of the graph are unimportant.
+          </p>
+
+          <p>
+            Also shown are the graphs of two functions <m>p_2(x)</m> and <m>p_4(x)</m>.
+            The function <m>p_2(x)</m> is quadratic, and its graph is a parabola that opens upward.
+            The function <m>p_4(x)</m> is a polynomial of degree 4.
+          </p>
+
+          <p>
+            All three graphs intersect at the point <m>(0,f(0))</m>,
+            and the values of both <m>p_2(x)</m> and <m>p_4(x)</m> are close to the value of <m>f(x)</m> when <m>x</m> is close to <m>0</m>.
+            Two observations are important: first, both of these polynomial graphs appear to lie more closely to the graph of <m>f(x)</m>
+            than the tangent line in the first image. Second, the graph of <m>p_4(x)</m> is a good approximation to <m>f(x)</m>
+            over a larger interval than the graph of <m>p_2(x)</m>.
+          </p>
+
+          <p>
+            In particular, the point <m>(0,f(0))</m> appears to be a local minimum,
+            and there is a corresponding minimum in the graphs of both <m>p_2(x)</m> and <m>p_4(x)</m>.
+            But the graph of <m>f(x)</m> also appears to have a local maximum near <m>x=1</m>.
+            Near <m>x=1</m>, the graph of <m>p_2(x)</m> separates from that of <m>f(x)</m>: 
+            the first continues to increase, while the second begins to decrease.
+            Near <m>x=1</m>, <m>p_2(x)</m> is no longer a good approximation to <m>f(x)</m>.
+          </p>
+
+          <p>
+            However, the graph of <m>p_4(x)</m> also has a maximum near <m>x=1</m>,
+            and <m>p_4(x)</m> appears to be a good approximation to <m>f(x)</m> at least until <m>x=2</m>.
+          </p>
+        </description>
         <latex-image>
 
       \begin{tikzpicture}
@@ -182,7 +226,7 @@
       \begin{axis}[
       axis on top,
       ymin=-5.5,ymax=8.5,
-      xmin=-4.2,xmax=4.4
+      xmin=-4.5,xmax=4.4
       ]
 
       \addplot+ [domain=-4:3.2,samples=120] {exp(x)*sin(deg(x))*cos(deg(x))+2} node [pos=0.6,left] { $y=f(x)$};
@@ -277,7 +321,16 @@
       <caption>Plotting <m>f</m> and <m>p_{13}</m></caption>
       <!-- START figures/fig_taypolyintroc.tex -->
       <image xml:id="img_taypolyintroc" width="47%">
-        <description></description>
+        <shortdescription>The graph of a function is shown, along with the graph of a degree 13 polynomial that closely approximates the function.</shortdescription>
+        <description>
+          <p>
+            The graph of a function <m>f(x)</m> is shown. It is the same function as in the previous two images.
+            Also shown is the graph of a degree 13 polynomial <m>p_{13}(x)</m>.
+            We can see that the values of <m>f(x)</m> and <m>p_{13}(x)</m> are very close over an interval
+            from <m>-2</m> to <m>3</m>. For <m>x \lt -3</m>, the graph of <m>f(x)</m> appears to approach a horizontal asymptote,
+            while the graph of <m>p_{13}(x)</m> approaches <m>-\infty</m>, so it ceases to be a good approximation to <m>f(x)</m> at this point.
+          </p>
+        </description>
         <latex-image>
 
       \begin{tikzpicture}
@@ -285,7 +338,7 @@
       \begin{axis}[
       axis on top,
       ymin=-5.5,ymax=8.5,
-      xmin=-4.2,xmax=4.4
+      xmin=-4.5,xmax=4.4
       ]
 
       \addplot+ [domain=-3.5:3.3,thick,samples=120] {exp(x)*sin(deg(x))*cos(deg(x))+2} node [pos=0, above] { $y=f(x)$};
@@ -488,7 +541,15 @@
           Maclaurin polynomial <m>p_5(x)</m></caption>
       <!-- START figures/fig_taypoly1b.tex -->
           <image xml:id="img_taypoly1b" width="47%">
-            <description></description>
+            <shortdescription>The graph of the exponential function and its degree 5 Maclaurin polynomial.</shortdescription>
+            <description>
+              <p>
+                The graph of <m>f(x)=e^x</m> is shown on the interval <m>[-3,2]</m>.
+                Also shown is the graph of <m>p_5(x)</m>, the degree 5 Maclaurin polynomial of <m>f(x)</m>.
+                For <m>-2\lt x\lt 2</m>, there is very little visible difference between the two graphs.
+                Near <m>x=3</m> we can see that the two graphs begin to separate.
+              </p>
+            </description>
             <latex-image>
 
                 \begin{tikzpicture}
@@ -683,7 +744,16 @@
             polynomial at <m>x=1</m></caption>
         <!-- START figures/fig_taypoly2b.tex -->
             <image xml:id="img_taypoly2b" width="47%">
-              <description></description>
+              <shortdescription>A graph of the natural logarithm function and its degree 6 Taylor polynomial centered at x=1.</shortdescription>
+              <description>
+                <p>
+                  The graph of <m>y=\ln(x)</m> is shown on the interval <m>(0,3)</m>.
+                  Also shown is the graph of <m>p_6(x)</m>, the degree 6 Taylor polynomial of <m>\ln(x)</m>,
+                  centered at <m>x=1</m>.
+                  The graph of <m>p_6(x)</m> is very close to the graph of <m>\ln(x)</m> on the interval <m>(0.5,1.5)</m>,
+                  but does not approximate the logarithm very well outside of this interval.
+                </p>
+              </description>
               <latex-image>
 
                 \begin{tikzpicture}
@@ -711,7 +781,15 @@
             Taylor polynomial at <m>x=1</m></caption>
         <!-- START figures/fig_taypoly2c.tex -->
             <image xml:id="img_taypoly2c" width="47%">
-              <description></description>
+              <shortdescription>A graph of the natural logarithm function and its degree 20 Taylor polynomial centered at x=1.</shortdescription>
+              <description>
+                <p>
+                  The graph <m>y=\ln(x)</m> is shown again, this time with the degree 20 Taylor polynomial of <m>\ln(x)</m>, centered at <m>x=1</m>.
+                  Unlike with the example involving <m>y=e^x</m>, increasing the degree of the Taylor polynomial did not do much to improve
+                  how well it approximates the logarithm. The approximation appears to be accurate over a slightly larger interval
+                  than the degree 6 approximation, but there is not a significant difference between the two images.
+                </p>
+              </description>
               <latex-image>
                 \begin{tikzpicture}
                   \begin{axis}[ymax=3]
@@ -1139,7 +1217,18 @@
           polynomial</caption>
           <!-- START figures/fig_taypoly4.tex -->
           <image xml:id="img_taypoly4b" width="47%">
-            <description></description>
+            <shortdescription>A graph of the cosine function is shown, along with its degree 8 Maclaurin polynomial approximation.</shortdescription>
+            <description>
+              <p>
+                The graph <m>y=\cos(x)</m> is given on the interval <m>[-5,5]</m>,
+                along with the graph of <m>p_8(x)</m>, the degree 8 Maclaurin polynomial approximation of <m>\cos(x)</m>.
+              </p>
+
+              <p>
+                The image illustrates how well the Maclaurin polynomials approximate the cosine function.
+                With a degree 8 polynomial, there is little to no visible difference between the graphs over the interval <m>(-\pi,\pi)</m>.
+              </p>
+            </description>
             <latex-image>
 
           \begin{tikzpicture}
@@ -1293,7 +1382,14 @@
           polynomial at <m>x=4</m></caption>
       <!-- START figures/fig_taypoly5.tex -->
           <image xml:id="img_taypoly5b" width="47%">
-            <description></description>
+            <shortdescription>The graph of the square root function and its degree 4 Taylor polynomial, centered at x=4.</shortdescription>
+            <description>
+              <p>
+                The graph <m>y=\sqrt{x}</m> is shown, for <m>x</m> in the interval <m>[0,10]</m>.
+                Also shown is the degree 4 Taylor polynomial <m>p_4(x)</m>, centered at <m>x=4</m>.
+                The Taylor polynomial appears to approximate <m>\sqrt{x}</m> very well over the interval <m>(2,7)</m>.
+              </p>
+            </description>
             <latex-image>
 
                 \begin{tikzpicture}
@@ -1422,12 +1518,29 @@
  <!--         which we have seen before is equivalent to <m>f(x)=\frac{1}{1-x}</m> on <m>(-1,1)</m>.-->
         </p>
 
+        <p>
+          It turns out that the differential equation we started with,
+          <m>y'=y^2</m>,
+          where <m>y(0)=1</m>, can be solved without too much difficulty:
+          <me>y = \frac{1}{1-x}</me>.
+          <xref ref="fig_taypoly6">Figure</xref>
+          shows this function plotted with <m>p_3(x)</m>.
+          Note how similar they are near <m>x=0</m>.
+        </p>
+
         <figure xml:id="fig_taypoly6">
           <caption>A graph of <m>y=-1/(x-1)</m> and <m>y=p_3(x)</m> from
           <xref ref="ex_taypoly6">Example</xref></caption>
           <!-- START figures/fig_taypoly6.tex -->
           <image xml:id="img_taypoly6" width="47%">
-            <description></description>
+            <shortdescription>The graph of the exact solution to the differential equation in this example, and a polynomial approximation.</shortdescription>
+            <description>
+              <p>
+                The graph <m>y=1/(1-x)</m> is shown, for <m>x</m> from <m>-1</m> to about <m>0.6</m>.
+                Also shown is the graph of <m>p_3(x)</m>, the Maclaurin polynomial obtained as an approximate solution to the differential equation in this example.
+                As expected, the polynomial is a good approximation to the exact solution when <m>x</m> is close to <m>0</m>.
+              </p>
+            </description>
             <latex-image>
 
           \begin{tikzpicture}
@@ -1448,16 +1561,6 @@
           </image>
           <!-- figures/fig_taypoly6.tex END -->
         </figure>
-
-        <p>
-          It turns out that the differential equation we started with,
-          <m>y'=y^2</m>,
-          where <m>y(0)=1</m>, can be solved without too much difficulty:
-          <me>y = \frac{1}{1-x}</me>.
-          <xref ref="fig_taypoly6">Figure</xref>
-          shows this function plotted with <m>p_3(x)</m>.
-          Note how similar they are near <m>x=0</m>.
-        </p>
       </solution>
     </example>
 

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -915,7 +915,15 @@
       <figure xml:id="fig_tayseries1">
         <caption>A graph of <m>f(x)</m> and its degree 5 Maclaurin polynomial</caption>
         <image xml:id="img_tayseries1" width="47%">
-          <description></description>
+          <shortdescription>A graph of the function from this example, and its degree 5 Maclaurin polynomial approximation.</shortdescription>
+          <description>
+            <p>
+              The image shows the graph of <m>f(x)=e^{\sin(x)}</m> on the interval <m>[-2,2]</m>,
+              along with the graph of <m>p_5(x)</m>, the degree 5 Maclaurin polynomial approximation of <m>f(x)</m>.
+              As we have come to expect, there is very little noticeable difference between the two graphs near <m>x=0</m>,
+              and it appears that the polynomial approximation remains good over the interval <m>(-1,1)</m>.
+            </p>
+          </description>
           <latex-image>
 
           \begin{tikzpicture}


### PR DESCRIPTION
This adds both short and long descriptions for the sequences and series chapter.

I also fixed one file where I noticed that a unicode apostrope was being used instead of the ascii one.

While writing the image descriptions I noticed that a few images that needed minor fixes: two had labels getting cropped incorrectly, one used `x` instead of `n` to lable the terms in a sequence, and one image used `x` in the function formula where it should have had `x+1`, so the first point in the scatter plot was wrong.

Apologies for the untidy commit history. I forgot to pull the last changes from upstream before I created a new local branch. I thought I could avoid adding a merge commit by rebasing my branch off of `main` but the result seems to have been that I just repeated all the commits somehow. Clearly I still don't understand `rebase`.