### PR TITLE
Image descriptions for plane curves chapter

### DIFF
--- a/ptx/apex-UL-accelerated.ptx
+++ b/ptx/apex-UL-accelerated.ptx
@@ -44,8 +44,7 @@
         <edition>5</edition>
 
         <website>
-          <name>www.apexcalculus.com</name>
-          <address>https://www.apexcalculus.com/</address>
+          <url href="https://www.apexcalculus.com/" visual="www.apexcalculus.com">apexcalculus.com</url>
         </website>
 
         <copyright>

--- a/ptx/apex-UL-standard.ptx
+++ b/ptx/apex-UL-standard.ptx
@@ -44,8 +44,7 @@
         <edition>5</edition>
 
         <website>
-          <name>www.apexcalculus.com</name>
-          <address>https://www.apexcalculus.com/</address>
+          <url href="https://www.apexcalculus.com/" visual="www.apexcalculus.com">apexcalculus.com</url>
         </website>
 
         <copyright>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -38,7 +38,7 @@
         <image xml:id="img_sinx_over_x_full">
           <description>
             <p>
-              Graph of <m>sin(x)/x</m> showing the domain and range of  
+              Graph of <m>\sin(x)/x</m> showing the domain and range of  
               <m>-7</m>to <m>7</m> and <m>0</m> to 
               <m>1</m> respectively. <m>x</m> intercepts are at 
               <m>x=--2\pi, -\pi, \pi. 2\pi</m> and a <m>y</m> intercept is at <m>y = 1</m>. 
@@ -75,10 +75,10 @@
         <image xml:id="img_zoom_sinx_over_x">
           <description>
             <p>
-              Graph of <m>sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>1</m>. The 
+              Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>1</m>. The 
               domain of the graph is <m>0.5</m> to <m>1.5</m>. 
               The line has only a slight downward curve. It shows that for <m>x = 1</m>, 
-              <m>sin(x)/x</m> is approx. <m>0.84</m>
+              <m>\sin(x)/x</m> is approx. <m>0.84</m>
             </p>
           </description>
           <shortdescription> 
@@ -136,7 +136,7 @@
       <image xml:id="img_sinx_over_x_2" width="47%">
         <description>
           <p>
-            Graph of <m>sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>0</m>. The 
+            Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>0</m>. The 
             domain of the graph is <m>-1</m> to <m>1</m>. The graph 
             has a downward curve and symmetric, peaking at <m>y = 1</m>. There is a dot at
             <m>x = 0</m> showing the equation is undefined for values of <m>x = 0</m>, 

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -176,7 +176,22 @@
                 <caption>Graphing tangent and normal lines in <xref ref="ex_parcalc1">Example</xref></caption>
               <!-- START figures/fig_parcalc1.tex -->
                 <image xml:id="img_parcalc1" width="47%">
-                  <description></description>
+                  <shortdescription>Plot of a parametric curve and its tangent and normal lines at one point.</shortdescription>
+                  <description>
+                    <p>
+                      The curve <m>x=5t^2-6t+4, y=t^2+6t-1</m> is shown.
+                      The shape of the curve is that of a distored parabola, opening to the right from a vertex near <m>(2,3)</m>.
+                      (The precise location is <m>\left(\frac{11}{5},\frac{74}{25}\right)</m>.)
+                      The curve begins below the <m>x</m> axis, traveling left until it reaches the vertex,
+                      after which it continues up and to the right.
+                    </p>
+
+                    <p>
+                      At the point <m>(31,26)</m>, the tangent and normal lines to the curve are shown.
+                      The tangent line has a positive slope, while the normal line has a negative slope,
+                      and as expected, the two lines are perpendicular.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -298,7 +313,19 @@
                 <caption>Illustrating how a circle's normal lines pass through its center</caption>
             <!-- START figures/fig_parcalc2.tex -->
                 <image xml:id="img_parcalc2" width="47%">
-                  <description></description>
+                  <shortdescription>Sketch of the unit circle and one normal line, which passes through the circle's center.</shortdescription>
+                  <description>
+                    <p>
+                      A sketch of the unit circle is shown.
+                      At a point on the circle in the first quadrant
+                      (corresponding to an angle that appears to be slightly more than <m>\pi/3</m>),
+                      a normal line is drawn.
+                    </p>
+
+                    <p>
+                      The normal line passes through the center of the circle, illustrating the conclusion of this example.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -340,7 +367,13 @@
           <caption>A graph of an astroid</caption>
           <!-- START figures/fig_planecurve1.tex -->
           <image xml:id="img_parcalc3" width="47%">
-            <description></description>
+            <shortdescription>Graph of an astroid.</shortdescription>
+            <description>
+              <p>
+                Graph of the astroid curve <m>x^{2/3}+y^{2/3}=1</m>.
+                It has cusps at the vertices <m>(1,0),(0,1),(-1,0)</m> and <m>(0,-1)</m>.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -499,7 +532,19 @@
           <caption>Graphing the parametric equations in <xref ref="ex_parcalc4">Example</xref> to demonstrate concavity</caption>
           <!-- START figures/fig_parcalc4.tex -->
           <image xml:id="img_parcalc4" width="47%">
-            <description></description>
+            <shortdescription>Sketch of a parametric curve illustrating concavity.</shortdescription>
+            <description>
+              <p>
+                The curve shown is the same distorted parabola from <xref ref="ex_parcalc1"/>,
+                but without the tangent and normal lines.
+              </p>
+
+              <p>
+                Below the vertex, which corresponds to <m>t=3/5</m>,
+                the curve is concave up, and there is a label on the curve indicating that for <m>t\lt 3/5</m>, the curve is concave up.
+                Above the vertex, the curve is concave down, and there is a label on the curve indicating that for <m>t\gt 3/5</m>, the curve is concave down.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -542,7 +587,14 @@
         </p>
 
         <image xml:id="img_parcalc4X" width="70%">
-          <description></description>
+          <shortdescription>A number line for the sign of the second derivative in this example.</shortdescription>
+          <description>
+            <p>
+              A number line is shown, on which the value <m>3/5</m> is marked.
+              To the left of this point there is text indicating that <m>\frac{d^2y}{dx^2}\gt 0</m>, and that the curve is concave up.
+              To the right of this point there is text indicating that <m>\frac{d^2y}{dx^2}\lt 0</m>, and that the curve is concave down.
+            </p>
+          </description>
           <latex-image>
 
           \begin{tikzpicture}
@@ -631,7 +683,14 @@
               <caption/>
             <!-- START figures/fig_parcalc5b.tex -->
               <image xml:id="img_parcalc5a">
-                <description></description>
+                <shortdescription>Graph of the second derivative is a sinusoid with increasing amplitude.</shortdescription>
+                <description>
+                  <p>
+                    The image shows the graph <m>y = 2\cos(t)-4t\sin(t)</m>, which is a graph of <m>\frac{d^2y}{dx^2}</m>.
+                    The curve is sinusoidal, but with an amplitude that increases as <m>t</m> increases.
+                    The graph allows us to estimate the values of <m>t</m> where the second derivative is zero.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -660,7 +719,13 @@
               <caption/>
             <!-- START figures/fig_parcalc5.tex -->
               <image xml:id="img_parcalc5">
-                <description></description>
+                <shortdescription>Graph of the parametric curve in this example, with points of inflection marked.</shortdescription>
+                <description>
+                  <p>
+                    The graph shows a curve that appears to be sinusoidal, but with a frequency that increases with <m>x</m>.
+                    On the graph are several marked points, indicating where the inflection points occur.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -819,7 +884,13 @@
           <caption>A graph of the parametric equations in <xref ref="ex_parcalc7">Example</xref>, where the arc length of the teardrop is calculated</caption>
           <!-- START figures/fig_parcalc7.tex -->
           <image xml:id="img_parcalc7" width="47%">
-            <description></description>
+            <shortdescription>Graph of a "teardrop" curve that intersects itself at the origin.</shortdescription>
+            <description>
+              <p>
+                The curve given by <m>x=t(t^2-1), y=t^2-1</m> forms a <q>teardrop</q> shape.
+                The curve crosses itself at the origin, and the teardrop portion of the graph lies below the <m>x</m> axis.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -931,7 +1002,14 @@
 
           <!-- START figures/figparcalc8_3D.asy -->
           <image xml:id="img_parcalc8" width="47%">
-            <description></description>
+            <shortdescription>The surface obtained by revolving the teardrop shape from the previous example about the x axis.</shortdescription>
+            <description>
+              <p>
+                The image, which is interactive, shows the surface in three dimensions that is obtained when the teardrop curve
+                from <xref ref="ex_parcalc7"/> is revolved about the <m>x</m> axis.
+                The result is a donut-like shape, but with a pinch-point in the center rather than a hole.
+              </p>
+            </description>
             <asymptote>
 
 

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -14,7 +14,37 @@
     <figure xml:id="fig_param_eqs_intro1">
       <caption>Plotting a graph <m>y=f(x)</m></caption>
       <image xml:id="img_param_eqs_intro1" width="95%">
-        <description></description>
+        <shortdescription>Diagram outlining the steps involved in plotting a function.</shortdescription>
+        <description>
+          <p>
+            A diagram containing mostly text, that outlines the process for plotting a function.
+            The steps illustrated are as follows:
+            <ol>
+              <li>
+                <p>
+                  Choose <m>x</m>
+                </p>
+              </li>
+              <li>
+                <p>
+                  Use function <m>f</m> to find <m>y</m> (<m>y=f(x)</m>)
+                </p>
+              </li>
+              <li>
+                <p>
+                  Plot point <m>(x,y)</m>
+                </p>
+              </li>
+            </ol>
+          </p>
+
+          <p>
+            This is not really indicative of how a person would sketch a graph by hand
+            (better techniques for doing so were covered in <xref ref="sec_sketch"/>),
+            but it is not far off from how a computer might generate a plot,
+            or how a student who is first learning about functions might use a table of values to create a plot.
+          </p>
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -47,7 +77,27 @@
     <figure xml:id="fig_param_eqs_intro2">
       <caption>Plotting a curve <m>(x(t),y(t))</m></caption>
       <image xml:id="img_param_eqs_intro2" width="60%">
-        <description></description>
+        <shortdescription>Diagram illustrating the process for plotting a parametric curve.</shortdescription>
+        <description>
+          <p>
+            This is another text-based diagram, which illustrates the method for plotting curves that will be covered in this section.
+            In this method, the coordinates <m>x</m> and <m>y</m> are both defined as functions of a third variable, <m>t</m>.
+            Four phrases are arranged in a diamond shape, with text left, right, top, and bottom.
+          </p>
+
+          <p>
+            To the left of the diagram is the text, <q>Choose <m>t</m></q>.
+            An arrow points up and to the left from this text to the phrase <q>Use a function <m>f</m> to find <m>x</m> (<m>x=f(t)</m>)</q>,
+            which is located at the top of the diagram.
+            Another arrow points down and to the left from <q>Choose <m>t</m></q> to the phrase
+            <q>Use a function <m>g</m> to find <m>y</m> (<m>y=g(t)</m>)</q>, which is located at the bottom of the diagram.
+          </p>
+
+          <p>
+            From the phrases at the top and bottom of the diagram there are two more arrows pointing to the right,
+            to a final phrase, which states, <q>Plot point <m>(x,y)</m></q>.
+          </p>
+        </description>
         <latex-image>
 
         \begin{tikzpicture}[every node/.append style={font=\large}]
@@ -183,7 +233,20 @@
               <caption/>
               <!-- START figures/fig_pareq1.tex -->
               <image xml:id="img_pareq1b">
-                <description></description>
+                <shortdescription>Plot of a parabola with its vertex at the point (0,1), opening to the right, with several marked points.</shortdescription>
+                <description>
+                  <p>
+                    The parametric curve obtained from the table of values in <xref ref="fig_pareq1a"/> is shown.
+                    On a set of coordinate axes, the points corresponding to the values <m>t=-2,-1,0,1,2</m> are plotted.
+                    These are, respectively, <m>(4,-1), (1,0), (0,1), (1,2), (4,3)</m>.
+                  </p>
+
+                  <p>
+                    The curve joining these points is plotted; it appears to be a parabola opening to the right,
+                    with its vertex at the point <m>(0,1)</m>.
+                    Arrow heads on the curve indicate a direction of travel corresponding to an increasing value of <m>t</m>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -285,7 +348,19 @@
               <caption/>
               <!-- START figures/fig_pareq2.tex -->
               <image xml:id="img_pareq2b">
-                <description></description>
+                <shortdescription>Plot of a parabola with its vertex at the point (0,1), opening to the right, with several marked points.</shortdescription>
+                <description>
+                  <p>
+                    The parametric curve obtained from the table of values in <xref ref="fig_pareq2a"/> is shown.
+                    The curve is very similar in appearance to the one in <xref ref="fig_pareq1b"/>;
+                    again it appears to be a parabola opening to the right, with its vertex at the point <m>(0,1)</m>.
+                  </p>
+
+                  <p>
+                    The primary difference is that the marked points now correspond to parameter values
+                    <m>t = 0, \pi/4, \pi/2, 3\pi/4, \pi</m>. The direction of travel is opposite to that in <xref ref="fig_pareq1b"/>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -411,7 +486,20 @@
               <caption/>
             <!-- START figures/fig_pareq3a.tex -->
               <image xml:id="img_pareq3a">
-                <description></description>
+                <shortdescription>Plot of the "unshifted" parametric curve in this example.</shortdescription>
+                <description>
+                  <p>
+                    A plot of the curve <m>x=t^2+1, y=t^2-t</m> is shown.
+                    The shape of the curve is similar to that of a parabola, but slightly distorted.
+                  </p>
+
+                  <p>
+                    The curve begins near the point <m>(2,6)</m>, and then descends to a <m>y</m> intercept at <m>(0,2)</m>.
+                    It briefly enters the second quadrant before passing through the origin into the fourth quadrant.
+                    A small portion of the curve lies in the fourth quarant before it crosses the <m>x</m> axis at <m>(2,0)</m>;
+                    after this point, it continues into the first quadrant, exiting the image near the point <m>(10,5)</m>.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -442,7 +530,13 @@
               <caption/>
             <!-- START figures/fig_pareq3b.tex -->
               <image xml:id="img_pareq3b">
-                <description></description>
+                <shortdescription>The shifted version of the curve in this example.</shortdescription>
+                <description>
+                  <p>
+                    The curve in this image is identical to the one beside it in <xref ref="fig_pareq3a"/>;
+                    the only difference is that it has been shifted 3 units to the right, and 2 units down.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -502,7 +596,22 @@
           <caption>A graph of the parametric equations from <xref ref="ex_pareq4">Example</xref></caption>
           <!-- START figures/fig_pareq4.tex -->
           <image xml:id="img_pareq4" width="47%">
-            <description></description>
+            <shortdescription>Plot of a more complicated parametric curve that has a self-intersection.</shortdescription>
+            <description>
+              <p>
+                The curve in this image could describe the path of a fly that turns sharply in a loop,
+                before heading off in another direction.
+                It begins in the second quadrant, traveling down and to the right,
+                and crossing the <m>y</m> axis at approximately <m>(0,6.5)</m>.
+              </p>
+
+              <p>
+                The curve continues in this direction until it turns sharply near the point <m>(12,2)</m>.
+                The curve then travels to the left and bends upwards, crossing itself at the point <m>(2,6)</m>.
+                After this point of self-intersection, the curve continues in the first quadrant,
+                traveling up and to the right.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -649,7 +758,15 @@
           <caption>Graphing projectile motion in <xref ref="ex_pareq6">Example</xref></caption>
           <!-- START figures/fig_pareq6.tex -->
           <image xml:id="img_pareq6" width="47%">
-            <description></description>
+            <shortdescription>A parabolic arc describing the motion of a projectile fired up and to the right from the origin.</shortdescription>
+            <description>
+              <p>
+                The curve is a parabola that opens downward from a vertex at <m>(96,144)</m>.
+                It illustrates the path of a projectile that is fired from the origin and travels up and to the right
+                before reaching its maximum height at the vertex of the parabola.
+                It then travels back down, returning to the <m>x</m> axis at the point <m>(192,0)</m>.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -726,7 +843,21 @@
           <caption>Graphing parametric and rectangular equations for a graph in <xref ref="ex_pareq7">Example</xref></caption>
           <!-- START figures/fig_pareq7.tex -->
           <image xml:id="img_pareq7" width="47%">
-            <description></description>
+            <shortdescription>A graph of two overlapping lines illustrating rectangular and parametric descriptions of a curve.</shortdescription>
+            <description>
+              <p>
+                Two lines are plotted. The first is the line <m>y=1-x</m>,
+                which is drawn from the point <m>(-1,2)</m> to the point <m>(2,-1)</m>.
+              </p>
+
+              <p>
+                A second, thicker line is drawn over the first line, from <m>(0,1)</m> to <m>(1,0)</m>.
+                At <m>(0,1)</m> there is a <q>hollow</q> (white-filled) dot,
+                indicating that the second line approaches, but does not reach, this point.
+                At <m>(1,0)</m> there is a solid dot, indicating the fact that the parametric version of the line
+                reaches this point, but does not go past it.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -816,7 +947,13 @@
           <caption>Graphing the parametric equations <m>x=4\cos(t) +3</m>, <m>y=2\sin(t) +1</m> in <xref ref="ex_pareq8">Example</xref></caption>
           <!-- START figures/fig_pareq8.tex -->
           <image xml:id="img_pareq8" width="47%">
-            <description></description>
+            <shortdescription>Graph of the ellipse obtained from the parametric equations in this example.</shortdescription>
+            <description>
+              <p>
+                The plot shows an ellipse. The major axis runs from <m>(-1,1)</m> to <m>(7,1)</m>,
+                and the minor axis runs from <m>(3,-1)</m> to <m>(3,5)</m>.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -915,7 +1052,16 @@
           <!-- START figures/fig_planecurve1.tex -->
             <caption>Astroid where <m>x=\cos^3(t)</m> and <m>y=\sin^3(t)</m></caption>
             <image xml:id="img_planecurve1">
-              <description></description>
+              <shortdescription>Plot of an astroid: a curve like a 4-pointed star.</shortdescription>
+              <description>
+                <p>
+                  A plot of the parametric curve <m>x=\cos^3(t)</m>, <m>y=\sin^3(x)</m>,
+                  known as an astroid.
+                  The curve has four cusps, at the points <m>(1,0), (0,1), (-1,0)</m>, and <m>(0,-1)</m>.
+                  The appearance is not unlike what one would get if one held these four points fixed on the unit circle,
+                  and then bent the rest of the circle so that it curves inward (toward the origin) rather than outward.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -941,7 +1087,14 @@
           <!-- START figures/fig_planecurve2.tex -->
             <caption>Rose Curve where <m>x=\cos(t)\sin(4t)</m> and <m>y=\sin(t)\sin(4t)</m></caption>
             <image xml:id="img_planecurve2">
-              <description></description>
+              <shortdescription>Plot of a rose curve with 8 loops.</shortdescription>
+              <description>
+                <p>
+                  The plot of the curve <m>x=\cos(t)\sin(4t), y=\sin(t)\sin(4t)</m> resembles a flower.
+                  It consists of eight loops, equal in size and shape, each passing through the origin.
+                  The shape of each loop resembles a narrow tear-drop.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -970,7 +1123,20 @@
           <!-- START figures/fig_planecurve3.tex -->
             <caption>Hypotrochoid where <m>x=2\cos(t)+5\cos(2t/3)</m> and <m>y=2\sin(t)-5\sin(2t/3)</m></caption>
             <image xml:id="img_planecurve3">
-              <description></description>
+              <shortdescription>Plot of a hypotrochoid, which resembles a smooth, five-pointed star.</shortdescription>
+              <description>
+                <p>
+                  The curve <m>x=2\cos(t)+5\cos(2t/3), y=2\sin(t)-5\sin(2t/3)</m>, known as a hypotrochoid, is shown.
+                  The curve is symmetric about the <m>x</m> axis, and resembles a five-pointed star,
+                  with one point on the <m>x</m> axis at <m>(7,0)</m>.
+                </p>
+
+                <p>
+                  The points of the star are rounded, rather than sharp.
+                  The curve passes through itself several times,
+                  in a manner similar to how a pentagram is drawn.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -995,7 +1161,19 @@
           <!-- START figures/fig_planecurve4.tex -->
             <caption>Epicycloid where <m>x=4\cos(t)-\cos(4t)</m> and <m>y=4\sin(t)-\sin(4t)</m></caption>
             <image xml:id="img_planecurve4">
-              <description></description>
+              <shortdescription>Plot of an epicycloid, which looks somewhat like a puffy clover leaf.</shortdescription>
+              <description>
+                <p>
+                  The epicycloid <m>x=4\cos(t)-\cos(4t), y=4\sin(t)-\sin(4t)</m> is shown.
+                  The curve travels once around the origin, and consists of three arcs,
+                  with each pair of arcs meeting at a cusp.
+                </p>
+
+                <p>
+                  The effect is not unlike the appearance of a three-leaf clover,
+                  if the leaves were much more puffy, and further from the center.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1095,7 +1273,19 @@
           <caption>Graphing the curve in <xref ref="ex_pareq9">Example</xref>; note it is not smooth at <m>(1,4)</m></caption>
           <!-- START figures/fig_pareq9.tex -->
           <image xml:id="img_pareq9" width="47%">
-            <description></description>
+            <shortdescription>Plot of a parametric curve with a sharp cusp.</shortdescription>
+            <description>
+              <p>
+                A plot of the curve <m>x=t^3-12t+17, y=t^2-4t+8</m> is shown.
+                Despite the fact that <m>x</m> and <m>y</m> are both differentiable functions of <m>t</m>,
+                there is a sharp cusp at the point corresponding to <m>t=2</m>,
+                which happens to be the point where the derivatives of <m>x</m> and <m>y</m> with respect to <m>t</m> are simultaneously zero.
+              </p>
+
+              <p>
+                The appearance of the curve is not unlike that of a set of tweezers.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -1261,7 +1451,16 @@
               <answer>
               <!-- START figures/fig_09_02_ex_05.tex -->
                   <image xml:id="img_09_02_ex_05X">
-                    <description></description>
+                    <shortdescription>Sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        The sketch for this exercise is a curve that lies mostly in the fourth quadrant.
+                        It resembles part of a slingshot orbit for a comet passing around the sun:
+                        the curve passes through the origin from below, turns quickly in the second quadrant,
+                        crossing the <m>y</m> axis at <m>(0,1)</m>, and then the <m>x</m> axis at <m>(2,0)</m>,
+                        where it returns to the fourth quadrant.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1300,7 +1499,13 @@
               <answer>
               <!-- START figures/fig_09_02_ex_06.tex -->
                   <image xml:id="img_09_02_ex_06X">
-                    <description></description>
+                    <shortdescription>The vertical line x=1.</shortdescription>
+                    <description>
+                      <p>
+                        The curve for this exercise is the vertical line <m>x=1</m>.
+                        An arrow on the line indicates that the direction of travel is up.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1339,7 +1544,15 @@
               <answer>
               <!-- START figures/fig_09_02_ex_07.tex -->
                   <image xml:id="img_09_02_ex_07X">
-                    <description></description>
+                    <shortdescription>The horizontal line y=2, marked with two arrows.</shortdescription>
+                    <description>
+                      <p>
+                        The horizontal line <m>y=2</m>.
+                        On the line there are two arrows pointing in opposite directions.
+                        These indicate that the direction of travel is to the left when <m>t\lt 0</m>,
+                        and to the right when <m>t\gt 0</m>.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1378,7 +1591,15 @@
               <answer>
               <!-- START figures/fig_09_02_ex_08.tex -->
                   <image xml:id="img_09_02_ex_08X">
-                    <description></description>
+                    <shortdescription>The solution curve for this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        The curve begins to the left of the <m>y</m> axis, and crosses near <m>(0,4)</m>.
+                        It passes through the first quadrant to the point <m>(3,2)</m>;
+                        it then bends downward and makes a teardrop-shaped loop before passing through <m>(3,2)</m> a second time,
+                        and then continuing up and to the right, through the first quadrant.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1428,7 +1649,15 @@
               <answer>
               <!-- START figures/fig_09_02_ex_09.tex -->
                   <image xml:id="img_09_02_ex_09X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        A curve resembling a check mark, with a cusp at the origin.
+                        Direction of travel is from the second quadrant toward the cusp,
+                        and then up from the cusp to a <m>y</m> intercept at <m>(0,4)</m>,
+                        and then into the first quadrant.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1465,7 +1694,13 @@
               <answer>
               <!-- START figures/fig_09_02_ex_10.tex -->
                   <image xml:id="img_09_02_ex_10X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        A curve resembling a sine wave with a period that gets longer for large values of <m>x</m>.
+                        The direction of travel is that of decreasing <m>x</m> value, with the <m>y</m> value oscillating.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1502,7 +1737,12 @@
               <answer>
               <!-- START figures/fig_09_02_ex_11.tex -->
                   <image xml:id="img_09_02_ex_11X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        The curve is an ellipse, centered at the origin, with counter-clockwise direction of travel.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1539,7 +1779,12 @@
               <answer>
               <!-- START figures/fig_09_02_ex_12.tex -->
                   <image xml:id="img_09_02_ex_12X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        An ellipse with center <m>(2,3)</m> and counter-clockwise direction of travel.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1578,7 +1823,13 @@
               <answer>
               <!-- START figures/fig_09_02_ex_13.tex -->
                   <image xml:id="img_09_02_ex_13X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        The curve resembles a parabola, with vertex at <m>(0,-1)</m>.
+                        The direction of travel is from right to left.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1615,7 +1866,15 @@
               <answer>
               <!-- START figures/fig_09_02_ex_14.tex -->
                   <image xml:id="img_09_02_ex_14X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        A figure-eight curve, centered at the origin.
+                        The orientation is counter-clockwise in the fourth and first quadrants;
+                        once the curve passes through the origin (a point of self-intersection)
+                        this direction becomes clockwise it the second and third quadrants.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1651,7 +1910,13 @@
               <answer>
               <!-- START figures/fig_09_02_ex_15.tex -->
                   <image xml:id="img_09_02_ex_15X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        The curve resembles one branch of a hyperbola, opening to the right, with a vertex at <m>(2,0)</m>.
+                        The direction of travel is that of increasing <m>y</m> value.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1687,6 +1952,13 @@
         </statement>
         <answer>
           <image xml:id="img_09_02_ex_55">
+            <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+            <description>
+              <p>
+                The curve resembles one branch of a hyperbola, opening to the right, with a vertex at <m>(1,0)</m>.
+                The direction of travel is that of increasing <m>y</m> value.
+              </p>
+            </description>
             <latex-image>
               \begin{tikzpicture}
               \begin{axis}[
@@ -1721,7 +1993,13 @@
               <answer>
               <!-- START figures/fig_09_02_ex_16.tex -->
                   <image xml:id="img_09_02_ex_16X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        A flower-shaped curve, with 7 <q>petals</q>.
+                        Each petal is an arc that loops around and intersects itself before continuing to the next arc.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -1758,7 +2036,14 @@
               <answer>
               <!-- START figures/fig_09_02_ex_17.tex -->
                   <image xml:id="img_09_02_ex_17X">
-                    <description></description>
+                    <shortdescription>Computer-generated sketch of the parametric curve in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        A curve that spirals around the origin, with several self-intersecting loops.
+                        This curve has 9 arcs and 9 loops. It is similar to the curve in the previous exercise,
+                        except that this time, the arcs bend inward toward the origin, rather than outward.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -1962,7 +1962,25 @@
               <caption/>
             <!-- START figures/fig_polar7.tex -->
               <image xml:id="img_polar7">
-                <description></description>
+                <shortdescription>Overlapping plots of a circle and a limaçon, showing their points of intersection.</shortdescription>
+                <description>
+                  <p>
+                    The two curves for this example are plotted.
+                    The curve <m>r=1+3\cos(\theta)</m> is a limaçon with an inner loop,
+                    while <m>r=\cos(\theta)</m> is a circle with radius <m>1/2</m> and center <m>(1/2,0)</m>.
+                  </p>
+
+                  <p>
+                    The circle is significantly smaller than the limaçon:
+                    it intersects the <m>x</m> axis at <m>(0,0)</m> and <m>(1,0)</m>,
+                    while the inner loop of the limaçon intersects the <m>x</m> axis at <m>(0,0)</m> and <m>(2,0)</m>.
+                  </p>
+
+                  <p>
+                    Near the origin, the inner loop of the limaçon narrows faster than the circle,
+                    and in addition to the origin, two other points of intersection can be seen.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1991,7 +2009,14 @@
               <caption/>
             <!-- START figures/fig_polar7b.tex -->
               <image xml:id="img_polar7b">
-                <description></description>
+                <shortdescription>Zoomed in view of the intersections between the two polar curves.</shortdescription>
+                <description>
+                  <p>
+                    The second image is a zoomed in view of <xref ref="fig_polar7a"/>,
+                    in which the three points of intersection can better be seen.
+                    One intersection is at the origin, and the other two points of intersection lie on opposite sides of the <m>x</m> axis.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -2209,7 +2234,17 @@
           </statement>
           <answer>
             <image xml:id="img_polar7bX1" width="47%">
-              <description></description>
+              <shortdescription>The four points plotted in this exercise.</shortdescription>
+              <description>
+                <p>
+                  On a polar grid, four points are plotted.
+                  The point <m>A</m> is at the intersection of the initial ray and the circle of radius 2.
+                  Points <m>B</m> and <m>D</m> are both on the circle of radius 1.
+                  The point <m>B</m> is on the same line as the initial ray, but in the opposite direction.
+                  The point <m>D</m> lies above the initial ray, making an angle of <m>\pi/4</m>.
+                  Finally, the point <m>C</m> is at the bottom of the circle of radius <m>2</m>.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -2273,7 +2308,20 @@
               </statement>
               <answer>
                   <image xml:id="img_polar7bX3" width="47%">
-                    <description></description>
+                    <shortdescription>The four points plotted in this exercise.</shortdescription>
+                    <description>
+                      <p>
+                        On a polar grid, four points are plotted.
+                        Points <m>A</m> and <m>B</m> are both on the same line as the initial ray,
+                        but to the left of the origin <m>O</m>, with <m>A</m> on the circle of radius 2,
+                        and <m>B</m> on the circle of radius 1.
+                        The point <m>C</m> is on the circle of radius 1,
+                        and makes an angle slightly greater than a right angle with the initial ray,
+                        placing it above and just to the left of the origin <m>O</m>.
+                        The point <m>D</m> lies almost immediately below the point <m>C</m>;
+                        the circle of radius <m>1/2</m> is not marked as part of the grid.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -2309,7 +2357,34 @@
                 </p>
 
                   <image xml:id="img_polar7bX4" width="47%">
-                    <description></description>
+                    <shortdescription>Four points plotted on a polar grid.</shortdescription>
+                    <description>
+                      <p>
+                        A standard polar grid is given, with circles of radius 1, 2, and 3.
+                        Rays marking the angles <m>\pi/6, \pi/4, \pi/3</m>, and <m>\pi/2</m> are also shown,
+                        along with rays for the corresponding angles in the other quadrants.
+                      </p>
+
+                      <p>
+                        The point <m>A</m> lies on the ray <m>\theta=\pi/4</m>,
+                        at a distance half way between the circles of radius 2 and 3.
+                      </p>
+
+                      <p>
+                        The point <m>B</m> lies on the ray <m>\theta=-\pi/6</m>,
+                        and on the circle <m>r=1</m>.
+                      </p>
+
+                      <p>
+                        The point <m>C</m> lies on the ray <m>\theta = 4\pi/3</m>,
+                        and on the circle <m>r=3</m>.
+                      </p>
+
+                      <p>
+                        The point <m>D</m> lies on the ray <m>\theta = 2\pi/3</m>,
+                        at a distance half way between the circles of radius 1 and 2.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -2381,7 +2456,34 @@
                 </p>
 
                 <image xml:id="img_polar-two-ways-2" width="47%">
-                  <description></description>
+                  <shortdescription>Four points plotted on a polar grid.</shortdescription>
+                    <description>
+                      <p>
+                        A standard polar grid is given, with circles of radius 1, 2, and 3.
+                        Rays marking the angles <m>\pi/6, \pi/4, \pi/3</m>, and <m>\pi/2</m> are also shown,
+                        along with rays for the corresponding angles in the other quadrants.
+                      </p>
+
+                      <p>
+                        The point <m>A</m> lies on the ray <m>\theta=\pi/6</m>,
+                        and on the circle <m>r=1</m>.
+                      </p>
+
+                      <p>
+                        The point <m>B</m> lies on the ray <m>\theta=-\pi/3</m>,
+                        and on the circle <m>r=1</m>.
+                      </p>
+
+                      <p>
+                        The point <m>C</m> lies on the ray <m>\theta = 3\pi/4</m>,
+                        and on the circle <m>r=2</m>.
+                      </p>
+
+                      <p>
+                        The point <m>D</m> lies on the ray <m>\theta = \pi</m>,
+                        at a distance half way between the circles of radius 2 and 3.
+                      </p>
+                    </description>
                   <latex-image>
                     \begin{tikzpicture}
                     \draw [dashed,gray] (-3.1,0) -- (0,0);
@@ -2604,7 +2706,13 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_11.tex -->
                     <image xml:id="img_09_04_ex_11X">
-                      <description></description>
+                      <shortdescription>Portion of the circle of radius 2, centered at the origin, in the first quadrant.</shortdescription>
+                      <description>
+                        <p>
+                          An arc of the circle <m>r=2</m> is shown, for <m>0\leq \theta\leq \pi/2</m>.
+                          This is the quarter of a circle of radius 2, centered at the origin, that lies in the first quadrant.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2639,7 +2747,15 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_12.tex -->
                     <image xml:id="img_09_04_ex_12X">
-                      <description></description>
+                      <shortdescription>A line segment through the origin with positive slope.</shortdescription>
+                      <description>
+                        <p>
+                          A line segment through the origin is shown.
+                          The segment makes an angle of <m>\pi/6</m> with the positive <m>x</m> axis,
+                          and it extends a distance of 2 units into the first quadrant,
+                          and one unit into the third quadrant.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2675,7 +2791,14 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_13.tex -->
                     <image xml:id="img_09_04_ex_13X">
-                      <description></description>
+                      <shortdescription>A cardioid, symmetric about the x axis, with x intercepts at -2 and 0.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a cardioid that is symmetric about the <m>x</m> axis.
+                          The cusp is at the origin, and the other <m>x</m> intercept is at <m>(-2,0)</m>.
+                          (It is in the opposite direction of the example in the gallery of polar curves.)
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2710,7 +2833,14 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_14.tex -->
                     <image xml:id="img_09_04_ex_14X">
-                      <description></description>
+                      <shortdescription>A convex limaçon, symmetric about the y axis.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a convex limaçon. This is the fourth type of limaçon in the gallery of polar curves.
+                          In this case, the limaçon is symmetric about the <m>y</m> axis,
+                          with the flattened part of the curve at the bottom.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2745,7 +2875,14 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_15.tex -->
                     <image xml:id="img_09_04_ex_15X">
-                      <description></description>
+                      <shortdescription>A convex limaçon, symmetric about the y axis.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a convex limaçon. This is the fourth type of limaçon in the gallery of polar curves.
+                          In this case, the limaçon is symmetric about the <m>y</m> axis,
+                          with the flattened part of the curve at the top.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2780,7 +2917,15 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_16.tex -->
                     <image xml:id="img_09_04_ex_16X">
-                      <description></description>
+                      <shortdescription>A limaçon with an inner loop, symmetric about the y axis.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a limaçon with an inner loop.
+                          It is symmetric about the <m>y</m> axis.
+                          The inner loop lies below the <m>x</m> axis, with <m>y</m> intercepts at <m>y=0</m> and <m>y=-1</m>.
+                          The outer loop has its other <m>y</m> intercept at <m>y=-3</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2815,7 +2960,15 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_17.tex -->
                     <image xml:id="img_09_04_ex_17X">
-                      <description></description>
+                      <shortdescription>A limaçon with an inner loop, symmetric about the y axis.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a limaçon with an inner loop.
+                          It is symmetric about the <m>y</m> axis.
+                          The inner loop lies above the <m>x</m> axis, with <m>y</m> intercepts at <m>y=0</m> and <m>y=1</m>.
+                          The outer loop has its other <m>y</m> intercept at <m>y=3</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2850,7 +3003,14 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_18.tex -->
                     <image xml:id="img_09_04_ex_18X">
-                      <description></description>
+                      <shortdescription>A rose curve with four petals.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a rose curve with four loops that all pass through the origin.
+                          The loops are symmetric about the two coordinate axes,
+                          with their second intercepts at <m>(\pm 1,0)</m> and <m>(0,\pm 1)</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2887,7 +3047,14 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_19.tex -->
                     <image xml:id="img_09_04_ex_19X">
-                      <description></description>
+                      <shortdescription>A rose curve with three loops, symmetric about the y axis.</shortdescription>
+                      <description>
+                        <p>
+                          A rose curve with three loops that all pass through the origin.
+                          One loop is along the negative <m>y</m> axis, with a <m>y</m> intercept at <m>(-1,0)</m>.
+                          The other two loops lie in the first and second quadrants.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2923,7 +3090,21 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_20.tex -->
                     <image xml:id="img_09_04_ex_20X">
-                      <description></description>
+                      <shortdescription>A limaçon with an inner loop.</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a limaçon with an inner loop,
+                          symmetric about the <m>x</m> axis,
+                          but it is shifted horizontally, to the left,
+                          relative to the example in the gallery of polar curves.
+                        </p>
+
+                        <p>
+                          The point of self-intersection is at <m>(-1/2, 0)</m>.
+                          The other end of the inner loop is at the origin,
+                          and the far end of the outer loop is at the point <m>(1,0)</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2960,7 +3141,17 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_21.tex -->
                     <image xml:id="img_09_04_ex_21X">
-                      <description></description>
+                      <shortdescription>An elaborate rose curve with many self-intersections and four primary loops.</shortdescription>
+                      <description>
+                        <p>
+                          This is a more complicated curve.
+                          It passes several times through the origin, and has eight other points of self-intersection.
+                          The largest loops in the curve are similar to cardioids;
+                          there are four of these passing through the origin, with a second intercept at one of the four points <m>(\pm 1, 0)</m>, <m>(0,\pm 1)</m>.
+                          As these loops intersect each other, they create four other loops of intermediate size,
+                          and four smaller loops in the center.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -2996,7 +3187,13 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_22.tex -->
                     <image xml:id="img_09_04_ex_22X">
-                      <description></description>
+                      <shortdescription>A counter-clockwise spiral</shortdescription>
+                      <description>
+                        <p>
+                          The curve is a counter-clockwise spiral that begins at the origin.
+                          It makes two full revolutions, and ends at the point <m>(2\pi, 0)</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -3031,7 +3228,13 @@
                 <answer>
                 <!-- START figures/fig_09_04_ex_23.tex -->
                     <image xml:id="img_09_04_ex_23X">
-                      <description></description>
+                      <shortdescription>A circle passing through the origin with its center on the positive y axis.</shortdescription>
+                      <description>
+                        <p>
+                          A circle of radius <m>3/2</m> with its center at <m>(0,3/2)</m>.
+                          It passes through the origin and the point <m>(0,3)</m>.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -3063,7 +3266,14 @@
           </statement>
           <answer>
               <image xml:id="img_09_04_ex_57">
-                <description></description>
+                <shortdescription>A semi-circle in the first quadrant.</shortdescription>
+                <description>
+                  <p>
+                    The curve is a semi-circle in the first quadrant.
+                    Its endpoints are <m>(0,0)</m> and <m>(2,0)</m>,
+                    making the center <m>(1,0)</m> and radius 1.
+                  </p>
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
                   \begin{axis}[
@@ -3094,7 +3304,13 @@
               <answer>
               <!-- START figures/fig_09_04_ex_24.tex -->
                   <image xml:id="img_09_04_ex_24X">
-                    <description></description>
+                    <shortdescription>A four-leaf rose with one petal in each quadrant.</shortdescription>
+                    <description>
+                      <p>
+                        The curve is a four-leafed rose that lies within the circle <m>r=1/2</m>.
+                        One leaf lies in each of the four quadrants.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -3129,7 +3345,17 @@
               <answer>
               <!-- START figures/fig_09_04_ex_25.tex -->
                   <image xml:id="img_09_04_ex_25X">
-                    <description></description>
+                    <shortdescription>A curve with two loops: a circle inside a larger leaf shape.</shortdescription>
+                    <description>
+                      <p>
+                        The curve for this exercise is a fairly strange shape.
+                        It is symmetric about the <m>x</m> axis.
+                        There is a large, outer loop that looks like a leaf or a raindrop.
+                        It has a cusp at <m>(-7,0)</m>, and also passes through the origin.
+                        There is a smaller, inner loop that looks almost like a circle.
+                        It passes through the origin and the point <m>(-3,0)</m>.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -3164,7 +3390,13 @@
               <answer>
               <!-- START figures/fig_09_04_ex_26.tex -->
                   <image xml:id="img_09_04_ex_26X">
-                    <description></description>
+                    <shortdescription>A straight line with positive slope.</shortdescription>
+                    <description>
+                      <p>
+                        The curve is a straight line with <m>x</m> intercept at <m>(-3,0)</m>
+                        and <m>y</m> intercept <m>(0,3/5)</m>.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -3199,7 +3431,13 @@
               <answer>
               <!-- START figures/fig_09_04_ex_27.tex -->
                   <image xml:id="img_09_04_ex_27X">
-                    <description></description>
+                    <shortdescription>A straight line with positive slope.</shortdescription>
+                    <description>
+                      <p>
+                        The curve is a straight line with <m>x</m> intercept at <m>(-2/3,0)</m>
+                        and <m>y</m> intercept <m>(0,1)</m>.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -3234,7 +3472,12 @@
               <answer>
               <!-- START figures/fig_09_04_ex_28.tex -->
                   <image xml:id="img_09_04_ex_28X">
-                    <description></description>
+                    <shortdescription>A vertical line with x=3.</shortdescription>
+                    <description>
+                      <p>
+                        The curve is the vertical line <m>x=3</m>.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -3269,7 +3512,12 @@
               <answer>
               <!-- START figures/fig_09_04_ex_29.tex -->
                   <image xml:id="img_09_04_ex_29X">
-                    <description></description>
+                    <shortdescription>The horizontal line y=4.</shortdescription>
+                    <description>
+                      <p>
+                        The curve is the horizontal line <m>y=4</m>.
+                      </p>
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -51,7 +51,24 @@
     <figure xml:id="fig_polar_intro1">
       <caption>Illustrating polar coordinates</caption>
       <image xml:id="img_polar_intro1" width="33%">
-        <description></description>
+        <shortdescription>Illustration of polar coordinates relative to a pole and initial ray.</shortdescription>
+        <description>
+          <p>
+            A description of polar coordinates.
+            An initial point <m>O</m> is shown, and from <m>O</m>,
+            a ray pointing to the right, called the initial ray.
+          </p>
+
+          <p>
+            An additional line segment is drawn from <m>O</m> in a direction up and to the right.
+            An angle is measured from the initial ray to the line segment, and labeled as <m>\theta</m>.
+            The length of the line segment is labeled <m>r</m>.
+          </p>
+
+          <p>
+            At the other end of the line segment, a point <m>P</m> is labeled, and assigned the coordinates <m>(r,\theta)</m>.
+          </p>
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -102,7 +119,23 @@
         </p>
 
         <image xml:id="img_polar_grid" width="47%">
-          <description></description>
+          <shortdescription>Drawing of a polar grid: a set of concentric circles, and rays from their common center.</shortdescription>
+          <description>
+            <p>
+              An illustration of the polar grid system.
+              It is intended as a polar adaptation of the Cartesian grid system.
+              Instead of <m>x</m> and <m>y</m> coordinate axes,
+              we see an origin <m>O</m>, and an initial ray, pointing horizontally to the right.
+              On the initial ray, points 1, 2, and 3 are marked.
+            </p>
+
+            <p>
+              Through each of these points passes a circle centered at <m>O</m>,
+              representing the polar coordinate values <m>r=1</m>, <m>r=2</m>, and <m>r=3</m>.
+              Also drawn are several dashed lines through the origin.
+              Viewed as rays from the origin, each of these lines represents a fixed value for the polar coordinate <m>\theta</m>.
+            </p>
+          </description>
           <latex-image>
 
           \begin{tikzpicture}
@@ -151,7 +184,23 @@
           <caption>Plotting polar points in <xref ref="ex_polar1">Example</xref></caption>
           <!-- START figures/fig_polar1.tex -->
           <image xml:id="img_polar1" width="47%">
-            <description></description>
+            <shortdescription>A plot of several points on a polar grid.</shortdescription>
+            <description>
+              <p>
+                The polar grid from the previous image is shown, with the dashed lines removed.
+                On the circle of radius 1, points <m>A</m> and <m>D</m> are marked.
+                The segment <m>OA</m> makes an angle of <m>\pi/4</m> with the initial ray,
+                while the point <m>D</m> is on the opposite end of the diameter through <m>A</m>.
+              </p>
+
+              <p>
+                The point <m>B</m> lies between the circles of radius 1 and 2,
+                to the left of the point <m>O</m>.
+                The point <m>C</m> is on the circle of radius <m>2</m>
+                and lies below the initial ray, so that the segment <m>OC</m>
+                makes an angle of <m>-\pi/3</m> with the initial ray.
+              </p>
+            </description>
             <latex-image>
 
               \begin{tikzpicture}[scale=.75,>=latex]
@@ -211,7 +260,20 @@
       <caption>Converting between rectangular and polar coordinates</caption>
       <!-- START figures/fig_polarintro2.tex -->
       <image xml:id="img_polar_intro2" width="33%">
-        <description></description>
+        <shortdescription>A triangle illustrating the conversion between rectangular and polar coordinates.</shortdescription>
+        <description>
+          <p>
+            An right-angled triangle is shown, with the right angle in the bottom-right corner.
+            The vertex on the left is labeled <m>O</m>, and the angle at that vertex is labeled <m>\theta</m>.
+            The label on the hypotenuse indicates a length of <m>r</m>, 
+            and the opposite end of the hypotenuse is labeled <m>P</m>.
+          </p>
+
+          <p>
+            The bottom of the triangle (the side adjacent to the angle <m>\theta</m>) is labeled with the length <m>x</m>,
+            and the altitude of the triangle (the side oppsite the angle <m>\theta</m>) is labeled with the length <m>y</m>.
+          </p>
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -311,7 +373,23 @@
                     <caption/>
               <!-- START figures/fig_polar2.tex -->
                     <image xml:id="img_polar2a">
-                      <description></description>
+                      <shortdescription>Overlaid rectangular and polar grid systems, with marked points.</shortdescription>
+                      <description>
+                        <p>
+                          A polar grid is shown, using a relatively thick line width.
+                          Also shown is a rectangular grid, with a much thinner line width, so that the polar grid is emphasized.
+                        </p>
+
+                        <p>
+                          The point <m>P(-1,5\pi/4)</m> is marked on the circle of radius 1;
+                          it lies in the first quadrant of the rectangular grid,
+                          since <m>5\pi/4</m> is in the third quadrant, but <m>r=-1</m> is negative.
+                        </p>
+
+                        <p>
+                          The point <m>P(2,2\pi/3)</m> is marked on the circle of radius 2 in the second quadrant.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -339,7 +417,18 @@
                     <caption/>
               <!-- START figures/fig_polar2b.tex -->
                     <image xml:id="img_polar2b">
-                      <description></description>
+                      <shortdescription>Overlaid rectangular and polar grid systems, with marked points.</shortdescription>
+                      <description>
+                        <p>
+                          Rectangular and polar grids are shown;
+                          this time the rectangular grid is emphasized with a thicker line width.
+                        </p>
+
+                        <p>
+                          The points <m>(0,0)</m>, <m>(1,2)</m>, and <m>(-1,1)</m> are marked on the rectangular grid.
+                          Also indicated are the angles each point makes with the initial ray.
+                        </p>
+                      </description>
                       <latex-image>
 
                       \begin{tikzpicture}
@@ -515,7 +604,14 @@
                 <caption>Plotting standard polar plots</caption>
             <!-- START figures/fig_polar3.tex -->
                 <image xml:id="img_polar3" width="47%">
-                  <description></description>
+                  <shortdescription>Polar plot showing curves of constant radius and constant angle</shortdescription>
+                  <description>
+                    <p>
+                      A polar grid is shown. On the grid, two curves are drawn.
+                      The curve <m>r=1.5</m> is a circle centered at the origin of radius <m>1.5</m>.
+                      The curve <m>\theta = \pi/4</m> is a line through the origin that makes an angle of <m>\pi/4</m> with the initial ray.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -634,7 +730,14 @@
               <!-- START figures/fig_polar4.tex -->
               <caption/>
               <image xml:id="img_polar4">
-                <description></description>
+                <shortdescription>A rough sketch of a polar function.</shortdescription>
+                <description>
+                  <p>
+                    On a polar grid, the points from the table in <xref ref="fig_polar4a"/> are plotted.
+                    Each point is joined to an adjacent point by a line segement to form a rough sketch of the polar curve <m>r=1+\cos(\theta)</m>.
+                    The curve appears to be roughly heart-shaped, with a cusp at the origin.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -715,7 +818,14 @@
       <caption>Using  technology to graph a polar function</caption>
       <!-- START figures/fig_polar4c.tex -->
       <image xml:id="img_polar4c" width="47%">
-        <description></description>
+        <shortdescription>A computer-generated sketch of a polar function.</shortdescription>
+        <description>
+          <p>
+            On a polar grid, the curve from <xref ref="fig_polar4"/> is plotted, using technology.
+            The result is a smooth version of the plot in <xref ref="fig_polar4b"/>.
+            The curve appears to be roughly heart-shaped, with a cusp at the origin.
+          </p>
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -806,7 +916,21 @@
               <caption/>
             <!-- START figures/fig_polar5.tex -->
               <image xml:id="img_polar5a">
-                <description></description>
+                <shortdescription>An initial rough sketch of a polar curve obtained by connecting points on the curve.</shortdescription>
+                <description>
+                  <p>
+                    On a polar grid, the points from the table in <xref ref="fig_polar5table"/> are plotted.
+                    The points are labeled consecutively from 1 to 17, using the values from the table.
+                    These points are then joined, in order, using straight lines, in the matter of a
+                    <q>connect-the-dots</q> drawing.
+                  </p>
+
+                  <p>
+                    The result is four diamond-shaped <q>leaves</q>.
+                    Each diamond has one point at the origin.
+                    The diamonds then point left, right, up, and down.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -849,7 +973,30 @@
               <caption/>
             <!-- START figures/fig_polar5b.tex -->
               <image xml:id="img_polar5b">
-                <description></description>
+                <shortdescription>A smoothed version of the plot for this example.</shortdescription>
+                <description>
+                  <p>
+                    The plot in <xref ref="fig_polar5a"/> is replaced by a <q>smoothed</q> version.
+                    The diamonds are replaced by rounded curves, each resembling a leaf or flower petal.
+                    Each loop (or leaf) has a cusp at the origin; however, the curve as a whole is traced smoothly.
+                  </p>
+
+                  <p>
+                    Beginning at the rectangular point <m>(1,0)</m> (on the positive <m>x</m> axis, when <m>\theta=0</m>),
+                    the curve bends up and to the left, before turning downward, and eventually reaching the origin.
+                    The curve then continues down and to the left into the third quadrant,
+                    until it bends to the right, reaching the <m>y</m> axis at the rectangular point <m>(0,-1)</m>.
+                    It then loops back up through the fourth quadrant to the origin;
+                    it then continues into the second quadrant, intersecting the <m>x</m> axis at <m>(-1,0)</m>,
+                    and passing through the third quadrant to form the left-hand loop as it returns to the origin.
+                  </p>
+
+                  <p>
+                    From there, we get the upper loop in a similar fashion, in the first quadrant and then the second,
+                    and finally, the curve passes through the origin one more time into the fourth quadrant,
+                    where it completes bottom of the right-hand loop.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -978,7 +1125,12 @@
                 <caption>Graphing <m>xy=1</m> from <xref ref="ex_polar6">Example</xref></caption>
             <!-- START figures/fig_polar6.tex -->
                 <image xml:id="img_polar6" width="47%">
-                  <description></description>
+                  <shortdescription>Graph of the hyperbola y=1/x.</shortdescription>
+                  <description>
+                    <p>
+                      The graph is that of the standard hyperbola <m>y=1/x</m>.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -1087,7 +1239,13 @@
             <caption>Through the origin: <m>\theta = \alpha</m></caption>
             <!-- START figures/fig_polarline1.tex -->
             <image xml:id="img_polar_lines1">
-              <description></description>
+              <shortdescription>A line through the origin with positive slope.</shortdescription>
+              <description>
+                <p>
+                  A line through the origin is shown on a set of rectangular axes.
+                  Also shown is an angle <m>\alpha</m>, measured from the positive <m>x</m> axis to the line.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1110,7 +1268,13 @@
             <caption>Horizontal line: <m>r=a\csc(\theta)</m></caption>
             <!-- START figures/fig_polarline2.tex -->
             <image xml:id="img_polar_lines2">
-              <description></description>
+              <shortdescription>A horizontal line.</shortdescription>
+              <description>
+                <p>
+                  The graph is that of a horizontal line, plotted on a set of rectangular axes.
+                  The graph is labeled with the value <m>a</m>, which is the distance from the <m>x</m> axis to the line.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1134,7 +1298,13 @@
             <caption>Vertical line: <m>r=a\sec(\theta)</m></caption>
             <!-- START figures/fig_polarline4.tex -->
             <image xml:id="img_polar_lines3">
-              <description></description>
+              <shortdescription>A vertical line.</shortdescription>
+              <description>
+                <p>
+                  A vertical line is plotted against a set of rectangular axes.
+                  The distance from the line to the <m>y</m> axis is labeled <m>a</m>.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1157,7 +1327,15 @@
             <caption>Not through origin: <m>\ds r=\frac{b}{\sin(\theta) -m\cos(\theta)}</m></caption>
             <!-- START figures/fig_polarline3.tex -->
             <image xml:id="img_polar_lines4">
-              <description></description>
+              <shortdescription>A line with positive slope m, and y intercept b.</shortdescription>
+              <description>
+                <p>
+                  A line is plotted against a set of rectangular axes.
+                  The line has a positive slope <m>m</m>, which is indicated next to the line.
+                  Also shown is a distance <m>b</m> from the origin to the <m>y</m> intercept of the line,
+                  indicating that this particular line does not pass through the origin.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1191,7 +1369,14 @@
             <caption>Centered on <m>x</m>-axis: <m>r=a\cos(\theta)</m></caption>
             <!-- START figures/fig_polarcircle1.tex -->
             <image xml:id="img_polar_circle1">
-              <description></description>
+              <shortdescription>A circle centered on the positive x axis and passing through the origin.</shortdescription>
+              <description>
+                <p>
+                  A circle is shown, with its center on the positive <m>x</m> axis.
+                  The circle passes through the origin, and the diameter of the circle is labeled as <m>a</m>.
+                  This suggests that the circle has center <m>(a/2,0)</m> and radius <m>a/2</m>.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1214,7 +1399,14 @@
             <caption>Centered on <m>y</m>-axis: <m>r=a\sin(\theta)</m></caption>
             <!-- START figures/fig_polarcircle2.tex -->
             <image xml:id="img_polar_circle2">
-              <description></description>
+              <shortdescription>A circle centered on the positive y axis and passing through the origin.</shortdescription>
+              <description>
+                <p>
+                  A circle is shown, with its center on the positive <m>y</m> axis.
+                  The circle passes through the origin, and the diameter of the circle is labeled as <m>a</m>.
+                  This suggests that the circle has center <m>(0,a/2)</m> and radius <m>a/2</m>.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1238,7 +1430,13 @@
             <caption>Centered on origin: <m>r=a</m></caption>
             <!-- START figures/fig_polarcircle3.tex -->
             <image xml:id="img_polar_circle3">
-              <description></description>
+              <shortdescription>A circle centered at the origin.</shortdescription>
+              <description>
+                <p>
+                  On a set of rectangular axes, a circle centered at the origin is plotted.
+                  The radius <m>a</m> of the circle is labeled.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1261,7 +1459,18 @@
             <caption>Archimedean spiral: <m>r=\theta</m></caption>
             <!-- START figures/fig_polarspiral.tex -->
             <image xml:id="img_polar_spiral">
-              <description></description>
+              <shortdescription>A counter-clockwise spiral that begins at the origin.</shortdescription>
+              <description>
+                <p>
+                  The curve begins at the origin and spirals outward, moving in a counter-clockwise direction.
+                  The distance from the curve to the origin increases with the angle,
+                  and three full revolutions of the spiral are shown.
+                </p>
+
+                <p>
+                  The appearance of the curve is not unlike that of a snail's shell.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1300,7 +1509,27 @@
             <caption>With inner loop: <m>\ds \frac ab \lt  1</m></caption>
             <!-- START figures/fig_polarlimacon1.tex -->
             <image xml:id="img_polar_limacon1">
-              <description></description>
+              <shortdescription>A limaçon curve with a loop at the origin, and symmetric about the x axis.</shortdescription>
+              <description>
+                <p>
+                  The first of several curves in the <q>limaçcon</q> family.
+                  The curve intersects the <m>x</m> axis three times: at the origin, which it passes through twice,
+                  and at two other points on the positive <m>x</m> axis.
+                </p>
+
+                <p>
+                  The curve consists of two loops that are joined at the origin.
+                  The larger, outer loop passes through the <m>x</m> intercept with the larger value of <m>x</m>.
+                  It is somewhat heart-shaped, with a cusp at the origin.
+                </p>
+
+                <p>
+                  The smaller curve lies inside the larger curve, and is shaped like a teardrop.
+                  The two curves join together in such a way that, although each individually has a cusp,
+                  the curve as a whole is traced out smoothly, with the two cusps occurring at the origin,
+                  where the curve intersects itself.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1320,7 +1549,18 @@
             <caption>Cardioid: <m>\ds \frac ab=1</m></caption>
             <!-- START figures/fig_polarlimacon2.tex -->
             <image xml:id="img_polar_limacon2">
-              <description></description>
+              <shortdescription>A heart-shaped curve in the limaçon family, known as a cardioid.</shortdescription>
+              <description>
+                <p>
+                  This is also a limaçon curve, and it is again symmetric about the <m>x</m> axis.
+                  Its appearance is similar to the previous curve, but with the inner loop removed.
+                </p>
+
+                <p>
+                  The resulting cusp at the origin gives this curve a heart-like shape;
+                  as a result, the curve is also known as a cardioid.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1342,7 +1582,22 @@
             <caption>Dimpled: <m>\ds 1\lt \frac ab \lt 2</m></caption>
             <!-- START figures/fig_polarlimacon3.tex -->
             <image xml:id="img_polar_limacon3">
-              <description></description>
+              <shortdescription>A dimpled limaçon curve.</shortdescription>
+              <description>
+                <p>
+                  A third curve in the limaçon family, also symmetric about the <m>x</m> axis.
+                  This curve does not pass through the origin.
+                  It has two <m>x</m> intercepts, one positive, and one negative.
+                  The positive <m>x</m> intercept has a larger absolute value (it is further from the origin).
+                </p>
+
+                <p>
+                  To the right of the <m>y</m> axis, the curve appears to be almost oval-like in shape.
+                  But as it crosses to the left of the <m>y</m> axis, it begins to bend more sharply toward the second <m>x</m> intercept.
+                  On this side, the curve bends inward, forming a <q>dimple</q>, or dent.
+                  The dent is smooth, however, and is not a cusp.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1362,7 +1617,18 @@
             <caption>Convex: <m>\ds \frac ab \gt 2</m></caption>
             <!-- START figures/fig_polarlimacon4.tex -->
             <image xml:id="img_polar_limacon4">
-              <description></description>
+              <shortdescription>A convex limaçon curve.</shortdescription>
+              <description>
+                <p>
+                  A fourth limaçon curve. It is also symmetric about the <m>x</m> axis.
+                  Like the dimpled limaçon, it has two <m>x</m> intercepts and does not pass through the origin.
+                </p>
+
+                <p>
+                  Unlike the dimpled limaçon, to the left of the <m>y</m> axis, the curve flattens out,
+                  but does not bend inward.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1405,7 +1671,13 @@
             <caption><m>r=a\cos(2\theta)</m></caption>
             <!-- START figures/fig_polarrose1.tex -->
             <image xml:id="img_polar_rose1">
-              <description></description>
+              <shortdescription>A rose curve with four leaves along the coordinate axes.</shortdescription>
+              <description>
+                <p>
+                  The curve <m>r=\cos(2\theta)</m> is four-leaf rose curve; it appears to be the same as the one in <xref ref="ex_polar5"/>.
+                  Two of the leaves lie along the <m>x</m> axis, and two leaves lie along the <m>y</m> axis.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1425,7 +1697,14 @@
             <caption><m>r=a\sin(2\theta)</m></caption>
             <!-- START figures/fig_polarrose2.tex -->
             <image xml:id="img_polar_rose2">
-              <description></description>
+              <shortdescription>A rose curve with four leaves, each in one of the quadrants.</shortdescription>
+              <description>
+                <p>
+                  The curve <m>r=\sin(2\theta)</m> is a rose curve with four leaves. 
+                  It is has the same appearance as the rose curve in <xref ref="fig_polar_rose1"/>,
+                  but it is rotated by 45 degrees, so that each leaf lies in one of the four quadrants.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1447,7 +1726,19 @@
             <caption><m>r=a\cos(3\theta)</m></caption>
             <!-- START figures/fig_polarrose4.tex -->
             <image xml:id="img_polar_rose3">
-              <description></description>
+              <shortdescription>A rose curve with three leaves, symmetric about the x axis.</shortdescription>
+              <description>
+                <p>
+                  The curve <m>r=\cos(3\theta)</m> is a rose curve with three leaves.
+                  The leaves are narrower in appearance than those of the four-leaf rose curves.
+                </p>
+
+                <p>
+                  The curve overall is symmetric about the <m>x</m> axis.
+                  One leaf lies along the positive <m>x</m> axis,
+                  while the other two leaves are in the second and third quadrants.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1467,7 +1758,15 @@
             <caption><m>r=a\sin(3\theta)</m></caption>
             <!-- START figures/fig_polarrose3.tex -->
             <image xml:id="img_polar_rose4">
-              <description></description>
+              <shortdescription>A rose curve with three leaves, symmetric about the <m>y</m> axis.</shortdescription>
+              <description>
+                <p>
+                  Another rose curve with three leaves, this time given by <m>r=\sin(3\theta)</m>.
+                  The curve is symmetric about the <m>y</m>.
+                  One leaf lies along the negative <m>y</m> axis,
+                  while the other two leaves are in the first and second quadrants.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1499,7 +1798,24 @@
             <caption>Rose curve: <m>r=a\sin(\theta/5)</m></caption>
             <!-- START figures/fig_polarspecial1.tex -->
             <image xml:id="img_polar_special1">
-              <description></description>
+              <shortdescription>A polar curve consisting of three loops.</shortdescription>
+              <description>
+                <p>
+                  The curve <m>r=\sin(\theta/5)</m> is also known as a rose curve,
+                  but it is more similar to a limaçon in appearance,
+                  except that it has more loops.
+                </p>
+
+                <p>
+                  The curve is symmetric about the <m>y</m> axis.
+                  There are three loops in total, each of which intersects the <m>y</m> axis twice.
+                  The smallest loop has a teardrop shape. It lies inside the middle loop,
+                  which is heart-shaped.
+                  The middle loop, in turn, lies inside of the largest loop,
+                  which appears nearly circular, except that it has a slight cusp at the bottom,
+                  where it joins with the middle loop.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1519,7 +1835,19 @@
             <caption>Rose curve: <m>r=a\sin(2\theta/5)</m></caption>
             <!-- START figures/fig_polarspecial2.tex -->
             <image xml:id="img_polar_special2">
-              <description></description>
+              <shortdescription>An elaborate polar curve consisting of many intersecting loops.</shortdescription>
+              <description>
+                <p>
+                  The curve <m>r=\sin(2\theta/5)</m> is also known as a rose curve,
+                  but it is more elaborate than any of the earlier examples.
+                </p>
+
+                <p>
+                  The curve is symmetric about both axes, and consists of many loops of varying size.
+                  These loops intesect each other several times.
+                  The overall appearance is similar to a sort of braided knot.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1541,7 +1869,15 @@
             <caption>Lemniscate: <m>r^2=a^2\cos(2\theta)</m></caption>
             <!-- START figures/fig_polarspecial3.tex -->
             <image xml:id="img_polar_special3">
-              <description></description>
+              <shortdescription>A lemniscate curve, which has the shape of a figure-eight.</shortdescription>
+              <description>
+                <p>
+                  The lemniscate <m>r^2 = \cos^2(2\theta)</m> is a figure-eight curve.
+                  Since <m>r^2</m> cannot be positive, 
+                  the points on the curve all correspond to angles where <m>\cos(2\theta)</m> is positive.
+                  The curve is symmetric about the <m>x</m> axis, and looks much like the symbol for infinity.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -1562,7 +1898,14 @@
             <caption>Eight Curve: <m>r^2=a^2\sec^4(\theta) \cos(2\theta)</m></caption>
             <!-- START figures/fig_polarspecial4.tex -->
             <image xml:id="img_polar_special4">
-              <description></description>
+              <shortdescription>A polar curve in the shape of a figure-eight.</shortdescription>
+              <description>
+                <p>
+                  This final curve in the gallery is also a figure-eight curve.
+                  Like the lemniscate, it is symmetric about the <m>x</m> axis,
+                  but it is flatter at the ends than the lemniscate.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -122,7 +122,31 @@
                 <caption>The limaçon in <xref ref="ex_polcalc1">Example</xref> with its tangent line at <m>\theta=\pi/4</m> and points of vertical and horizontal tangency</caption>
             <!-- START figures/fig_polcalc1.tex -->
                 <image xml:id="img_polcalc1" width="47%">
-                  <description></description>
+                  <shortdescription>A limaçon with an inner loops, symmetric about the y axis, and a tangent line.</shortdescription>
+                  <description>
+                    <p>
+                      The curve is a limaçon with an inner loop.
+                      It is symmetric about the <m>y</m> axis, with intercepts on the positive <m>y</m> axis.
+                      There are several marked points on the curve, indicating the location of horizontal and vertical tangent lines.
+                    </p>
+
+                    <p>
+                      Points marking horizontal tangent lines are at the top of both loops,
+                      at the points <m>(0,3)</m> (outer loop) and <m>(0,1)</m> (inner loop).
+                      There are also two points marking horizontal tangent lines at the bottom of the outer loop;
+                      these lie below the <m>x</m> axis, on either side of the <m>y</m> axis.
+                    </p>
+
+                    <p>
+                      There are also four points marking vertical tangent lines.
+                      These are on the left and right <q>sides</q> of each loop.
+                    </p>
+
+                    <p>
+                      Just above the point where the vertical tangent on the right side of the outer loop is marked,
+                      a tangent line to the curve is drawn. The tangent line has a relatively large negative slope.
+                    </p>
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -272,7 +296,20 @@
           <caption>Graphing the tangent lines at the pole in <xref ref="ex_polcalc2">Example</xref></caption>
           <!-- START figures/fig_polcalc2.tex -->
           <image xml:id="img_polcalc2" width="47%">
-            <description></description>
+            <shortdescription>A zoomed in view of a limaçon near the origin, and two tangent lines at that point.</shortdescription>
+            <description>
+              <p>
+                The curve is the same limaçon as in <xref ref="fig_polcalc1"/>, but zoomed in near the origin.
+                The origin is a point of self-intersection for the curve, and there are two tangent lines:
+                one for the first time the curve passes through the origin, and one for the second.
+              </p>
+
+              <p>
+                The two lines together make an X shape at the origin.
+                Due to the symmetry of the curve, one tangent line has positive slope,
+                and the other has a negative slope of the same absolute value.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -337,7 +374,14 @@
       </p>
 
       <image xml:id="img_polcalc2X" width="47%">
-        <description></description>
+        <shortdescription>Illustration of a pie-shaped sector of a circle.</shortdescription>
+        <description>
+          <p>
+            A sector of a circle of radius <m>r</m> is shown,
+            spanning an angle <m>\theta</m>.
+            The angle <m>\theta</m> is acute, resulting in a sector similar in shape to a slice of pie.
+          </p>
+        </description>
         <latex-image>
 
         \begin{tikzpicture}[x=30pt,y=30pt,thick]
@@ -383,7 +427,21 @@
           <caption/>
         <!-- START figures/fig_polarea1.tex -->
           <image xml:id="img_polarea1">
-            <description></description>
+            <shortdescription>Plot of a generic polar function and the area it encloses between two angles.</shortdescription>
+            <description>
+              <p>
+                The plot of some unknown polar curve <m>r=f(\theta)</m> is shown.
+                The curve lies entirely in the first quadrant, and has a somewhat wavy shape,
+                although the particular shape of the curve is unimportant.
+              </p>
+
+              <p>
+                Two rays labeled <m>\theta=\alpha</m> and <m>\theta=\beta</m> are drawn,
+                and the area bounded by the two rays and the polar curve is shaded.
+                Several rays corresponding to angles between <m>\alpha</m> and <m>\beta</m>
+                are also shown as dashed lines.
+              </p>
+            </description>
             <latex-image>
 
 
@@ -422,7 +480,27 @@
           <caption/>
         <!-- START figures/fig_polarea2.tex -->
           <image xml:id="img_polarea2">
-            <description></description>
+            <shortdescription>Plot of a region bounded by a polar curve, and its approximation by cicular wedges.</shortdescription>
+            <description>
+              <p>
+                A curve <m>r=f(\theta)</m> is shown; it is the same curve as <xref ref="fig_polarea1"/>.
+                The rays <m>\theta=\alpha</m> and <m>\theta=\beta</m> are also shown,
+                as well as the shaded region bounded by these rays and the polar curve.
+              </p>
+
+              <p>
+                Overlaid on the shaded region are four circular wedges.
+                The angle between <m>\theta=\alpha</m> and <m>\theta=\beta</m> is divided into four smaller angles;
+                these correspond to the rays shown as dashed lines in <xref ref="fig_polarea1"/>.
+                Each wedge is a sector of a circle that spans one of these angles,
+                with radius corresponding some the value of <m>f(\theta)</m>.
+              </p>
+
+              <p>
+                Overall, the image illustrates the fact that the area bounded by the polar curve and the two rays
+                is approximated by the sum of the areas of the four circular wedges.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -560,7 +638,18 @@
           <caption>Finding the area of the shaded region of a cardioid in <xref ref="ex_polcalc4">Example</xref></caption>
           <!-- START figures/fig_polcalc4.tex -->
           <image xml:id="img_polcalc4" width="47%">
-            <description></description>
+            <shortdescription>A cardioid curve, within which is a shaded region bounded by the curve and two rays.</shortdescription>
+            <description>
+              <p>
+                The polar curve <m>r=1+\cos(\theta)</m> is a cardioid that is symmetric about the <m>x</m> axis,
+                with a cusp at the origin, and second <m>x</m> intercept at <m>(2,0)</m>.
+              </p>
+
+              <p>
+                The rays <m>\theta=\pi/6</m> and <m>\theta=\pi/3</m> are drawn from the origin to where they meet the cardioid.
+                The region bounded by the cardioid and the two rays is shaded.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -630,7 +719,22 @@
         <caption>Illustrating area bound between two polar curves</caption>
         <!-- START figures/fig_polarea3.tex -->
         <image xml:id="img_polarea3" width="47%">
-          <description></description>
+          <shortdescription>Illustration of a region bounded by two polar curves and two rays.</shortdescription>
+          <description>
+            <p>
+              Polar curves <m>r=f_1(\theta)</m> and <m>r=f_2(\theta)</m> are drawn in the first quadrant.
+              The functions are not specified, but the curves are intended to appear as generic polar curves:
+              both begin on the positive <m>x</m> axis and end on the positive <m>y</m> axis,
+              and both are somewhat wavy, with a value of <m>r</m> that oscillates on the interval <m>[0,\pi/2]</m>.
+            </p>
+
+            <p>
+              The curve <m>r=f_1(\theta)</m> lies closer to the origin than <m>r=f_2(\theta)</m> at all points.
+              Two rays <m>\theta=\alpha</m> and <m>\theta=\beta</m> are shown.
+              The region bounded by the two rays and the two polar curves is shaded.
+              (The region corresponds to <m>\alpha\leq\theta\leq \beta</m> and <m>f_1(\theta)\leq r\leq f_2(\theta)</m>.)
+            </p>
+          </description>
           <latex-image>
 
           \begin{tikzpicture}
@@ -703,7 +807,23 @@
             <caption>Finding the area between polar curves in <xref ref="ex_polcalc5">Example</xref></caption>
             <!-- START figures/fig_polcalc5.tex -->
             <image xml:id="img_polcalc5" width="47%">
-              <description></description>
+              <shortdescription>A circle and a cardioid enclose a region that is inside the circle but outside the cardioid.</shortdescription>
+              <description>
+                <p>
+                  Two polar curves are plotted. The first is a circle with center at <m>(3/2,0)</m> and radius <m>3/2</m>.
+                  (The circle intercepts the <m>x</m> axis at <m>(0,0)</m> and <m>(3,0)</m> and is symmetric about the <m>x</m> axis.)
+                  The second curve is a cardioid; it is symmetric about the <m>x</m> axis,
+                  with its cusp at the origin, and a second <m>x</m> intercept at <m>(2,0)</m>.
+                </p>
+
+                <p>
+                  The two curves intersect at two points on opposite sides of the <m>x</m> axis.
+                  The cardioid covers up a significant portion of the circle, for <m>x</m> between <m>0</m> and <m>2</m>.
+                  The portion of the circle that is not covered by the cardioid is shaded.
+                  This is the region that lies outside of the cardioid, but inside the circle.
+                  It has a shape similar to that of a crescent moon.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -788,7 +908,23 @@
           <figure xml:id="fig_polcalc6a">
             <caption>The region bounded by the functions in <xref ref="ex_polcalc6">Example</xref></caption>
             <image xml:id="img_polcalc6" width="47%">
-              <description></description>
+              <shortdescription>A zoomed in view of a region bounded by a circle, a rose curve, and the x axis.</shortdescription>
+              <description>
+                <p>
+                  Two polar curves are plotted: a four-leaf rose curve, and a the unit circle.
+                  The image is zoomed in to give a better view of the region whose area is being computed in this example.
+                  One leaf of the rose curve is along the positive <m>x</m> axis.
+                  It intersects the unit circle at a point in the first quadrant.
+                </p>
+
+                <p>
+                  A shaded region is also shown. The region is bounded below by the <m>x</m> axis.
+                  To the left of the point where the rose curve intersects the circle,
+                  the region is bounded above by the rose curve.
+                  To the right of this point, until the circle meets the <m>x</m> axis at <m>(1,0)</m>,
+                  the region is bounded between the <m>x</m> axis and the circle.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -831,7 +967,23 @@
           <figure xml:id="fig_polcalc6b">
             <caption>Breaking the region bounded by the functions in <xref ref="ex_polcalc6">Example</xref> into its component parts</caption>
             <image xml:id="img_polcalc6a" width="47%">
-              <description></description>
+              <shortdescription>A zoomed in view of a polar region, showing it divided into two parts.</shortdescription>
+              <description>
+                <p>
+                  The region in <xref ref="fig_polcalc6a"/> is shown again, but zoomed in even further.
+                  The point at which the rose curve intersects the circle is found to have polar coordinates <m>(1,\pi/6)</m>.
+                  The ray <m>\theta=\pi/6</m> is shown as a dashed line; it divides the region into two parts.
+                </p>
+
+                <p>
+                  The first part corresponds to <m>0\leq \theta\leq \pi/6</m>;
+                  it is the part of the region that lies below the ray <m>\theta=\pi/6</m>.
+                  It is bounded by the <m>x</m> axis, the unit circle, and the ray <m>\theta=\pi/6</m>.
+                  The second part of the region lies above the ray <m>\theta=\pi/6</m>,
+                  corresponding to angles <m>\pi/6\leq \theta\leq \pi/4</m>.
+                  This part of the region lies between the rose curve and the ray <m>\theta=\pi/6</m>.
+                </p>
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -953,7 +1105,7 @@
       <title>Arc length of a limaçon</title>
       <statement>
         <p>
-          Find the arc length of the limaçon <m>r=1+2\sin(t)</m>.
+          Find the arc length of the limaçon <m>r=1+2\sin(\theta)</m>.
         </p>
       </statement>
       <solution component="video">
@@ -962,7 +1114,7 @@
       </solution>
       <solution>
         <p>
-          With <m>r=1+2\sin(t)</m>, we have <m>r\,' = 2\cos(t)</m>.
+          With <m>r=1+2\sin(\theta)</m>, we have <m>r\,' = 2\cos(\theta)</m>.
           The limaçon is traced out once on <m>[0,2\pi]</m>,
           giving us our bounds of integration.
           Applying <xref ref="thm_polar_arclength">Theorem</xref>, we have
@@ -978,7 +1130,16 @@
           <caption>The limaçon in <xref ref="ex_polcalc7">Example</xref> whose arc length is measured</caption>
           <!-- START figures/fig_polcalc7.tex -->
           <image xml:id="img_polcalc7" width="47%">
-            <description></description>
+            <shortdescription>A limaçon with an inner loop that is symmetric about the y axis.</shortdescription>
+            <description>
+              <p>
+                The limaçon <m>r=1+2\sin(\theta)</m> has an inner loop,
+                and is symmetric about the <m>y</m> axis.
+                The point of self-intersection is at the origin;
+                the inner loop meets the <m>y</m> axis again at <m>(0,1)</m>,
+                and the outer loop meets the <m>y</m> axis again at <m>(0,3)</m>.
+              </p>
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -1073,7 +1234,16 @@
               <caption/>
         <!-- START figures/fig_polcalc8.tex -->
               <image xml:id="img_polcalc8">
-                <description></description>
+                <shortdescription>A four leaf rose curve, with leaves along the coordinate axes.</shortdescription>
+                <description>
+                  <p>
+                    The four leaf rose curve <m>r=\cos(2\theta)</m> is plotted.
+                    Although the entire curve is plotted, the portion of the right-hand leaf
+                    that lies in the first quadrant is highlighted.
+                    This is the part of the curve corresponding to <m>0\leq \theta\leq \pi/4</m>;
+                    it begins at <m>(1,0)</m> and ends at the origin.
+                  </p>
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1106,7 +1276,15 @@
             <figure xml:id="fig_polcalc8a_3D">
               <caption/>
               <image xml:id="img_polcalc8a_3D">
-                <description></description>
+                <shortdescription>The surface of revolution obtained by revolving one leaf of a rose curve about the x axis.</shortdescription>
+                <description>
+                  <p>
+                    A three-dimensional plot shows the surface of revolution obtained when the portion of the rose curve
+                    from the previous image is revolved about the <m>x</m> axis.
+                    The surface is similar in appearance to a teardrop,
+                    or perhaps a blimp.
+                  </p>
+                </description>
                 <asymptote>
 
 
@@ -1894,7 +2072,20 @@
                 </p>
 
                 <image xml:id="img_09_05_ex_25">
-                  <description></description>
+                  <shortdescription>Two circles, one along each axis, bound a region in the first quadrant.</shortdescription>
+                  <description>
+                    <p>
+                      There are two circles of radius 1.
+                      The first circle lies along the <m>x</m> axis, with intercepts at <m>(0,0)</m> and <m>(2,0)</m>.
+                      The second circle lies along the <m>y</m> axis, with intercepts at <m>(0,0)</m> and <m>(0,2)</m>.
+                      The two circles intersect in the first quadrant, at the point <m>(1,1)</m>.
+                    </p>
+
+                    <p>
+                      The shaded region consists of everything that is between the <m>x</m> axis and the first circle,
+                      except for the portion of the first circle that overlaps with the second circle.
+                    </p>
+                  </description>
                   <latex-image>
                     \begin{tikzpicture}
                     \begin{axis}[
@@ -1932,7 +2123,18 @@
                 </p>
 
                 <image xml:id="img_09_05_ex_24">
-                  <description></description>
+                  <shortdescription>A semi-circle and one leaf of a rose curve, both in the first quadrant, overlapping in a shaded area.</shortdescription>
+                  <description>
+                    <p>
+                      Two curves are shown. One is a semi-circular arc, from <m>(0,0)</m> to <m>(1,0)</m>, in the first quadrant.
+                      The other curve the leaf of the four-leaf rose <m>r=\sin(2\theta)</m> that lies in the first quadrant.
+                    </p>
+
+                    <p>
+                      The two curves overlap in a region that lies above the rose curve, but below the circle.
+                      This region is shaded.
+                    </p>
+                  </description>
                   <latex-image>
                     \begin{tikzpicture}
                     \begin{axis}[
@@ -1969,7 +2171,15 @@
                 </p>
               
                 <image xml:id="img_09_05_ex_26">
-                  <description></description>
+                  <shortdescription>Overlapping leaves of two different three-leaf rose curves.</shortdescription>
+                  <description>
+                    <p>
+                      Two curves are shown. The first is the leaf of the three-leaf rose curve <m>r=\sin(3\theta)</m> that lies in the first quadrant.
+                      The second is the leaf of the three-leaf rose curve <m>r=\cos(3\theta)</m> that lies along the positive <m>x</m> axis.
+                      The shaded region is the interior of the leaf of <m>r=\sin(3\theta)</m>,
+                      except for the part that overlaps with the leaf of <m>r=\cos(3\theta)</m>.
+                    </p>
+                  </description>
                   <latex-image>
                     \begin{tikzpicture}
                     \begin{axis}[
@@ -2007,7 +2217,25 @@
                 </p>
 
                 <image xml:id="img_09_05_ex_27">
-                  <description></description>
+                  <shortdescription>A cardioid and a circle, and a region of overlap in the first quadrant.</shortdescription>
+                  <description>
+                    <p>
+                      Two polar curves are plotted. The first is a circle with center <m>(1/2,0)</m> and radius <m>1/2</m>;
+                      it is symmetric about the <m>x</m> axis and passes through <m>(0,0)</m> and <m>(1,0)</m>.
+                    </p>
+
+                    <p>
+                      The second curve is a cardioid. It is larger than the circle, and <q>points</q> in the opposite direction.
+                      That is, it is symmetric about the <m>x</m> axis, with its cusp at the origin,
+                      but its other <m>x</m> intercept lies on the negative <m>x</m> axis, at <m>(-2,0)</m>.
+                    </p>
+
+                    <p>
+                      The two curves overlap in a small region in the first quadrant, which is shaded.
+                      The region extends from the origin to the point in the first quadrant where the two curves intersect.
+                      It is bounded above (and to the left) by the circle, and below (and to the right) by the cardioid.
+                    </p>
+                  </description>
                   <latex-image>
                     \begin{tikzpicture}
                     \begin{axis}[


### PR DESCRIPTION
The chapter on plane curves had image descriptions for the section on conic sections, but not for the other four sections.

This adds image descriptions for the sections on parametric and polar curves.

There are also a few small fixes included. In the section on polar calculus there was an arc length example where the variable `t` was used instead of `\theta`. I changed it to `\theta`.