### PR TITLE
Ensure consistent/current xref syntax

### DIFF
--- a/ptx/chapter_app_of_int.ptx
+++ b/ptx/chapter_app_of_int.ptx
@@ -4,7 +4,7 @@
   <title>Applications of Integration</title>
   <introduction>
     <p>
-      We begin this chapter with a reminder of a few key concepts from <xref ref="chapter_integration">Chapter</xref>.
+      We begin this chapter with a reminder of a few key concepts from <xref ref="chapter_integration"/>.
       Let <m>f</m> be a continuous function on <m>[a,b]</m> which is partitioned into <m>n</m> equally spaced subintervals as
       <me>
         a=x_0 \lt  x_1 \lt  \cdots \lt  x_n\lt x_{n}=b
@@ -14,7 +14,7 @@
     <p>
       Let <m>\dx=(b-a)/n</m> denote the length of the subintervals,
       and let <m>c_i</m> be any <m>x</m>-value in the <m>i</m>th subinterval.
-      <xref ref="def_rie_sum">Definition</xref> states that the sum
+      <xref ref="def_rie_sum"/> states that the sum
       <me>
         \sum_{i=1}^n f(c_i)\dx
       </me>
@@ -28,7 +28,7 @@
     </p>
 
     <p>
-      <xref ref="thm_riemann_sum">Theorem</xref>
+      <xref ref="thm_riemann_sum"/>
       connects limits of Riemann Sums to definite integrals:
       <me>
         \lim_{n\to\infty} \sum_{i=1}^n f(c_i)\dx = \int_a^b f(x)\, dx
@@ -89,7 +89,7 @@
     <p>
       This Key Idea will make more sense after we have had a chance to use it several times.
       We begin with Area Between Curves,
-      which we addressed briefly in <xref ref="sec_FTC">Section</xref>.
+      which we addressed briefly in <xref ref="sec_FTC"/>.
     </p>
   </introduction>
 

--- a/ptx/chapter_deriv_apps.ptx
+++ b/ptx/chapter_deriv_apps.ptx
@@ -4,7 +4,7 @@
   <title>Applications of the Derivative</title>
   <introduction>
     <p>
-      In <xref ref="chapter_graphbehavior">Chapter</xref>,
+      In <xref ref="chapter_graphbehavior"/>,
       we learned how the first and second derivatives of a function influence its graph.
       In this chapter we explore other applications of the derivative.
     </p>

--- a/ptx/chapter_deriv_apps_UL-acc.ptx
+++ b/ptx/chapter_deriv_apps_UL-acc.ptx
@@ -4,7 +4,7 @@
   <title>Applications of the Derivative</title>
   <introduction>
     <p>
-      In <xref ref="chapter_graphbehavior">Chapter</xref>,
+      In <xref ref="chapter_graphbehavior"/>,
       we learned how the first and second derivatives of a function influence its graph.
       In this chapter we explore other applications of the derivative.
     </p>

--- a/ptx/chapter_deriv_apps_UL-std.ptx
+++ b/ptx/chapter_deriv_apps_UL-std.ptx
@@ -4,7 +4,7 @@
   <title>Applications of the Derivative</title>
   <introduction>
     <p>
-      In <xref ref="chapter_graphbehavior">Chapter</xref>,
+      In <xref ref="chapter_graphbehavior"/>,
       we learned how the first and second derivatives of a function influence its graph.
       In this chapter we explore other applications of the derivative.
     </p>

--- a/ptx/chapter_derivatives.ptx
+++ b/ptx/chapter_derivatives.ptx
@@ -4,7 +4,7 @@
   <title>Derivatives</title>
   <introduction>
     <p>
-      <xref ref="chapter_limits">Chapter</xref> introduced the most fundamental of calculus topics:
+      <xref ref="chapter_limits"/> introduced the most fundamental of calculus topics:
       the limit.
       This chapter introduces the second most fundamental of calculus topics:
       the derivative.

--- a/ptx/chapter_integration.ptx
+++ b/ptx/chapter_integration.ptx
@@ -43,9 +43,9 @@
       We used the definite integral to compute areas,
       and also to compute displacements and distances traveled.
       There is far more we can do than that.
-      In <xref ref="chapter_app_of_int">Chapter</xref>
+      In <xref ref="chapter_app_of_int"/>
       we'll see more applications of the definite integral.
-      Before that, in <xref ref="chapter_anti_tech">Chapter</xref>
+      Before that, in <xref ref="chapter_anti_tech"/>
       we'll learn advanced techniques of integration,
       analogous to learning rules like the Product, Quotient and Chain Rules of differentiation.
     </p>

--- a/ptx/chapter_integration_UL-acc.ptx
+++ b/ptx/chapter_integration_UL-acc.ptx
@@ -45,9 +45,9 @@
       We used the definite integral to compute areas,
       and also to compute displacements and distances traveled.
       There is far more we can do than that.
-      In <xref ref="chapter_app_of_int">Chapter</xref>
+      In <xref ref="chapter_app_of_int"/>
       we'll see more applications of the definite integral.
-      Before that, in <xref ref="chapter_anti_tech">Chapter</xref>
+      Before that, in <xref ref="chapter_anti_tech"/>
       we'll learn advanced techniques of integration,
       analogous to learning rules like the Product, Quotient and Chain Rules of differentiation.
     </p>

--- a/ptx/chapter_mult_int.ptx
+++ b/ptx/chapter_mult_int.ptx
@@ -5,14 +5,14 @@
   <title>Multiple Integration</title>
   <introduction>
     <p>
-      <xref ref="chapter_multi">Chapter</xref> introduced multivariable functions and we applied concepts of differential calculus to these functions.
+      <xref ref="chapter_multi"/> introduced multivariable functions and we applied concepts of differential calculus to these functions.
       We learned how we can view a function of two variables as a surface in space,
       and learned how partial derivatives convey information about how the surface is changing in any direction.
     </p>
 
     <p>
       In this chapter we apply techniques of integral calculus to multivariable functions.
-      In <xref ref="chapter_integration">Chapter</xref>
+      In <xref ref="chapter_integration"/>
       we learned how the definite integral of a single variable function gave us
       <q>area under the curve.</q>
       In this chapter we will see that integration applied to a multivariable function gives us

--- a/ptx/chapter_mult_int_UL.ptx
+++ b/ptx/chapter_mult_int_UL.ptx
@@ -5,14 +5,14 @@
   <title>Multiple Integration</title>
   <introduction>
     <p>
-      <xref first="chapter_multi_UL3" last="chapter_multi_UL4">Chapters</xref> introduced multivariable functions and we applied concepts of differential calculus to these functions.
+      <xref first="chapter_multi_UL3" last="chapter_multi_UL4" text="global">Chapters</xref> introduced multivariable functions and we applied concepts of differential calculus to these functions.
       We learned how we can view a function of two variables as a surface in space,
       and learned how partial derivatives convey information about how the surface is changing in any direction.
     </p>
 
     <p>
       In this chapter we apply techniques of integral calculus to multivariable functions.
-      In <xref ref="chapter_integration">Chapter</xref>
+      In <xref ref="chapter_integration"/>
       we learned how the definite integral of a single variable function gave us
       <q>area under the curve.</q>
       In this chapter we will see that integration applied to a multivariable function gives us

--- a/ptx/chapter_multi.ptx
+++ b/ptx/chapter_multi.ptx
@@ -7,7 +7,7 @@
     <p>
       A function of the form <m>y=f(x)</m> is a function of a single variable;
       given a value of <m>x</m>, we can find a value <m>y</m>.
-      Even the vector-valued functions of <xref ref="chap_vvf">Chapter</xref>
+      Even the vector-valued functions of <xref ref="chap_vvf"/>
       are single-variable functions;
       the input is a single variable though the output is a vector.
     </p>

--- a/ptx/chapter_multi_UL3.ptx
+++ b/ptx/chapter_multi_UL3.ptx
@@ -7,7 +7,7 @@
     <p>
       A function of the form <m>y=f(x)</m> is a function of a single variable;
       given a value of <m>x</m>, we can find a value <m>y</m>.
-      Even the vector-valued functions of <xref ref="chap_vvf">Chapter</xref>
+      Even the vector-valued functions of <xref ref="chap_vvf"/>
       are single-variable functions;
       the input is a single variable though the output is a vector.
     </p>
@@ -24,7 +24,7 @@
     <p>
       This chapter introduces <em>multivariable</em> functions, that is,
       functions with more than one input.
-      A more detailed study of differential calculus for multivariable functions continues in <xref ref="chapter_multi_UL4">Chapter</xref>.
+      A more detailed study of differential calculus for multivariable functions continues in <xref ref="chapter_multi_UL4"/>.
     </p>
   </introduction>
 

--- a/ptx/chapter_multi_UL4.ptx
+++ b/ptx/chapter_multi_UL4.ptx
@@ -5,10 +5,10 @@
   <title>Functions of Several Variables, Continued</title>
   <introduction>
     <p>
-      In <xref ref="chapter_multi_UL3">Chapter</xref> we introduced functions of several variables,
+      In <xref ref="chapter_multi_UL3"/> we introduced functions of several variables,
       and considered limits, continuity, and partial derivatives.
       This chapter continues the study of functions of several variables in more detail.
-      We begin in <xref ref="sec_total_differential">Section</xref>
+      We begin in <xref ref="sec_total_differential"/>
       with what it means for a multivariable function to be <em>differentiable</em>.
       We then continue with multivariable analogues of elements from single variable calculus,
       such as the chain rule and extreme values.

--- a/ptx/chapter_vector_calc.ptx
+++ b/ptx/chapter_vector_calc.ptx
@@ -19,7 +19,7 @@
     <assemblage xml:id="assemblage-integration-review">
       <title>Integration review</title>
       <p>
-        Recall from <xref ref="sec_iterated_integrals">Section</xref>
+        Recall from <xref ref="sec_iterated_integrals"/>
         that when <m>R</m> is a region in the <m>xy</m>-plane,
         <m>\iint_R dA</m> gives the area of the region <m>R</m>.
         The integral symbols are <q>elongated esses</q> meaning <q>sum</q>
@@ -49,7 +49,7 @@
         That is, <m>dA = dx\,dy</m> or <m>dA = dy\,dx</m>.
         We could also compute a small amount of area by thinking in terms of polar coordinates,
         where <m>dA = r\,dr\,d\theta</m>.
-        These understandings lead us to the iterated integrals we used in <xref ref="chapter_mult_int">Chapter</xref>.
+        These understandings lead us to the iterated integrals we used in <xref ref="chapter_mult_int"/>.
       </p>
 
       <p>

--- a/ptx/chapter_vectors.ptx
+++ b/ptx/chapter_vectors.ptx
@@ -6,7 +6,7 @@
   <introduction>
     <!--<p>
       This chapter introduces a new mathematical object, the <em>vector</em>.
-      Defined in <xref ref="sec_vector_intro">Section</xref>,
+      Defined in <xref ref="sec_vector_intro"/>,
       we will see that vectors provide a powerful language for describing quantities that have magnitude and direction aspects.
       A simple example of such a quantity is force:
       when applying a force,

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -3,12 +3,12 @@
   <title>Area Between Curves</title>
   <p>
     We are often interested in knowing the area of a region.
-    Forget momentarily that we addressed this already in <xref ref="sec_FTC">Section</xref>
-    and approach it instead using the technique described in <xref ref="idea_app_of_defint">Key Idea</xref>.
+    Forget momentarily that we addressed this already in <xref ref="sec_FTC"/>
+    and approach it instead using the technique described in <xref ref="idea_app_of_defint"/>.
   </p>
 
   <figure xml:id="vid-intapp-area-intro" component="video">
-    <caption>Video introduction to <xref ref="sec_ABC">Section</xref></caption>
+    <caption>Video introduction to <xref ref="sec_ABC"/></caption>
     <video youtube="HAWBGypgKoQ" label="vid-intapp-area-intro"/>
   </figure>
 
@@ -25,12 +25,12 @@
   <p>
     The issue to address next is how to systematically break a region into subregions.
     A graph will help.
-    Consider <xref ref="fig_abcintroa">Figure</xref>
+    Consider <xref ref="fig_abcintroa"/>
     where a region between two curves is shaded.
     While there are many ways to break this into subregions,
     one particularly efficient way is to
     <q>slice</q> it vertically,
-    as shown in <xref ref="fig_abcintrob">Figure</xref>,
+    as shown in <xref ref="fig_abcintrob"/>,
     into <m>n</m> equally spaced slices.
   </p>
 
@@ -42,7 +42,7 @@
     the difference of the corresponding <m>y</m>-values.
     The width of the rectangle is a small difference in <m>x</m>-values,
     which we represent with <m>\dx</m>.
-    <xref ref="fig_abcintroc">Figure</xref>
+    <xref ref="fig_abcintroc"/>
     shows sample points <m>c_i</m> chosen in each subinterval and appropriate rectangles drawn.
     (Each of these rectangles represents a differential element.)
     Each slice has an area approximately equal to <m>\big(f(c_i)-g(c_i)\big)\dx</m>;
@@ -210,7 +210,7 @@
 
   <theorem xml:id="thm_areabetweencurves">
     <title>Area Between Curves
-    (restatement of <xref ref="thm_areabtwncurves">Theorem</xref>)</title>
+    (restatement of <xref ref="thm_areabtwncurves"/>)</title>
     <statement>
       <p>
         Let <m>f(x)</m> and <m>g(x)</m> be continuous functions defined on <m>[a,b]</m> where
@@ -232,11 +232,11 @@
         Find the area of the region bounded by <m>f(x) = \sin(x) +2</m>,
         <m>g(x) = \frac12\cos(2x)-1</m>,
         <m>x=0</m> and <m>x=4\pi</m>,
-        as shown in <xref ref="fig_abc1">Figure</xref>.
+        as shown in <xref ref="fig_abc1"/>.
       </p>
 
       <figure xml:id="fig_abc1">
-        <caption>Graphing an enclosed region in <xref ref="ex_abc1">Example</xref></caption>
+        <caption>Graphing an enclosed region in <xref ref="ex_abc1"/></caption>
         <!-- START figures/fig_abc1.tex -->
         <image xml:id="img_abc1" width="47%">
           <description>
@@ -297,11 +297,11 @@
     <statement>
       <p>
         Find the total area of the region enclosed by the functions <m>f(x) = -2x+5</m> and
-        <m>g(x) = x^3-7x^2+12x-3</m> as shown in <xref ref="fig_abc2">Figure</xref>.
+        <m>g(x) = x^3-7x^2+12x-3</m> as shown in <xref ref="fig_abc2"/>.
       </p>
 
       <figure xml:id="fig_abc2">
-        <caption>Graphing a region enclosed by two functions in <xref ref="ex_abc2">Example</xref></caption>
+        <caption>Graphing a region enclosed by two functions in <xref ref="ex_abc2"/></caption>
         <!-- START figures/fig_abc2.tex -->
         <image xml:id="img_abc2" width="47%">
           <description>
@@ -380,7 +380,7 @@
   </p>
 
   <p>
-    The previous example also demonstrates that we often have to break a given region into subregions before applying <xref ref="thm_areabetweencurves">Theorem</xref>.
+    The previous example also demonstrates that we often have to break a given region into subregions before applying <xref ref="thm_areabetweencurves"/>.
     The following example shows another situation where this is applicable,
     along with an alternate view of applying the Theorem.
   </p>
@@ -391,10 +391,10 @@
       <p>
         Find the area of the region enclosed by the functions <m>y=\sqrt{x}+2</m>,
         <m>y=-(x-1)^2+3</m> and <m>y=2</m>,
-        as shown in <xref ref="fig_abc3">Figure</xref>.
+        as shown in <xref ref="fig_abc3"/>.
       </p>
       <figure xml:id="fig_abc3">
-        <caption>Graphing a region for <xref ref="ex_abc3">Example</xref></caption>
+        <caption>Graphing a region for <xref ref="ex_abc3"/></caption>
         <!-- START figures/fig_abc3.tex -->
         <image xml:id="img_abc3" width="47%">
           <description>
@@ -475,7 +475,7 @@
       </p>
 
       <figure xml:id="fig_abc3b">
-        <caption>The region used in <xref ref="ex_abc3">Example</xref> with boundaries relabeled as functions of <m>y</m></caption>
+        <caption>The region used in <xref ref="ex_abc3"/> with boundaries relabeled as functions of <m>y</m></caption>
         <!-- START figures/fig_abc3b.tex -->
         <image xml:id="img_abc3b" width="47%">
           <description>
@@ -515,7 +515,7 @@
       </figure>
 
       <p>
-        <xref ref="fig_abc3b">Figure</xref>
+        <xref ref="fig_abc3b"/>
         shows the region with the boundaries relabeled.
         A differential element, a horizontal rectangle, is also pictured.
         The width of the rectangle is a small change in <m>y</m>:
@@ -548,7 +548,7 @@
 
   <p>
     This calculus-based technique of finding area can be useful even with shapes that we normally think of as <q>easy.</q>
-    <xref ref="ex_abc4">Example</xref>
+    <xref ref="ex_abc4"/>
     computes the area of a triangle.
     While the formula <q><m>\frac12\times\,\text{base}\, \times\,\text{height}</m></q> is well known,
     in arbitrary triangles it can be nontrivial to compute the height.
@@ -564,11 +564,11 @@
 
       <p>
         <m>y=x+1</m>, <m>y=-2x+7</m> and <m>y=-\frac12x+\frac52</m>,
-        as shown in <xref ref="fig_abc4">Figure</xref>.
+        as shown in <xref ref="fig_abc4"/>.
       </p>
 
       <figure xml:id="fig_abc4">
-        <caption>Graphing a triangular region in <xref ref="ex_abc4">Example</xref></caption>
+        <caption>Graphing a triangular region in <xref ref="ex_abc4"/></caption>
         <!-- START figures/fig_abc4.tex -->
         <image xml:id="img_abc4" width="47%">
           <description>
@@ -653,11 +653,11 @@
 
   <p>
     While we have focused on producing exact answers,
-    we are also able to make approximations using the principle of <xref ref="thm_areabetweencurves">Theorem</xref>.
+    we are also able to make approximations using the principle of <xref ref="thm_areabetweencurves"/>.
     The integrand in the theorem is a distance (<q>top minus bottom</q>);
     integrating this distance function gives an area.
     By taking discrete measurements of distance,
-    we can approximate an area using numerical integration techniques developed in <xref ref="sec_numerical_integration">Section</xref>.
+    we can approximate an area using numerical integration techniques developed in <xref ref="sec_numerical_integration"/>.
     The following example demonstrates this.
   </p>
 
@@ -666,8 +666,8 @@
     <statement>
       <p>
         To approximate the area of a lake,
-        shown in <xref ref="fig_abc5a">Figure</xref>,
-        the <q>length</q> of the lake is measured at 200-foot increments, as shown in <xref ref="fig_abc5b">Figure</xref>.
+        shown in <xref ref="fig_abc5a"/>,
+        the <q>length</q> of the lake is measured at 200-foot increments, as shown in <xref ref="fig_abc5b"/>.
         The lengths are given in hundreds of feet.
         Approximate the area of the lake.
       </p>

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -357,7 +357,7 @@
         <mrow>\int_a^b f(t)\, dt \amp = \int_a^c f(t)\, dt + \int_c^b f(t)\, dt</mrow>
         <mrow>\amp = -\int_c^a f(t)\, dt + \int_c^b f(t)\, dt</mrow>
       </md>
-      Using <xref ref="eq_ftc_c" text="local">Equation</xref>,
+      Using <xref ref="eq_ftc_c">Equation</xref>,
       let <m>x=a</m> in the first integral and <m>x=b</m> in the second integral so that
       <m>\int_c^a f(t)\, dt =F(a)</m> and <m>\int_c^b f(t)\, dt =F(b)</m>.
       Therefore:

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -20,7 +20,7 @@
 
     <p>
       Let <m>F(x) = \int_a^x f(t)\, dt</m>.
-      It computes the area under <m>f</m> on <m>[a,x]</m> as illustrated in <xref ref="fig_ftc0">Figure</xref>.
+      It computes the area under <m>f</m> on <m>[a,x]</m> as illustrated in <xref ref="fig_ftc0"/>.
       We can study this function using our knowledge of the definite integral.
       For instance, <m>F(a)=0</m> since <m>\int_a^af(t)\, dt=0</m>.
     </p>
@@ -71,7 +71,7 @@
       <title>Exploring the <q>Area so far</q> function</title>
       <statement>
         <p>
-          Consider <m>f(t)=2t</m> pictured in Figure <xref ref="fig_ftc1">Figure </xref>
+          Consider <m>f(t)=2t</m> pictured in Figure <xref ref="fig_ftc1"/>
           and its associated <q>area so far</q> function,
           <m>F(x)=\int_1^x 2t\, dt</m>.
           Using the graph of <m>f</m> and geometry,
@@ -127,7 +127,7 @@
       <solution>
 
         <p>
-          We can see from <xref ref="fig_ftc1b">Figure</xref> that for <m>x \geq 1</m>,
+          We can see from <xref ref="fig_ftc1b"/> that for <m>x \geq 1</m>,
           the area under the curve can be found by subtracting the area of two triangles.
           The larger triangle will have a base of <m>x</m> and a height of <m>f(x)=2x</m>,
           while the smaller triangle will have a base of <m>1</m> and a height of <m>2</m>.
@@ -208,7 +208,7 @@
         <p>
           Therefore, we can reasonably say that <m>F(x)=x^2-1</m>.
           A plot of both <m>f(x)=2x</m> and
-          <m>F(x)=x^2-1</m> are given in Figure <xref ref="fig_ftc1c">Figure</xref>.
+          <m>F(x)=x^2-1</m> are given in Figure <xref ref="fig_ftc1c"/>.
           You should notice a familiar relationship between these two functions.
           This relationship is formally stated in <xref ref="thm_FTC1"/>.
         </p>
@@ -268,10 +268,10 @@
   <subsection>
     <title>Fundamental Theorem of Calculus, Parts 1 and 2</title>
     <p>
-      As <xref ref="ex_ftc1">Example</xref> hinted,
+      As <xref ref="ex_ftc1"/> hinted,
       we can apply calculus ideas to <m>F(x)</m>;
       in particular, we can compute its derivative.
-      In <xref ref="ex_ftc1">Example</xref>,
+      In <xref ref="ex_ftc1"/>,
       <m>F(x)=x^2-1</m>, so <m>F'(x)=2x=f(x)</m>.
       While this may seem like an innocuous thing to do,
       it has far-reaching implications,
@@ -343,7 +343,7 @@
     </example>
 
     <p>
-      What we have done in <xref ref="ex_ftc2">Example</xref>
+      What we have done in <xref ref="ex_ftc2"/>
       was more than finding a complicated way of computing an antiderivative.
       Consider a function <m>f</m> defined on an open interval containing <m>a</m>,
       <m>b</m> and <m>c</m>.
@@ -352,12 +352,12 @@
       <men xml:id="eq_ftc_c">
         F(x) = \int_c^x f(t)\, dt
       </men>.
-      Using the properties of the definite integral found in <xref ref="thm_defintprop">Theorem</xref>, we know
+      Using the properties of the definite integral found in <xref ref="thm_defintprop"/>, we know
       <md>
         <mrow>\int_a^b f(t)\, dt \amp = \int_a^c f(t)\, dt + \int_c^b f(t)\, dt</mrow>
         <mrow>\amp = -\int_c^a f(t)\, dt + \int_c^b f(t)\, dt</mrow>
       </md>
-      Using <xref ref="eq_ftc_c">Equation</xref>,
+      Using <xref ref="eq_ftc_c" text="local">Equation</xref>,
       let <m>x=a</m> in the first integral and <m>x=b</m> in the second integral so that
       <m>\int_c^a f(t)\, dt =F(a)</m> and <m>\int_c^b f(t)\, dt =F(b)</m>.
       Therefore:
@@ -370,7 +370,7 @@
     <p>
       We now see how indefinite integrals and definite integrals are related:
       we can evaluate a definite integral using antiderivatives!
-      In fact, this is exactly what we noticed in <xref ref="ex_ftc1">Example</xref>.
+      In fact, this is exactly what we noticed in <xref ref="ex_ftc1"/>.
       The <q>area so far</q> function was indeed an anti-derivative of the integrand.
       This is the second part of the Fundamental Theorem of Calculus.
     </p>
@@ -451,7 +451,7 @@
       A special notation is often used in the process of evaluating definite integrals using the Fundamental Theorem of Calculus.
       Instead of explicitly writing <m>F(b)-F(a)</m>,
       the notation <m>F(x)\Big|_a^b</m> is used.
-      Thus the solution to <xref ref="ex_ftc3">Example</xref> would be written as:
+      Thus the solution to <xref ref="ex_ftc3"/> would be written as:
       <md>
         <mrow>\int_0^4(4x-x^2)\, dx \amp = \left.\left(2x^2-\frac13x^3\right)\right|_0^4</mrow>
         <mrow>\amp = \big(2(4)^2-\frac134^3\big)-\big(0-0\big) =  32/3</mrow>
@@ -563,7 +563,7 @@
     <title>Understanding Motion with the Fundamental Theorem of Calculus</title>
     <p>
       We established,
-      starting with <xref ref="idea_motion">Key Idea</xref>,
+      starting with <xref ref="idea_motion"/>,
       that the derivative of a position function is a velocity function,
       and the derivative of a velocity function is an acceleration function.
       Now consider definite integrals of velocity and acceleration functions.
@@ -638,12 +638,12 @@
         </p>
 
         <p>
-          As we can see in <xref ref="fig_ftcmotion1a">Figure</xref>,
+          As we can see in <xref ref="fig_ftcmotion1a"/>,
           the positive area between <m>v(t)</m> and the <m>t</m>-axis,
           <m>A_1=25/4</m>, while the negative area, <m>A_2=-9/4</m>.
           When we add these two areas, we get the displacement of <m>4</m> ft.
           But when we add the absolute value of both of these areas
-          (as in <xref ref="fig_ftcmotion1b">Figure</xref>),
+          (as in <xref ref="fig_ftcmotion1b"/>),
           we get the total distance of <m>9</m> ft.
         </p>
 
@@ -766,7 +766,7 @@
       Speed is also the rate of position change,
       but does not account for direction.
       That is, the speed an object is the absolute value of its velocity.
-      This is what we saw in <xref ref="ex_ftcmotion1">Example</xref>
+      This is what we saw in <xref ref="ex_ftcmotion1"/>
       when we evaluated <m>\int_0^1 \abs{v(t)}\, dt</m>.
       So integrating a speed function gives total change of position,
       without the possibility of <q>negative position change.</q>
@@ -895,7 +895,7 @@
     <p>
       Consider continuous functions <m>f(x)</m> and <m>g(x)</m> defined on <m>[a,b]</m>,
       where <m>f(x) \geq g(x)</m> for all <m>x</m> in <m>[a,b]</m>,
-      as demonstrated in <xref ref="fig_ftc5">Figure</xref>.
+      as demonstrated in <xref ref="fig_ftc5"/>.
       What is the area of the shaded region bounded by the two curves over <m>[a,b]</m>?
           <idx><h>integration</h><h>area between curves</h></idx>
     </p>
@@ -1053,11 +1053,11 @@
 
         <p>
           It will help to sketch these two functions,
-          as done in <xref ref="fig_ftc6">Figure</xref>.
+          as done in <xref ref="fig_ftc6"/>.
         </p>
 
         <figure xml:id="fig_ftc6">
-          <caption>Sketching the region enclosed by <m>y=x^2+x-5</m> and <m>y=3x-2</m> in <xref ref="ex_ftc6">Example</xref></caption>
+          <caption>Sketching the region enclosed by <m>y=x^2+x-5</m> and <m>y=3x-2</m> in <xref ref="ex_ftc6"/></caption>
           <image xml:id="img_ftc6" width="47%">
             <shortdescription>
               Graph of region enclosed by y=x^2+x-5 and y=3*x-2.
@@ -1111,7 +1111,7 @@
         </p>
 
         <p>
-          Following <xref ref="thm_areabtwncurves">Theorem</xref>,
+          Following <xref ref="thm_areabtwncurves"/>,
           the area is
           <md>
             <mrow>\int_{-1}^3\big(3x-2 -(x^2+x-5)\big)\, dx \amp = \int_{-1}^3 (-x^2+2x+3)\, dx</mrow>
@@ -1175,22 +1175,22 @@
     </figure>
 
     <p>
-      Consider the graph of a function <m>f</m> in <xref ref="fig_ftc7a">Figure</xref>
+      Consider the graph of a function <m>f</m> in <xref ref="fig_ftc7a"/>
       and the area defined by <m>\int_1^4 f(x)\, dx</m>.
-      Three rectangles are drawn in <xref ref="fig_ftc7b">Figure</xref>;
-      in <xref ref="fig_ftc7b2">Figure</xref>,
+      Three rectangles are drawn in <xref ref="fig_ftc7b"/>;
+      in <xref ref="fig_ftc7b2"/>,
       the height of the rectangle is greater than <m>f</m> on <m>[1,4]</m>,
       hence the area of this rectangle is is greater than <m>\int_1^4 f(x)\, dx</m>.
     </p>
 
     <p>
-      In <xref ref="fig_ftc7b1">Figure</xref>,
+      In <xref ref="fig_ftc7b1"/>,
       the height of the rectangle is smaller than <m>f</m> on <m>[1,4]</m>,
       hence the area of this rectangle is less than <m>\int_1^4 f(x)\, dx</m>.
     </p>
 
     <p>
-      Finally, in <xref ref="fig_ftc7b3">Figure</xref>
+      Finally, in <xref ref="fig_ftc7b3"/>
       the height of the rectangle is such that the area of the rectangle is <em>exactly</em>
       that of <m>\int_1^4 f(x)\, dx</m>.
       Since rectangles that are <q>too big</q>,
@@ -1359,14 +1359,14 @@
     <p>
       This is an <em>existential</em> statement;
       <m>c</m> exists, but we do not provide a method of finding it.
-      <xref ref="thm_mvt2">Theorem</xref>
+      <xref ref="thm_mvt2"/>
       is directly connected to the Mean Value Theorem of Differentiation, given
-      as <xref ref="thm_mvt">Theorem</xref>;
+      as <xref ref="thm_mvt"/>;
       we leave it to the reader to see how.
     </p>
     <aside>
       <p>
-        The <xref ref="thm_mvt2">Theorem</xref>
+        The <xref ref="thm_mvt2"/>
         simply says that there is a rectangle with height <m>f(c)</m> and width <m>b-a</m>,
         the area of which is the same as the area between <m>f</m> and the <m>x</m>-axis over<m>[a,b]</m>.
         Furthermore,
@@ -1388,7 +1388,7 @@
       <solution>
         <p>
           We first need to evaluate <m>\int_0^\pi \sin(x) \, dx</m>.
-          (This was previously done in <xref ref="ex_ftc4">Example</xref>.)
+          (This was previously done in <xref ref="ex_ftc4"/>.)
           <me>
             \int_0^\pi\sin(x) \, dx =	-\cos(x) \Big|_0^\pi = 2
           </me>.
@@ -1449,7 +1449,7 @@
         </figure>
 
         <p>
-          In <xref ref="fig_ftc8">Figure</xref>
+          In <xref ref="fig_ftc8"/>
           <m>\sin(x)</m> is sketched along with a rectangle with height <m>\sin(0.69)</m>.
           The area of the rectangle is the same as the area under <m>\sin(x)</m> on <m>[0,\pi]</m>.
         </p>
@@ -1470,7 +1470,7 @@
     <p>
       When <m>f(x)</m> is shifted by <m>-f(c)</m>,
       the amount of area under <m>f</m> above the <m>x</m>-axis on <m>[a,b]</m> is the same as the amount of area below the <m>x</m>-axis above <m>f</m>;
-      see <xref ref="fig_ftc9">Figure</xref> for an illustration of this.
+      see <xref ref="fig_ftc9"/> for an illustration of this.
       In this sense,
       we can say that <m>f(c)</m> is the <em>average value</em>
       of <m>f</m> on <m>[a,b]</m>.
@@ -1595,10 +1595,10 @@
       for some value of <m>c</m> in <m>[a,b]</m>.
 
 <!--ToDo: have Greg review the change here. This was made during the previous conversion.-->
-      Replacing the integral with the limit of a Riemann sum (as in <xref ref="thm_riemann_sum">Theorem</xref>):
+      Replacing the integral with the limit of a Riemann sum (as in <xref ref="thm_riemann_sum"/>):
       <md>
         <mrow>f(c) \amp = \frac{1}{b-a}\int_a^b f(x)\, dx \amp</mrow>
-        <mrow>\amp = \frac{1}{b-a} \lim\limits_{n \to \infty}\sum_{i=1}^n f(c_i)\,\Delta x \amp \text{Using } <xref ref="thm_riemann_sum">Theorem</xref></mrow>
+        <mrow>\amp = \frac{1}{b-a} \lim\limits_{n \to \infty}\sum_{i=1}^n f(c_i)\,\Delta x \amp \text{Using } <xref ref="thm_riemann_sum"/></mrow>
         <mrow>\amp =\frac{1}{b-a} \lim\limits_{n \to \infty}\sum_{i=1}^n f(c_i)\,\frac{b-a}{n}\amp \Delta x =\frac{b-a}{n}</mrow>
         <mrow>\amp =\lim\limits_{n \to \infty}\sum_{i=1}^n f(c_i)\frac{1}{n} \amp \text{Cancelling the common factor of } b-a</mrow>
       </md>.
@@ -1700,7 +1700,7 @@
     </p>
 
     <p>
-      What was the displacement of the object in <xref ref="ex_ftc10">Example</xref>?
+      What was the displacement of the object in <xref ref="ex_ftc10"/>?
       We calculate this by integrating its velocity function:
       <m>\int_0^3 (t-1)^2\, dt = 3</m> ft.
       Its final position was 3 feet from its initial position after 3 seconds:
@@ -1711,7 +1711,7 @@
       This section has laid the groundwork for a lot of great mathematics to follow.
       The most important lesson is this:
       definite integrals can be evaluated using antiderivatives.
-      Since <xref ref="sec_riemann">Section</xref>
+      Since <xref ref="sec_riemann"/>
       established that definite integrals are the limit of Riemann sums,
       we can later create Riemann sums to approximate values other than
       <q>area under the curve,</q>
@@ -1725,10 +1725,10 @@
     <p>
       The downside is this: generally speaking,
       computing antiderivatives is much more difficult than computing derivatives.
-      <xref ref="chapter_anti_tech">Chapter</xref>
+      <xref ref="chapter_anti_tech"/>
       is devoted to techniques of finding antiderivatives so that a wide variety of definite integrals can be evaluated.
       Before that,
-      <xref ref="sec_numerical_integration">Section</xref>
+      <xref ref="sec_numerical_integration"/>
       explores techniques of approximating the value of definite integrals beyond using the Left Hand, Right Hand and Midpoint Rules.
       These techniques are invaluable when antiderivatives cannot be computed,
       or when the actual function <m>f</m> is unknown and all we know is the value of <m>f</m> at certain <m>x</m>-values.

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -1075,8 +1075,8 @@
           are plotted in <xref ref="fig_20_01_euler2"/>.
         </p>
         <figure xml:id="fig_20_01_euler2">
-          <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1" text="local">Examples</xref>
-            and <xref ref="ex_euler2" text="local"/>, along with the analytical solution</caption>
+          <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1" text="global">Examples</xref>
+            and <xref ref="ex_euler2" text="global"/>, along with the analytical solution</caption>
           <image xml:id="img-euler2" width="47%">
             <shortdescription>
               Euler's Method approximation to y'=x+y with y(1)=-1 along with the analytical solution.
@@ -1130,8 +1130,8 @@
 
 
     <p>
-      Using the results from <xref ref="ex_euler1" text="local">Examples</xref>
-      and <xref ref="ex_euler2" text="local"/>,
+      Using the results from <xref ref="ex_euler1" text="global">Examples</xref>
+      and <xref ref="ex_euler2" text="global"/>,
       we can make a few observations about Euler's method.
       First, the Euler approximation generally gets worse as we get farther from the initial condition.
       This is because Euler's method involves two sources of error.

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -3,7 +3,7 @@
   <title>Graphical and Numerical Solutions to Differential Equations</title>
   <introduction>
     <p>
-      In <xref ref="sec_antider">Section</xref>,
+      In <xref ref="sec_antider"/>,
       we were introduced to the idea of a differential equation.
       Given a function <m>y = f(x)</m>,
       we defined a <em>differential equation</em>
@@ -14,7 +14,7 @@
       to a differential equation is simply a function that satisfies the differential equation.
     </p>
     <figure xml:id="vid-diffeq-basic-intro" component="video">
-      <caption>Video introduction to <xref ref="sec_Graphical_Numerical">Section</xref></caption>
+      <caption>Video introduction to <xref ref="sec_Graphical_Numerical"/></caption>
       <video youtube="aevFioTbghg" label="vid-diffeq-basic-intro"/>
     </figure>
   </introduction>
@@ -185,7 +185,7 @@
           </me>.
         </p>
         <p>
-          <xref ref="fig_general_particular">Figure</xref>
+          <xref ref="fig_general_particular"/>
           shows various members of the general solution to the differential equation <m>\displaystyle \yp = 2y</m>.
           Each <m>C</m> value yields a different member of the family,
           and a different function.
@@ -194,7 +194,7 @@
         <figure xml:id="fig_general_particular">
           <caption>A representation of some of the members of general solution to the differential equation <m>\yp = 2y</m>,
           including the particular solution to the initial value problem with <m>y(0)=\displaystyle 3/2</m>,
-          from <xref ref="ex_simple_de">Example</xref></caption>
+          from <xref ref="ex_simple_de"/></caption>
           <image xml:id="img_general_particular" width="47%">
             <shortdescription>
               Graph of the members of the general solution to the equation y' =2y, including a particular solution.
@@ -266,7 +266,7 @@
     </example>
 
     <p>
-      The differential equation in <xref ref="ex_simple_de2">Example</xref>
+      The differential equation in <xref ref="ex_simple_de2"/>
       is <em>second order</em>, because the equation involves a second derivative.
       In general, the number of initial conditions required to specify a particular solution depends on the order of the differential equation.
       For the remainder of the chapter,
@@ -424,7 +424,7 @@
       The algebraic equation <m>x^2 + 3x - 1 = 0</m> has two real solutions that can be found analytically by using the quadratic formula.
       The equation <m>\cos(x) = x</m> has one real solution,
       but we can't find it analytically.
-      As shown in <xref ref="fig_20_01_intersection">Figure</xref>,
+      As shown in <xref ref="fig_20_01_intersection"/>,
       we can find an approximate solution graphically by plotting <m>\cos(x)</m> and <m>x</m> and observing the <m>x</m>-value of the intersection.
       We can similarly use graphical tools to understand the qualitative behavior of solutions to a first order-differential equation.
     </p>
@@ -550,10 +550,10 @@
           we usually use a computer to make the drawing.
           Most popular computer algebra systems can draw slope fields.
           There are also various online tools that can make the drawings.
-          The slope field for <m>\yp = x+y</m> is shown in <xref ref="fig_20_01_slopefield1">Figure</xref>.
+          The slope field for <m>\yp = x+y</m> is shown in <xref ref="fig_20_01_slopefield1"/>.
         </p>
         <figure xml:id="fig_20_01_slopefield1">
-          <caption>Slope field for <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref></caption>
+          <caption>Slope field for <m>\yp = x+y</m> from <xref ref="ex_slope_field"/></caption>
           <image xml:id="img_slopefield1" width="47%">
             <shortdescription>
               Graph of slope field of y' = y+x.
@@ -626,10 +626,10 @@
           we sketch a solution to the initial value problem by starting at the point <m>(1,-1)</m> and
           <q>following the lines</q>
           in either direction.
-          A sketch of the solution is shown in <xref ref="fig_20_01_slopefield1solution">Figure</xref>.
+          A sketch of the solution is shown in <xref ref="fig_20_01_slopefield1solution"/>.
         </p>
         <figure xml:id="fig_20_01_slopefield1solution">
-          <caption>Solution to the initial value problem <m>\yp = x+y</m>, with <m>y(1)=-1</m> from <xref ref="ex_IVP_graphical">Example</xref></caption>
+          <caption>Solution to the initial value problem <m>\yp = x+y</m>, with <m>y(1)=-1</m> from <xref ref="ex_IVP_graphical"/></caption>
           <image xml:id="img_slopefield1solution" width="47%">
             <shortdescription>
               Graph of slope field of y' = y+x with initial value y(1) = -1.
@@ -684,11 +684,11 @@
       <statement>
         <p>
           Use the slope field for the differential equation <m>\yp = y(1-y)</m>,
-          shown in <xref ref="fig_20_01_slopefield2">Figure</xref>,
+          shown in <xref ref="fig_20_01_slopefield2"/>,
           to predict long term behavior of solutions to the equation.
         </p>
         <figure xml:id="fig_20_01_slopefield2">
-          <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref></caption>
+          <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field"/></caption>
           <image xml:id="img_slopefield2" width="47%">
             <shortdescription>
               Graph of slope field for the logistic differential equation y’=y(1-y) from the example.
@@ -741,7 +741,7 @@
         </p>
 
         <p>
-          Looking at the slope field in <xref ref="fig_20_01_slopefield2">Figure</xref>,
+          Looking at the slope field in <xref ref="fig_20_01_slopefield2"/>,
           we can predict long term behavior for a given initial condition.
           <ul>
             <li>
@@ -769,13 +769,13 @@
         <p>
           The slope field for the logistic differential equation,
           along with representative solution curves,
-          is shown in <xref ref="fig_20_01_slopefield2solution">Figure</xref>.
+          is shown in <xref ref="fig_20_01_slopefield2solution"/>.
           Notice that any solution curve with positive initial value will tend towards the value <m>y=1</m>.
           We call this the <em>carrying capacity.</em>
           <idx><h>carrying capacity</h></idx>
         </p>
         <figure xml:id="fig_20_01_slopefield2solution">
-          <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field">Example</xref>
+          <caption>Slope field for the logistic differential equation <m>\yp = y(1-y)</m> from <xref ref="ex_logistic_slope_field"/>
           with a few representative solution curves</caption>
           <image xml:id="img_slopefield2solution" width="47%">
             <shortdescription>
@@ -844,7 +844,7 @@
       it is difficult to use a slope field to make quantitative predictions.
       For example,
       if we have the slope field for the differential equation
-      <m>\yp = x+y</m> from <xref ref="ex_slope_field">Example</xref>
+      <m>\yp = x+y</m> from <xref ref="ex_slope_field"/>
       along with the initial condition <m>y(0)=1</m>,
       we can understand the qualitative behavior of the solution to the initial value problem,
       but will struggle to predict a specific value,
@@ -916,7 +916,7 @@
       we can find an approximation for the solution at the value <m>x+h</m> by taking our <m>y</m>-value and adding <m>h</m> times the function <m>f</m> evaluated at the <m>x</m> and <m>y</m> values.
       Euler's method uses the initial condition of an initial value problem as the starting point,
       and then uses the above idea to find approximate values for the solution <m>y</m> at later <m>x</m>-values.
-      The algorithm is summarized in <xref ref="idea_Euler">Key Idea</xref>.
+      The algorithm is summarized in <xref ref="idea_Euler"/>.
     </p>
     <insight xml:id="idea_Euler">
       <title>Euler's Method</title>
@@ -988,10 +988,10 @@
         <p>
           To help visualize the Euler's method approximation, these three points
           (connected by line segments)
-          are plotted along with the analytical solution to the initial value problem in <xref ref="fig_20_01_euler1">Figure</xref>.
+          are plotted along with the analytical solution to the initial value problem in <xref ref="fig_20_01_euler1"/>.
         </p>
         <figure xml:id="fig_20_01_euler1">
-          <caption>Euler's Method approximation to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Example</xref>,
+          <caption>Euler's Method approximation to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1"/>,
           along with the analytical solution to the initial value problem</caption>
           <image xml:id="img-euler1" width="47%">
             <shortdescription>
@@ -1071,12 +1071,12 @@
 
         <p>
           These five points,
-          along with the points from <xref ref="ex_euler1">Example</xref> and the analytic solution,
-          are plotted in <xref ref="fig_20_01_euler2">Figure</xref>.
+          along with the points from <xref ref="ex_euler1"/> and the analytic solution,
+          are plotted in <xref ref="fig_20_01_euler2"/>.
         </p>
         <figure xml:id="fig_20_01_euler2">
-          <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1">Examples</xref>
-          and <xref ref="ex_euler2"></xref>, along with the analytical solution</caption>
+          <caption>Euler's Method approximations to <m>\yp = x + y</m> with <m>y(1) = -1</m> from <xref ref="ex_euler1" text="local">Examples</xref>
+            and <xref ref="ex_euler2" text="local"/>, along with the analytical solution</caption>
           <image xml:id="img-euler2" width="47%">
             <shortdescription>
               Euler's Method approximation to y'=x+y with y(1)=-1 along with the analytical solution.
@@ -1130,15 +1130,15 @@
 
 
     <p>
-      Using the results from <xref ref="ex_euler1">Examples</xref>
-      and <xref ref="ex_euler2"></xref>,
+      Using the results from <xref ref="ex_euler1" text="local">Examples</xref>
+      and <xref ref="ex_euler2" text="local"/>,
       we can make a few observations about Euler's method.
       First, the Euler approximation generally gets worse as we get farther from the initial condition.
       This is because Euler's method involves two sources of error.
       The first comes from the fact that we're using a positive <m>h</m>-value in the derivative approximation instead of using a limit as <m>h</m> approaches zero.
       Essentially,
       we're using a linear approximation to the solution <m>y</m>
-      (similar to the process described in <xref ref="sec_differentials">Section</xref> on Differentials.)
+      (similar to the process described in <xref ref="sec_differentials"/> on Differentials.)
       This error is often called the <em>local truncation error.</em>
       The second source of error comes from the fact that every step in Euler's method uses the result of the previous step.
       That means we're using an approximate <m>y</m>-value to approximate the next <m>y</m>-value.
@@ -1151,8 +1151,8 @@
     <p>
       A second observation is that the Euler approximation is more accurate for smaller <m>h</m>-values.
       This accuracy comes at a cost, though.
-      <xref ref="ex_euler2">Example</xref>
-      is more accurate than <xref ref="ex_euler1">Example</xref>,
+      <xref ref="ex_euler2"/>
+      is more accurate than <xref ref="ex_euler1"/>,
       but takes twice as many computations.
       In general, numerical algorithms
       (even when performed by a computer program)
@@ -1215,11 +1215,11 @@
         </p>
         <p>
           These 11 points, along with the the analytic solution,
-          are plotted in <xref ref="fig_20_01_euler3">Figure</xref>.
+          are plotted in <xref ref="fig_20_01_euler3"/>.
           Notice how well they seem to match the true solution.
         </p>
         <figure xml:id="fig_20_01_euler3">
-          <caption>Euler's Method approximation to <m>\yp = y(1-y)</m> with <m>y(0) = 0.25</m> from <xref ref="ex_euler3">Example</xref>,
+          <caption>Euler's Method approximation to <m>\yp = y(1-y)</m> with <m>y(0) = 0.25</m> from <xref ref="ex_euler3"/>,
           along with the analytical solution</caption>
           <image xml:id="img_euler3" width="47%">
             <shortdescription>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -120,7 +120,7 @@
       <p>
         It is generally useful to make a small table of these values as done below.
         Right now we only know <m>u</m> and <m>dv</m> as shown on the left of
-        <xref ref="fig_ibp1">Figure</xref>;
+        <xref ref="fig_ibp1"/>;
         on the right we fill in the rest of what we need.
         If <m>u = x</m>, then <m>du = dx</m>.
         Since <m>dv = \cos(x)\, dx</m>,
@@ -182,7 +182,7 @@
   </example>
 
   <p>
-    You may wonder what would have happened in <xref ref="ex_ibp1"> Example</xref>
+    You may wonder what would have happened in <xref ref="ex_ibp1"/>
     if we had chosen our <m>u</m> and <m>dv</m> differently.
     If we had chosen <m>u=\cos(x)</m> and
     <m>dv=x \, dx</m> then <m>du=-\sin(x)\, dx</m> and <m>v=x^2/2</m>.
@@ -195,7 +195,7 @@
   </p>
 
   <p>
-    <xref ref="ex_ibp1"> Example</xref>
+    <xref ref="ex_ibp1"/>
     demonstrates how Integration by Parts works in general.
     We try to identify <m>u</m> and <m>dv</m> in the integral we are given,
     and the key is that we usually want to choose <m>u</m> and <m>dv</m>
@@ -677,7 +677,7 @@
         </p>
 
         <p>
-          We evaluated this integral on the right in <xref ref="ex_ibp4">Example</xref>. (This integral can also be found in a table of integrals).
+          We evaluated this integral on the right in <xref ref="ex_ibp4"/>. (This integral can also be found in a table of integrals).
           Using the result there, we have:
           <md>
             <mrow>\int \cos(\ln(x) )\, dx \amp = \int e^u\cos(u) \, du</mrow>
@@ -695,7 +695,7 @@
     <p>
       So far we have focused only on evaluating indefinite integrals.
       Of course, we can use Integration by Parts to evaluate definite integrals as well,
-      as <xref ref="thm_IBP">Theorem</xref> states.
+      as <xref ref="thm_IBP"/> states.
       We do so in the next example.
     </p>
 
@@ -785,7 +785,7 @@
       second only to Substitution.
       In the following sections of this chapter,
       we continue to learn other integration techniques.
-      <xref ref="sec_trigint">Section</xref>
+      <xref ref="sec_trigint"/>
       focuses on handling integrals containing trigonometric functions.
     </p>
   </paragraphs>
@@ -1543,7 +1543,7 @@
           <p>
             Evaluate the definite integral.
             Note: the corresponding indefinite integral appears in
-            <xref ref="ibp_prob_5">Exercises</xref><ndash/><xref ref="ibp_prob_13" text="global"/>.
+            <xref first="ibp_prob_5" last="ibp_prob_13" text="local">Exercises</xref>.
           </p>
         </introduction>
         <!-- Exercise 41 -->

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -97,7 +97,7 @@
       Notice that linearity depends on the dependent variable <m>y</m>,
       not the independent variable <m>x</m>.
       The functions <m>p(x)</m> and <m>q(x)</m> need not be linear,
-      as demonstrated in part (c) of <xref ref="ex_identify_linear">Example</xref>.
+      as demonstrated in part (c) of <xref ref="ex_identify_linear"/>.
       Neither <m>\cos(x)</m> nor <m>\sin(x)</m> are linear functions of <m>x</m>,
       but the differential equation is still linear.
     </p>
@@ -140,7 +140,7 @@
       <me>
         \frac{dy}{dx} + \frac{1}{x} y = \frac{\sin(x) \cos(x)}{x}
       </me>,
-      which matches the form in <xref ref="def_Linear">Definition</xref>.
+      which matches the form in <xref ref="def_Linear"/>.
       Reversing our steps would lead us back to the original form our our differential equation.
     </p>
     <aside>
@@ -270,7 +270,7 @@
       Though this formula can be used to write down the solution to a first order linear equation,
       we shy away from simply memorizing a formula.
       The process is lost, and it's easy to forget the formula.
-      Rather, we always always follow the steps outlined in <xref ref="idea_solving_linear">Key Idea</xref>
+      Rather, we always always follow the steps outlined in <xref ref="idea_solving_linear"/>
       when solving equations of this type.
     </p>
 
@@ -319,7 +319,7 @@
     </insight>
 
     <p>
-      Let's practice the process by solving the two first order linear differential equations from <xref ref="ex_identify_linear">Example</xref>.
+      Let's practice the process by solving the two first order linear differential equations from <xref ref="ex_identify_linear"/>.
     </p>
 
     <example xml:id="ex_linear1">
@@ -335,7 +335,7 @@
       </solution>
       <solution>
         <p>
-          We solve by following the steps in <xref ref="idea_solving_linear">Key Idea</xref>.
+          We solve by following the steps in <xref ref="idea_solving_linear"/>.
           Unlike the process for solving separable equations,
           we need not worry about losing constant solutions.
           The answer we find <em>will</em>
@@ -634,7 +634,7 @@
     </example>
 
     <figure xml:id="fig_20_03_falling_object">
-      <caption>The velocity functions from <xref ref="ex_falling_object">Examples</xref> (dashed) and <xref ref="ex_falling_object1"></xref> (solid) under the assumption that <m>v(0)=0</m>, with <m>g=9.8, m=1</m>, and <m>k=1</m></caption>
+      <caption>The velocity functions from <xref ref="ex_falling_object" text="global">Examples</xref> (dashed) and <xref ref="ex_falling_object1" text="global"/> (solid) under the assumption that <m>v(0)=0</m>, with <m>g=9.8, m=1</m>, and <m>k=1</m></caption>
       <image xml:id="img_falling_object" width="47%">
         <shortdescription>
           The velocity functions from the previous examples.
@@ -676,17 +676,17 @@
       This value is called the <em>terminal velocity</em>.
       If we assume a zero initial velocity
       (the object is dropped, not thrown from the plane),
-      the velocities from <xref ref="ex_falling_object">Examples</xref>
-      and <xref ref="ex_falling_object1"></xref>
+      the velocities from <xref ref="ex_falling_object" text="global">Examples</xref>
+      and <xref ref="ex_falling_object1" text="global"/>
       are given by <m>v = gt</m> and <m>v = \displaystyle \frac{mg}{k}\left (1 - e^{-\frac{k}{m}t}\right )</m>,
       respectively.
-      These two functions are shown in <xref ref="fig_20_03_falling_object">Figure</xref>,
+      These two functions are shown in <xref ref="fig_20_03_falling_object"/>,
       with <m>g = 9.8, m=1</m>, and <m>k=1</m>.
       Notice that the two curves agree well for short times,
       but have dramatically different behaviors as <m>t</m> increases.
       Part of the art in mathematical modeling is deciding on the level of detail required to answer the question of interest.
       If we are only interested in the initial behavior of the falling object,
-      the simple model in <xref ref="ex_falling_object">Example</xref> may be sufficient.
+      the simple model in <xref ref="ex_falling_object"/> may be sufficient.
       If we are interested in the longer term behavior of the object,
       the simple model is not sufficient,
       and we should consider a more complicated model.

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -68,7 +68,7 @@
       mean we have a constant multiplied by something.
     </p>
     <p>
-      The differential equation in <xref ref="fig_20_translation">Figure</xref>
+      The differential equation in <xref ref="fig_20_translation"/>
       is easily solved using separation of variables.
       We find
       <me>
@@ -317,15 +317,15 @@
         </p>
         <p>
           Notice that this function approaches <m>y=1</m> in the limit as <m>t \to \infty</m>,
-          and does not suffer from the non-physical behavior described in <xref ref="ex_disease_exponential">Example</xref>.
+          and does not suffer from the non-physical behavior described in <xref ref="ex_disease_exponential"/>.
         </p>
       </solution>
     </example>
 
     <p>
-      In <xref ref="ex_disease_exponential">Example</xref>,
+      In <xref ref="ex_disease_exponential"/>,
       we assumed disease spread depends on the number of infected individuals.
-      In <xref ref="ex_disease_newton">Example</xref>,
+      In <xref ref="ex_disease_newton"/>,
       we assumed disease spread depends on the number of susceptible individuals who are able to become infected.
       In reality, we would expect many diseases to require the interaction of both infected and susceptible individuals in order to spread.
       One of the simplest ways to model this required interaction is to assume disease spread depends on the product of the proportions of infected and uninfected individuals.
@@ -358,7 +358,7 @@
         </p>
         <p>
           This is exactly the logistic equation with <m>M = 1</m>.
-          We solved this differential equation in <xref ref="ex_logistic">Example</xref>,
+          We solved this differential equation in <xref ref="ex_logistic"/>,
           and found
           <me>
             y = \frac{1}{1 + be^{-kt}}
@@ -377,13 +377,13 @@
           we now have three different functions giving the proportion of a population that is sick at time <m>t</m>.
           Each of the three functions meets the conditions
           <m>y(0)=0.05</m> and <m>y(1) = 0.1</m>.
-          The three functions are shown in <xref ref="fig_disease">Figure</xref>.
+          The three functions are shown in <xref ref="fig_disease"/>.
         </p>
 
         <p>
-          Notice that the logistic function mimics specific parts of the functions from <xref ref="ex_disease_exponential">Examples</xref>
-          and <xref ref="ex_disease_newton"></xref>.
-          We see in <xref ref="fig_diseasea">Figure</xref> that the logistic and exponential functions are virtually indistinguishable for small <m>t</m> values.
+          Notice that the logistic function mimics specific parts of the functions from <xref ref="ex_disease_exponential" text="global">Examples</xref>
+          and <xref ref="ex_disease_newton" text="global"/>.
+          We see in <xref ref="fig_diseasea"/> that the logistic and exponential functions are virtually indistinguishable for small <m>t</m> values.
           When there are few infected individuals and lots of susceptible individuals,
           the spread of a disease is largely determined by the number of sick people.
           The logistic curve captures this feature, and is
@@ -392,9 +392,9 @@
         </p>
 
         <p>
-          In <xref ref="fig_diseaseb">Figure</xref>,
-          we see that the logistic curve leaves the exponential curve from <xref ref="ex_disease_exponential">Example</xref>
-          and approaches the curve from <xref ref="ex_disease_newton">Example</xref>.
+          In <xref ref="fig_diseaseb"/>,
+          we see that the logistic curve leaves the exponential curve from <xref ref="ex_disease_exponential"/>
+          and approaches the curve from <xref ref="ex_disease_newton"/>.
           This result implies that when most of the population is sick,
           the spread of the disease is largely dependent on the number of susceptible individuals.
           Though there are much more sophisticated mathematical models describing the spread of infections,
@@ -404,9 +404,9 @@
         </p>
 
         <figure xml:id="fig_disease">
-          <caption>Plots of the functions from <xref ref="ex_disease_exponential">Example</xref> (dotted),
-          <xref ref="ex_disease_newton">Example</xref> (dashed),
-          and <xref ref="ex_disease_logistic">Example</xref> (solid)</caption>
+          <caption>Plots of the functions from <xref ref="ex_disease_exponential"/> (dotted),
+          <xref ref="ex_disease_newton"/> (dashed),
+          and <xref ref="ex_disease_logistic"/> (solid)</caption>
           <sidebyside widths="45% 45%">
             <figure xml:id="fig_diseasea">
               <caption/>
@@ -657,14 +657,14 @@
           is the particular solution to our initial value problem.
         </p>
         <p>
-          This function is plotted in <xref ref="fig_equal_flow">Figure</xref>.
+          This function is plotted in <xref ref="fig_equal_flow"/>.
           Notice that in the limit as <m>t\to\infty</m>,
           <m>y</m> approaches <m>15</m>.
           This corresponds to a bucket concentration of
           <m>15/5 = 3</m> g/L. It should not be surprising that salt concentration inside the tank will move to match the inflow salt concentration.
         </p>
         <figure xml:id="fig_equal_flow">
-          <caption>Salt concentration at time <m>t</m>, from <xref ref="ex_equal_flow">Example</xref></caption>
+          <caption>Salt concentration at time <m>t</m>, from <xref ref="ex_equal_flow"/></caption>
           <image xml:id="img_equal_flow" width="47%">
             <shortdescription>
               Graph of salt concentration at time t used in this example.
@@ -702,7 +702,7 @@
       <title>Unequal Flow Rates</title>
       <statement>
         <p>
-          Suppose the setup is identical to the setup in <xref ref="ex_equal_flow">Example</xref>
+          Suppose the setup is identical to the setup in <xref ref="ex_equal_flow"/>
           except that now liquid flows out of the bucket at a rate of 1 L/min.
           Find a function that gives the amount of salt in the bucket at time <m>t</m>.
           What is the salt concentration when the solution ceases to be valid?
@@ -740,7 +740,7 @@
           </me>.
         </p>
         <p>
-          Unlike <xref ref="ex_equal_flow">Example</xref>,
+          Unlike <xref ref="ex_equal_flow"/>,
           where we had equal flow rates,
           this differential equation is no longer separable.
           We must proceed with an integrating factor.

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -14,7 +14,7 @@
       <em>separable equations.</em>
     </p>
     <figure xml:id="vid-diffeq-separable-intro" component="video">
-      <caption>Video introduction to <xref ref="sec_Separable">Section</xref></caption>
+      <caption>Video introduction to <xref ref="sec_Separable"/></caption>
       <video youtube="tIkZsA3kK6o" label="vid-diffeq-separable-intro"/>
     </figure>
     <definition xml:id="def_Separable">
@@ -56,7 +56,7 @@
     <p>
       Notice that a separable equation requires that the functions of the dependent and independent variables be multiplied,
       not added
-      (like <xref ref="item-not-sep">item</xref> in <xref ref="list_nonseparable_examples">List</xref>).
+      (like <xref ref="item-not-sep" text="local">item</xref> in <xref ref="list_nonseparable_examples" text="global">List</xref>).
       An alternate definition of a separable differential equation states that an equation is separable if it can be written in the form
       <me>
         \frac{dy}{dx} = f(x)g(y)
@@ -126,7 +126,7 @@
       we can find an implicit form for the solution.
       Sometimes we are able to solve for <m>y</m> in the implicit solution to find an explicit form of the solution to the differential equation.
       We practice the technique by solving the three differential equations listed in the separable column above,
-      and conclude by revisiting and finding the general solution to the logistic differential equation from <xref ref="sec_Graphical_Numerical">Section</xref>.
+      and conclude by revisiting and finding the general solution to the logistic differential equation from <xref ref="sec_Graphical_Numerical"/>.
     </p>
     <example xml:id="ex_separable_DE">
       <title>Solving a Separable Differential Equation</title>
@@ -319,7 +319,7 @@
       </solution>
       <solution>
         <p>
-          We looked at a slope field for this equation in <xref ref="sec_Graphical_Numerical">Section</xref>
+          We looked at a slope field for this equation in <xref ref="sec_Graphical_Numerical"/>
           in the specific case of <m>k = M = 1</m>.
           Here, we use separation of variables to find an analytic solution to the more general equation.
           Notice that the independent variable <m>t</m> does not explicitly appear in the differential equation.
@@ -336,7 +336,7 @@
         </p>
         <p>
           The antiderivative of the left hand side of the equation can be found by making use of partial fractions.
-          Using the techniques discussed in <xref ref="sec_partial_fraction">Section</xref>, we write
+          Using the techniques discussed in <xref ref="sec_partial_fraction"/>, we write
           <me>
             \frac{1}{y\left(1-\frac{y}{M}\right)} = \frac{1}{y} + \frac{1}{M-y}
           </me>.
@@ -354,7 +354,7 @@
           </me>.
         </p>
         <p>
-          Similarly to <xref ref="ex_separable_DE">Example</xref>,
+          Similarly to <xref ref="ex_separable_DE"/>,
           we can write
           <me>
             \frac{y}{M-y} = Ae^{kt}
@@ -380,7 +380,7 @@
       <p>
         Solving for <m>y</m> initially yields the explicit solution <m>\displaystyle y = \frac{AMe^{kt}}{1+Ae^{kt}}</m>.
         Dividing numerator and denominator by <m>Ae^{kt}</m> and defining <m>b = 1/A</m>
-        yields the commonly presented form of the solution given in <xref ref="ex_logistic">Example</xref>.
+        yields the commonly presented form of the solution given in <xref ref="ex_logistic"/>.
       </p>
     </aside>
   </subsection>

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -56,7 +56,7 @@
     <p>
       Notice that a separable equation requires that the functions of the dependent and independent variables be multiplied,
       not added
-      (like <xref ref="item-not-sep" text="local">item</xref> in <xref ref="list_nonseparable_examples" text="global">List</xref>).
+      (like <xref ref="item-not-sep" text="local">Item</xref> in <xref ref="list_nonseparable_examples" text="global">List</xref>).
       An alternate definition of a separable differential equation states that an equation is separable if it can be written in the form
       <me>
         \frac{dy}{dx} = f(x)g(y)

--- a/ptx/sec_alt_series.ptx
+++ b/ptx/sec_alt_series.ptx
@@ -3,7 +3,7 @@
   <title>Alternating Series and Absolute Convergence</title>
   <p>
     All of the series convergence tests we have used require that the underlying sequence <m>\{a_n\}</m> be a positive sequence.
-    (We can relax this with <xref ref="thm_series_behavior">Theorem</xref>
+    (We can relax this with <xref ref="thm_series_behavior"/>
     and state that there must be an <m>N \gt 0</m> such that <m>a_n \gt 0</m> for all <m>n \gt N</m>;
     that is, <m>\{a_n\}</m> is positive for all but a finite number of values of <m>n</m>.)
   </p>
@@ -47,7 +47,7 @@
   </p>
 
   <p>
-    <xref ref="thm_geom_series">Theorem</xref>
+    <xref ref="thm_geom_series"/>
     states that geometric series converge when <m>\abs{r}\lt 1</m> and gives the sum:
     <m>\ds \infser[0] r^n = \frac1{1-r}</m>.
     When <m>r=-1/2</m> as above, we find
@@ -85,7 +85,7 @@
   </figure>
 
   <p>
-    The basic idea behind <xref ref="thm_alt_series_test">Theorem</xref>
+    The basic idea behind <xref ref="thm_alt_series_test"/>
     is illustrated in <xref first="fig_alt_series_converge_a" last="fig_alt_series_converge_b"/>.
     A positive, decreasing sequence <m>\{a_n\}</m> is shown along with the partial sums
     <me>
@@ -101,7 +101,7 @@
     while the even terms of <m>S_n</m> form an increasing,
     bounded sequence.
     Since bounded, monotonic sequences converge
-    (see <xref ref="thm_monotonic_converge">Theorem</xref>)
+    (see <xref ref="thm_monotonic_converge"/>)
     and the terms of <m>\{a_n\}</m> approach 0, one can show the odd and even terms of <m>S_n</m> converge to the same common limit <m>L</m>,
     the sum of the series.
   </p>
@@ -293,7 +293,7 @@
               for all <m>n \gt e</m>),
               meaning <m>a(n)=a_n</m> is decreasing on <m>[3,\infty)</m>.
               We can apply the Alternating Series Test to the series when we start with <m>n=3</m> and conclude that <m>\ds \sum_{n=3}^\infty(-1)^n\frac{\ln(n) }{n}</m> converges;
-              adding the terms with <m>n=1</m> and <m>n=2</m> do not change the convergence (<ie/>, we apply <xref ref="thm_series_behavior">Theorem</xref>).
+              adding the terms with <m>n=1</m> and <m>n=2</m> do not change the convergence (<ie/>, we apply <xref ref="thm_series_behavior"/>).
               The important lesson here is that as before,
               if a series fails to meet the criteria of the Alternating Series Test on only a finite number of terms,
               we can still apply the test.
@@ -309,7 +309,7 @@
               We cannot remove a finite number of terms to make <m>\{a_n\}</m> decreasing,
               therefore we cannot apply the Alternating Series Test.
 
-              Keep in mind that this does not mean we conclude the series diverges; in fact, it does converge. We are just unable to conclude this based on <xref ref="thm_alt_series_test">Theorem</xref>. We will be able to show that this series converges shortly.
+              Keep in mind that this does not mean we conclude the series diverges; in fact, it does converge. We are just unable to conclude this based on <xref ref="thm_alt_series_test"/>. We will be able to show that this series converges shortly.
             </p>
           </li>
         </ol>
@@ -318,7 +318,7 @@
   </example>
 
   <p>
-    <xref ref="idea_famous_series">Key Idea</xref>
+    <xref ref="idea_famous_series"/>
     gives the sum of some important series.
     Two of these are
     <me>
@@ -378,9 +378,9 @@
   </figure>
 
   <p>
-    Part 1 of <xref ref="thm_alt_series_approx">Theorem</xref>
+    Part 1 of <xref ref="thm_alt_series_approx"/>
     states that the <m>n</m>th partial sum of a convergent alternating series will be within <m>a_{n+1}</m> of its total sum.
-    You can see this visually in <xref ref="fig_alt_series_converge_b">Figure</xref>.
+    You can see this visually in <xref ref="fig_alt_series_converge_b"/>.
     Look at the distance between <m>S_6</m> and <m>L</m>.
     Clearly this distance is less than the length of the arrow corresponding to <m>a_7</m>.
   </p>
@@ -401,7 +401,7 @@
 
   <p>
     Some alternating series converge slowly.
-    In <xref ref="ex_alt1">Example</xref>
+    In <xref ref="ex_alt1"/>
     we determined the series <m>\ds\infser (-1)^{n+1}\frac{\ln(n) }{n}</m> converged.
     With <m>n=1001</m>, we find <m>\ln(n) /n \approx 0.0069</m>,
     meaning that <m>S_{1000} \approx 0.1633</m> is accurate to one,
@@ -443,7 +443,7 @@
         <ol>
           <li>
             <p>
-              Using <xref ref="thm_alt_series_approx">Theorem</xref>,
+              Using <xref ref="thm_alt_series_approx"/>,
               we want to find <m>n</m> where <m>1/n^3 \leq 0.001</m>.
               That is, we want to find the the first time a term in the sequence <m>a_n</m> is smaller than the desired level of error:
               <md>
@@ -542,7 +542,7 @@
 
   <aside>
     <p>
-      In <xref ref="def_abs_converge">Definition</xref>,
+      In <xref ref="def_abs_converge"/>,
       <m>\ds \infser a_n</m> is not necessarily an alternating series;
       it just may have some negative terms.
     </p>
@@ -702,7 +702,7 @@
 
     <proof>
       <p>
-        We will provide a proof for <xref ref="thm_abs_convergence_1">Part </xref>
+        We will provide a proof for <xref ref="thm_abs_convergence_1" text="local">Part </xref>
         of <xref ref="thm_abs_convergence" text="title"/>.
         Suppose that <m>\infser \abs{a_n}</m> converges.
         We start by noting that for any sequence <m>a_n</m>, we have
@@ -714,7 +714,7 @@
         We are now in a position to apply the <xref ref="thm_series_direct_compare" text="title"/> to the series <m>\infser \left(a_n+\abs{a_n}\right)</m>.
         Since <m>\infser \abs{a_n}</m> converges by our supposition,
         so does <m>\infser 2\abs{a_n}</m>
-        (the scalar multiple of a convergent series also converges by <xref ref="thm_series_prop">theorem</xref>).
+        (the scalar multiple of a convergent series also converges by <xref ref="thm_series_prop"/>).
         Therefore <m>\infser \left(a_n+\abs{a_n}\right)</m> converges by the <xref ref="thm_series_direct_compare" text="title"/>.
       </p>
 
@@ -726,7 +726,7 @@
           <mrow>\amp =\infser \left(a_n+\abs{a_n}\right)-\infser \abs{a_n}</mrow>
         </md>.
         The last line is the difference between two convergent series,
-        which is also convergent by  <xref ref="thm_series_prop">Theorem</xref>.
+        which is also convergent by  <xref ref="thm_series_prop"/>.
         Therefore <m>\infser a_n</m> converges.
       </p>
     </proof>
@@ -734,9 +734,9 @@
   </theorem>
 
   <p>
-    In <xref ref="ex_alt_series2">Example</xref>,
-    we determined the series in <xref ref="ex_alt_series2_b">Part</xref> converges absolutely.
-    <xref ref="thm_abs_convergence">Theorem</xref> tells us the series converges
+    In <xref ref="ex_alt_series2"/>,
+    we determined the series in <xref ref="ex_alt_series2_b" text="local">Part</xref> converges absolutely.
+    <xref ref="thm_abs_convergence"/> tells us the series converges
     (which we could also determine using the Alternating Series Test).
   </p>
 
@@ -760,8 +760,8 @@
   </p>
 
   <p>
-    (see <xref ref="idea_famous_series">Key Idea</xref>
-    or <xref ref="ex_alt1">Example</xref>).
+    (see <xref ref="idea_famous_series"/>
+    or <xref ref="ex_alt1"/>).
   </p>
 
   <p>
@@ -1578,7 +1578,7 @@
           <p>
             In the following exercises,
             a convergent alternating series is given along with its sum and a value of <m>\varepsilon</m>.
-            Use <xref ref="thm_alt_series_approx">Theorem</xref>
+            Use <xref ref="thm_alt_series_approx"/>
             to find <m>n</m> such that the
             <m>n</m>th partial sum of the series is within
             <m>\varepsilon</m> of the sum of the series.

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -104,7 +104,7 @@
       one of its antiderivatives <m>F</m>,
       we know <em>all</em> antiderivatives of <m>f</m> on <m>I</m> have the form
       <m>F(x) + C</m> for some constant <m>C</m>.
-      Using <xref ref="def_antider">Definition</xref>, we can say that
+      Using <xref ref="def_antider"/>, we can say that
       <me>
         \int f(x) \,dx = F(x) + C
       </me>.
@@ -173,7 +173,7 @@
     </figure>
 
     <p>
-      <xref ref="fig_anti1">Figure</xref>
+      <xref ref="fig_anti1"/>
       shows the typical notation of the indefinite integral.
       The integration symbol, <m>\int</m>,
       is in reality an <q>elongated S,</q>
@@ -360,7 +360,7 @@
       Differentiation <q>undoes</q> the work done by antidifferentiation.
     </p>
     <p>
-      <xref ref="thm_deriv_glossary">Theorem</xref>
+      <xref ref="thm_deriv_glossary"/>
       gave a list of the derivatives of common functions we had learned at that point.
       We restate part of that list here to stress the relationship between
       derivatives and antiderivatives.
@@ -397,7 +397,7 @@
     </theorem>
 
     <p>
-      We highlight a few important points from <xref ref="thm_indef_alg">Theorem</xref>.
+      We highlight a few important points from <xref ref="thm_indef_alg"/>.
     </p>
     <p>
       <ul>
@@ -441,7 +441,7 @@
 
             we can split integrals apart when the integrand contains terms
             that are added/subtracted,
-            as we did in <xref ref="ex_anti3">Example</xref>.
+            as we did in <xref ref="ex_anti3"/>.
             So:
             <md>
               <mrow>\int(3x^2+4x+5)\, dx \amp = \int 3x^2\, dx + \int 4x\,dx + \int 5\,dx</mrow>
@@ -531,7 +531,7 @@
     </figure>
 
     <p>
-      In <xref ref="sec_basic_diff_rules">Section</xref>
+      In <xref ref="sec_basic_diff_rules"/>
       we saw that the derivative of a position function gave a velocity function,
       and the derivative of a velocity function describes acceleration.
           <idx><h>initial value problem</h></idx>
@@ -696,7 +696,7 @@
       In the next section,
       we will see how position and velocity are unexpectedly related by the
       areas of certain regions on a graph of the velocity function.
-      Then, in <xref ref="sec_FTC">Section</xref>,
+      Then, in <xref ref="sec_FTC"/>,
       we will see how areas and antiderivatives are closely tied together.
       This connection is incredibly important,
       as indicated by the name of the theorem that describes it:
@@ -1301,7 +1301,7 @@
         <!-- <webwork xml:id="webwork-ex-antiderivatives-log-abs"> -->
           <introduction>
             <p>
-              This problem investigates why <xref ref="thm_indef_alg">Theorem</xref>
+              This problem investigates why <xref ref="thm_indef_alg"/>
               states that <m>\ds \int \frac1x\,dx = \ln\abs{x} + C</m>.
             </p>
           </introduction>

--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -50,7 +50,7 @@
   <subsection xml:id="subsec-arc-length">
     <title>Arc Length</title>
     <p>
-      Consider the graph of <m>y=\sin(x)</m> on <m>[0,\pi]</m> given in <xref ref="fig_arcintroa">Figure</xref>.
+      Consider the graph of <m>y=\sin(x)</m> on <m>[0,\pi]</m> given in <xref ref="fig_arcintroa"/>.
       How long is this curve?
       That is, if we were to use a piece of string to exactly match the shape of this curve,
       how long would the string be?
@@ -152,7 +152,7 @@
     </figure>
 
     <p>
-      In <xref ref="fig_arcintrob">Figure</xref>,
+      In <xref ref="fig_arcintrob"/>,
       the curve <m>y=\sin(x)</m> has been approximated with 4 line segments
       (the interval <m>[0,\pi]</m> has been divided into 4 subintervals of equal length).
       It is clear that these four line segments approximate
@@ -225,7 +225,7 @@
     </figure>
 
     <p>
-      <xref ref="fig_arcintro2">Figure</xref>
+      <xref ref="fig_arcintro2"/>
       zooms in on the <m>i</m>th subinterval where <m>y=f(x)</m> is approximated by a straight line segment.
       The dashed lines show that we can view this line segment as the hypotenuse of a right triangle whose sides have length <m>\dx_i</m> and <m>\dy_i</m>.
       Using the Pythagorean Theorem,
@@ -256,14 +256,14 @@
           This is nearly a Riemann Sum. Consider the <m>\Delta y_i^2/\dx_i^2</m> term.
           The expression <m>\Delta y_i/\dx_i</m> measures the <q>change in <m>y</m>/change in <m>x</m>,</q>
           that is, the <q>rise over run</q> of <m>f</m> on the <m>i</m>th subinterval.
-          The Mean Value Theorem of Differentiation (<xref ref="thm_mvt">Theorem</xref>)
+          The Mean Value Theorem of Differentiation (<xref ref="thm_mvt"/>)
           states that there is a <m>c_i</m> in the <m>i</m>th subinterval where
           <m>\fp(c_i) = \Delta y_i/\dx_i</m>. Thus we can rewrite our above expression as:
         </intertext>
         <mrow>\amp = \sum_{i=1}^n\sqrt{1+\fp(c_i)^2}\,\dx_i.</mrow>
         <intertext>
           This <em>is</em> a Riemann Sum.
-          As long as <m>\fp</m> is continuous, we can invoke <xref ref="thm_riemann_sum">Theorem</xref>
+          As long as <m>\fp</m> is continuous, we can invoke <xref ref="thm_riemann_sum"/>
           and conclude
         </intertext>
         <mrow>\amp = \int_a^b\sqrt{1+\fp(x)^2}\, dx</mrow>
@@ -288,7 +288,7 @@
 
     <aside>
       <p>
-        <em>Note:</em> This is our first use of differentiability on a closed interval since <xref ref="sec_derivative">Section</xref>.
+        <em>Note:</em> This is our first use of differentiability on a closed interval since <xref ref="sec_derivative"/>.
       </p>
 
       <p>
@@ -299,7 +299,7 @@
     </aside>
     <p>
       As the integrand contains a square root,
-      it is often difficult to use the formula in <xref ref="thm_arclength">Theorem</xref> to find the length exactly.
+      it is often difficult to use the formula in <xref ref="thm_arclength"/> to find the length exactly.
       When exact answers are difficult to come by,
       we resort to using numerical methods of approximating definite integrals.
       The following examples will demonstrate this.
@@ -332,7 +332,7 @@
         </p>
 
         <figure xml:id="fig_arc1">
-          <caption>A graph of <m>f(x) = x^{3/2}</m> from <xref ref="ex_arc1">Example</xref></caption>
+          <caption>A graph of <m>f(x) = x^{3/2}</m> from <xref ref="ex_arc1"/></caption>
           <!-- START figures/fig_arc1.tex -->
           <image xml:id="img_arc1" width="47%">
             <description>
@@ -363,7 +363,7 @@
         </figure>
 
         <p>
-          A graph of <m>f</m> is given in <xref ref="fig_arc1">Figure</xref>.
+          A graph of <m>f</m> is given in <xref ref="fig_arc1"/>.
         </p>
       </solution>
     </example>
@@ -398,7 +398,7 @@
         </p>
 
         <figure xml:id="fig_arc2">
-          <caption>A graph of <m>f(x) =\frac18x^2-\ln(x)</m> from <xref ref="ex_arc2">Example</xref></caption>
+          <caption>A graph of <m>f(x) =\frac18x^2-\ln(x)</m> from <xref ref="ex_arc2"/></caption>
           <!-- START figures/fig_arc2.tex -->
           <image xml:id="img_arc2" width="47%">
             <description>
@@ -431,7 +431,7 @@
         </figure>
 
         <p>
-          A graph of <m>f</m> is given in <xref ref="fig_arc2">Figure</xref>;
+          A graph of <m>f</m> is given in <xref ref="fig_arc2"/>;
           the portion of the curve measured in this problem is in bold.
         </p>
       </solution>
@@ -452,7 +452,7 @@
       <solution>
         <p>
           This is somewhat of a mathematical curiosity;
-          in <xref ref="ex_ftc4">Example</xref>
+          in <xref ref="ex_ftc4"/>
           we found the area under one <q>hump</q>
           of the sine curve is 2 square units;
           now we are measuring its arc length.
@@ -472,7 +472,7 @@
         </p>
 
         <figure xml:id="fig_arc3">
-          <caption>A table of values of <m>y=\sqrt{1+\cos^2(x) }</m> to evaluate a definite integral in <xref ref="ex_arc3">Example</xref></caption>
+          <caption>A table of values of <m>y=\sqrt{1+\cos^2(x) }</m> to evaluate a definite integral in <xref ref="ex_arc3"/></caption>
           <tabular>
             <row bottom="minor">
               <cell><m>x</m></cell><cell><m>\sqrt{1+\cos^2(x) }</m></cell>
@@ -680,10 +680,10 @@
       where the <m>i</m>th subinterval is <m>[x_{i-1},x_{i}]</m>.
       On each subinterval,
       we can approximate the curve <m>y=f(x)</m> with a straight line that connects <m>f(x_{i-1})</m> and
-      <m>f(x_{i})</m> as shown in <xref ref="fig_arc4a">Figure</xref>.
+      <m>f(x_{i})</m> as shown in <xref ref="fig_arc4a"/>.
       Revolving this line segment about the <m>x</m>-axis creates part of a cone
       (called a <em>frustum</em> of a cone)
-      as shown in <xref ref="fig_arc4b_3D">Figure</xref>.
+      as shown in <xref ref="fig_arc4b_3D"/>.
       The surface area of a frustum of a cone is
       <me>
         2\pi\cdot\,\text{length} \,\cdot\,\text{average of the two radii \(R\) and \(r\)}
@@ -772,7 +772,7 @@
       the radii of the resulting frustum are <m>x_{i-1}</m> and <m>x_{i}</m>;
       their average value is simply the midpoint of the interval.
       In the limit, this midpoint is just <m>x</m>.
-      This gives the second part of <xref ref="thm_surface_area">Theorem</xref>.)
+      This gives the second part of <xref ref="thm_surface_area"/>.)
     </p>
 
     <example xml:id="ex_sa1">
@@ -781,7 +781,7 @@
         <p>
           Find the surface area of the solid formed by revolving
           <m>y=\sin(x)</m> on <m>[0,\pi]</m> around the <m>x</m>-axis,
-          as shown in <xref ref="fig_sa1_3D">Figure</xref>.
+          as shown in <xref ref="fig_sa1_3D"/>.
         </p>
 
         <figure xml:id="fig_sa1_3D">
@@ -864,7 +864,7 @@
       <solution>
         <p>
           The setup is relatively straightforward.
-          Using <xref ref="thm_surface_area">Theorem</xref>,
+          Using <xref ref="thm_surface_area"/>,
           we have the surface area <m>SA</m> is:
           <md>
             <mrow>SA  \amp =	2\pi\int_0^\pi \sin(x) \sqrt{1+\cos^2(x) }\, dx</mrow>
@@ -876,7 +876,7 @@
 
         <p>
           The integration step above is nontrivial,
-          utilizing the integration method of Trigonometric Substitution from <xref ref="sec_trig_sub">Section</xref>.
+          utilizing the integration method of Trigonometric Substitution from <xref ref="sec_trig_sub"/>.
         </p>
 
         <p>
@@ -911,7 +911,7 @@
         </p>
 
         <figure xml:id="fig_sa2">
-          <caption>The solids used in <xref ref="ex_sa2">Example</xref></caption>
+          <caption>The solids used in <xref ref="ex_sa2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
 
             <figure xml:id="fig_sa2a_3D">
@@ -1046,12 +1046,12 @@
                 The integral is straightforward to setup:
                 <md>
                   <mrow>SA \amp = 2\pi\int_0^1 x^2\sqrt{1+(2x)^2}\, dx.</mrow>
-                  <intertext>Like the integral in <xref ref="ex_sa1">Example</xref>, this requires Trigonometric Substitution.</intertext>
+                  <intertext>Like the integral in <xref ref="ex_sa1"/>, this requires Trigonometric Substitution.</intertext>
                   <mrow>\amp = \left.\frac{\pi}{32}\left(2(8x^3+x)\sqrt{1+4x^2}-\sinh^{-1}(2x)\right)\right|_0^1</mrow>
                   <mrow>\amp =\frac{\pi}{32}\left(18\sqrt{5}-\sinh^{-1}(2) \right)</mrow>
                   <mrow>\amp \approx 3.81\,\text{units}^2</mrow>
                 </md>.
-                The solid formed by revolving <m>y=x^2</m> around the <m>x</m>-axis is graphed in <xref ref="fig_sa2a_3D">Figure</xref>.
+                The solid formed by revolving <m>y=x^2</m> around the <m>x</m>-axis is graphed in <xref ref="fig_sa2a_3D"/>.
               </p>
             </li>
 
@@ -1068,7 +1068,7 @@
                   <mrow>\amp = \frac{\pi}6\left(5\sqrt{5}-1\right)</mrow>
                   <mrow>\amp \approx 5.33\,\text{units}^2</mrow>
                 </md>.
-                The solid formed by revolving <m>y=x^2</m> about the <m>y</m>-axis is graphed in <xref ref="fig_sa2b_3D">Figure</xref>.
+                The solid formed by revolving <m>y=x^2</m> about the <m>y</m>-axis is graphed in <xref ref="fig_sa2b_3D"/>.
               </p>
             </li>
           </ol>
@@ -1087,7 +1087,7 @@
           Consider the solid formed by revolving <m>y=1/x</m> about the <m>x</m>-axis on <m>[1,\infty)</m>.
           Find the volume and surface area of this solid.
           (This shape,
-          as graphed in <xref ref="fig_gabriel">Figure</xref>,
+          as graphed in <xref ref="fig_gabriel"/>,
           is known as <q>Gabriel's Horn</q>
           since it looks like a very long horn that only a supernatural person,
           such as an angel, could play.)
@@ -1190,7 +1190,7 @@
         </p>
 
         <p>
-          By <xref ref="idea_impint1">Key Idea</xref>,
+          By <xref ref="idea_impint1"/>,
           the improper integral on the left diverges.
           Since the integral on the right is larger,
           we conclude it also diverges,
@@ -1566,7 +1566,7 @@
           <p>
             In the following exercises, use Simpson's Rule, with <m>n=4</m>,
             to approximate the arc length of the function on the given interval.
-            Note: these are the same problems as in <xref ref="ex_07_04_ex_13">Exercises</xref><ndash/> <xref ref="ex_07_04_ex_20"/>.
+            Note: these are the same problems as in <xref first="ex_07_04_ex_13" last="ex_07_04_ex_20" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_center_of_mass.ptx
+++ b/ptx/sec_center_of_mass.ptx
@@ -43,8 +43,8 @@
       (and physicists and engineers)
       call such a sheet a <em>lamina</em>.
       So consider a lamina,
-      as shown in <xref ref="fig_mass_introa">Figure</xref>,
-      with the shape of some planar region <m>R</m>, as shown in <xref ref="fig_mass_introb">Figure</xref>.
+      as shown in <xref ref="fig_mass_introa"/>,
+      with the shape of some planar region <m>R</m>, as shown in <xref ref="fig_mass_introb"/>.
           <idx><h>lamina</h></idx>
           <idx><h>mass</h></idx>
     </p>
@@ -199,12 +199,12 @@
       </statement>
       <solution>
         <p>
-          We represent the lamina with a square region in the plane as shown in <xref ref="fig_mass1">Figure</xref>.
+          We represent the lamina with a square region in the plane as shown in <xref ref="fig_mass1"/>.
           As the density is constant, it does not matter where we place the square.
         </p>
 
         <figure xml:id="fig_mass1">
-          <caption>A region <m>R</m> representing a lamina in <xref ref="ex_mass1">Example</xref></caption>
+          <caption>A region <m>R</m> representing a lamina in <xref ref="ex_mass1"/></caption>
           <!-- START figures/fig_mass1.tex -->
           <image xml:id="img_mass1" width="47%">
             <description></description>
@@ -230,7 +230,7 @@
         </figure>
 
         <p>
-          Following <xref ref="def_mass">Definition</xref>,
+          Following <xref ref="def_mass"/>,
           the mass <m>M</m> of the lamina is
           <me>
             M = \iint_R 3\, dA = \int_0^1\int_0^1 3\, dx\, dy = 3\int_0^1\int_0^1 \, dx\, dy=3\,\text{g}
@@ -251,11 +251,11 @@
         <p>
           Find the mass of a square lamina,
           represented by the unit square with lower lefthand corner at the origin
-          (see <xref ref="fig_mass1">Figure</xref>),
+          (see <xref ref="fig_mass1"/>),
           with variable density <m>\delta(x,y) = (x+y+2)\,\text{g/cm}^2</m>.
         </p>
         <figure xml:id="fig_mass2">
-          <caption>Graphing the density functions in <xref ref="ex_mass1">Examples</xref> and <xref ref="ex_mass2"/></caption>
+          <caption>Graphing the density functions in <xref ref="ex_mass1"/> and <xref ref="ex_mass2"/></caption>
 
           <!-- START figures/figmass2_3D.asy -->
           <image xml:id="img_mass2" width="47%">
@@ -323,7 +323,7 @@
           The variable density <m>\delta</m>,
           in this example, is very uniform,
           giving a density of 3 in the center of the square and changing linearly.
-          A graph of <m>\delta(x,y)</m> can be seen in <xref ref="fig_mass2">Figure</xref>;
+          A graph of <m>\delta(x,y)</m> can be seen in <xref ref="fig_mass2"/>;
           notice how <q>same amount</q> of density is above <m>z=3</m> as below.
           We'll comment on the significance of this momentarily.
         </p>
@@ -345,9 +345,9 @@
         <p>
           It turns out that since the density of the lamina is so uniformly distributed <q>above and below</q>
           <m>z=3</m> that the mass of the lamina is the same as if it had a constant density of 3.
-          The density functions in <xref ref="ex_mass1">Examples</xref>
+          The density functions in <xref ref="ex_mass1"/>
           and <xref ref="ex_mass2"/>
-          are graphed in <xref ref="fig_mass2">Figure</xref>,
+          are graphed in <xref ref="fig_mass2"/>,
           which illustrates this concept.
         </p>
       </solution>
@@ -367,7 +367,7 @@
       </statement>
       <solution>
         <p>
-          A direct application of <xref ref="def_mass">Definition</xref>
+          A direct application of <xref ref="def_mass"/>
           states that the weight of the lamina is <m>\iint_R\delta(x,y)\, dA</m>.
           Since our lamina is in the shape of a circle,
           it makes sense to approach the double integral using polar coordinates.
@@ -408,11 +408,11 @@
           as we have here.
           The density functions were chosen, though, to be similar:
           each gives a density of 1 at the origin and a density of 5 at the outside edge of the circle,
-          as seen in <xref ref="fig_mass3">Figure</xref>.
+          as seen in <xref ref="fig_mass3"/>.
         </p>
 
         <figure xml:id="fig_mass3">
-          <caption>Graphing the density functions in <xref ref="ex_mass3">Example</xref>. In (a) is the density function <m>\delta(x,y) = x^2+y^2+1</m>; in (b) is <m>\delta(x,y) = 2\sqrt{x^2+y^2}+1</m></caption>
+          <caption>Graphing the density functions in <xref ref="ex_mass3"/>. In (a) is the density function <m>\delta(x,y) = x^2+y^2+1</m>; in (b) is <m>\delta(x,y) = 2\sqrt{x^2+y^2}+1</m></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_mass3a_3D">
               <caption/>
@@ -661,13 +661,13 @@
           <ol>
             <li>
               <p>
-                Following <xref ref="thm_center_mass_points">Theorem</xref>,
+                Following <xref ref="thm_center_mass_points"/>,
                 we compute the center of mass as:
                 <me>
                   \overline{x}=\frac{2(-1) + 2(2)+2(3)}{2+2+2} = \frac43 = 1.\overline{3}
                 </me>.
                 So the system would balance on a point placed at <m>x=4/3</m>,
-                as illustrated in <xref ref="fig_mass4a">Figure</xref>.
+                as illustrated in <xref ref="fig_mass4a"/>.
               </p>
 
               <figure xml:id="fig_mass4">
@@ -745,12 +745,12 @@
 
             <li>
               <p>
-                Again following <xref ref="thm_center_mass_points">Theorem</xref>, we find:
+                Again following <xref ref="thm_center_mass_points"/>, we find:
                 <me>
                   \overline{x} = \frac{10(-1)+2(2)+1(3)}{10+2+1} = \frac{-3}{13} \approx -0.23
                 </me>.
                 Placing a large weight at the left hand side of the system moves the center of mass left,
-                as shown in <xref ref="fig_mass4b">Figure</xref>.
+                as shown in <xref ref="fig_mass4b"/>.
               </p>
             </li>
           </ol>
@@ -763,7 +763,7 @@
       not along a continuum) we find the center of mass by dividing the mass into a
       <em>moment</em> of the system.
       In general, a moment is a weighted measure of distance from a particular point or line.
-      In the case described by <xref ref="thm_center_mass_points">Theorem</xref>,
+      In the case described by <xref ref="thm_center_mass_points"/>,
       we are finding a weighted measure of distances from the <m>y</m>-axis,
       so we refer to this as <em>the moment about the <m>y</m>-axis</em>,
       represented by <m>M_y</m>.
@@ -858,8 +858,8 @@
       </statement>
       <solution>
         <p>
-          We follow <xref ref="thm_center_mass_points_plane">Theorem</xref>
-          and <xref ref="def_moment">Definition</xref> to find <m>M</m>,
+          We follow <xref ref="thm_center_mass_points_plane"/>
+          and <xref ref="def_moment"/> to find <m>M</m>,
           <m>M_x</m> and <m>M_y</m>:
         </p>
 
@@ -885,7 +885,7 @@
         </sidebyside>
 
         <figure xml:id="fig_mass5">
-          <caption>Illustrating the center of mass of a discrete planar system in <xref ref="ex_mass5">Example</xref></caption>
+          <caption>Illustrating the center of mass of a discrete planar system in <xref ref="ex_mass5"/></caption>
           <!-- START figures/fig_mass5.tex -->
           <image xml:id="img_mass5" width="47%">
             <description></description>
@@ -920,7 +920,7 @@
 
         <p>
           Thus the center of mass is <m>\ds (\overline{x},\overline{y}) = \left(\frac{M_y}{M},\frac{M_x}M\right) = \left(\frac{{19}}8,\frac78\right) =(2.375,0.875)</m>,
-          illustrated in <xref ref="fig_mass5">Figure</xref>.
+          illustrated in <xref ref="fig_mass5"/>.
         </p>
       </solution>
     </example>
@@ -1013,16 +1013,16 @@
         <p>
           Find the center mass of a square lamina,
           with side length 1, with a density of <m>\delta = 3\,\text{g/cm}^2</m>.
-          (Note: this is the lamina from <xref ref="ex_mass1">Example</xref>.)
+          (Note: this is the lamina from <xref ref="ex_mass1"/>.)
         </p>
       </statement>
       <solution>
         <p>
-          We represent the lamina with a square region in the plane as shown in <xref ref="fig_mass6">Figure</xref> as done previously.
+          We represent the lamina with a square region in the plane as shown in <xref ref="fig_mass6"/> as done previously.
         </p>
 
         <figure xml:id="fig_mass6">
-          <caption>A region <m>R</m> representing a lamina in <xref ref="ex_mass1">Example</xref></caption>
+          <caption>A region <m>R</m> representing a lamina in <xref ref="ex_mass1"/></caption>
           <!-- START figures/fig_mass1.tex -->
           <image xml:id="img_mass6" width="47%">
             <description></description>
@@ -1048,7 +1048,7 @@
         </figure>
 
         <p>
-          Following <xref ref="thm_center_of_mass">Theorem</xref>,
+          Following <xref ref="thm_center_of_mass"/>,
           we find <m>M</m>, <m>M_x</m> and <m>M_y</m>:
           <md>
             <mrow>M \amp = \iint_R 3\, dA = \int_0^1\int_0^1 3\, dx\, dy =3\,\text{g}</mrow>
@@ -1071,14 +1071,14 @@
         <p>
           Find the center of mass of a square lamina,
           represented by the unit square with lower lefthand corner at the origin
-          (see <xref ref="fig_mass6">Figure</xref>),
+          (see <xref ref="fig_mass6"/>),
           with variable density <m>\delta(x,y) = (x+y+2)\,\text{g/cm}^2</m>.
-          (Note: this is the lamina from <xref ref="ex_mass2">Example</xref>.)
+          (Note: this is the lamina from <xref ref="ex_mass2"/>.)
         </p>
       </statement>
       <solution>
         <p>
-          We follow <xref ref="thm_center_of_mass">Theorem</xref>,
+          We follow <xref ref="thm_center_of_mass"/>,
           to find <m>M</m>, <m>M_x</m> and <m>M_y</m>:
           <md>
             <mrow>M \amp = \iint_R (x+y+2)\, dA = \int_0^1\int_0^1 (x+y+2)\, dx\, dy =3\,\text{g}</mrow>
@@ -1105,12 +1105,12 @@
           Find the center of mass of the lamina represented by the circle with radius <quantity><mag>2</mag><unit base="foot"/></quantity>,
           centered at the origin,
           with density function <m>\delta(x,y) = (x^2+y^2+1)\,\text{lb/ft}^2</m>.
-          (Note: this is one of the lamina used in <xref ref="ex_mass3">Example</xref>.)
+          (Note: this is one of the lamina used in <xref ref="ex_mass3"/>.)
         </p>
       </statement>
       <solution>
         <p>
-          As done in <xref ref="ex_mass3">Example</xref>,
+          As done in <xref ref="ex_mass3"/>,
           it is best to describe <m>R</m> using polar coordinates.
           Thus when we compute <m>M_y</m>,
           we will integrate not <m>x\delta(x,y) = x(x^2+y^2+1)</m>,
@@ -1135,13 +1135,13 @@
       <title>Finding the center of mass of a lamina</title>
       <statement>
         <p>
-          Find the center of mass of the lamina represented by the region <m>R</m> shown in <xref ref="fig_mass9">Figure</xref>,
+          Find the center of mass of the lamina represented by the region <m>R</m> shown in <xref ref="fig_mass9"/>,
           half an annulus with outer radius <quantity><mag>6</mag><unit base="foot"/></quantity>
           and inner radius <quantity><mag>5</mag><unit base="foot"/></quantity>,
           with constant density <quantity><mag>2</mag><unit base="pound"/><per base="foot" exp="2"/></quantity>.
         </p>
         <figure xml:id="fig_mass9">
-          <caption>Illustrating the region <m>R</m> in <xref ref="ex_mass9">Example</xref></caption>
+          <caption>Illustrating the region <m>R</m> in <xref ref="ex_mass9"/></caption>
           <!-- START figures/fig_mass9.tex -->
           <image xml:id="img_mass9" width="47%">
             <description></description>
@@ -1187,7 +1187,7 @@
 
         <p>
           Thus the center of mass is <m>(\overline{x},\overline{y}) = \left(0,\frac{364}{33\pi}\right) \approx (0,3.51)</m>.
-          The center of mass is indicated in <xref ref="fig_mass9">Figure</xref>;
+          The center of mass is indicated in <xref ref="fig_mass9"/>;
           note how it lies outside of <m>R</m>!
         </p>
       </solution>
@@ -1312,7 +1312,7 @@
               <p>
                 If the lamina is an annulus,
                 the center of mass will likely be in the middle, outside of the region.
-                (See <xref ref="ex_mass9">Example</xref>.)
+                (See <xref ref="ex_mass9"/>.)
               </p>
             </solution>
         <!--</webwork>-->
@@ -1587,7 +1587,7 @@
           </p>
 
         <p>
-            Note: these are the same lamina as in <xref ref="x13_04_ex_11">Exercises</xref>
+            Note: these are the same lamina as in <xref ref="x13_04_ex_11"/>
             <mdash/> <xref ref="x13_04_ex_18"/>.
           </p>
         </introduction>

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -16,7 +16,7 @@
 
     <p>
       The three <q>most interesting</q>
-      conic sections are given in the top row of <xref ref="fig_nondeg_conic">Figure</xref>.
+      conic sections are given in the top row of <xref ref="fig_nondeg_conic"/>.
       They are the parabola, the ellipse
       (which includes circles)
       and the hyperbola.
@@ -142,7 +142,7 @@
 
     <p>
       When the plane does contain the origin,
-      three <em>degenerate</em> cones can be formed as shown the bottom row of <xref ref="fig_nondeg_conic">Figure</xref>:
+      three <em>degenerate</em> cones can be formed as shown the bottom row of <xref ref="fig_nondeg_conic"/>:
       a point, a line, and crossed lines.
       We focus here on the nondegenerate cases.
           <idx><h>conic sections</h></idx>
@@ -243,7 +243,7 @@
     </figure>
 
     <p>
-      <xref ref="fig_parabola_def">Figure</xref> illustrates this definition.
+      <xref ref="fig_parabola_def"/> illustrates this definition.
       The point halfway between the focus and the directrix is the <em>vertex</em>.
       The line through the focus,
       perpendicular to the directrix,
@@ -342,7 +342,7 @@
           The vertex is located halfway between the focus and directrix,
           so <m>(h,k) = (1,2.5)</m>.
           This gives <m>p=-0.5</m>.
-          Using <xref ref="idea_parabola">Key Idea</xref>
+          Using <xref ref="idea_parabola"/>
           we have the equation of the parabola as
           <me>
             y=\frac{1}{4(-0.5)}(x-1)^2+2.5 = -\frac12(x-1)^2+2.5
@@ -350,7 +350,7 @@
         </p>
 
         <figure xml:id="fig_conic1">
-          <caption>The parabola described in <xref ref="ex_conic1">Example</xref></caption>
+          <caption>The parabola described in <xref ref="ex_conic1"/></caption>
           <!-- START figures/fig_conic1.tex -->
           <image xml:id="img_conic1" width="47%">
             <shortdescription>A downward opening parabola with a vertex in the first quadrant.</shortdescription>
@@ -382,7 +382,7 @@
         </figure>
 
         <p>
-          The parabola is sketched in <xref ref="fig_conic1">Figure</xref>.
+          The parabola is sketched in <xref ref="fig_conic1"/>.
         </p>
       </solution>
     </example>
@@ -417,12 +417,12 @@
           Hence the vertex is located at <m>(-1,4)</m>.
           We have <m>\frac18=\frac1{4p}</m>, so <m>p=2</m>.
           We conclude that the focus is located at <m>(1,4)</m> and the directrix is <m>x=-3</m>.
-          The parabola is graphed in <xref ref="fig_conic2">Figure</xref>,
+          The parabola is graphed in <xref ref="fig_conic2"/>,
           along with its focus and directrix.
         </p>
 
         <figure xml:id="fig_conic2">
-          <caption>The parabola described in <xref ref="ex_conic2">Example</xref>. The distances from a point on the parabola to the focus and directrix are given.</caption>
+          <caption>The parabola described in <xref ref="ex_conic2"/>. The distances from a point on the parabola to the focus and directrix are given.</caption>
           <!-- START figures/fig_conic2.tex -->
           <image xml:id="img_conic2" width="47%">
             <shortdescription>A parabola opening to the right with its directrix and focus drawn.</shortdescription>
@@ -491,7 +491,7 @@
       </blockquote>
 
       <p>
-      	This is illustrated in <xref ref="fig_conic_reflect">Figure</xref>. The following theorem states this more rigorously.
+      	This is illustrated in <xref ref="fig_conic_reflect"/>. The following theorem states this more rigorously.
       </p>
 
       <figure xml:id="fig_conic_reflect">
@@ -611,7 +611,7 @@
       Holding a pencil tight against the string places the pencil on the ellipse;
       the sum of distances from the pencil to the pins is constant:
       the length of the string.
-      See <xref ref="fig_ellipse_def">Figure</xref>.
+      See <xref ref="fig_ellipse_def"/>.
     </p>
 
     <figure xml:id="fig_ellipse_def">
@@ -695,7 +695,7 @@
 
     <p>
       This choice of <m>a</m> and <m>b</m> is not without reason;
-      as shown in <xref ref="fig_ellipse_label">Figure</xref>,
+      as shown in <xref ref="fig_ellipse_label"/>,
       the values of <m>a</m> and <m>b</m> have geometric meaning in the graph of the ellipse.
     </p>
 
@@ -799,11 +799,11 @@
       <title>Finding the equation of an ellipse</title>
       <statement>
         <p>
-          Find the general equation of the ellipse graphed in <xref ref="fig_conic3">Figure</xref>.
+          Find the general equation of the ellipse graphed in <xref ref="fig_conic3"/>.
         </p>
 
         <figure xml:id="fig_conic3">
-          <caption>The ellipse used in <xref ref="ex_conic3">Example</xref></caption>
+          <caption>The ellipse used in <xref ref="ex_conic3"/></caption>
           <!-- START figures/fig_conic3.tex -->
           <image xml:id="img_conic3" width="47%">
             <shortdescription>An ellipse centered in the second quadrant, lying entirely in the second and third quadrants.</shortdescription>
@@ -895,11 +895,11 @@
           We find <m>c=\sqrt{9-4} = \sqrt{5}\approx 2.24</m>.
           The foci are located along the major axis,
           approximately <m>2.24</m> units from the center, at <m>(1\pm 2.24,2)</m>.
-          This is all graphed in <xref ref="fig_conic4">Figure</xref>
+          This is all graphed in <xref ref="fig_conic4"/>
         </p>
 
         <figure xml:id="fig_conic4">
-          <caption>Graphing the ellipse in <xref ref="ex_conic4">Example</xref></caption>
+          <caption>Graphing the ellipse in <xref ref="ex_conic4"/></caption>
           <!-- START figures/fig_conic4.tex -->
           <image xml:id="img_conic4" width="47%">
             <shortdescription>An ellipse centered at (1,2), with vertices at (-2,2) and (4,2).</shortdescription>
@@ -957,9 +957,9 @@
       </p>
 
       <p>
-        Consider <xref ref="fig_ellipse_ecc">Figure</xref>,
+        Consider <xref ref="fig_ellipse_ecc"/>,
         where several ellipses are graphed with <m>a=1</m>.
-        In <xref ref="fig_ellipse_ecca">Figure</xref>, we have <m>c=0</m> and the ellipse is a circle.
+        In <xref ref="fig_ellipse_ecca"/>, we have <m>c=0</m> and the ellipse is a circle.
         As <m>c</m> grows,
         the resulting ellipses look less and less circular.
         A measure of this <q>noncircularness</q>
@@ -1147,7 +1147,7 @@
         that is, a circle has no <q>noncircularness.</q>
         As <m>c</m> approaches <m>a</m>,
         <m>e</m> approaches 1, giving rise to a very noncircular ellipse,
-        as seen in <xref ref="fig_ellipse_eccd">Figure</xref>.
+        as seen in <xref ref="fig_ellipse_eccd"/>.
       </p>
 
       <p>
@@ -1169,7 +1169,7 @@
       <p>
         The ellipse also possesses an interesting reflective property.
         Any ray emanating from one focus of an ellipse reflects off the ellipse along a line through the other focus,
-        as illustrated in <xref ref="fig_ellipse_reflect">Figure</xref>.
+        as illustrated in <xref ref="fig_ellipse_reflect"/>.
         This property is given formally in the following theorem.
       </p>
 
@@ -1282,7 +1282,7 @@
       each a <em>vertex</em> of the hyperbola.
       The line through the center and perpendicular to the transverse axis is the
       <em>conjugate axis.</em>
-      This is illustrated in <xref ref="fig_hyperbola_def">Figure</xref>.
+      This is illustrated in <xref ref="fig_hyperbola_def"/>.
       It is easy to show that the constant difference of distances used in the definition of the hyperbola is the distance between the vertices,
       <ie/>, <m>2a</m>.
     </p>
@@ -1395,7 +1395,7 @@
         That is, as <m>x</m> gets large,
         the graph of the hyperbola looks very much like the lines <m>y=\pm x/3</m>.
         These lines are asymptotes of the hyperbola,
-        as shown in <xref ref="fig_hyperbola_asy1">Figure</xref>.
+        as shown in <xref ref="fig_hyperbola_asy1"/>.
       </p>
 
       <figure xml:id="fig_hyperbola_asy1">
@@ -1439,7 +1439,7 @@
         This is a valuable tool in sketching.
         Given the equation of a hyperbola in general form,
         draw a rectangle centered at <m>(h,k)</m> with sides of length <m>2a</m> parallel to the transverse axis and sides of length <m>2b</m> parallel to the conjugate axis.
-        (See <xref ref="fig_hyperbola_asy2">Figure</xref>
+        (See <xref ref="fig_hyperbola_asy2"/>
         for an example with a horizontal transverse axis.)
         The diagonals of the rectangle lie on the asymptotes.
       </p>
@@ -1533,7 +1533,7 @@
           <p>
             The hyperbola is centered at <m>(1,2)</m>;
             <m>a=5</m> and <m>b=2</m>.
-            In <xref ref="fig_conic5">Figure</xref>
+            In <xref ref="fig_conic5"/>
             we draw the prescribed rectangle centered at <m>(1,2)</m> along with the asymptotes defined by its diagonals.
             The hyperbola has a vertical transverse axis,
             so the vertices are located at <m>(1,7)</m> and <m>(1,-3)</m>.
@@ -1541,13 +1541,13 @@
           </p>
 
           <figure xml:id="fig_conic5">
-            <caption>Graphing the hyperbola in <xref ref="ex_conic5">Example</xref></caption>
+            <caption>Graphing the hyperbola in <xref ref="ex_conic5"/></caption>
             <!-- START figures/fig_conic5.tex -->
             <image xml:id="img_conic5" width="47%">
-              <shortdescription>A graph of the hyperbola given in <xref ref="ex_conic5">Example</xref></shortdescription>
+              <shortdescription>A graph of the hyperbola given in <xref ref="ex_conic5"/></shortdescription>
               <description>
                 <p>
-                 A graph of the hyperbola given in <xref ref="ex_conic5">Example</xref>.
+                 A graph of the hyperbola given in <xref ref="ex_conic5"/>.
                  The hyperbola has the equation <m>\frac{(y-2)^2}{25} - \frac{(x-1)^2}{4} = 1</m>.
                  The center of the hyperbola is drawn at <m>(1,2)</m>.
                  A rectangle is drawn around the center, with a height of <m>10</m> and a width of <m>4</m>.
@@ -1628,13 +1628,13 @@
           </p>
 
           <figure xml:id="fig_conic6">
-            <caption>Graphing the hyperbola in <xref ref="ex_conic6">Example</xref></caption>
+            <caption>Graphing the hyperbola in <xref ref="ex_conic6"/></caption>
             <!-- START figures/fig_conic6.tex -->
             <image xml:id="img_conic6" width="47%">
-              <shortdescription>The hyperbola described in <xref ref="ex_conic6">Example</xref>.</shortdescription>
+              <shortdescription>The hyperbola described in <xref ref="ex_conic6"/>.</shortdescription>
               <description>
                 <p>
-                  The hyperbola described in  <xref ref="ex_conic6">Example</xref>.
+                  The hyperbola described in  <xref ref="ex_conic6"/>.
                   The hyperbola comes from the equation <m>9x^2 - y^2 + 2y = 10</m>.
                   The hyperbola is centered at <m>(0,1)</m>, around which a rectangle is drawn.
                   The rectangle has a height of 6 and a width of 2.
@@ -1681,7 +1681,7 @@
             We see the hyperbola is centered at <m>(0,1)</m>,
             with a horizontal transverse axis,
             where <m>a=1</m> and <m>b=3</m>.
-            The appropriate rectangle is sketched in <xref ref="fig_conic6">Figure</xref>
+            The appropriate rectangle is sketched in <xref ref="fig_conic6"/>
             along with the asymptotes of the hyperbola.
             The vertices are located at <m>(\pm 1,1)</m>.
             We have <m>c=\sqrt{10}\approx 3.2</m>,
@@ -1913,13 +1913,13 @@
         When <m>c</m> is close in value to <m>a</m> (<ie/>, <m>e\approx 1</m>),
         the hyperbola is very narrow
         (looking almost like crossed lines).
-        <xref ref="fig_hyperbola_ecc">Figure</xref>
+        <xref ref="fig_hyperbola_ecc"/>
         shows hyperbolas centered at the origin with <m>a=1</m>.
-        The graph in <xref ref="fig_hyperbola_ecca">Figure</xref> has <m>c=1.05</m>,
+        The graph in <xref ref="fig_hyperbola_ecca"/> has <m>c=1.05</m>,
         giving an eccentricity of <m>e=1.05</m>, which is close to 1.
         As <m>c</m> grows larger,
         the hyperbola widens and begins to look like parallel lines,
-        as shown in <xref ref="fig_hyperbola_eccd">Figure</xref>.
+        as shown in <xref ref="fig_hyperbola_eccd"/>.
       </p>
     </paragraphs>
 
@@ -1930,7 +1930,7 @@
         However, in the case of a hyperbola,
         a ray emanating from a focus that intersects the hyperbola reflects along a line containing the other focus,
         but moving <em>away</em> from that focus.
-        This is illustrated in <xref ref="fig_hyperbola_reflect">Figure</xref>
+        This is illustrated in <xref ref="fig_hyperbola_reflect"/>
         (on the next page).
         Hyperbolic mirrors are commonly used in telescopes because of this reflective property.
         It is stated formally in the following theorem.
@@ -2052,7 +2052,7 @@
         and location <m>C</m> records the noise exactly 2 seconds after that.
         We are interested in the <em>difference</em> of times.
         Since the speed of sound is approximately 340 m/s, we can conclude quickly that the sound was created 340 meters closer to position <m>A</m> than position <m>B</m>.
-        If <m>A</m> and <m>B</m> are a known distance apart (as shown in <xref ref="fig_hyperbola_locatea">Figure</xref>),
+        If <m>A</m> and <m>B</m> are a known distance apart (as shown in <xref ref="fig_hyperbola_locatea"/>),
         then we can determine a hyperbola on which <m>D</m> must lie.
       </p>
 
@@ -2062,7 +2062,7 @@
         So we know <m>2a= 340</m>.
         Positions <m>A</m> and <m>B</m> lie on the foci, so <m>2c=1000</m>.
         From this we can find <m>b\approx 470</m> and can sketch the hyperbola,
-        given in <xref ref="fig_hyperbola_locateb">Figure</xref>.
+        given in <xref ref="fig_hyperbola_locateb"/>.
         We only care about the side closest to <m>A</m>. (Why?)
       </p>
 
@@ -2073,7 +2073,7 @@
         We still have <m>2c=1000</m>,
         centering this hyperbola at <m>(-500,500)</m>.
         We find <m>b\approx 367</m>.
-        This hyperbola is sketched in <xref ref="fig_hyperbola_locatec">Figure</xref>.
+        This hyperbola is sketched in <xref ref="fig_hyperbola_locatec"/>.
         The intersection point of the two graphs is the location of the sound,
         at approximately <m>(188,-222.5)</m>.
       </p>
@@ -2121,10 +2121,10 @@
           <figure xml:id="fig_hyperbola_locateb">
             <caption/>
             <image xml:id="img_hyperbola_locateb">
-              <shortdescription>A hyperbola drawn from points A and B in <xref ref="fig_hyperbola_locatea">Figure</xref> </shortdescription>
+              <shortdescription>A hyperbola drawn from points A and B in <xref ref="fig_hyperbola_locatea"/> </shortdescription>
               <description>
                 <p>
-                  A hyperbola drawn from points <m>A</m> and <m>B</m> in <xref ref="fig_hyperbola_locatea">Figure</xref>.
+                  A hyperbola drawn from points <m>A</m> and <m>B</m> in <xref ref="fig_hyperbola_locatea"/>.
                   <m>A</m> and <m>B</m> are the foci of the hyperbola.
                   The vertices of the hyperbola are 170 units away from the origin.
                   The left half of the hyperbola is drawn with a dashed line, while the right half of the parabola is drawn with a solid line.
@@ -2158,10 +2158,10 @@
           <figure xml:id="fig_hyperbola_locatec">
             <caption/>
             <image xml:id="img_hyperbola_locatec">
-              <shortdescription>A fourth point found from hyperbolas given by points in <xref ref="fig_hyperbola_locatea">Figure</xref></shortdescription>
+              <shortdescription>A fourth point found from hyperbolas given by points in <xref ref="fig_hyperbola_locatea"/></shortdescription>
               <description>
                 <p>
-                  A hyperbola drawn from points <m>B</m> and <m>C</m> in <xref ref="fig_hyperbola_locatea">Figure</xref>, intersecting with the hyperbola drawn in <xref ref="fig_hyperbola_locateb">Figure</xref>.
+                  A hyperbola drawn from points <m>B</m> and <m>C</m> in <xref ref="fig_hyperbola_locatea"/>, intersecting with the hyperbola drawn in <xref ref="fig_hyperbola_locateb"/>.
                   The hyperbola uses <m>B</m> and <m>C</m> as the foci. The vertices of the hyperbola are 640 units apart.
                   The bottom hyperbola, with focus <m>B</m>, extends towards the right.
                   The point at which it intersects with the hyperbola with focus <m>A</m> is labeled as <m>D</m>.

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -609,7 +609,7 @@
       </figure>
 
       <p>
-        We illustrate using Equation <xref ref="eq_crossp1"/> in the following example.
+        We illustrate using <xref ref="eq_crossp1">Equation</xref> in the following example.
             <idx><h>cross product</h><h>applications!area of parallelogram</h></idx>
       </p>
 
@@ -981,7 +981,7 @@
         </solution>
         <solution>
           <p>
-            We apply Equation <xref ref="eq_crossp2"/>.
+            We apply <xref ref="eq_crossp2">Equation</xref>.
             We first find <m>\crossp vw =\la 1,1,-1\ra</m>.
             Then
             <me>
@@ -1185,7 +1185,7 @@
                   we can conclude it is making an angle of <m>-45^\circ</m> with the horizontal.
                   As it has a magnitude of 10lb, we can state <m>\vec F = 10\la \cos(-45^\circ), \sin(-45^\circ)\ra = \la 5\sqrt2,-5\sqrt2\ra</m>.
 
-                  Using Equation <xref ref="eq_crossp3"/> to find the torque requires a cross product. We again let the third component of each vector be 0  and compute the cross product:
+                  Using <xref ref="eq_crossp3">Equation</xref> to find the torque requires a cross product. We again let the third component of each vector be 0  and compute the cross product:
                   <md>
                     <mrow>\vec\tau \amp = \crossp \ell F</mrow>
                     <mrow>\amp = \la \sqrt2,\sqrt2,0\ra \times \la 5\sqrt2,-5\sqrt2,0\ra</mrow>

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -71,7 +71,7 @@
       </solution>
       <solution>
         <p>
-          Using <xref ref="def_cross_product">Definition</xref>, we have
+          Using <xref ref="def_cross_product"/>, we have
           <me>
             \crossp uv = \la (-1)5-(4)2,-\big((2)5-(4)3\big), (2)2-(-1)3\ra = \la -13,2,7\ra
           </me>.
@@ -106,7 +106,7 @@
       <m>\vec j</m>, and <m>\vec k</m>.
       The second and third rows are the vectors <m>\vec u</m> and <m>\vec v</m>,
       respectively.
-      Using <m>\vec u</m> and <m>\vec v</m> from <xref ref="ex_crossp1">Example</xref>,
+      Using <m>\vec u</m> and <m>\vec v</m> from <xref ref="ex_crossp1"/>,
       we begin with:
       <me>
         \begin{matrix} \veci\amp \vecj\amp \veck \\  2\amp -1\amp 4\\3\amp 2\amp 5
@@ -223,7 +223,7 @@
     <p>
       It is not coincidence that
       <m>\crossp vu = -(\crossp uv)</m> in the preceding example;
-      one can show using <xref ref="def_cross_product">Definition</xref>
+      one can show using <xref ref="def_cross_product"/>
       that this will always be the case.
       The following theorem states several useful properties of the cross product,
       each of which can be verified by referring to the definition.
@@ -319,8 +319,8 @@
 
     <p>
       We introduced the cross product as a way to find a vector orthogonal to two given vectors,
-      but we did not give a proof that the construction given in <xref ref="def_cross_product">Definition</xref> satisfies this property.
-      <xref ref="thm_cross_prod_prop">Theorem</xref> asserts this property holds;
+      but we did not give a proof that the construction given in <xref ref="def_cross_product"/> satisfies this property.
+      <xref ref="thm_cross_prod_prop"/> asserts this property holds;
       we leave it as a problem in the Exercise section to verify this.
     </p>
 
@@ -333,15 +333,15 @@
       Consider their cross product:
       <md>
         <mrow>\crossp uv \amp = \vecu \times (c\vec u)</mrow>
-        <mrow>\amp =  c(\crossp uu) \text{ (by Property 3 of } <xref ref="thm_cross_prod_prop">Theorem</xref>\text{)}</mrow>
-        <mrow>\amp = \vec 0 \text{ (by Property 5 of } <xref ref="thm_cross_prod_prop">Theorem</xref>\text{)}</mrow>
+        <mrow>\amp =  c(\crossp uu) \text{ (by Property 3 of } <xref ref="thm_cross_prod_prop"/>\text{)}</mrow>
+        <mrow>\amp = \vec 0 \text{ (by Property 5 of } <xref ref="thm_cross_prod_prop"/>\text{)}</mrow>
       </md>.
     </p>
 
     <p>
       We have just shown that the cross product of parallel vectors is <m>\vec 0</m>.
       This hints at something deeper.
-      <xref ref="thm_dot_product">Theorem</xref>
+      <xref ref="thm_dot_product"/>
       related the angle between two vectors and their dot product;
       there is a similar relationship relating the cross product of two vectors and the angle between them,
       given by the following theorem.
@@ -368,14 +368,14 @@
       <title>Parallel vectors and the cross product</title>
 
       <p>
-        We could rewrite <xref ref="def_orthogonal">Definition</xref>
-        and <xref ref="thm_cross_product">Theorem</xref> to include <m>\vec 0</m>,
+        We could rewrite <xref ref="def_orthogonal"/>
+        and <xref ref="thm_cross_product"/> to include <m>\vec 0</m>,
         then define that <m>\vec u</m> and <m>\vec v</m> are parallel if <m>\vec u\times\vec v=\vec 0</m>.
         Since <m>\vec 0\cdot \vec v =0</m> and <m>\vec 0\times \vec v = \vec 0</m>,
         this would mean that <m>\vec 0</m> is both parallel <em>and</em>
         orthogonal to all vectors.
         Apparent paradoxes such as this are not uncommon in mathematics and can be very useful.
-        (See also the <xref ref="aside-def-orthogonal" text="custom">aside</xref> in <xref ref="sec_vector_intro">Section</xref>.)
+        (See also the <xref ref="aside-def-orthogonal" text="custom">aside</xref> in <xref ref="sec_vector_intro"/>.)
       </p>
     </aside>
     <p>
@@ -384,8 +384,8 @@
       When the angle between <m>\vecu</m> and <m>\vecv</m> is 0 or <m>\pi</m> (<ie/>, the vectors are parallel),
       the magnitude of the cross product is 0.
       The only vector with a magnitude of 0 is <m>\vec 0</m>
-      (see <xref ref="thm_zero_norm">Property</xref>
-      of <xref ref="thm_vector_properties">Theorem</xref>),
+      (see <xref ref="thm_zero_norm" text="local">Property</xref>
+      of <xref ref="thm_vector_properties"/>),
       hence the cross product of parallel vectors is <m>\vec 0</m>.
     </p>
 
@@ -403,15 +403,15 @@
       <statement>
         <p>
           Let <m>\vec u = \la 1,3,6\ra</m> and
-          <m>\vec v = \la -1,2,1\ra</m> as in <xref ref="ex_crossp2">Example</xref>.
-          Verify <xref ref="thm_cross_product">Theorem</xref> by finding <m>\theta</m>,
+          <m>\vec v = \la -1,2,1\ra</m> as in <xref ref="ex_crossp2"/>.
+          Verify <xref ref="thm_cross_product"/> by finding <m>\theta</m>,
           the angle between <m>\vecu</m> and <m>\vecv</m>,
           and the magnitude of <m>\crossp uv</m>.
         </p>
       </statement>
       <solution>
         <p>
-          We use <xref ref="thm_dot_product">Theorem</xref>
+          We use <xref ref="thm_dot_product"/>
           to find the angle between <m>\vecu</m> and <m>\vecv</m>.
           <md>
             <mrow>\theta \amp = \cos^{-1}\left(\frac{\dotp uv}{\vnorm u\, \vnorm v}\right)</mrow>
@@ -421,7 +421,7 @@
         </p>
 
         <p>
-          Our work in <xref ref="ex_crossp2">Example</xref>
+          Our work in <xref ref="ex_crossp2"/>
           showed that <m>\crossp uv = \la -9,-7,5\ra</m>,
           hence <m>\norm{\crossp uv} = \sqrt{155}</m>.
           Is <m>\norm{\crossp uv} = \vnorm u\, \vnorm v\sin(\theta)</m>?
@@ -463,7 +463,7 @@
         point the index finger of your right hand in the direction of <m>\vecu</m> and let your middle finger point in the direction of <m>\vecv</m>
         (much as we did when establishing the right hand rule for the 3-dimensional coordinate system).
         Your thumb will naturally extend in the direction of <m>\crossp uv</m>.
-        One can <q>practice</q> this using <xref ref="fig_crossp_rhr">Figure</xref>.
+        One can <q>practice</q> this using <xref ref="fig_crossp_rhr"/>.
         If you switch,
         and point the index finder in the direction of <m>\vecv</m> and the middle finger in the direction of <m>\vecu</m>,
         your thumb will now point in the opposite direction,
@@ -548,16 +548,16 @@
       <p>
         It is a standard geometry fact that the area of a parallelogram is <m>A = bh</m>,
         where <m>b</m> is the length of the base and <m>h</m> is the height of the parallelogram,
-        as illustrated in <xref ref="fig_crossp_parallelograma">Figure</xref>.
+        as illustrated in <xref ref="fig_crossp_parallelograma"/>.
         As shown when defining the Parallelogram Law of vector addition,
         two vectors <m>\vecu</m> and <m>\vecv</m> define a parallelogram when drawn from the same initial point,
-        as illustrated in <xref ref="fig_crossp_parallelogramb">Figure</xref>.
+        as illustrated in <xref ref="fig_crossp_parallelogramb"/>.
         Trigonometry tells us that <m>h = \vnorm u \sin(\theta)</m>,
         hence the area of the parallelogram is
         <men xml:id="eq_crossp1">
           A = \vnorm u\,\vnorm v\sin(\theta) = \norm{\crossp uv}
         </men>,
-        where the second equality comes from <xref ref="thm_cross_product">Theorem</xref>.
+        where the second equality comes from <xref ref="thm_cross_product"/>.
       </p>
 
       <figure xml:id="fig_crossp_parallelogram">
@@ -644,7 +644,7 @@
             <ol>
               <li>
                 <p>
-                  <xref ref="fig_crossp4a">Figure</xref> sketches the parallelogram defined by the vectors <m>\vec u</m> and <m>\vec v</m>.
+                  <xref ref="fig_crossp4a"/> sketches the parallelogram defined by the vectors <m>\vec u</m> and <m>\vec v</m>.
                   We have a slight problem in that our vectors exist in
                   <m>\mathbb{R}^2</m>, not <m>\mathbb{R}^3</m>,
                   and the cross product is only defined on vectors in <m>\mathbb{R}^3</m>.
@@ -655,7 +655,7 @@
                 </p>
 
                 <figure xml:id="fig_crossp4">
-                  <caption>Sketching the parallelograms in <xref ref="ex_crossp4">Example</xref></caption>
+                  <caption>Sketching the parallelograms in <xref ref="ex_crossp4"/></caption>
                   <sidebyside widths="47% 47%" valign="bottom" margins="0%">
                     <figure xml:id="fig_crossp4a">
                       <caption/>
@@ -748,7 +748,7 @@
 
               <li>
                 <p>
-                  To show that the quadrilateral <m>ABCD</m> is a parallelogram (shown in <xref ref="fig_crossp4b_3D">Figure</xref>),
+                  To show that the quadrilateral <m>ABCD</m> is a parallelogram (shown in <xref ref="fig_crossp4b_3D"/>),
                   we need to show that the opposite sides are parallel.
                   We can quickly show that <m>\overrightarrow{AB} =\overrightarrow{DC} = \la 1,2,1\ra</m> and <m>\overrightarrow{BC} = \overrightarrow{AD} = \la 2,2,1\ra</m>.
                   We find the area by computing the magnitude of the cross product of <m>\overrightarrow{AB}</m> and <m>\overrightarrow{BC}</m>:
@@ -774,10 +774,10 @@
           <p>
             Find the area of the triangle with vertices <m>A=(1,2)</m>,
             <m>B=(2,3)</m> and <m>C=(3,1)</m>,
-            as pictured in <xref ref="fig_crossp5">Figure</xref>.
+            as pictured in <xref ref="fig_crossp5"/>.
           </p>
           <figure xml:id="fig_crossp5">
-            <caption>Finding the area of a triangle in <xref ref="ex_crossp5">Example</xref></caption>
+            <caption>Finding the area of a triangle in <xref ref="ex_crossp5"/></caption>
             <!-- START figures/fig_crossp5.tex -->
             <image xml:id="img_crossp5" width="47%">
               <description></description>
@@ -812,7 +812,7 @@
         </solution>
         <solution>
           <p>
-            We found the area of this triangle in <xref ref="ex_abc4">Example</xref>
+            We found the area of this triangle in <xref ref="ex_abc4"/>
             to be <m>1.5</m> using integration.
             There we discussed the fact that finding the area of a triangle can be inconvenient using the
             <q><m>\frac12bh</m></q>
@@ -845,7 +845,7 @@
         The three dimensional analogue to the parallelogram is the
         <em>parallelepiped</em>.
         Each face is parallel to the opposite face,
-        as illustrated in <xref ref="fig_crossp_parallelepiped">Figure</xref>.
+        as illustrated in <xref ref="fig_crossp_parallelepiped"/>.
         By crossing <m>\vec v</m> and <m>\vec w</m>,
         one gets a vector whose magnitude is the area of the base.
         Dotting this vector with <m>\vecu</m> computes the volume 
@@ -958,7 +958,7 @@
 
       <p>
         Note how this is the Triple Scalar Product,
-        first seen in <xref ref="thm_cross_prod_prop">Theorem</xref>.
+        first seen in <xref ref="thm_cross_prod_prop"/>.
         Applying the identities given in the theorem shows that we can apply the Triple Scalar Product in any <q>order</q>
         we choose to find the volume.
         That is,
@@ -994,7 +994,7 @@
           </p>
 
           <figure xml:id="fig_crossp6">
-            <caption>A parallelepiped in <xref ref="ex_crossp6">Example</xref></caption>
+            <caption>A parallelepiped in <xref ref="ex_crossp6"/></caption>
 
             <!-- START figures/figcrossp6_3D.asy -->
             <image xml:id="img_crossp6" width="47%">
@@ -1113,7 +1113,7 @@
           </p>
 
           <figure xml:id="fig_crossp7">
-            <caption>Showing a force being applied to a lever in <xref ref="ex_crossp7">Example</xref></caption>
+            <caption>Showing a force being applied to a lever in <xref ref="ex_crossp7"/></caption>
             <!-- START figures/fig_crossp7.tex -->
             <image xml:id="img_crossp7" width="47%">
               <description></description>
@@ -1165,7 +1165,7 @@
               <li>
                 <p>
                   the force makes an angle of <m>60^\circ</m> with the lever,
-                  as shown in <xref ref="fig_crossp7">Figure</xref>.
+                  as shown in <xref ref="fig_crossp7"/>.
                 </p>
               </li>
             </ol>
@@ -1181,7 +1181,7 @@
                   <m>45^\circ</m> angle with the horizontal and is 2ft long,
                   we can state that <m>\vec \ell = 2\la \cos(45^\circ) ,\sin(45^\circ) \ra = \la \sqrt2,\sqrt2\ra</m>.
 
-                  Since the force vector is perpendicular to the lever arm (as seen in the left hand side of <xref ref="fig_crossp7">Figure</xref>),
+                  Since the force vector is perpendicular to the lever arm (as seen in the left hand side of <xref ref="fig_crossp7"/>),
                   we can conclude it is making an angle of <m>-45^\circ</m> with the horizontal.
                   As it has a magnitude of 10lb, we can state <m>\vec F = 10\la \cos(-45^\circ), \sin(-45^\circ)\ra = \la 5\sqrt2,-5\sqrt2\ra</m>.
 

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -21,7 +21,7 @@
     <p>
       Currently, our vector-valued functions have defined points with a parameter <m>t</m>,
       which we often take to represent time.
-      Consider <xref ref="fig_vvfarc_intro1a">Figure</xref>,
+      Consider <xref ref="fig_vvfarc_intro1a"/>,
       where <m>\vrt = \la t^2-t,t^2+t\ra</m> is graphed and the points corresponding to <m>t=0,\ 1</m> and <m>2</m> are shown.
       Note how the arc length between <m>t=0</m> and <m>t=1</m> is smaller than the arc length between <m>t=1</m> and <m>t=2</m>;
       if the parameter <m>t</m> is time and <m>\vec r</m> is position,
@@ -101,7 +101,7 @@
     </figure>
 
     <p>
-      Now consider <xref ref="fig_vvfarc_intro1b">Figure</xref>,
+      Now consider <xref ref="fig_vvfarc_intro1b"/>,
       where the same graph is parametrized by a different variable <m>s</m>.
       Points corresponding to <m>s=0</m> through <m>s=6</m> are plotted.
       The arc length of the graph between each adjacent pair of points is 1.
@@ -185,7 +185,7 @@
         </p>
 
         <p>
-          Clearly, as shown in <xref ref="fig_vvfarc1">Figure</xref>,
+          Clearly, as shown in <xref ref="fig_vvfarc1"/>,
           the graph of <m>\vec r</m> is a line,
           where <m>t=0</m> corresponds to the point <m>(-1,2)</m>.
           What point on the line is 2 units away from this initial point?
@@ -193,7 +193,7 @@
         </p>
 
         <figure xml:id="fig_vvfarc1">
-          <caption>Graphing <m>\vec r</m> in <xref ref="ex_vvfarc1">Example</xref> with parameters <m>t</m> and <m>s</m></caption>
+          <caption>Graphing <m>\vec r</m> in <xref ref="ex_vvfarc1"/> with parameters <m>t</m> and <m>s</m></caption>
           <!-- START figures/fig_vvfarc1.tex -->
           <image xml:id="img_vvfarc1" width="47%">
             <description></description>
@@ -244,7 +244,7 @@
     </example>
 
     <p>
-      Things worked out very nicely in <xref ref="ex_vvfarc1">Example</xref>;
+      Things worked out very nicely in <xref ref="ex_vvfarc1"/>;
       we were able to establish directly that <m>s=5t</m>.
       Usually, the arc length parameter is much more difficult to describe in terms of <m>t</m>,
       a result of integrating a square root.
@@ -255,7 +255,7 @@
     <p>
       First, take the derivative of <m>s</m> with respect to <m>t</m>.
       The Fundamental Theorem of Calculus
-      (see <xref ref="thm_FTC1">Theorem</xref>)
+      (see <xref ref="thm_FTC1"/>)
       states that
       <men xml:id="eq_vvfarc3">
         \frac{ds}{dt}=s\primeskip'(t) = \norm{\vrp(t)}
@@ -283,7 +283,7 @@
         \vrp(s) = \frac{\vrp(t)}{\norm{\vrp(t)}} = \unittangent(t)
       </men>,
       where <m>\unittangent(t)</m> is the unit tangent vector.
-      <xref ref="eq_vvfarc2">Equation</xref> is often misinterpreted,
+      <xref ref="eq_vvfarc2" text="local">Equation</xref> is often misinterpreted,
       as one is tempted to think it states <m>\vrp(t) = \unittangent(t)</m>,
       but there is a big difference between <m>\vrp(s)</m> and <m>\vrp(t)</m>.
       The key to take from it is that <m>\vrp(s)</m> is a unit vector.
@@ -311,7 +311,7 @@
   <subsection>
     <title>Curvature</title>
     <p>
-      Consider points <m>A</m> and <m>B</m> on the curve graphed in <xref ref="fig_curvature_introa">Figure</xref>.
+      Consider points <m>A</m> and <m>B</m> on the curve graphed in <xref ref="fig_curvature_introa"/>.
       One can readily argue that the curve curves more sharply at <m>A</m> than at <m>B</m>.
       It is useful to use a number to describe how sharply the curve bends;
       that number is the <em>curvature</em> of the curve.
@@ -391,7 +391,7 @@
 
     <p>
       We derive this number in the following way.
-      Consider <xref ref="fig_curvature_introb">Figure</xref>,
+      Consider <xref ref="fig_curvature_introb"/>,
       where unit tangent vectors are graphed around points <m>A</m> and <m>B</m>.
       Notice how the direction of the unit tangent vector changes quite a bit near <m>A</m>,
       whereas it does not change as much around <m>B</m>.
@@ -448,15 +448,15 @@
     </p>
 
     <p>
-      We use <xref ref="def_curvature">Definition</xref>
-      to find the curvature of the line in <xref ref="ex_vvfarc1">Example</xref>.
+      We use <xref ref="def_curvature"/>
+      to find the curvature of the line in <xref ref="ex_vvfarc1"/>.
     </p>
 
     <example xml:id="ex_curvature1">
       <title>Finding the curvature of a line</title>
       <statement>
         <p>
-          Use <xref ref="def_curvature">Definition</xref>
+          Use <xref ref="def_curvature"/>
           to find the curvature of <m>\vrt = \la 3t-1,4t+2\ra</m>.
         </p>
       </statement>
@@ -466,7 +466,7 @@
       </solution>
       <solution>
         <p>
-          In <xref ref="ex_vvfarc1">Example</xref>,
+          In <xref ref="ex_vvfarc1"/>,
           we found that the arc length parameter was defined by <m>s=5t</m>,
           so <m>\vec r(s) =\la 3s/5-1, 4s/5+2\ra</m> parametrized <m>\vec r</m> with the arc length parameter.
           To find <m>\kappa</m>, we need to find <m>\unittangentprime(s)</m>.
@@ -563,7 +563,7 @@
         </p>
 
         <p>
-          We compute <m>\kappa</m> using the second part of <xref ref="thm_curvature_formulas">Theorem</xref>.
+          We compute <m>\kappa</m> using the second part of <xref ref="thm_curvature_formulas"/>.
           <md>
             <mrow>\kappa \amp = \frac{\abs{(-r\sin(t) )(-r\sin(t) ) - (-r\cos(t) )(r\cos(t) )}}{\big( (-r\sin(t) )^2+(r\cos(t) )^2\big)^{3/2}}</mrow>
             <mrow>\amp = \frac{r^2(\sin^2(t) +\cos^2(t) )}{\big(r^2(\sin^2(t) +\cos^2(t) )\big)^{3/2}}</mrow>
@@ -578,7 +578,7 @@
     </example>
 
     <p>
-      <xref ref="ex_curvature2">Example</xref> gives a great result.
+      <xref ref="ex_curvature2"/> gives a great result.
       Before this example, if we were told
       <q>The curve has a curvature of 5 at point <m>A</m>,</q>
       we would have no idea what this really meant.
@@ -634,15 +634,15 @@
           <idx><h>circle of curvature</h></idx>
           <idx><h>radius of curvature</h></idx>
           <idx><h>curvature</h><h>radius of</h></idx>
-      <xref ref="fig_curvature_osculate">Figure</xref> shows the graph of the curve seen earlier in
-      <xref ref="fig_curvature_intro">Figure</xref> and its osculating circles at <m>A</m> and <m>B</m>.
+      <xref ref="fig_curvature_osculate"/> shows the graph of the curve seen earlier in
+      <xref ref="fig_curvature_intro"/> and its osculating circles at <m>A</m> and <m>B</m>.
       A sharp turn corresponds to a circle with a small radius;
       a gradual turn corresponds to a circle with a large radius.
       Being able to think of curvature in terms of the radius of a circle is very useful.
     </p>
 
     <figure xml:id="fig_curvature_osculate">
-      <caption>Illustrating the osculating circles for the curve seen in <xref ref="fig_curvature_intro">Figure</xref></caption>
+      <caption>Illustrating the osculating circles for the curve seen in <xref ref="fig_curvature_intro"/></caption>
       <!-- START figures/fig_curvature_introc.tex -->
       <image xml:id="img_curvature_osculate" width="47%">
         <description></description>
@@ -694,7 +694,7 @@
       </statement>
       <solution>
         <p>
-          We use the first formula found in <xref ref="thm_curvature_formulas">Theorem</xref>.
+          We use the first formula found in <xref ref="thm_curvature_formulas"/>.
           <md>
             <mrow>\kappa(x) \amp = \frac{\abs{2}}{\big(1+(2x)^2\big)^{3/2}}</mrow>
             <mrow>\amp = \frac2{\big(1+4x^2\big)^{3/2}}</mrow>
@@ -736,7 +736,7 @@
           the curvature of <m>y=x^2</m> is that of a circle of radius <m>1/2</m>;
           at <m>x=1</m>,
           the curvature is that of a circle with radius <m>\approx 1/0.179 \approx 5.59</m>.
-          This is illustrated in <xref ref="fig_curvature3">Figure</xref>.
+          This is illustrated in <xref ref="fig_curvature3"/>.
           At <m>x=3</m>, the curvature is <m>0.009</m>;
           the graph is nearly straight as the curvature is very close to 0.
         </p>
@@ -752,7 +752,7 @@
       </statement>
       <solution>
         <p>
-          We use the third formula in <xref ref="thm_curvature_formulas">Theorem</xref>
+          We use the third formula in <xref ref="thm_curvature_formulas"/>
           as <m>\vrt</m> is defined in space.
           We leave it to the reader to verify that
           <me>
@@ -860,10 +860,10 @@
           we should solve <m>\kappa'(t)=0</m> for <m>t</m>.
           This is doable, but <em>very</em> time consuming.
           Instead, consider the graph of
-          <m>\kappa(t)</m> as given in <xref ref="fig_curvature4a">Figure</xref>.
+          <m>\kappa(t)</m> as given in <xref ref="fig_curvature4a"/>.
           We see that <m>\kappa</m> is maximized at two <m>t</m> values;
           using a numerical solver, we find these values are <m>t\approx\pm 0.189</m>.
-          In <xref ref="fig_curvature4b_3D">Figure</xref> we graph <m>\vrt</m> and indicate the points where curvature is maximized.
+          In <xref ref="fig_curvature4b_3D"/> we graph <m>\vrt</m> and indicate the points where curvature is maximized.
         </p>
       </solution>
     </example>
@@ -874,7 +874,7 @@
     <p>
       Let <m>\vrt</m> be a position function of an object,
       with velocity <m>\vvt = \vrp(t)</m> and acceleration <m>\vec a(t)=\vrpp(t)</m>.
-      In <xref ref="sec_tan_norm">Section</xref>
+      In <xref ref="sec_tan_norm"/>
       we established that acceleration is in the plane formed by
       <m>\unittangent(t)</m> and <m>\unitnormal(t)</m>,
       and that we can find scalars <m>a_\text{T}</m> and
@@ -890,7 +890,7 @@
     </p>
 
     <p>
-      <xref ref="thm_acc_plane">Theorem</xref>
+      <xref ref="thm_acc_plane"/>
       gives formulas for <m>a_\text{T}</m> and <m>a_\text{N}</m>:
       <me>
         a_\text{T}  = \frac{d}{dt}\Big(\norm{\vvt}\Big)  \text{ and }   a_\text{N}  = \frac{\norm{\vvt\times \vat}}{\norm{\vvt}}
@@ -922,7 +922,7 @@
 
     <p>
       Now compare the formula for
-      <m>a_\text{N}</m> above to the formula for curvature in <xref ref="thm_curvature_formulas">Theorem</xref>:
+      <m>a_\text{N}</m> above to the formula for curvature in <xref ref="thm_curvature_formulas"/>:
       <me>
         a_\text{N}  = \frac{\norm{\vvt\times \vat}}{\norm{\vvt}} \text{ and }  \kappa = \frac{\norm{\vrp(t)\times\vrpp(t)}}{\norm{\vrp(t)}^3}=\frac{\norm{\vvt\times \vat}}{\norm{\vvt}^3}
       </me>.

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -159,7 +159,7 @@
       </solution>
       <solution>
         <p>
-          Using Equation <xref ref="eq_vvfarc"/>, we write
+          Using <xref ref="eq_vvfarc">Equation</xref>, we write
           <me>
             s(t) = \int_0^t \norm{\vrp(u)}\, du
           </me>.
@@ -248,7 +248,7 @@
       we were able to establish directly that <m>s=5t</m>.
       Usually, the arc length parameter is much more difficult to describe in terms of <m>t</m>,
       a result of integrating a square root.
-      There are a number of things that we can learn about the arc length parameter from Equation <xref ref="eq_vvfarc"/>, though,
+      There are a number of things that we can learn about the arc length parameter from <xref ref="eq_vvfarc">Equation</xref>, though,
       that are incredibly useful.
     </p>
 
@@ -283,7 +283,7 @@
         \vrp(s) = \frac{\vrp(t)}{\norm{\vrp(t)}} = \unittangent(t)
       </men>,
       where <m>\unittangent(t)</m> is the unit tangent vector.
-      <xref ref="eq_vvfarc2" text="local">Equation</xref> is often misinterpreted,
+      <xref ref="eq_vvfarc2">Equation</xref> is often misinterpreted,
       as one is tempted to think it states <m>\vrp(t) = \unittangent(t)</m>,
       but there is a big difference between <m>\vrp(s)</m> and <m>\vrp(t)</m>.
       The key to take from it is that <m>\vrp(s)</m> is a unit vector.
@@ -905,7 +905,7 @@
     </p>
 
     <p>
-      In Equation <xref ref="eq_vvfarc3"/> at the beginning of this section, we found
+      In <xref ref="eq_vvfarc3">Equation</xref> at the beginning of this section, we found
       <m>s\primeskip'(t) = \norm{\vvt}</m>.
       We can combine this fact with the above formula for <m>a_\text{T}</m> to write
       <me>
@@ -1004,7 +1004,7 @@
         </table>
 
         <p>
-          Using Equation <xref ref="eq_curvature"/>,
+          Using <xref ref="eq_curvature">Equation</xref>,
           we can compute the acceleration normal to the curve in each case.
           We start by converting each speed from
           <q>miles per hour</q> to <q>feet per second</q>

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -40,7 +40,7 @@
       given in cylindrical coordinates,
       where the <m>z</m>-value in both systems is the same,
       and the point <m>(x_0,y_0)</m> in the <m>xy</m>-plane is identified with the polar point <m>P(r_0,\theta_0)</m>;
-      see <xref ref="fig_cylindricalintro">Figure</xref>.
+      see <xref ref="fig_cylindricalintro"/>.
       So that each point in space that does not lie on the <m>z</m>-axis is defined uniquely,
       we will restrict <m>r\geq 0</m> and <m>0\leq \theta\leq 2\pi</m>.
           <idx><h>cylindrical coordinates</h></idx>
@@ -111,7 +111,7 @@
     </figure>
 
     <p>
-      We use the identity <m>z=z</m> along with the identities found in <xref ref="idea_polarconvert">Key Idea</xref>
+      We use the identity <m>z=z</m> along with the identities found in <xref ref="idea_polarconvert"/>
       to convert between the rectangular coordinate <m>(x,y,z)</m> and the cylindrical coordinate <m>(r,\theta,z)</m>, namely:
       <me>
         \begin{array}{l} \text{ From rectangular to cylindrical: }  r=\sqrt{x^2+y^2}, \tan(\theta) = y/x \text{ and }  z=z;\\
@@ -131,7 +131,7 @@
     <p>
       These identities,
       along with conversions related to spherical coordinates,
-      are given later in <xref ref="idea_convert_coords">Key Idea</xref>.
+      are given later in <xref ref="idea_convert_coords"/>.
     </p>
 
     <figure xml:id="vid-trigint-cylindrical-definition" component="video">
@@ -151,7 +151,7 @@
       <solution>
         <p>
           Following the identities given above (and,
-          later in <xref ref="idea_convert_coords">Key Idea</xref>),
+          later in <xref ref="idea_convert_coords"/>),
           we have <m>r = \sqrt{2^2+(-2)^2} = 2\sqrt{2}</m>.
           Using <m>\tan(\theta) = y/x</m>,
           we find <m>\theta = \tan^{-1}(-2/2) =-\pi/4</m>.
@@ -190,7 +190,7 @@
           The equation <m>r=1</m> describes all points in space that are 1 unit away from the <m>z</m>-axis.
           This surface is a <q>tube</q> or <q>cylinder</q>
           of radius 1, centered on the <m>z</m>-axis,
-          as graphed in <xref ref="fig_spacecylinder1">Figure</xref>
+          as graphed in <xref ref="fig_spacecylinder1"/>
           (which describes the cylinder <m>x^2+y^2=1</m> in space).
         </p>
 
@@ -206,7 +206,7 @@
         </p>
 
         <figure xml:id="fig_cylindrical1">
-          <caption>Graphing the canonical surfaces in cylindrical coordinates from <xref ref="ex_cylindrical1">Example</xref></caption>
+          <caption>Graphing the canonical surfaces in cylindrical coordinates from <xref ref="ex_cylindrical1"/></caption>
           <image xml:id="img_cylindrical1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -311,7 +311,7 @@
         </figure>
 
         <p>
-          All three surfaces are graphed in <xref ref="fig_cylindrical1">Figure</xref>.
+          All three surfaces are graphed in <xref ref="fig_cylindrical1"/>.
           Note how their intersection uniquely defines the point <m>P=(1,\pi/3,2)</m>.
         </p>
       </solution>
@@ -323,7 +323,7 @@
     </p>
 
     <p>
-      <xref ref="thm_triple_integration2">Theorem</xref>
+      <xref ref="thm_triple_integration2"/>
       shows how to evaluate <m>\iiint_Dh(x,y,z)\, dV</m> using rectangular coordinates.
       In that evaluation, we use <m>dV = dz\,dy\,dx</m>
       (or one of the other five orders of integration).
@@ -331,7 +331,7 @@
       the bounds on <m>y</m> are <q>curve to curve</q>
       and the bounds on <m>x</m> are <q>point to point</q>:
       these bounds describe a region <m>R</m> in the <m>xy</m>-plane.
-      We could describe <m>R</m> using polar coordinates as done in <xref ref="sec_double_int_polar">Section</xref>.
+      We could describe <m>R</m> using polar coordinates as done in <xref ref="sec_double_int_polar"/>.
       In that section, we saw how we used
       <m>dA = r\,dr\,d\theta</m> instead of <m>dA = dy\,dx</m>.
     </p>
@@ -380,13 +380,13 @@
         <p>
           Find the mass of the solid represented by the region in space bounded by <m>z=0</m>,
           <m>z=\sqrt{4-x^2-y^2}+3</m> and the cylinder <m>x^2+y^2=4</m>
-          (as shown in <xref ref="fig_cylindrical2">Figure</xref>),
+          (as shown in <xref ref="fig_cylindrical2"/>),
           with density function <m>\delta(x,y,z) = x^2+y^2+z+1</m>,
           using a triple integral in cylindrical coordinates.
           Distances are measured in centimeters and density is measured in grams per cubic centimeter.
         </p>
         <figure xml:id="fig_cylindrical2">
-          <caption>Visualizing the solid used in <xref ref="ex_cylindrical2">Example</xref></caption>
+          <caption>Visualizing the solid used in <xref ref="ex_cylindrical2"/></caption>
           <image xml:id="img_cylindrical2_3D" width="47%">
             <description></description>
             <asymptote>
@@ -475,8 +475,8 @@
         </p>
 
         <p>
-          Using <xref ref="def_mass_3d">Definition</xref>
-          and <xref ref="thm_triple_int_cylindrical">Theorem</xref>,
+          Using <xref ref="def_mass_3d"/>
+          and <xref ref="thm_triple_int_cylindrical"/>,
           we have the mass of the solid is
           <md>
             <mrow>M=\iiint_D\delta(x,y,z)\, dV \amp = \int_0^{2\pi}\int_0^2\int_0^{\sqrt{4-r^2}+3}\big(r^2+z+1\big)r\,dz\,dr\,d\theta</mrow>
@@ -495,11 +495,11 @@
           Find the center of mass of the solid with constant density whose base can be described by the polar curve
           <m>r=\cos(3\theta)</m> and whose top is defined by the plane <m>z=1-x+0.1y</m>,
           where distances are measured in feet,
-          as seen in <xref ref="fig_cylindrical3">Figure</xref>.
-          (The volume of this solid was found in <xref ref="ex_doublepol4">Example</xref>.)
+          as seen in <xref ref="fig_cylindrical3"/>.
+          (The volume of this solid was found in <xref ref="ex_doublepol4"/>.)
         </p>
         <figure xml:id="fig_cylindrical3">
-          <caption>Visualizing the solid used in <xref ref="ex_cylindrical3">Example</xref></caption>
+          <caption>Visualizing the solid used in <xref ref="ex_cylindrical3"/></caption>
           <image xml:id="img_doublepol4_3D" width="47%">
             <description></description>
             <asymptote>
@@ -591,14 +591,14 @@
           Since density is constant,
           we set <m>\delta = 1</m> and finding the mass is equivalent to finding the volume of the solid.
           We set up the triple integral to compute this but do not evaluate it;
-          we leave it to the reader to confirm it evaluates to the same result found in <xref ref="ex_doublepol4">Example</xref>.
+          we leave it to the reader to confirm it evaluates to the same result found in <xref ref="ex_doublepol4"/>.
           <me>
             M = \iiint_D\delta \, dV = \int_0^{\pi}\int_0^{\cos(3\theta)}\int_0^{1-r\cos(\theta)+0.1r\sin(\theta)} r\,dz\,dr\,d\theta = \frac{\pi}{4}
           </me>.
         </p>
 
         <p>
-          From <xref ref="def_mass_3d">Definition</xref>
+          From <xref ref="def_mass_3d"/>
           we set up the triple integrals to compute the moments about the three coordinate planes.
           The computation of each is left to the reader (using technology is recommended):
           <md>
@@ -639,7 +639,7 @@
       where <m>\rho</m> is the distance from the origin to <m>P</m>,
       <m>\theta</m> is the same angle as would be used to describe <m>P</m> in the cylindrical coordinate system,
       and <m>\varphi</m> is the angle between the <m>xy</m>-plane and the ray from the origin to <m>P</m>;
-      see <xref ref="fig_sphericalintro">Figure</xref>.
+      see <xref ref="fig_sphericalintro"/>.
       So that each point in space that does not lie on the <m>z</m>-axis is defined uniquely,
       we will restrict <m>\rho \geq 0</m>,
       <m>0 \leq \theta \leq 2\pi</m> and <m>-\pi/2 \leq \varphi \leq \pi/2</m>.
@@ -845,10 +845,10 @@
       </statement>
       <solution>
         <p>
-          This rectangular point is the same as used in <xref ref="ex_cylindrical4">Example</xref>.
-          Using <xref ref="idea_convert_coords">Key Idea</xref>,
+          This rectangular point is the same as used in <xref ref="ex_cylindrical4"/>.
+          Using <xref ref="idea_convert_coords"/>,
           we find <m>\rho = \sqrt{2^2+(-1)^2+1^2} = 3</m>.
-          Using the same logic as in <xref ref="ex_cylindrical4">Example</xref>,
+          Using the same logic as in <xref ref="ex_cylindrical4"/>,
           we find <m>\theta = 7\pi/4</m>.
           Finally, <m>\sin(\varphi) = 1/3</m>,
           giving <m>\varphi = \sin^{-1}(1/3) \approx 0.34</m>,
@@ -901,7 +901,7 @@
         </p>
 
         <figure xml:id="fig_spherical1">
-          <caption>Graphing the canonical surfaces in spherical coordinates from <xref ref="ex_spherical1">Example</xref></caption>
+          <caption>Graphing the canonical surfaces in spherical coordinates from <xref ref="ex_spherical1"/></caption>
           <image xml:id="img_spherical1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -1009,7 +1009,7 @@
         </figure>
 
         <p>
-          All three surfaces are graphed in <xref ref="fig_spherical1">Figure</xref>.
+          All three surfaces are graphed in <xref ref="fig_spherical1"/>.
           Note how their intersection uniquely defines the point <m>P=(1,\pi/3,\pi/6)</m>.
         </p>
       </solution>
@@ -1024,7 +1024,7 @@
     </p>
 
     <p>
-      Considering <xref ref="fig_sphericalwedge">Figure</xref>,
+      Considering <xref ref="fig_sphericalwedge"/>,
       we can make a small <q>spherical wedge</q> by varying <m>\rho</m>,
       <m>\theta</m> and <m>\varphi</m> each a small amount, <m>\Delta\rho</m>,
       <m>\Delta\theta</m> and <m>\Delta\varphi</m>, respectively.
@@ -1205,7 +1205,7 @@
     </p>
     <aside>
       <p>
-        It is generally most intuitive to evaluate the triple integral in <xref ref="thm_triple_int_spherical">Theorem</xref>
+        It is generally most intuitive to evaluate the triple integral in <xref ref="thm_triple_int_spherical"/>
         by integrating with respect to <m>\rho</m> first;
         it often does not matter whether we next integrate with respect to <m>\theta</m> or <m>\varphi</m>.
         Different texts present different standard orders,
@@ -1274,10 +1274,10 @@
       <statement>
         <p>
           Find the center of mass of the solid with constant density enclosed above by <m>\rho=4</m> and below by <m>\varphi = \pi/3</m>,
-          as illustrated in <xref ref="fig_spherical3">Figure</xref>.
+          as illustrated in <xref ref="fig_spherical3"/>.
         </p>
         <figure xml:id="fig_spherical3">
-          <caption>Graphing the solid, and its center of mass, from <xref ref="ex_spherical3">Example</xref></caption>
+          <caption>Graphing the solid, and its center of mass, from <xref ref="ex_spherical3"/></caption>
           <image xml:id="img_spherical3_3D" width="47%">
             <description></description>
             <asymptote>
@@ -1404,7 +1404,7 @@
 
         <p>
           To compute <m>M_{yz}</m>, the integrand is <m>x</m>;
-          using <xref ref="idea_convert_coords">Key Idea</xref>,
+          using <xref ref="idea_convert_coords"/>,
           we have <m>x = \rho\cos(\varphi)\cos(\theta)</m>.
           This gives:
           <md>
@@ -1418,7 +1418,7 @@
 
         <p>
           To compute <m>M_{xz}</m>, the integrand is <m>y</m>;
-          using <xref ref="idea_convert_coords">Key Idea</xref>,
+          using <xref ref="idea_convert_coords"/>,
           we have <m>y = \rho\cos(\varphi)\sin(\theta)</m>.
           This gives:
           <md>
@@ -1432,7 +1432,7 @@
 
         <p>
           To compute <m>M_{xy}</m>, the integrand is <m>z</m>;
-          using <xref ref="idea_convert_coords">Key Idea</xref>,
+          using <xref ref="idea_convert_coords"/>,
           we have <m>z = \rho\sin(\varphi)</m>.
           This gives:
           <md>
@@ -1445,7 +1445,7 @@
 
         <p>
           Thus the center of mass is <m>(0,0,M_{xy}/M) \approx (0,0,2.799)</m>,
-          as indicated in <xref ref="fig_spherical3">Figure</xref>.
+          as indicated in <xref ref="fig_spherical3"/>.
         </p>
       </solution>
     </example>
@@ -2338,7 +2338,7 @@ draw(arc((0,0,0),.8*(r1*cos(t1)*sin(p2),r1*sin(t1)*sin(p2),0),.7*(r1*cos(t1)*sin
               Bounded below by the cone <m>z=\sqrt{x^2+y^2}</m> and above by the sphere <m>x^2+y^2+z^2=4</m>:
               describes a shape that is somewhat <q>diamond</q>-like;
               some think of it as looking like an ice cream cone
-              (see <xref ref="fig_spherical3">Figure</xref>).
+              (see <xref ref="fig_spherical3"/>).
               It describes a cone,
               where the side makes an angle of <m>\pi/4</m> with the <m>xy</m>-plane,
               topped by the portion of the ball of radius 2, centered at the origin.
@@ -2489,8 +2489,7 @@ draw(arc((0,0,0),.8*(r1*cos(t1)*sin(p2),r1*sin(t1)*sin(p2),0),.7*(r1*cos(t1)*sin
             In the following exercises,
             a solid is described along with its density function.
             Find the center of mass of the solid using cylindrical coordinates.
-            (Note: these are the same solids and density functions as found in <xref ref="ex_13_07_ex_23">Exercises</xref>
-            through <xref ref="ex_13_07_ex_26"></xref>.)
+            (Note: these are the same solids and density functions as found in <xref first="ex_13_07_ex_23" last="ex_13_07_ex_26" text="local">Exercises</xref>.)
           </p>
         </introduction>
 
@@ -2682,8 +2681,7 @@ draw(arc((0,0,0),.8*(r1*cos(t1)*sin(p2),r1*sin(t1)*sin(p2),0),.7*(r1*cos(t1)*sin
             In the following exercises,
             a solid is described along with its density function.
             Find the center of mass of the solid using spherical coordinates.
-            (Note: these are the same solids and density functions as found in <xref ref="ex_13_07_ex_31">Exercises</xref>
-            through <xref ref="ex_13_07_ex_34"></xref>.)
+            (Note: these are the same solids and density functions as found in <xref first="ex_13_07_ex_31" last="ex_13_07_ex_34" text="local">Exercises</xref>.)
           </p>
         </introduction>
 

--- a/ptx/sec_cylindrical_spherical_old.ptx
+++ b/ptx/sec_cylindrical_spherical_old.ptx
@@ -26,7 +26,7 @@
       given in cylindrical coordinates,
       where the <m>z</m>-value in both systems is the same,
       and the point <m>(x_0,y_0)</m> in the <m>xy</m>-plane is identified with the polar point <m>P(r_0,\theta_0)</m>;
-      see <xref ref="fig_cylindricalintro">Figure</xref>.
+      see <xref ref="fig_cylindricalintro"/>.
       So that each point in space that does not lie on the <m>z</m>-axis is defined uniquely,
       we will restrict <m>r\geq 0</m> and <m>0\leq \theta\leq 2\pi</m>.
           <idx><h>cylindrical coordinates</h></idx>
@@ -97,7 +97,7 @@
     </figure>
 
     <p>
-      We use the identity <m>z=z</m> along with the identities found in <xref ref="idea_polarconvert">Key Idea</xref>
+      We use the identity <m>z=z</m> along with the identities found in <xref ref="idea_polarconvert"/>
       to convert between the rectangular coordinate <m>(x,y,z)</m> and the cylindrical coordinate <m>(r,\theta,z)</m>, namely:
       <me>
         \begin{array}{l} \text{ From rectangular to cylindrical: }  r=\sqrt{x^2+y^2}, \tan(\theta) = y/x \text{ and }  z=z;\\
@@ -117,7 +117,7 @@
     <p>
       These identities,
       along with conversions related to spherical coordinates,
-      are given later in <xref ref="idea_convert_coords">Key Idea</xref>.
+      are given later in <xref ref="idea_convert_coords"/>.
     </p>
 
     <figure xml:id="vid-trigint-cylindrical-definition" component="video">
@@ -137,7 +137,7 @@
       <solution>
         <p>
           Following the identities given above (and,
-          later in <xref ref="idea_convert_coords">Key Idea</xref>),
+          later in <xref ref="idea_convert_coords"/>),
           we have <m>r = \sqrt{2^2+(-2)^2} = 2\sqrt{2}</m>.
           Using <m>\tan(\theta) = y/x</m>,
           we find <m>\theta = \tan^{-1}(-2/2) =-\pi/4</m>.
@@ -176,7 +176,7 @@
           The equation <m>r=1</m> describes all points in space that are 1 unit away from the <m>z</m>-axis.
           This surface is a <q>tube</q> or <q>cylinder</q>
           of radius 1, centered on the <m>z</m>-axis,
-          as graphed in <xref ref="fig_spacecylinder1">Figure</xref>
+          as graphed in <xref ref="fig_spacecylinder1"/>
           (which describes the cylinder <m>x^2+y^2=1</m> in space).
         </p>
 
@@ -192,7 +192,7 @@
         </p>
 
         <figure xml:id="fig_cylindrical1">
-          <caption>Graphing the canonical surfaces in cylindrical coordinates from <xref ref="ex_cylindrical1">Example</xref></caption>
+          <caption>Graphing the canonical surfaces in cylindrical coordinates from <xref ref="ex_cylindrical1"/></caption>
           <image xml:id="img_cylindrical1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -297,7 +297,7 @@
         </figure>
 
         <p>
-          All three surfaces are graphed in <xref ref="fig_cylindrical1">Figure</xref>.
+          All three surfaces are graphed in <xref ref="fig_cylindrical1"/>.
           Note how their intersection uniquely defines the point <m>P=(1,\pi/3,2)</m>.
         </p>
       </solution>
@@ -309,7 +309,7 @@
     </p>
 
     <p>
-      <xref ref="thm_triple_integration2">Theorem</xref>
+      <xref ref="thm_triple_integration2"/>
       shows how to evaluate <m>\iiint_Dh(x,y,z)\, dV</m> using rectangular coordinates.
       In that evaluation, we use <m>dV = dz\,dy\,dx</m>
       (or one of the other five orders of integration).
@@ -317,7 +317,7 @@
       the bounds on <m>y</m> are <q>curve to curve</q>
       and the bounds on <m>x</m> are <q>point to point</q>:
       these bounds describe a region <m>R</m> in the <m>xy</m>-plane.
-      We could describe <m>R</m> using polar coordinates as done in <xref ref="sec_double_int_polar">Section</xref>.
+      We could describe <m>R</m> using polar coordinates as done in <xref ref="sec_double_int_polar"/>.
       In that section, we saw how we used
       <m>dA = r\,dr\,d\theta</m> instead of <m>dA = dy\,dx</m>.
     </p>
@@ -366,13 +366,13 @@
         <p>
           Find the mass of the solid represented by the region in space bounded by <m>z=0</m>,
           <m>z=\sqrt{4-x^2-y^2}+3</m> and the cylinder <m>x^2+y^2=4</m>
-          (as shown in <xref ref="fig_cylindrical2">Figure</xref>),
+          (as shown in <xref ref="fig_cylindrical2"/>),
           with density function <m>\delta(x,y,z) = x^2+y^2+z+1</m>,
           using a triple integral in cylindrical coordinates.
           Distances are measured in centimeters and density is measured in grams per cubic centimeter.
         </p>
         <figure xml:id="fig_cylindrical2">
-          <caption>Visualizing the solid used in <xref ref="ex_cylindrical2">Example</xref></caption>
+          <caption>Visualizing the solid used in <xref ref="ex_cylindrical2"/></caption>
           <image xml:id="img_cylindrical2_3D" width="47%">
             <description></description>
             <asymptote>
@@ -461,8 +461,8 @@
         </p>
 
         <p>
-          Using <xref ref="def_mass_3d">Definition</xref>
-          and <xref ref="thm_triple_int_cylindrical">Theorem</xref>,
+          Using <xref ref="def_mass_3d"/>
+          and <xref ref="thm_triple_int_cylindrical"/>,
           we have the mass of the solid is
           <md>
             <mrow>M=\iiint_D\delta(x,y,z)\, dV \amp = \int_0^{2\pi}\int_0^2\int_0^{\sqrt{4-r^2}+3}\big(r^2+z+1\big)r\,dz\,dr\,d\theta</mrow>
@@ -481,11 +481,11 @@
           Find the center of mass of the solid with constant density whose base can be described by the polar curve
           <m>r=\cos(3\theta)</m> and whose top is defined by the plane <m>z=1-x+0.1y</m>,
           where distances are measured in feet,
-          as seen in <xref ref="fig_cylindrical3">Figure</xref>.
-          (The volume of this solid was found in <xref ref="ex_doublepol4">Example</xref>.)
+          as seen in <xref ref="fig_cylindrical3"/>.
+          (The volume of this solid was found in <xref ref="ex_doublepol4"/>.)
         </p>
         <figure xml:id="fig_cylindrical3">
-          <caption>Visualizing the solid used in <xref ref="ex_cylindrical3">Example</xref></caption>
+          <caption>Visualizing the solid used in <xref ref="ex_cylindrical3"/></caption>
           <image xml:id="img_doublepol4_3D" width="47%">
             <description></description>
             <asymptote>
@@ -577,14 +577,14 @@
           Since density is constant,
           we set <m>\delta = 1</m> and finding the mass is equivalent to finding the volume of the solid.
           We set up the triple integral to compute this but do not evaluate it;
-          we leave it to the reader to confirm it evaluates to the same result found in <xref ref="ex_doublepol4">Example</xref>.
+          we leave it to the reader to confirm it evaluates to the same result found in <xref ref="ex_doublepol4"/>.
           <me>
             M = \iiint_D\delta \, dV = \int_0^{\pi}\int_0^{\cos(3\theta)}\int_0^{1-r\cos(\theta)+0.1r\sin(\theta)} r\,dz\,dr\,d\theta \approx 0.785
           </me>.
         </p>
 
         <p>
-          From <xref ref="def_mass_3d">Definition</xref>
+          From <xref ref="def_mass_3d"/>
           we set up the triple integrals to compute the moments about the three coordinate planes.
           The computation of each is left to the reader (using technology is recommended):
           <md>
@@ -624,7 +624,7 @@
       where <m>\rho</m> is the distance from the origin to <m>P</m>,
       <m>\theta</m> is the same angle as would be used to describe <m>P</m> in the cylindrical coordinate system,
       and <m>\varphi</m> is the angle between the positive <m>z</m>-axis and the ray from the origin to <m>P</m>;
-      see <xref ref="fig_sphericalintro">Figure</xref>.
+      see <xref ref="fig_sphericalintro"/>.
       So that each point in space that does not lie on the <m>z</m>-axis is defined uniquely,
       we will restrict <m>\rho \geq 0</m>,
       <m>0 \leq \theta \leq 2\pi</m> and <m>0 \leq \varphi \leq \pi</m>.
@@ -756,10 +756,10 @@
       </statement>
       <solution>
         <p>
-          This rectangular point is the same as used in <xref ref="ex_cylindrical4">Example</xref>.
-          Using <xref ref="idea_convert_coords">Key Idea</xref>,
+          This rectangular point is the same as used in <xref ref="ex_cylindrical4"/>.
+          Using <xref ref="idea_convert_coords"/>,
           we find <m>\rho = \sqrt{2^2+(-1)^2+1^2} = 3</m>.
-          Using the same logic as in <xref ref="ex_cylindrical4">Example</xref>,
+          Using the same logic as in <xref ref="ex_cylindrical4"/>,
           we find <m>\theta = 7\pi/4</m>.
           Finally, <m>\cos(\varphi) = 1/3</m>,
           giving <m>\varphi = \cos^{-1}(1/3) \approx 1.23</m>,
@@ -811,7 +811,7 @@
         </p>
 
         <figure xml:id="fig_spherical1">
-          <caption>Graphing the canonical surfaces in spherical coordinates from <xref ref="ex_spherical1">Example</xref></caption>
+          <caption>Graphing the canonical surfaces in spherical coordinates from <xref ref="ex_spherical1"/></caption>
           <image xml:id="img_spherical1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -919,7 +919,7 @@
         </figure>
 
         <p>
-          All three surfaces are graphed in <xref ref="fig_spherical1">Figure</xref>.
+          All three surfaces are graphed in <xref ref="fig_spherical1"/>.
           Note how their intersection uniquely defines the point <m>P=(1,\pi/3,\pi/6)</m>.
         </p>
       </solution>
@@ -934,7 +934,7 @@
     </p>
 
     <p>
-      Considering <xref ref="fig_sphericalwedge">Figure</xref>,
+      Considering <xref ref="fig_sphericalwedge"/>,
       we can make a small <q>spherical wedge</q> by varying <m>\rho</m>,
       <m>\theta</m> and <m>\varphi</m> each a small amount, <m>\Delta\rho</m>,
       <m>\Delta\theta</m> and <m>\Delta\varphi</m>, respectively.
@@ -1115,7 +1115,7 @@
     </p>
     <aside>
       <p>
-        It is generally most intuitive to evaluate the triple integral in <xref ref="thm_triple_int_spherical">Theorem</xref>
+        It is generally most intuitive to evaluate the triple integral in <xref ref="thm_triple_int_spherical"/>
         by integrating with respect to <m>\rho</m> first;
         it often does not matter whether we next integrate with respect to <m>\theta</m> or <m>\varphi</m>.
         Different texts present different standard orders,
@@ -1184,10 +1184,10 @@
       <statement>
         <p>
           Find the center of mass of the solid with constant density enclosed above by <m>\rho=4</m> and below by <m>\varphi = \pi/6</m>,
-          as illustrated in <xref ref="fig_spherical3">Figure</xref>.
+          as illustrated in <xref ref="fig_spherical3"/>.
         </p>
         <figure xml:id="fig_spherical3">
-          <caption>Graphing the solid, and its center of mass, from <xref ref="ex_spherical3">Example</xref></caption>
+          <caption>Graphing the solid, and its center of mass, from <xref ref="ex_spherical3"/></caption>
           <image xml:id="img_spherical3_3D" width="47%">
             <description></description>
             <asymptote>
@@ -1314,7 +1314,7 @@
 
         <p>
           To compute <m>M_{yz}</m>, the integrand is <m>x</m>;
-          using <xref ref="idea_convert_coords">Key Idea</xref>,
+          using <xref ref="idea_convert_coords"/>,
           we have <m>x = \rho\sin(\varphi)\cos(\theta)</m>.
           This gives:
           <md>
@@ -1328,7 +1328,7 @@
 
         <p>
           To compute <m>M_{xz}</m>, the integrand is <m>y</m>;
-          using <xref ref="idea_convert_coords">Key Idea</xref>,
+          using <xref ref="idea_convert_coords"/>,
           we have <m>y = \rho\sin(\varphi)\sin(\theta)</m>.
           This gives:
           <md>
@@ -1342,7 +1342,7 @@
 
         <p>
           To compute <m>M_{xy}</m>, the integrand is <m>z</m>;
-          using <xref ref="idea_convert_coords">Key Idea</xref>,
+          using <xref ref="idea_convert_coords"/>,
           we have <m>z = \rho\cos(\varphi)</m>.
           This gives:
           <md>
@@ -1355,7 +1355,7 @@
 
         <p>
           Thus the center of mass is <m>(0,0,M_{xy}/M) \approx (0,0,2.799)</m>,
-          as indicated in <xref ref="fig_spherical3">Figure</xref>.
+          as indicated in <xref ref="fig_spherical3"/>.
         </p>
       </solution>
     </example>
@@ -2261,7 +2261,7 @@
               Bounded below by the cone <m>z=\sqrt{x^2+y^2}</m> and above by the sphere <m>x^2+y^2+z^2=4</m>:
               describes a shape that is somewhat <q>diamond</q>-like;
               some think of it as looking like an ice cream cone
-              (see <xref ref="fig_spherical3">Figure</xref>).
+              (see <xref ref="fig_spherical3"/>).
               It describes a cone,
               where the side makes an angle of <m>\pi/4</m> with the positive <m>z</m>-axis,
               topped by the portion of the ball of radius 2, centered at the origin.
@@ -2412,8 +2412,7 @@
             In the following exercises,
             a solid is described along with its density function.
             Find the center of mass of the solid using cylindrical coordinates.
-            (Note: these are the same solids and density functions as found in <xref ref="ex_13_07_ex_23">Exercises</xref>
-            through <xref ref="ex_13_07_ex_26"></xref>.)
+            (Note: these are the same solids and density functions as found in <xref first="ex_13_07_ex_23" last="ex_13_07_ex_26" text="local">Exercises</xref>.)
           </p>
         </introduction>
 
@@ -2605,8 +2604,7 @@
             In the following exercises,
             a solid is described along with its density function.
             Find the center of mass of the solid using spherical coordinates.
-            (Note: these are the same solids and density functions as found in <xref ref="ex_13_07_ex_31">Exercises</xref>
-            through <xref ref="ex_13_07_ex_34"></xref>.)
+            (Note: these are the same solids and density functions as found in <xref first="ex_13_07_ex_31" last="ex_13_07_ex_34" text="local">Exercises</xref>.)
           </p>
         </introduction>
 

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -29,7 +29,7 @@
   <p>
     It is interesting to note that this solution of 50 feet can be represented
     graphically.
-    Consider <xref ref="fig_defint1">Figure</xref>,
+    Consider <xref ref="fig_defint1"/>,
     where the constant velocity of
     <quantity><mag>5</mag><unit base="foot"/><per base="second"/></quantity>
     is graphed on the axes.
@@ -105,7 +105,7 @@
 
   <p>
     We can again depict this situation graphically.
-    In <xref ref="fig_defint2">Figure</xref>
+    In <xref ref="fig_defint2"/>
     we have the velocities graphed as straight lines on <m>[0,10]</m> and
     <m>[10,14]</m>,
     respectively.
@@ -276,7 +276,7 @@
       </p>
 
       <p>
-        <xref ref="fig_defint3">Figure</xref>
+        <xref ref="fig_defint3"/>
         shows a graph of <m>v(t)</m> on axes from <m>t=0</m> to <m>t=3</m>.
         It is again straightforward to find <m>v(0)</m>.
         How can we use the graph to find the maximum height of the object?
@@ -380,7 +380,7 @@
     The above example does not <em>prove</em>
     a relationship between area under a velocity function and displacement,
     but it does imply a relationship exists.
-    <xref ref="sec_FTC">Section</xref>
+    <xref ref="sec_FTC"/>
     will fully establish fact that the area under a velocity function is
     displacement.
   </p>
@@ -447,7 +447,7 @@
     which relates to areas under a function.
     The two are very much related,
     as we'll see when we learn the Fundamental Theorem of Calculus in
-    <xref ref="sec_FTC">Section</xref>.
+    <xref ref="sec_FTC"/>.
     Recall that earlier we said that the
     <q><m>\int</m></q> symbol was an <q>elongated S</q>
     that represented finding a <q>sum.</q>
@@ -464,11 +464,11 @@
     <title>Evaluating definite integrals</title>
     <statement>
       <p>
-        Consider the function <m>f</m> given in <xref ref="fig_defint4">Figure</xref>.
+        Consider the function <m>f</m> given in <xref ref="fig_defint4"/>.
       </p>
 
       <figure xml:id="fig_defint4">
-        <caption>A graph of <m>f(x)</m> in <xref ref="ex_defint4">Example</xref></caption>
+        <caption>A graph of <m>f(x)</m> in <xref ref="ex_defint4"/></caption>
         <image xml:id="img_defint4" width="47%">
           <shortdescription>
           The graph of f(x) that shows the areas it forms with the x axis.
@@ -558,7 +558,7 @@
           <li>
             <p>
               <m>\int_0^35f(x)\, dx</m> is the area under <m>5f</m> on <m>[0,3]</m>.
-              This is sketched in <xref ref="fig_defint4a">Figure</xref>.
+              This is sketched in <xref ref="fig_defint4a"/>.
               Again, the region is a triangle,
               with height 5 times that of the height of the original triangle.
               Thus the area is <m>\int_0^35f(x)\, dx = \frac12(15)(1) = 7.5</m>.
@@ -577,8 +577,8 @@
         </ol>
       </p>
       <figure xml:id="fig_defint4a">
-      <caption>A graph of <m>5f</m> in <xref ref="ex_defint4">Example</xref>.
-      (Yes, it looks just like the graph of <m>f</m> in <xref ref="fig_defint4">Figure</xref>, just with a different <m>y</m>-scale.)</caption>
+      <caption>A graph of <m>5f</m> in <xref ref="ex_defint4"/>.
+      (Yes, it looks just like the graph of <m>f</m> in <xref ref="fig_defint4"/>, just with a different <m>y</m>-scale.)</caption>
       <image xml:id="img_defint4a" width="47%">
         <shortdescription>
           The graph of f(x) that shows the areas it forms with the x axis.
@@ -652,7 +652,7 @@
 
 
   <p>
-    We give a brief justification of <xref ref="thm_defintprop">Theorem</xref> here.
+    We give a brief justification of <xref ref="thm_defintprop"/> here.
   </p>
 
   <p>
@@ -660,7 +660,7 @@
       <li>
         <title>1.</title>
         <p>
-          As demonstrated in <xref ref="ex_defint4">Example</xref>,
+          As demonstrated in <xref ref="ex_defint4"/>,
           there is no <q>area under the curve</q>
           when the region has no width;
           hence this definite integral is 0.
@@ -731,15 +731,15 @@
   </p>
 
   <example xml:id="ex_defint5">
-    <title>Evaluating definite integrals using <xref ref="thm_defintprop">Theorem</xref></title>
+    <title>Evaluating definite integrals using <xref ref="thm_defintprop"/></title>
     <statement>
       <p>
         Consider the graph of a function <m>f(x)</m> shown in
-        <xref ref="fig_defint5">Figure</xref>.
+        <xref ref="fig_defint5"/>.
       </p>
 
       <figure xml:id="fig_defint5">
-        <caption>A graph of a function in <xref ref="ex_defint5">Example</xref></caption>
+        <caption>A graph of a function in <xref ref="ex_defint5"/></caption>
         <image xml:id="img_defint5" width="47%">         
         <shortdescription>
         The graph of function in this example.
@@ -864,7 +864,7 @@
           <li>
             <p>
               It is useful to sketch the function in the integrand,
-              as shown in <xref ref="fig_defint8a">Figure</xref>.
+              as shown in <xref ref="fig_defint8a"/>.
               We see we need to compute the areas of two regions,
               which we have labeled <m>R_1</m> and <m>R_2</m>.
               Both are triangles, so the area computation is straightforward:
@@ -885,7 +885,7 @@
             <p>
               Recognize that the integrand of this definite integral describes
               a half circle,
-              as sketched in <xref ref="fig_defint8b">Figure</xref>,
+              as sketched in <xref ref="fig_defint8b"/>,
               with radius 3.
               Thus the area is:
               <me>
@@ -976,7 +976,7 @@
       <p>
         Consider the graph of a velocity function of an object moving in a
         straight line,
-        given in <xref ref="fig_defint6">Figure</xref>,
+        given in <xref ref="fig_defint6"/>,
         where the numbers in the given regions gives the area of that region.
         Assume that the definite integral of a velocity function gives displacement.
         Find the maximum speed of the object and its maximum displacement from
@@ -984,7 +984,7 @@
       </p>
 
       <figure xml:id="fig_defint6">
-        <caption>A graph of a velocity in <xref ref="ex_defint6">Example</xref></caption>
+        <caption>A graph of a velocity in <xref ref="ex_defint6"/></caption>
         <image xml:id="img_defint6" width="47%">
           <shortdescription>
             The graph of velocity for this example.
@@ -1065,7 +1065,7 @@
     we have either found the areas of regions that have nice geometric shapes
     (such as rectangles, triangles and circles)
     or the areas were given to us.
-    Consider <xref ref="fig_defint7">Figure</xref>,
+    Consider <xref ref="fig_defint7"/>,
     where a region below <m>y=x^2</m> is shaded.
     What is its area?
     The function <m>y=x^2</m> is relatively simple,
@@ -1106,7 +1106,7 @@
   </figure>
 
   <p>
-    In <xref ref="sec_riemann">Section</xref>
+    In <xref ref="sec_riemann"/>
     we will explore how to find the areas of such regions.
   </p>
 

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -698,7 +698,7 @@
           </men>.
           How do Equations <xref ref="eq_defint1"/> and <xref ref="eq_defint2"/>
           relate?
-          Start with Equation <xref ref="eq_defint1"/>:
+          Start with <xref ref="eq_defint1">Equation</xref>:
           <md>
             <mrow>\int_b^a f(x)\, dx + \int_a^c f(x)\, dx \amp = \int_b^c f(x)\, dx</mrow>
             <mrow>\int_a^c f(x)\, dx \amp = -\int_b^a f(x)\, dx + \int_b^c f(x)\, dx</mrow>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -222,7 +222,7 @@
             </li>
             <li>
               <p>
-                See <xref ref="fig_xcubedwithderiv">Figure</xref>.
+                See <xref ref="fig_xcubedwithderiv"/>.
               </p>
             </li>
           </ol>
@@ -277,7 +277,7 @@
     </example>
 
     <p>
-      <xref ref="thm_deriv_common">Theorem</xref> gives useful information,
+      <xref ref="thm_deriv_common"/> gives useful information,
       but we will need much more.
       For instance, using the theorem,
       we can easily find the derivative of <m>y=x^3</m>,
@@ -345,10 +345,10 @@
 
 
     <p>
-      <xref ref="thm_deriv_prop">Theorem</xref>
+      <xref ref="thm_deriv_prop"/>
       allows us to find the derivatives of a wide variety of functions.
       It can be used in conjunction with the <xref ref="power-derivative-rule" text="title"/> to find the derivatives of any polynomial.
-      Recall in <xref ref="ex_deriv1">Example</xref> that we found,
+      Recall in <xref ref="ex_deriv1"/> that we found,
       using the limit definition, the derivative of <m>f(x) = 3x^2+5x-7</m>.
       We can now find its derivative without expressly using limits:
       <md>
@@ -402,7 +402,7 @@
         </p>
 
         <p>
-          Using <xref ref="thm_deriv_common">Theorem</xref>
+          Using <xref ref="thm_deriv_common"/>
           we find <m>\fp(x) = \cos(x) + 2</m>.
           The slope of the tangent line is thus <m>\fp(\pi) = \cos(\pi) + 2 =1</m>.
           Also, <m>f(\pi) = 2\pi+1 \approx 7.28</m>.
@@ -431,9 +431,9 @@
         </p>
 
         <p>
-          The graphs in <xref ref="fig_sintangapprox">Figure</xref>
+          The graphs in <xref ref="fig_sintangapprox"/>
           shows the graph of the function <m>f(x)</m> along with the tangent line constructed at <m>x=\pi</m>.
-          The graph in <xref ref="fig_sintangapprox">Figure</xref>
+          The graph in <xref ref="fig_sintangapprox"/>
           shows the same tangent line and function.
           Once zoomed in,
           you can barely distinguish the tangent line from the function.
@@ -585,7 +585,7 @@
     <aside xml:id="aside-derivative-second-order-caveat">
       <title>Higher Order Derivative Caveat</title>
       <p>
-        <xref ref="def_Higher_Deriv">Definition</xref>
+        <xref ref="def_Higher_Deriv"/>
         comes with the caveat <q>Where the corresponding limits exist.</q>
         With <m>f</m> differentiable on <m>I</m>,
         it is possible that <m>\fp</m> is <em>not</em>
@@ -640,7 +640,7 @@
             </li>
             <li>
               <p>
-                We employ <xref ref="thm_deriv_common">Theorem</xref> repeatedly.
+                We employ <xref ref="thm_deriv_common"/> repeatedly.
                 <md>
                   <mrow>\fp(x)\amp=\cos(x)\amp \fp''(x)\amp= -\cos(x)</mrow>
                   <mrow>\fp'(x)\amp= -\sin(x)\amp f^{(4)}(x)\amp = \sin(x)</mrow>
@@ -650,7 +650,7 @@
             </li>
             <li>
               <p>
-                Employing <xref ref="thm_deriv_common">Theorem</xref>
+                Employing <xref ref="thm_deriv_common"/>
                 and the Constant Multiple Rule, we can see that
                 <me>
                   \fp(x) = \fp'(x) = \fp''(x) = f^{(4)}(x) = 5e^x
@@ -688,7 +688,7 @@
 
     <p>
       One way to grasp this concept is to let <m>f</m> describe a position function.
-      Then, as stated in <xref ref="idea_motion">Key Idea</xref>,
+      Then, as stated in <xref ref="idea_motion"/>,
       <m>\fp</m> describes the rate of position change: velocity.
       We now consider <m>\fp'</m>, which describes the rate of velocity change.
       Sports car enthusiasts talk of how fast a car can go from <m>0</m> to
@@ -845,7 +845,7 @@
           </pg-code>
           <statement>
             <p>
-              The derivative rules introduced in <xref ref="sec_basic_diff_rules">Section</xref>
+              The derivative rules introduced in <xref ref="sec_basic_diff_rules"/>
               explain how to compute the derivative of which of the following functions?
             </p>
             <p>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -33,7 +33,7 @@
     However, this is not the case;
     <m>\fp(x)\neq -\sin(2x)</m>.
     One way to see this is to examine the graph of
-    <m>y=\cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="fig_chain">Figure</xref>
+    <m>y=\cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="fig_chain"/>
     and its tangent line at <m>x=\pi/2</m>.
     Clearly the slope of the tangent line there is nonzero,
     but <m>-2\sin(2\cdot\pi/2)=0</m>.
@@ -73,7 +73,7 @@
   </figure>
 
   <p>
-    In <xref ref="ex_chain7">Example</xref>
+    In <xref ref="ex_chain7"/>
     we'll see the correct way to compute the derivative of <m>\sin\mathopen{}\left(x^2\right)\mathclose{}</m>,
     which employs the new rule this section introduces, the <em>Chain Rule</em>.
   </p>
@@ -165,7 +165,7 @@
     </p>
 
     <p>
-      The statement of <xref ref="thm_chain_rule">Theorem</xref> takes care to ensure
+      The statement of <xref ref="thm_chain_rule"/> takes care to ensure
       this problem does not arise, but our focus is more on the derivative result than
       on the domain/range conditions.
     </p>
@@ -208,7 +208,7 @@
 
   <p>
     To help understand the Chain Rule,
-    we return to <xref ref="ex_chain1">Example</xref>.
+    we return to <xref ref="ex_chain1"/>.
   </p>
 
   <example xml:id="ex_chain2">
@@ -217,12 +217,12 @@
       <p>
         Use the Chain Rule to find the derivatives of the functions <m>F_1(x)</m>,
         <m>F_2(x)</m>, and <m>F_3(x)</m>,
-        as given in <xref ref="ex_chain1">Example</xref>.
+        as given in <xref ref="ex_chain1"/>.
       </p>
     </statement>
     <solution>
       <p>
-        <xref ref="ex_chain1">Example</xref>
+        <xref ref="ex_chain1"/>
         ended with the recognition that each of the given functions was actually a composition of functions.
         To avoid confusion, we ignore most of the subscripts here.
       </p>
@@ -292,7 +292,7 @@
   </example>
 
   <p>
-    <xref ref="ex_chain2">Example</xref>
+    <xref ref="ex_chain2"/>
     demonstrated a particular pattern:
     when <m>f(x)=x^n</m>, then <m>y' =n\cdot (g(x))^{n-1}\cdot g'(x)</m>.
     This is called the Generalized Power Rule.
@@ -438,7 +438,7 @@
       </p>
 
       <p>
-        The tangent line is sketched along with <m>f</m> in <xref ref="fig_chain7">Figure</xref>.
+        The tangent line is sketched along with <m>f</m> in <xref ref="fig_chain7"/>.
       </p>
 
       <figure xml:id="fig_chain7">
@@ -788,7 +788,7 @@
       notation instead of <m>y'</m> notation.
       Suppose that <m>y=f(u)</m> is a function of <m>u</m>,
       where <m>u=g(x)</m> is a function of <m>x</m>,
-      as stated in <xref ref="thm_chain_rule">Theorem</xref>.
+      as stated in <xref ref="thm_chain_rule"/>.
       Then, through the composition <m>f \circ g</m>,
       we can think of <m>y</m> as a function of <m>x</m>, as <m>y=f(g(x))</m>.
       Thus the derivative of <m>y</m> with respect to <m>x</m> makes sense;
@@ -827,7 +827,7 @@
     <p>
       One of the most common ways of <q>visualizing</q>
       the <xref ref="thm_chain_rule" text="title"/> is to consider a set of gears,
-      as shown in <xref ref="fig_chainrulegears">Figure</xref>.
+      as shown in <xref ref="fig_chainrulegears"/>.
       The gears have <m>36</m>, <m>18</m>,
       and <m>6</m> teeth, respectively.
       That means for every revolution of the <m>x</m> gear,
@@ -932,13 +932,13 @@
     </p>
 
     <p>
-      In <xref ref="sec_imp_deriv">Section</xref>,
+      In <xref ref="sec_imp_deriv"/>,
       we use the <xref ref="thm_chain_rule" text="title"/> to justify another differentiation technique.
       There are many curves that we can draw in the plane that fail the
       <q>vertical line test.</q> For instance,
       consider <m>x^2+y^2=1</m>, which describes the unit circle.
       We may still be interested in finding slopes of tangent lines to the circle at various points.
-      <xref ref="sec_imp_deriv">Section</xref>
+      <xref ref="sec_imp_deriv"/>
       shows how we can find <m>\lz{y}{x}</m> without first
       <q>solving for <m>y</m>.</q>
       While we can in this instance,
@@ -1742,8 +1742,7 @@
         <introduction>
           <p>
             Find the equations of tangent and normal lines to the graph of the function at the given point.
-            Note: the functions here are the same as in <xref ref="exer_02_05_06">Exercises</xref>
-            through <xref ref="exer_02_05_09"/>.
+            Note: the functions here are the same as in <xref first="exer_02_05_06" last="exer_02_05_09" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -36,7 +36,7 @@
       Sometimes the <em>implicit</em>
       relationship between <m>x</m> and <m>y</m> is complicated.
       Suppose we are given <m>\sin(y)+y^3=6-x^3</m>.
-      A graph of this implicit relationship is given in <xref ref="fig_implicit1">Figure</xref>.
+      A graph of this implicit relationship is given in <xref ref="fig_implicit1"/>.
       In this case there is absolutely no way to solve for <m>y</m> in terms of elementary functions.
       The surprising thing is, however,
       that we can still find <m>y'</m> via a process known as
@@ -144,7 +144,7 @@
         <p>
           The left hand side requires more consideration.
           We take the derivative term-by-term.
-          Using the technique derived from <xref ref="eq_implicit1">Equation</xref> above,
+          Using the technique derived from <xref ref="eq_implicit1"/> above,
           we can see that
           <me>
             \lzoo{x}{\sin(y)} = \cos(y) \cdot y'
@@ -219,7 +219,7 @@
       <solution>
 
         <p>
-          In <xref ref="ex_implicit1">Example</xref> we found that
+          In <xref ref="ex_implicit1"/> we found that
           <me>
             y' = \frac{-3x^2}{\cos(y) +3y^2}
           </me>.
@@ -243,7 +243,7 @@
         </p>
 
         <p>
-          The curve and this tangent line are shown in <xref ref="fig_implicit2">Figure</xref>.
+          The curve and this tangent line are shown in <xref ref="fig_implicit2"/>.
         </p>
 
         <figure xml:id="fig_implicit2">
@@ -255,7 +255,7 @@
             </shortdescription>
             <description>
               <p>
-                The same curve as <xref ref="fig_implicit1">Figure</xref>, but with a tangent line drawn at
+                The same curve as <xref ref="fig_implicit1"/>, but with a tangent line drawn at
                 <m>x=\sqrt[3]{6}</m>. The tangent line is pointing sharply downward.
               </p>
             </description>
@@ -291,7 +291,7 @@
             Treat the <m>x</m> terms like normal.
             When taking the derivatives of <m>y</m> terms,
             the usual rules apply except that,
-            because of the <xref ref="thm_chain_rule">Chain Rule</xref>,
+            because of the <xref ref="thm_chain_rule"/>,
             we need to multiply each term by <m>y'</m>.
           </p>
         </li>
@@ -373,7 +373,7 @@
           It is easy to confirm that the point <m>(0,1)</m> lies on the graph of this function.
           At this point, <m>y' = 2/3</m>.
           So the equation of the tangent line is <m>y = 2/3(x-0)+1</m>.
-          The function and its tangent line are graphed in <xref ref="fig_implicit4">Figure</xref>.
+          The function and its tangent line are graphed in <xref ref="fig_implicit4"/>.
         </p>
 
         <figure xml:id="fig_implicit4">
@@ -486,7 +486,7 @@
         </p>
 
         <p>
-          A graph of this implicit function is given in <xref ref="fig_implicit5">Figure</xref>.
+          A graph of this implicit function is given in <xref ref="fig_implicit5"/>.
         </p>
 
         <figure xml:id="fig_implicit5">
@@ -537,7 +537,7 @@
             <li>At <m>(0,-1)</m>, the slope is also <m>1/2</m>.</li>
           </ul>
 
-          The tangent lines have been added to the graph of the function in <xref ref="fig_implicit6">Figure</xref>.
+          The tangent lines have been added to the graph of the function in <xref ref="fig_implicit6"/>.
         </p>
 
         <figure xml:id="fig_implicit6">
@@ -549,7 +549,7 @@
             </shortdescription>
             <description>
               <p>
-                The graph in <xref ref="fig_implicit5">Figure</xref>, with tagent lines drawn at <m>(0,-1)</m>, <m>(0,0)</m>, and <m>(0,1)</m>.
+                The graph in <xref ref="fig_implicit5"/>, with tagent lines drawn at <m>(0,-1)</m>, <m>(0,0)</m>, and <m>(0,1)</m>.
                 The tangent line at <m>(0,-1)</m> has a positive slope less than 1.
                 The tangent line at <m>(0,0)</m> has a negative slope, close to -1.
                 The tangent line at <m>(0,1)</m> has a positive slope, less than 1.
@@ -616,7 +616,7 @@
 
         <p>
           A graph of the circle and its tangent line at
-          <m>\left(1/2,\sqrt{3}/2\right)</m> is given in <xref ref="fig_implicit7">Figure</xref>,
+          <m>\left(1/2,\sqrt{3}/2\right)</m> is given in <xref ref="fig_implicit7"/>,
           along with a thin dashed line from the origin that is perpendicular to the tangent line.
           (It turns out that all normal lines to a circle pass through the center of the circle.)
         </p>
@@ -756,7 +756,7 @@
         <p>
           This is a particularly interesting curve called an <term>astroid</term>.
           It is the shape traced out by a point on the edge of a circle that is rolling around inside of a larger circle,
-          as shown in <xref ref="fig_implicit9">Figure</xref>.
+          as shown in <xref ref="fig_implicit9"/>.
         </p>
 
         <figure xml:id="fig_implicit9">
@@ -808,7 +808,7 @@
           Plugging in <m>x=8</m> and <m>y=8</m>,
           we get a slope of <m>-1</m>.
           The astroid, with its tangent line at <m>(8,8)</m>,
-          is shown in <xref ref="fig_implicit8">Figure</xref>.
+          is shown in <xref ref="fig_implicit8"/>.
         </p>
 
         <figure xml:id="fig_implicit8">
@@ -820,7 +820,7 @@
             </shortdescription>
             <description>
               <p>
-                The curve sketched in <xref ref="fig_implicit9">Figure</xref> with a tangent line at <m>(8,8)</m>.
+                The curve sketched in <xref ref="fig_implicit9"/> with a tangent line at <m>(8,8)</m>.
                 It has a slope of -1.
               </p>
             </description>
@@ -869,7 +869,7 @@
       <solution>
 
         <p>
-          We found that <m>y' = \lz{y}{x} = -x/y</m> in <xref ref="ex_implicit7">Example</xref>.
+          We found that <m>y' = \lz{y}{x} = -x/y</m> in <xref ref="ex_implicit7"/>.
           To find <m>y''</m>, we apply implicit differentiation to <m>y'</m>.
           <md>
             <mrow>y'' \amp = \lzoo{x}{y'}</mrow>
@@ -883,7 +883,7 @@
         <p>
           While this is not a particularly simple expression, it is usable.
           We can see that <m>y'' \gt 0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y \gt 0</m>.
-          In <xref ref="sec_concavity">Section</xref>,
+          In <xref ref="sec_concavity"/>,
           we will see how this relates to the shape of the graph.
         </p>
 
@@ -905,7 +905,7 @@
     <title>Logarithmic Differentiation</title>
     <p>
       Consider the function <m>y=x^x</m>;
-      it is graphed in <xref ref="fig_logdiffa">Figure</xref>.
+      it is graphed in <xref ref="fig_logdiffa"/>.
       It is well-defined for <m>x \gt 0</m> and we might be interested in finding equations of lines tangent and normal to its graph.
       How do we take its derivative?
 
@@ -1017,7 +1017,7 @@
 
         <p>
           Thus the equation of the tangent line is (approximately) <m>y \approx 2.582(x-1.5)+1.837</m>.
-          <xref ref="fig_implicit10">Figure</xref>
+          <xref ref="fig_implicit10"/>
           graphs <m>y=x^x</m> along with this tangent line.
         </p>
 
@@ -1030,7 +1030,7 @@
             </shortdescription>
             <description>
               <p>
-                The graph shown in <xref ref="fig_logdiffa">Figure</xref>, with a tangent line at
+                The graph shown in <xref ref="fig_logdiffa"/>, with a tangent line at
                 <m>(1.5,1.5^{1.5})</m>. It has a slope of around 2.6.
               </p>
             </description>
@@ -1070,7 +1070,7 @@
       In particular,
       it extended the <xref ref="thm_finalpower" text="title"/> to rational exponents,
       which we then extended to all real numbers.
-      In <xref ref="sec_deriv_inverse_function">Section</xref>,
+      In <xref ref="sec_deriv_inverse_function"/>,
       implicit differentiation will be used to find the derivatives of
       <term>inverse</term> functions,
       such as <m>y=\sin^{-1}(x)</m>.
@@ -2279,7 +2279,7 @@
           <p>
             An implicitly defined function is given.
             Find <m>\lzn{2}{y}{x}</m>.
-            Note: these are the same functions used in Exercises <xref ref="exer_02_06_ex_09" text="global"/> through <xref ref="exer_02_06_ex_12" text="global"/>.
+            Note: these are the same functions used in Exercises <xref ref="exer_02_06_ex_09" text="local"/> through <xref ref="exer_02_06_ex_12" text="local"/>.
           </p>
         </introduction>
         <exercise label="ex-deriv-implicit-second-1">

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -144,7 +144,7 @@
         <p>
           The left hand side requires more consideration.
           We take the derivative term-by-term.
-          Using the technique derived from <xref ref="eq_implicit1"/> above,
+          Using the technique derived from <xref ref="eq_implicit1">Equation</xref> above,
           we can see that
           <me>
             \lzoo{x}{\sin(y)} = \cos(y) \cdot y'

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -3,11 +3,11 @@
   <title>Interpretations of the Derivative</title>
   <introduction>
     <p>
-      <xref ref="sec_derivative">Section</xref>
+      <xref ref="sec_derivative"/>
       defined the derivative of a function and gave examples of how to compute it using its definition (<ie/>, using limits).
       The section also started with a brief motivation for this definition, that is,
       finding the instantaneous velocity of a falling object given its position function.
-      <xref ref="sec_basic_diff_rules">Section</xref>
+      <xref ref="sec_basic_diff_rules"/>
       will give us more accessible tools for computing the derivative;
       tools that are easier to use than repeated use of limits.
     </p>
@@ -29,7 +29,7 @@
   <subsection>
     <title>Interpretation of the Derivative as Instantaneous Rate of Change</title>
     <p>
-      <xref ref="sec_derivative">Section</xref>
+      <xref ref="sec_derivative"/>
       started with an example of using the position of an object
       (in this case, a falling amusement park rider)
       to find the object's velocity.
@@ -330,7 +330,7 @@
       <title>Understanding the derivative: the rate of change</title>
       <statement>
         <p>
-          Consider <m>f(x) = x^2</m> as shown in <xref ref="fig_xsquared">Figure</xref>.
+          Consider <m>f(x) = x^2</m> as shown in <xref ref="fig_xsquared"/>.
           It is clear that at <m>x=3</m> the function is growing faster than at <m>x=1</m>,
           as it is steeper at <m>x=3</m>.
           How much faster is it growing at <m>3</m> compared to <m>1</m>?
@@ -373,7 +373,7 @@
         <p>
           We can answer this exactly
           (and quickly)
-          after <xref ref="sec_basic_diff_rules">Section</xref>,
+          after <xref ref="sec_basic_diff_rules"/>,
           where we learn to quickly compute derivatives.
           For now, we will answer graphically,
           by considering the slopes of the respective tangent lines.
@@ -419,7 +419,7 @@
         <p>
           With practice,
           one can fairly effectively sketch tangent lines to a curve at a particular point.
-          In <xref ref="fig_xsquaredwithgrid">Figure</xref>,
+          In <xref ref="fig_xsquaredwithgrid"/>,
           we have sketched the tangent lines to <m>f</m> at <m>x=1</m> and <m>x=3</m>,
           along with a grid to help us measure the slopes of these lines.
           At <m>x=1</m>, the slope is <m>2</m>;
@@ -435,13 +435,13 @@
       <statement>
         <p>
           Consider the graph of <m>f(x)</m> and its derivative,
-          <m>\fp(x)</m>, in <xref ref="fig_fwithderiv">Figure</xref>.
+          <m>\fp(x)</m>, in <xref ref="fig_fwithderiv"/>.
           Use these graphs to find the slopes of the tangent lines to the graph of <m>f</m> at <m>x=1</m>,
           <m>x=2</m>, and <m>x=3</m>.
         </p>
 
         <figure xml:id="fig_fwithderiv">
-          <caption>Graphs of <m>f</m> and <m>\fp</m> in <xref ref="ex_der_meaning4">Example</xref></caption>
+          <caption>Graphs of <m>f</m> and <m>\fp</m> in <xref ref="ex_der_meaning4"/></caption>
           <!-- START figures/fig_fwithderiv.tex -->
           <image xml:id="img_fwithderiv" width="47%">
             <shortdescription> Graphs of a function and its derivative. </shortdescription>
@@ -503,13 +503,13 @@
 
         <p>
           Using these slopes,
-          tangent line segments to <m>f</m> are sketched in <xref ref="fig_fwithderivdots">Figure</xref>.
+          tangent line segments to <m>f</m> are sketched in <xref ref="fig_fwithderivdots"/>.
           Included on the graph of <m>\fp</m> in this figure are points where <m>x=1</m>,
           <m>x=2</m> and <m>x=3</m> to help better visualize the <m>y</m> value of <m>\fp</m> at those points.
         </p>
 
         <figure xml:id="fig_fwithderivdots">
-          <caption>Graphs of <m>f</m> and <m>\fp</m> in <xref ref="ex_der_meaning4">Example</xref></caption>
+          <caption>Graphs of <m>f</m> and <m>\fp</m> in <xref ref="ex_der_meaning4"/></caption>
           <!-- START figures/fig_fwithderivdots.tex -->
           <image xml:id="img_fwithderivdots" width="47%">
             <shortdescription> Graphs of function f and its derivative</shortdescription>
@@ -554,13 +554,13 @@
       <title>Approximation with the derivative</title>
       <statement>
         <p>
-          Consider again the graph of <m>f(x)</m> and its derivative <m>\fp(x)</m> in <xref ref="ex_der_meaning4">Example</xref>.
+          Consider again the graph of <m>f(x)</m> and its derivative <m>\fp(x)</m> in <xref ref="ex_der_meaning4"/>.
           Use the tangent line to <m>f</m> at <m>x=3</m> to approximate the value of <m>f(3.1)</m>.
         </p>
       </statement>
       <solution>
         <p>
-          <xref ref="fig_fwithderivzoom3">Figure</xref>
+          <xref ref="fig_fwithderivzoom3"/>
           shows the graph of <m>f</m> along with its tangent line,
           zoomed in at <m>x=3</m>.
           Notice that near <m>x=3</m>,
@@ -606,7 +606,7 @@
         </figure>
 
         <p>
-          While the tangent line to <m>f</m> was drawn in <xref ref="ex_der_meaning4">Example</xref>,
+          While the tangent line to <m>f</m> was drawn in <xref ref="ex_der_meaning4"/>,
           it was not explicitly computed.
           Recall that the tangent line to <m>f</m> at <m>x=c</m> is <m>y = \fp(c)(x-c)+f(c)</m>.
           While <m>f</m> is not explicitly given,
@@ -635,7 +635,7 @@
 
     <p>
       To demonstrate the accuracy of the tangent line approximation,
-      we now state that in <xref ref="ex_der_meaning5">Example</xref>,
+      we now state that in <xref ref="ex_der_meaning5"/>,
       <m>f(x) = -x^3+7x^2-12x+4</m>.
       We can evaluate <m>f(3.1) = 4.279</m>.
       Had we known <m>f</m> all along,
@@ -664,7 +664,7 @@
     </p>
 
     <p>
-      This last example has a direct connection to our approximation method explained above after <xref ref="ex_der_meaning2">Example</xref>.
+      This last example has a direct connection to our approximation method explained above after <xref ref="ex_der_meaning2"/>.
       We stated there that
       <me>
         f(c+h) \approx f(c)+\fp(c)\cdot h
@@ -675,7 +675,7 @@
       If we know <m>f(c)</m> and <m>\fp(c)</m> for some value <m>x=c</m>,
       then computing the tangent line at <m>(c,f(c))</m> is easy:
       <m>y(x) = \fp(c)(x-c)+f(c)</m>.
-      In <xref ref="ex_der_meaning5">Example</xref>,
+      In <xref ref="ex_der_meaning5"/>,
       we used the tangent line to approximate a value of <m>f</m>.
       Let's use the tangent line at <m>x=c</m> to approximate a value of <m>f</m> near <m>x=c</m>;
       <ie/>, compute <m>y(c+h)</m> to approximate <m>f(c+h)</m>,

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -41,7 +41,7 @@
       (If we travel <m>60</m> miles in <m>2</m> hours,
       we know we had an average velocity of
       <quantity><mag>30</mag><unit base="mileperhour"/></quantity>.)
-      We looked at this concept in <xref ref="sec_limit_intro">Section</xref>
+      We looked at this concept in <xref ref="sec_limit_intro"/>
       when we introduced the difference quotient.
       We have
       <me>
@@ -116,7 +116,7 @@
       We really want to use <m>h=0</m>, but this, of course,
       returns the familiar <q><m>0/0</m></q> indeterminate form.
       So we employ a limit,
-      as we did in <xref ref="sec_limit_intro">Section</xref>.
+      as we did in <xref ref="sec_limit_intro"/>.
     </p>
 
     <p>
@@ -173,9 +173,9 @@
       <m>(2,f(2))</m> and <m>(2+h,f(2+h))</m>.
       In <xref first="fig_derivfalling" last="fig_derivfalling3">Figures</xref>,
       the secant line corresponding to <m>h=1</m> is shown in three contexts.
-      <xref ref="fig_derivfalling">Figure</xref> shows a <q>zoomed out</q>
+      <xref ref="fig_derivfalling"/> shows a <q>zoomed out</q>
       version of <m>f</m> with its secant line.
-      In <xref ref="fig_derivfalling2">Figure</xref>,
+      In <xref ref="fig_derivfalling2"/>,
       we zoom in around the points of intersection between <m>f</m> and the secant line.
       Notice how well this secant line approximates <m>f</m> between those two points <mdash/> it is a common practice to approximate functions with straight lines.
     </p>
@@ -331,11 +331,11 @@
       <term>tangent line</term>,
       a line that goes through the point
       <m>(2,f(2))</m> with the special slope of <m>-64</m>.
-      In <xref ref="fig_derivfalling3">Figure</xref>
-      and <xref ref="fig_derivfalling4">Figure</xref>,
+      In <xref ref="fig_derivfalling3"/>
+      and <xref ref="fig_derivfalling4"/>,
       we zoom in around the point <m>(2,86)</m>.
       We see the secant line, which approximates <m>f</m> well,
-      but not as well the tangent line shown in <xref ref="fig_derivfalling4">Figure</xref>.
+      but not as well the tangent line shown in <xref ref="fig_derivfalling4"/>.
     </p>
 
     <p>
@@ -437,7 +437,7 @@
           <ol marker="a">
             <li>
               <p>
-                We compute this directly using <xref ref="def_derivative_at_a_point">Definition</xref>.
+                We compute this directly using <xref ref="def_derivative_at_a_point"/>.
                 <md>
                   <mrow>\fp(1)\amp = \lim_{h\to 0} \frac{f(1+h)-f(1)}{h}</mrow>
                   <mrow>\amp = \lim_{h\to 0} \frac{3(1+h)^2+5(1+h)-7 - (3(1)^2+5(1)-7)}{h}</mrow>
@@ -483,7 +483,7 @@
         </p>
 
         <p>
-          A graph of <m>f</m> is given in <xref ref="fig_tangent1">Figure</xref>
+          A graph of <m>f</m> is given in <xref ref="fig_tangent1"/>
           along with the tangent lines at <m>x=1</m> and <m>x=3</m>.
         </p>
 
@@ -569,14 +569,14 @@
       <title>Finding equations of normal lines</title>
       <statement>
         <p>
-          Let <m>f(x) = 3x^2+5x-7</m>, as in <xref ref="ex_derv_point1">Example</xref>.
+          Let <m>f(x) = 3x^2+5x-7</m>, as in <xref ref="ex_derv_point1"/>.
           Find the equations of the normal lines to the graph of <m>f</m> at <m>x=1</m> and
           <m>x=3</m>.
         </p>
       </statement>
       <solution>
         <p>
-          In <xref ref="ex_derv_point1">Example</xref>,
+          In <xref ref="ex_derv_point1"/>,
           we found that <m>\fp(1)=11</m>.
           Hence at <m>x=1</m>, the normal line will have slope <m>-1/11</m>.
           An equation for the normal line is
@@ -586,7 +586,7 @@
         </p>
 
         <p>
-          The normal line is plotted with <m>y=f(x)</m> in <xref ref="fig_normal1">Figure</xref>.
+          The normal line is plotted with <m>y=f(x)</m> in <xref ref="fig_normal1"/>.
           Note how the line looks perpendicular to <m>f</m>. (A key word here is
           <q>looks.</q> Mathematically,
           we say that the normal line <em>is</em>
@@ -751,7 +751,7 @@
         <p>
           Thus our approximation of the equation of the tangent line is
           <m>y = 0.9983(x-0) +0 = 0.9983x</m>;
-          it is graphed in <xref ref="fig_tangentsinx">Figure</xref>.
+          it is graphed in <xref ref="fig_tangentsinx"/>.
           The graph seems to imply the approximation is rather good.
         </p>
 
@@ -796,7 +796,7 @@
     </example>
 
     <p>
-      Recall from <xref ref="sec_limit_analytically">Section</xref>
+      Recall from <xref ref="sec_limit_analytically"/>
       that <m>\lim_{x\to 0}\frac{\sin(x)}x =1</m>,
       meaning for values of <m>x</m> near <m>0</m>, <m>\sin(x) \approx x</m>.
       Since the slope of the line <m>y=x</m> is <m>1</m> at <m>x=0</m>,
@@ -809,7 +809,7 @@
     </p>
 
     <p>
-      Consider again <xref ref="ex_derv_point1">Example</xref>.
+      Consider again <xref ref="ex_derv_point1"/>.
       To find the derivative of <m>f</m> at <m>x=1</m>,
       we needed to evaluate a limit.
       To find the derivative of <m>f</m> at <m>x=3</m>,
@@ -917,13 +917,13 @@
       <title>Finding the derivative of a function</title>
       <statement>
         <p>
-          Let <m>f(x) = 3x^2+5x-7</m> as in <xref ref="ex_derv_point1">Example</xref>.
+          Let <m>f(x) = 3x^2+5x-7</m> as in <xref ref="ex_derv_point1"/>.
           Find <m>\fp(x)</m>.
         </p>
       </statement>
       <solution>
         <p>
-          We apply <xref ref="def_the_derivative">Definition</xref>.
+          We apply <xref ref="def_the_derivative"/>.
           <md>
             <mrow>\fp(x) \amp = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}</mrow>
             <mrow>\amp = \lim_{h\to 0} \frac{3(x+h)^2+5(x+h)-7-(3x^2+5x-7)}{h}</mrow>
@@ -957,7 +957,7 @@
       <solution>
 
         <p>
-          We apply <xref ref="def_the_derivative">Definition</xref>.
+          We apply <xref ref="def_the_derivative"/>.
           <md>
             <mrow>\fp(x)     \amp = \lim_{h\to 0} \frac{f(x+h)-f(x)}{h}</mrow>
             <mrow>\amp =    \lim_{h\to 0} \frac{\frac{1}{x+h+1}-\frac{1}{x+1}}{h}</mrow>
@@ -998,10 +998,10 @@
       <solution>
 
         <p>
-          Before applying <xref ref="def_the_derivative">Definition</xref>,
+          Before applying <xref ref="def_the_derivative"/>,
           note that once this is found,
           we can find the actual tangent line to <m>f(x) = \sin(x)</m> at <m>x=0</m>,
-          whereas we settled for an approximation in <xref ref="ex_der_num_approx">Example</xref>.
+          whereas we settled for an approximation in <xref ref="ex_der_num_approx"/>.
           <md>
             <mrow>\fp(x) \amp = \lim_{h\to 0} \frac{\sin(x+h)-\sin(x)}{h} \amp  \amp
             \text{Derivative definition}</mrow>
@@ -1015,7 +1015,7 @@
             <mrow>\amp\quad{}+\lim_{h\to 0}\cos(x)\cdot  \lim_{h\to 0}\frac{\sin(h)}{h} \amp  \amp
             \text{Product/sum limit rules}</mrow>
             <mrow>\amp = \sin(x)\cdot 0 + \cos(x) \cdot 1 \amp \amp  \text{Applied }
-            <xref ref="thm_special_limits">Theorem </xref></mrow>
+            <xref ref="thm_special_limits"/></mrow>
             <mrow>\amp = \cos(x). \amp \amp \text{(Are you surprised?)}</mrow>
           </md>
         </p>
@@ -1032,7 +1032,7 @@
         </p>
 
         <p>
-          Thinking back to <xref ref="ex_der_num_approx">Example</xref>,
+          Thinking back to <xref ref="ex_der_num_approx"/>,
           we can find the slope of the tangent line to
           <m>f(x)=\sin(x)</m> at <m>x=0</m> using our derivative.
           We approximated the slope as <m>0.9983</m>;
@@ -1064,7 +1064,7 @@
         </p>
 
         <p>
-          See <xref ref="fig_absolutevalue">Figure</xref>.
+          See <xref ref="fig_absolutevalue"/>.
         </p>
 
         <figure xml:id="fig_absolutevalue">
@@ -1172,7 +1172,7 @@
         <p>
           At <m>x=0</m>, <m>\fp(x)</m> does not exist;
           there is a jump discontinuity at <m>0</m>;
-          see <xref ref="fig_absolutevalueprime">Figure</xref>.
+          see <xref ref="fig_absolutevalueprime"/>.
           So <m>f(x) = \abs{x}</m> is differentiable everywhere except at <m>0</m>.
         </p>
 
@@ -1229,11 +1229,11 @@
           <me>
             f(x) = \begin{cases}\sin(x) \amp x\leq \pi/2 \\ 1 \amp x \gt \pi/2\end{cases}
           </me>.
-          See <xref ref="fig_piecewisesinx1">Figure</xref>.
+          See <xref ref="fig_piecewisesinx1"/>.
         </p>
 
         <figure xml:id="fig_piecewisesinx1">
-          <caption>A graph of <m>f(x)</m> as defined in <xref ref="ex_diff_piecewise">Example</xref></caption>
+          <caption>A graph of <m>f(x)</m> as defined in <xref ref="ex_diff_piecewise"/></caption>
           <!-- START figures/fig_piecewisesinx1.tex -->
           <image xml:id="img_piecewisesinx1" width="47%">
             <shortdescription>
@@ -1266,7 +1266,7 @@
       </statement>
       <solution>
         <p>
-          Using <xref ref="ex_deriv_sinx">Example</xref>,
+          Using <xref ref="ex_deriv_sinx"/>,
           we know that when <m>x\lt \pi/2</m>, <m>\fp(x) = \cos(x)</m>.
           It is easy to verify that when <m>x \gt \pi/2</m>,
           <m>\fp(x) = 0</m>; consider:
@@ -1330,12 +1330,12 @@
         </p>
 
         <p>
-          See <xref ref="fig_piecewisecosx1">Figure</xref>
+          See <xref ref="fig_piecewisecosx1"/>
           for a graph of this derivative function.
         </p>
 
         <figure xml:id="fig_piecewisecosx1">
-          <caption>A graph of <m>\fp(x)</m> in <xref ref="ex_diff_piecewise">Example</xref>.
+          <caption>A graph of <m>\fp(x)</m> in <xref ref="ex_diff_piecewise"/>.
           </caption>
           <!-- START figures/fig_piecewisecosx1.tex -->
           <image xml:id="img_piecewisecosx1" width="47%">
@@ -1385,11 +1385,11 @@
       We can give a pseudo-definition for differentiability as well:
       it is a continuous function that does not have any <q>sharp corners</q>
       or a vertical tangent line.
-      One such sharp corner is shown in <xref ref="fig_absolutevalue">Figure</xref>.
-      Even though the function <m>f</m> in <xref ref="ex_diff_piecewise">Example</xref> is   piecewise-defined,
+      One such sharp corner is shown in <xref ref="fig_absolutevalue"/>.
+      Even though the function <m>f</m> in <xref ref="ex_diff_piecewise"/> is   piecewise-defined,
       the transition is <q>smooth</q>
       hence it is differentiable.
-      Note how in the graph of <m>f</m> in <xref ref="fig_piecewisesinx1">Figure</xref>
+      Note how in the graph of <m>f</m> in <xref ref="fig_piecewisesinx1"/>
       it is difficult to tell when <m>f</m> switches from one piece to the other;
       there is no <q>corner.</q>
     </p>
@@ -1398,7 +1398,7 @@
   <subsection>
     <title>Differentiability on Closed Intervals</title>
     <p>
-      When we defined the derivative at a point in <xref ref="def_derivative_at_a_point">Definition</xref>,
+      When we defined the derivative at a point in <xref ref="def_derivative_at_a_point"/>,
       we specified that the interval <m>I</m> over which a function <m>f</m> was defined needed to be an open interval.
       Open intervals are required so that we can take a limit at any point <m>c</m> in <m>I</m>,
       meaning we want to approach <m>c</m> from both the left and right.
@@ -1409,7 +1409,7 @@
     </p>
 
     <p>
-      Recall we also required open intervals in <xref ref="def_continuous">Definition</xref>
+      Recall we also required open intervals in <xref ref="def_continuous"/>
       when we defined what it meant for a function to be continuous.
       Later, we used one-sided limits to extend continuity to closed intervals.
       We now extend differentiability to closed intervals by again considering one-sided limits.
@@ -1418,7 +1418,7 @@
     <p>
       Our motivation is three-fold.
       First, we consider <q>common sense.</q>
-      In <xref ref="ex_deriv1">Example</xref>
+      In <xref ref="ex_deriv1"/>
       we found that when <m>f(x) = 3x^2+5x-7</m>, <m>\fp(x) = 6x+5</m>,
       and this derivative is defined for all real numbers,
       hence <m>f</m> is differentiable everywhere.
@@ -1437,7 +1437,7 @@
     <p>
       Finally, in later sections,
       having the derivative defined on closed intervals will prove useful.
-      One such place is <xref ref="sec_arc_length">Section</xref>
+      One such place is <xref ref="sec_arc_length"/>
       where the derivative plays a role in measuring the length of a curve.
     </p>
 
@@ -1515,7 +1515,7 @@
         </p>
 
         <figure xml:id="fig_diff_closed1">
-          <caption>A graph of <m>y=x^{1/2}</m> and <m>y=x^{3/2}</m> in <xref ref="ex_diff_closed1">Example</xref></caption>
+          <caption>A graph of <m>y=x^{1/2}</m> and <m>y=x^{3/2}</m> in <xref ref="ex_diff_closed1"/></caption>
           <image xml:id="img_diff_closed1" width="47%">
             <shortdescription>
               Two curves, one of function of square root of x and the other of x to the power 3/2.  
@@ -1556,7 +1556,7 @@
         </p>
 
         <p>
-          The two functions are graphed in <xref ref="fig_diff_closed1">Figure</xref>.
+          The two functions are graphed in <xref ref="fig_diff_closed1"/>.
           Note how <m>f(x) = \sqrt{x}</m> seems to <q>go vertical</q>
           as <m>x</m> approaches 0, implying the slopes of its tangent lines are growing toward infinity.
           Also note how the slopes of the tangent lines to
@@ -1573,7 +1573,7 @@
       we could remove the word <q>open</q>
       and just use <q><m>\ldots</m> on an interval <m>I</m>,</q>
       but choose to not do so in keeping with the current mathematical tradition.
-      Our first use of differentiability on closed intervals comes in <xref ref="chapter_app_of_int">Chapter</xref>,
+      Our first use of differentiability on closed intervals comes in <xref ref="chapter_app_of_int"/>,
       where we measure the lengths of curves.
     </p>
 
@@ -1862,8 +1862,7 @@
         <introduction>
           <p>
             A function and an <m>x</m>-value are given.
-            (Note: these functions are the same as those given in <xref ref="exer_derivative_definition_constant">Exercises</xref>
-            through <xref ref="exer_derivative_definition_fractional_linear"/>.)
+            (Note: these functions are the same as those given in <xref first="exer_derivative_definition_constant" last="exer_derivative_definition_fractional_linear" text="local">Exercises</xref>.)
             Give the equations of the tangent line and the normal line at that <m>x</m>-value.
           </p>
         </introduction>
@@ -2796,7 +2795,7 @@
             <solution>
               <p>
                 The limit of the difference quotient is difficult to evaluate.
-                Using <xref ref="thm_special_limits">Theorem</xref>,
+                Using <xref ref="thm_special_limits"/>,
                 we can determine <m>\lim_{x\to0^+}\fp(x) = -1/2</m>.
               </p>
               <p>

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -67,7 +67,7 @@
     When the point <m>(a,b)</m> lies on the graph of <m>f</m>,
     the point <m>(b,a)</m> lies on the graph of <m>g</m>.
     This leads us to discover that the graph of <m>g</m> is the reflection of <m>f</m> across the line <m>y=x</m>.
-    In <xref ref="fig_inverse1">Figure</xref>
+    In <xref ref="fig_inverse1"/>
     we see a function graphed along with its inverse.
     See how the point <m>(1,1.5)</m> lies on one graph,
     whereas <m>(1.5,1)</m> lies on the other.
@@ -113,7 +113,7 @@
   </figure>
 
   <p>
-    For example, consider <xref ref="fig_inverse2">Figure</xref>
+    For example, consider <xref ref="fig_inverse2"/>
     where the tangent line to <m>f</m> at the point <m>(1,1.5)</m> is drawn.
     That line has slope <m>3</m>.
     Through reflection across <m>y=x</m>,
@@ -271,14 +271,14 @@
   </figure>
 
   <p>
-    The results of <xref ref="thm_deriv_inverse_functions">Theorem</xref> are not trivial;
+    The results of <xref ref="thm_deriv_inverse_functions"/> are not trivial;
     the notation may seem confusing at first.
     Careful consideration, along with examples,
     should earn understanding.
   </p>
 
   <p>
-    In the next example we apply <xref ref="thm_deriv_inverse_functions">Theorem</xref> to the arcsine function.
+    In the next example we apply <xref ref="thm_deriv_inverse_functions"/> to the arcsine function.
   </p>
 
   <p xml:id="vidint_deriv_inverse_restrict_domain" component="video">
@@ -301,7 +301,7 @@
     <statement>
       <p>
         Let <m>y = \arcsin(x) = \sin^{-1}(x)</m>.
-        Find <m>y'</m> using <xref ref="thm_deriv_inverse_functions">Theorem</xref>.
+        Find <m>y'</m> using <xref ref="thm_deriv_inverse_functions"/>.
       </p>
     </statement>
     <solution component="video">
@@ -324,7 +324,7 @@
       <p>
         This last expression is not immediately illuminating.
         Drawing a figure will help,
-        as shown in <xref ref="fig_inverse3">Figure</xref>.
+        as shown in <xref ref="fig_inverse3"/>.
         Recall that the sine function can be viewed as taking in an angle and returning a ratio of sides of a right triangle,
         specifically,
         the ratio <q>opposite over hypotenuse.</q>
@@ -464,7 +464,7 @@
   </figure>
 
   <p>
-    In <xref ref="fig_inversesine">Figure</xref>
+    In <xref ref="fig_inversesine"/>
     we see <m>f(x) = \sin(x)</m> and
     <m>f^{-1}(x) = \sin^{-1}(x)</m> graphed on their respective domains.
     The line tangent to <m>\sin(x)</m> at the point
@@ -564,7 +564,7 @@
     <statement>
       <p>
         The inverse trigonometric functions are differentiable on all open sets contained in their domains
-        (as listed in <xref ref="tab_domain_trig">Table</xref>)
+        (as listed in <xref ref="tab_domain_trig"/>)
         and their derivatives are as follows:
 
         <ol>
@@ -601,9 +601,9 @@
 
 
   <p>
-    In <xref ref="sec_basic_diff_rules">Section</xref>,
+    In <xref ref="sec_basic_diff_rules"/>,
     we stated without proof or explanation that <m>\lzoo{x}{\ln(x)}=\frac{1}{x}</m>.
-    We can justify that now using <xref ref="thm_deriv_inverse_functions">Theorem</xref>,
+    We can justify that now using <xref ref="thm_deriv_inverse_functions"/>,
     as shown in the example.
   </p>
 
@@ -611,7 +611,7 @@
     <title>Finding the derivative of <m>y=\ln(x)</m></title>
     <statement>
       <p>
-        Use <xref ref="thm_deriv_inverse_functions">Theorem</xref>
+        Use <xref ref="thm_deriv_inverse_functions"/>
         to compute <m>\lzoo{x}{\ln(x)}</m>.
       </p>
     </statement>
@@ -621,7 +621,7 @@
         Therefore, using our standard notation,
         let <m>f(x) = e^x</m> and <m>g(x) = \ln(x)</m>.
         We wish to find <m>g'(x)</m>.
-        <xref ref="thm_deriv_inverse_functions">Theorem</xref> gives:
+        <xref ref="thm_deriv_inverse_functions"/> gives:
         <md>
           <mrow>g'(x) \amp = \frac{1}{\fp(g(x))}</mrow>
           <mrow>\amp = \frac{1}{e^{\ln(x) }}</mrow>
@@ -865,7 +865,7 @@
         <introduction>
           <p>
             An invertible function <m>f(x)</m> is given along with a point that lies on its graph.
-            Using <xref ref="thm_deriv_inverse_functions">Theorem</xref>,
+            Using <xref ref="thm_deriv_inverse_functions"/>,
             evaluate <m>\left(f^{-1}\right)'(x)</m> at the indicated value.
           </p>
         </introduction>

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -2,7 +2,7 @@
 <section xml:id="sec_prod_quot_rules">
   <title>The Product and Quotient Rules</title>
   <p>
-    <xref ref="sec_basic_diff_rules">Section</xref> showed that,
+    <xref ref="sec_basic_diff_rules"/> showed that,
     in some ways, derivatives behave nicely.
     The <xref ref="constant-multiple-derivative-rule" text="title"/> and <xref ref="sum-difference-derivative-rule" text="title"/> established that the derivative of <m>f(x) = 5x^2+\sin(x)</m> was not complicated.
     We neglected computing the derivative of things like
@@ -84,7 +84,7 @@
       <p>
         We graph <m>y</m> and its tangent line at <m>x=\pi/2</m>,
         which has a slope of <m>5\pi</m>,
-        in <xref ref="fig_5xsquaredsinx">Figure</xref>.
+        in <xref ref="fig_5xsquaredsinx"/>.
         While this does not <em>prove</em>
         that the Product Rule is the correct way to handle derivatives of products,
         it helps validate its truth.
@@ -136,7 +136,7 @@
     <video width="98%" youtube="i791Y97O5hI" xml:id="vid_deriv_prod_quot_proof_prod_rule" label="vid_deriv_prod_quot_proof_prod_rule" component="video"/>
 
     <p>
-      We can use the definition of the derivative to prove <xref ref="thm_ProductRule">Theorem</xref>.
+      We can use the definition of the derivative to prove <xref ref="thm_ProductRule"/>.
     </p>
 
     <p>
@@ -461,7 +461,7 @@
         we can find the equation of the tangent line to <m>y=\tan(x)</m> at <m>x=\pi/4</m>.
         The slope is <m>\sec^2(\pi/4) = 2</m>;
         <m>y=\tan(x)</m>, along with its tangent line,
-        is graphed in <xref ref="fig_tanx">Figure</xref>.
+        is graphed in <xref ref="fig_tanx"/>.
       </p>
 
       <figure xml:id="fig_tanx">
@@ -507,10 +507,10 @@
   <p>
     We include this result in the following theorem about the derivatives of the trigonometric functions.
     Recall we found the derivative of
-    <m>y=\sin(x)</m> in <xref ref="ex_deriv_sinx">Example</xref>
-    and stated the derivative of the cosine function in <xref ref="thm_deriv_common">Theorem</xref>.
+    <m>y=\sin(x)</m> in <xref ref="ex_deriv_sinx"/>
+    and stated the derivative of the cosine function in <xref ref="thm_deriv_common"/>.
     The derivatives of the cotangent,
-    cosecant and secant functions can all be computed directly using <xref ref="thm_deriv_common">Theorem</xref>
+    cosecant and secant functions can all be computed directly using <xref ref="thm_deriv_common"/>
     and the <xref ref="thm_QuotientRule" text="title"/>.
   </p>
 
@@ -541,16 +541,16 @@
     <title>Exploring alternate derivative methods</title>
     <statement>
       <p>
-        In <xref ref="ex_quot1">Example</xref>
+        In <xref ref="ex_quot1"/>
         the derivative of <m>f(x) = \frac{5x^2}{\sin(x) }</m> was found using the <xref ref="thm_QuotientRule" text="title"/>.
         Rewriting <m>f</m> as <m>f(x) = 5x^2\csc(x)</m>,
-        find <m>\fp</m> using <xref ref="thm_deriv_trig">Theorem</xref>
+        find <m>\fp</m> using <xref ref="thm_deriv_trig"/>
         and verify the two answers are the same.
       </p>
     </statement>
     <solution>
       <p>
-        We found in <xref ref="ex_quot1">Example</xref>
+        We found in <xref ref="ex_quot1"/>
         that <m>\fp(x) = \frac{10x\sin(x) - 5x^2\cos(x) }{\sin^2(x) }</m>.
         We now find <m>\fp</m> using the <xref ref="thm_ProductRule" text="title"/>, considering <m>f</m> as <m>f(x) = 5x^2\csc(x)</m>.
         <md>
@@ -634,7 +634,7 @@
     It gets better.
     Consider:
     <md>
-      <mrow>\lzoo{x}{\frac{1}{x^n}} \amp = \lzoo{x}{x^{-n}} \amp\amp\text{ (apply result from } <xref ref="ex_deriv_power">Example</xref>\text{)}</mrow>
+      <mrow>\lzoo{x}{\frac{1}{x^n}} \amp = \lzoo{x}{x^{-n}} \amp\amp\text{ (apply result from } <xref ref="ex_deriv_power"/>\text{)}</mrow>
       <mrow>\amp = -\frac{n}{x^{n+1}} \amp\amp \text{ (rewrite algebraically) }</mrow>
       <mrow>\amp = -nx^{-(n+1)}\amp</mrow>
       <mrow>\amp = -nx^{-n-1}\amp</mrow>
@@ -752,7 +752,7 @@
   </example>
 
   <p>
-    <xref ref="ex_multiple_deriv">Example</xref>
+    <xref ref="ex_multiple_deriv"/>
     demonstrates three methods of finding <m>\fp</m>.
     One is hard pressed to argue for a <q>best method</q>
     as all three gave the same result without too much difficulty,

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -8,7 +8,7 @@
   </figure>
 
   <p>
-    In <xref ref="sec_interp_deriv">Section</xref>
+    In <xref ref="sec_interp_deriv"/>
     we explored the meaning and use of the derivative.
     This section starts by revisiting some of those ideas.
   </p>

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -307,7 +307,7 @@
         <li>
           <p>
             Let <m>dy = \fp(x)dx</m> which,
-            by <xref ref="eq_differential"/>,
+            by <xref ref="eq_differential">Equation</xref>,
             is an <em>approximation</em> of the change in <m>y</m>-value as <m>x</m> changes by <m>\dx</m>;
             <m>dy \approx \dy</m>.
           </p>

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -105,14 +105,14 @@
       </statement>
       <solution>
         <p>
-          The surface is plotted in <xref ref="fig_direct1">Figure</xref>,
+          The surface is plotted in <xref ref="fig_direct1"/>,
           where the point <m>P=(1,2)</m> is indicated in the <m>x,y</m>-plane as well as the point <m>(1,2,9)</m> which lies on the surface of <m>f</m>.
           We find that <m>f_x(x,y) = -2x</m> and <m>f_x(1,2) = -2</m>;
           <m>f_y(x,y) = -2y</m> and <m>f_y(1,2) = -4</m>.
         </p>
 
         <figure xml:id="fig_direct1">
-          <caption>Understanding the directional derivative in <xref ref="ex_direct1">Example</xref></caption>
+          <caption>Understanding the directional derivative in <xref ref="ex_direct1"/></caption>
 
           <!-- START figures/figdirect1_3D.asy -->
           <image xml:id="img_direct1" width="47%">
@@ -487,7 +487,7 @@
         </p>
 
         <p>
-          <xref ref="fig_direct2">Figure</xref>
+          <xref ref="fig_direct2"/>
           shows the surface plotted from two different perspectives.
           In each, the gradient is drawn at <m>P</m> with a dashed line
           (because of the nature of this surface,
@@ -504,7 +504,7 @@
         </p>
 
         <figure xml:id="fig_direct2">
-          <caption>Graphing the surface and important directions in <xref ref="ex_direct2">Example</xref></caption>
+          <caption>Graphing the surface and important directions in <xref ref="ex_direct2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_direct2a_3D">
               <caption/>
@@ -672,7 +672,7 @@
         <p>
           We find <m>\nabla f = \la -2x+2, -2y+2\ra</m>.
           At <m>P</m>, we have <m>\nabla f(1,1) = \la 0,0\ra</m>.
-          According to <xref ref="thm_gradient">Theorem</xref>,
+          According to <xref ref="thm_gradient"/>,
           this is the direction of maximal increase.
           However, <m>\la 0,0\ra</m> is directionless;
           it has no displacement.
@@ -681,7 +681,7 @@
         </p>
 
         <p>
-          <xref ref="fig_direct9">Figure</xref>
+          <xref ref="fig_direct9"/>
           helps us understand what this means.
           We can see that <m>P</m> lies at the top of a paraboloid.
           In all directions, the instantaneous rate of change is 0.
@@ -832,7 +832,7 @@
         </p>
 
         <figure xml:id="fig_direct3">
-          <caption>A sketch of the surface described in <xref ref="ex_direct3">Example</xref> along with the path in the <m>xy</m>-plane with the level curves</caption>
+          <caption>A sketch of the surface described in <xref ref="ex_direct3"/> along with the path in the <m>xy</m>-plane with the level curves</caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_direct3a_3D">
               <caption/>
@@ -932,8 +932,8 @@
 
         <p>
           Thus the water follows the curve <m>y=x^2/4</m> in the <m>xy</m>-plane.
-          The surface and the path of the water is graphed in <xref ref="fig_direct3a_3D">Figure</xref>.
-          In <xref ref="fig_direct3b">Figure</xref>,
+          The surface and the path of the water is graphed in <xref ref="fig_direct3a_3D"/>.
+          In <xref ref="fig_direct3b"/>,
           the level curves of the surface are plotted in the <m>xy</m>-plane,
           along with the curve <m>y=x^2/4</m>.
           Notice how the path intersects the level curves at right angles.
@@ -955,9 +955,9 @@
       The concepts of directional derivatives and the gradient are easily extended to three
       (and more)
       variables.
-      We combine the concepts behind <xref ref="def_direct_deriv">Definitions</xref>
-      and <xref ref="def_gradient"/>
-      and <xref ref="thm_direct_deriv1">Theorem</xref> into one set of definitions.
+      We combine the concepts behind <xref ref="def_direct_deriv" text="global">Definitions</xref>
+      and <xref ref="def_gradient" text="global"/>
+      and <xref ref="thm_direct_deriv1"/> into one set of definitions.
     </p>
 
     <definition xml:id="def_direct_deriv3">
@@ -990,7 +990,7 @@
     </definition>
 
     <p>
-      The same properties of the gradient given in <xref ref="thm_gradient">Theorem</xref>,
+      The same properties of the gradient given in <xref ref="thm_gradient"/>,
       when <m>f</m> is a function of two variables,
       hold for <m>F</m>, a function of three variables.
     </p>
@@ -1626,8 +1626,7 @@
           </p>
 
           <p>
-            Note: these are the same functions and points as in <xref ref="x12_05_ex_11">Exercises</xref>
-            through <xref ref="x12_05_ex_23"/>.
+            Note: these are the same functions and points as in <xref first="x12_05_ex_11" last="x12_05_ex_23" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -3,7 +3,7 @@
   <title>Volume by Cross-Sectional Area; Disk and Washer Methods</title>
   <p>
     The volume of a general right cylinder,
-    as shown in <xref ref="fig_cross1">Figure</xref>, is
+    as shown in <xref ref="fig_cross1"/>, is
   </p>
 
   <blockquote>
@@ -102,7 +102,7 @@
   </p>
 
   <figure xml:id="vid-intapp-disk-intro" component="video">
-    <caption>Video introduction to <xref ref="sec_disk">Section</xref></caption>
+    <caption>Video introduction to <xref ref="sec_disk"/></caption>
     <video youtube="jx9XyQKDaP4" label="vid-intapp-disk-intro"/>
   </figure>
 
@@ -164,12 +164,12 @@
       <p>
         There are many ways to <q>orient</q>
         the pyramid along the <m>x</m>-axis;
-        <xref ref="fig_disk0">Figure</xref> gives one such way,
+        <xref ref="fig_disk0"/> gives one such way,
         with the pointed top of the pyramid at the origin and the <m>x</m>-axis going through the center of the base.
       </p>
 
       <figure xml:id="fig_disk0">
-        <caption>Orienting a pyramid along the <m>x</m>-axis in <xref ref="ex_disk0">Example</xref></caption>
+        <caption>Orienting a pyramid along the <m>x</m>-axis in <xref ref="ex_disk0"/></caption>
 
         <!-- START figures/figcross_area1_3D.asy -->
         <image xml:id="img_disk0" width="47%">
@@ -267,7 +267,7 @@
 
       <p>
         If one were to cut a slice out of the pyramid at <m>x=3</m>,
-        as shown in <xref ref="fig_disk0a">Figure</xref>,
+        as shown in <xref ref="fig_disk0a"/>,
         one would have a shape with square bottom and top with sloped sides.
         If the slice were thin,
         both the bottom and top squares would have sides lengths of about 6, and thus the cross-sectional area of the bottom and top would be about
@@ -277,7 +277,7 @@
       </p>
 
       <figure xml:id="fig_disk0a">
-        <caption>Cutting a slice in the pyramid in <xref ref="ex_disk0">Example</xref> at <m>x=3</m></caption>
+        <caption>Cutting a slice in the pyramid in <xref ref="ex_disk0"/> at <m>x=3</m></caption>
 
         <!-- START figures/figcross_area1a_3D.asy -->
         <image xml:id="img_disk0a" width="47%">
@@ -409,7 +409,7 @@
       <p>
         Taking the limit as <m>n\to\infty</m> gives the actual volume of the pyramid;
         recoginizing this sum as a Riemann Sum allows us to find the exact answer using a definite integral,
-        matching the definite integral given by <xref ref="thm_volume_by_cross_section">Theorem</xref>.
+        matching the definite integral given by <xref ref="thm_volume_by_cross_section"/>.
       </p>
 
       <p>
@@ -439,7 +439,7 @@
   </example>
 
   <p>
-    An important special case of <xref ref="thm_volume_by_cross_section">Theorem</xref>
+    An important special case of <xref ref="thm_volume_by_cross_section"/>
     is when the solid is a <em>solid of revolution</em>, that is,
     when the solid is formed by rotating a shape around an axis.
   </p>
@@ -450,7 +450,7 @@
     (thin circles).
     Let <m>R(x)</m> represent the radius of the cross-sectional disk at <m>x</m>;
     the area of this disk is <m>\pi R(x)^2</m>.
-    Applying <xref ref="thm_volume_by_cross_section">Theorem</xref> gives the Disk Method.
+    Applying <xref ref="thm_volume_by_cross_section"/> gives the Disk Method.
   </p>
 
   <insight xml:id="idea_disk_method">
@@ -482,12 +482,12 @@
     <solution>
       <p>
         A sketch can help us understand this problem.
-        In <xref ref="fig_disk1a_3D">Figure</xref>, the curve <m>y=1/x</m> is sketched along with the differential element <mdash/> a disk <mdash/> at <m>x</m> with radius <m>R(x)=1/x</m>.
-        In <xref ref="fig_disk1b_3D">Figure</xref> the whole solid is pictured, along with the differential element.
+        In <xref ref="fig_disk1a_3D"/>, the curve <m>y=1/x</m> is sketched along with the differential element <mdash/> a disk <mdash/> at <m>x</m> with radius <m>R(x)=1/x</m>.
+        In <xref ref="fig_disk1b_3D"/> the whole solid is pictured, along with the differential element.
       </p>
 
       <p>
-        The volume of the differential element shown in <xref ref="fig_disk1a_3D">Figure</xref> is approximately <m>\pi R(x_i)^2\Delta x</m>,
+        The volume of the differential element shown in <xref ref="fig_disk1a_3D"/> is approximately <m>\pi R(x_i)^2\Delta x</m>,
         where <m>R(x_i)</m> is the radius of the disk shown and
         <m>\Delta x</m> is the thickness of that slice.
         The radius <m>R(x_i)</m> is the distance from the <m>x</m>-axis to the curve,
@@ -495,7 +495,7 @@
       </p>
 
       <figure xml:id="fig_disk1">
-        <caption>Sketching a solid in <xref ref="ex_disk1">Example</xref></caption>
+        <caption>Sketching a solid in <xref ref="ex_disk1"/></caption>
         <sidebyside widths="47% 47%" margins="0%">
           <figure xml:id="fig_disk1a_3D">
             <caption/>
@@ -665,7 +665,7 @@
         Taking the limit of the above sum as
         <m>n\to\infty</m> gives the actual volume;
         recognizing this sum as a Riemann sum allows us to evaluate the limit with a definite integral,
-        which matches the formula given in <xref ref="idea_disk_method">Key Idea</xref>:
+        which matches the formula given in <xref ref="idea_disk_method"/>:
         <md>
           <mrow>V \amp = \lim_{n\to\infty}\sum_{i=1}^n \pi \left(\frac1{x_i}\right)^2\Delta x</mrow>
           <mrow>\amp = \pi\int_1^2 \left(\frac1x\right)^2\, dx</mrow>
@@ -681,7 +681,7 @@
   </example>
 
   <p>
-    While <xref ref="idea_disk_method">Key Idea</xref>
+    While <xref ref="idea_disk_method"/>
     is given in terms of functions of <m>x</m>,
     the principle involved can be applied to functions of <m>y</m> when the axis of rotation is vertical,
     not horizontal.
@@ -713,12 +713,12 @@
       <p>
         Thus we are rotating the curve <m>x=1/y</m>,
         from <m>y=1/2</m> to <m>y=1</m> about the <m>y</m>-axis to form a solid.
-        The curve and sample differential element are sketched in <xref ref="fig_disk2a_3D">Figure</xref>,
-        with a full sketch of the solid in <xref ref="fig_disk2b_3D">Figure</xref>.
+        The curve and sample differential element are sketched in <xref ref="fig_disk2a_3D"/>,
+        with a full sketch of the solid in <xref ref="fig_disk2b_3D"/>.
       </p>
 
       <figure xml:id="fig_disk2">
-        <caption>Sketching a solid in <xref ref="ex_disk2">Example</xref></caption>
+        <caption>Sketching a solid in <xref ref="ex_disk2"/></caption>
         <sidebyside widths="47% 47%" margins="0%">
           <figure xml:id="fig_disk2a_3D">
             <caption/>
@@ -907,7 +907,7 @@
   </p>
 
   <figure xml:id="fig_washeridea1">
-    <caption>Establishing the Washer Method; see also <xref ref="fig_washeridea2_3D">Figure</xref></caption>
+    <caption>Establishing the Washer Method; see also <xref ref="fig_washeridea2_3D"/></caption>
     <sidebyside widths="47% 47%" margins="0%">
       <figure xml:id="fig_washeridea1a_3D">
         <caption/>
@@ -1136,18 +1136,18 @@
 
   <p>
     One can generate a solid of revolution with a hole in the middle by revolving a region about an axis.
-    Consider <xref ref="fig_washeridea1a_3D">Figure</xref>,
+    Consider <xref ref="fig_washeridea1a_3D"/>,
     where a region is sketched along with a dashed,
     horizontal axis of rotation.
     By rotating the region about the axis,
-    a solid is formed as sketched in <xref ref="fig_washeridea1b_3D">Figure</xref>.
+    a solid is formed as sketched in <xref ref="fig_washeridea1b_3D"/>.
     The outside of the solid has radius <m>R(x)</m>,
     whereas the inside has radius <m>r(x)</m>.
-    Each cross section of this solid will be a washer (a disk with a hole in the center) as sketched in <xref ref="fig_washeridea2_3D">Figure</xref>. This leads us to the Washer Method.
+    Each cross section of this solid will be a washer (a disk with a hole in the center) as sketched in <xref ref="fig_washeridea2_3D"/>. This leads us to the Washer Method.
   </p>
 
   <figure xml:id="fig_washeridea2_3D">
-    <caption>Establishing the Washer Method; see also <xref ref="fig_washeridea1">Figure</xref></caption>
+    <caption>Establishing the Washer Method; see also <xref ref="fig_washeridea1"/></caption>
 
     <!-- START figures/figwasher_idea_c_3D.asy -->
     <image xml:id="img_washeridea2_3D" width="47%">
@@ -1291,10 +1291,10 @@
 
       <p>
         A sketch of the region will help,
-        as given in <xref ref="fig_wash1a_3D">Figure</xref>.
+        as given in <xref ref="fig_wash1a_3D"/>.
         Rotating about the <m>x</m>-axis will produce cross sections in the shape of washers,
-        as shown in <xref ref="fig_wash1b_3D">Figure</xref>;
-        the complete solid is shown in <xref ref="fig_wash1c_3D">Figure</xref>.
+        as shown in <xref ref="fig_wash1b_3D"/>;
+        the complete solid is shown in <xref ref="fig_wash1c_3D"/>.
         The outside radius of this washer is <m>R(x) = 2x-1</m>;
         the inside radius is <m>r(x) = x^2-2x+2</m>.
         As the region is bounded from <m>x=1</m> to <m>x=3</m>,
@@ -1308,7 +1308,7 @@
       </p>
 
       <figure xml:id="fig_wash1">
-        <caption>Sketching the differential element and solid in <xref ref="ex_wash1">Example</xref></caption>
+        <caption>Sketching the differential element and solid in <xref ref="ex_wash1"/></caption>
         <sidebyside widths="31% 31% 31%" margins="0%">
           <figure xml:id="fig_wash1a_3D">
             <caption/>
@@ -1554,8 +1554,8 @@
     </solution>
     <solution>
       <p>
-        The triangular region is sketched in <xref ref="fig_wash2a_3D">Figure</xref>;
-        the differential element is sketched in <xref ref="fig_wash2b_3D">Figure</xref> and the full solid is drawn in <xref ref="fig_wash2c_3D">Figure</xref>.
+        The triangular region is sketched in <xref ref="fig_wash2a_3D"/>;
+        the differential element is sketched in <xref ref="fig_wash2b_3D"/> and the full solid is drawn in <xref ref="fig_wash2c_3D"/>.
         They help us establish the outside and inside radii.
         Since the axis of rotation is vertical,
         each radius is a function of <m>y</m>.
@@ -1569,7 +1569,7 @@
       </p>
 
       <figure xml:id="fig_wash2">
-        <caption>Sketching the solid in <xref ref="ex_wash2">Example</xref></caption>
+        <caption>Sketching the solid in <xref ref="ex_wash2"/></caption>
         <sidebyside widths="31% 31% 31%" margins="0%">
           <figure xml:id="fig_wash2a_3D">
             <caption/>
@@ -1863,7 +1863,7 @@
     The ultimate goal of this section is not to compute volumes of solids.
     That can be useful,
     but what is more useful is the understanding of this basic principle of integral calculus,
-    outlined in <xref ref="idea_app_of_defint">Key Idea</xref>:
+    outlined in <xref ref="idea_app_of_defint"/>:
     to find the exact value of some quantity,
   </p>
 
@@ -1939,7 +1939,7 @@
             </pg-code> -->
             <statement>
               <p>
-                Explain the how the units of volume are found in the integral of <xref ref="thm_volume_by_cross_section">Theorem</xref>:
+                Explain the how the units of volume are found in the integral of <xref ref="thm_volume_by_cross_section"/>:
                 if <m>A(x)</m> has units of <m>\text{in}^2</m>,
                 how does <m>\int A(x)\,dx</m> have units of <m>\text{in}^3</m>?
               </p>
@@ -2761,7 +2761,7 @@
         <introduction>
           <p>
             Orient the given solid along the <m>x</m>-axis such that a cross-sectional area function <m>A(x)</m> can be obtained,
-            then apply <xref ref="thm_volume_by_cross_section">Theorem</xref>
+            then apply <xref ref="thm_volume_by_cross_section"/>
             to find the volume of the solid.
           </p>
         </introduction>
@@ -2871,7 +2871,7 @@
               </answer>
               <solution>
                 <p>
-                  The cross-sections of this cone are the same as the cone in <xref ref="ex_07_02_ex_18">Exercise</xref>.
+                  The cross-sections of this cone are the same as the cone in <xref ref="ex_07_02_ex_18"/>.
                   Thus they have the same volume of <m>250\pi/3</m> units<m>^3</m>.
                 </p>
               </solution>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -1298,7 +1298,7 @@
     </p>
 
     <p>
-      This leads us to rewrite Equation <xref ref="eq_orthogproj"/> in a seemingly silly way:
+      This leads us to rewrite <xref ref="eq_orthogproj">Equation</xref> in a seemingly silly way:
       <me>
         \vec u = \proj uv + (\vec u - \proj uv)
       </me>.

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -87,7 +87,7 @@
           <ol>
             <li>
               <p>
-                Using <xref ref="def_dot_product">Definition</xref>, we have
+                Using <xref ref="def_dot_product"/>, we have
                 <me>
                   \dotp uv = 1(3)+2(-1) = 1
                 </me>.
@@ -180,7 +180,7 @@
     <p>
       The next theorem extends this understanding by connecting the dot product to magnitudes and angles.
       Given vectors <m>\vec u</m> and <m>\vec v</m> in the plane,
-      an angle <m>\theta</m> is clearly formed when <m>\vec u</m> and <m>\vec v</m> are drawn with the same initial point as illustrated in <xref ref="fig_dotpanglea">Figure</xref>. (We always take <m>\theta</m> to be the angle in <m>[0,\pi]</m> as two angles are actually created.)
+      an angle <m>\theta</m> is clearly formed when <m>\vec u</m> and <m>\vec v</m> are drawn with the same initial point as illustrated in <xref ref="fig_dotpanglea"/>. (We always take <m>\theta</m> to be the angle in <m>[0,\pi]</m> as two angles are actually created.)
     </p>
 
     <figure xml:id="fig_dotpangle">
@@ -295,7 +295,7 @@
       In that plane,
       we can again find an angle <m>\theta</m> between them
       (and again, <m>0\leq \theta\leq \pi</m>).
-      This is illustrated in <xref ref="fig_dotpangleb_3D">Figure</xref>.
+      This is illustrated in <xref ref="fig_dotpangleb_3D"/>.
     </p>
 
     <p>
@@ -326,7 +326,7 @@
     </figure>
 
     <p>
-      Using <xref ref="thm_dot_product_properties">Theorem</xref>,
+      Using <xref ref="thm_dot_product_properties"/>,
       we can rewrite this theorem as
       <me>
         \frac{\vec u}{\norm{\vec u}}\cdot \frac{\vec v}{\norm{\vec v}} = \cos(\theta)
@@ -337,7 +337,7 @@
       Note how on the left hand side of the equation,
       we are computing the dot product of two unit vectors.
       Recalling that unit vectors essentially only provide direction information,
-      we can informally restate <xref ref="thm_dot_product">Theorem</xref>
+      we can informally restate <xref ref="thm_dot_product"/>
       as saying <q>The dot product of two directions gives the cosine of the angle between them.</q>
     </p>
 
@@ -348,7 +348,7 @@
       when <m>\theta</m> is an obtuse angle (<m>\pi/2\lt \theta \leq \pi</m>),
       <m>\cos(\theta)</m> is negative.
       Thus the sign of the dot product gives a general indication of the angle between the vectors,
-      illustrated in <xref ref="fig_dotpanglesign">Figure</xref>.
+      illustrated in <xref ref="fig_dotpanglesign"/>.
     </p>
 
     <figure xml:id="fig_dotpanglesign">
@@ -400,7 +400,7 @@
     </figure>
 
     <p>
-      We <em>can</em> use <xref ref="thm_dot_product">Theorem</xref> to compute the dot product,
+      We <em>can</em> use <xref ref="thm_dot_product"/> to compute the dot product,
       but generally this theorem is used to find the angle between known vectors
       (since the dot product is generally easy to compute).
       To this end, we rewrite the theorem's equation as
@@ -419,12 +419,12 @@
         <p>
           Let <m>\vec u = \la 3,1\ra</m>,
           <m>\vec v = \la -2,6\ra</m> and <m>\vec w = \la -4,3\ra</m>,
-          as shown in <xref ref="fig_dotp2">Figure</xref>.
+          as shown in <xref ref="fig_dotp2"/>.
           Find the angles <m>\alpha</m>,
           <m>\beta</m> and <m>\theta</m>.
         </p>
         <figure xml:id="fig_dotp2">
-          <caption>Vectors used in <xref ref="ex_dotp2">Example</xref></caption>
+          <caption>Vectors used in <xref ref="ex_dotp2"/></caption>
           <!-- START figures/fig_dotp2.tex -->
           <image xml:id="img_dotp2" width="47%">
             <shortdescription>
@@ -493,7 +493,7 @@
         </p>
 
         <p>
-          We now apply <xref ref="thm_dot_product">Theorem</xref> to find the angles.
+          We now apply <xref ref="thm_dot_product"/> to find the angles.
           <md>
             <mrow>\alpha \amp = \cos^{-1}\left(\frac{\dotp uv}{(\sqrt{10})(2\sqrt{10})}\right)</mrow>
             <mrow>\amp = \cos^{-1}(0) = \frac{\pi}2 = 90^\circ</mrow>
@@ -512,7 +512,7 @@
 
     <p>
       We see from our computation that <m>\alpha + \beta = \theta</m>,
-      as indicated by <xref ref="fig_dotp2">Figure</xref>.
+      as indicated by <xref ref="fig_dotp2"/>.
       While we knew this should be the case,
       it is nice to see that this non-intuitive formula indeed returns the results we expected.
     </p>
@@ -527,11 +527,11 @@
         <p>
           Let <m>\vec u = \la 1,1,1\ra</m>,
           <m>\vec v = \la -1,3,-2\ra</m> and <m>\vec w = \la -5,1,4\ra</m>,
-          as illustrated in <xref ref="fig_dotp3">Figure</xref>.
+          as illustrated in <xref ref="fig_dotp3"/>.
           Find the angle between each pair of vectors.
         </p>
         <figure xml:id="fig_dotp3">
-          <caption>Vectors used in <xref ref="ex_dotp3">Example</xref></caption>
+          <caption>Vectors used in <xref ref="ex_dotp3"/></caption>
           <!-- START figures/figdotp3_3D.asy -->
           <image xml:id="img_dotp3" width="47%">
             <shortdescription>
@@ -649,7 +649,7 @@
 
         <p>
           While our work shows that each angle is <m>\pi/2</m>, <ie/>, <m>90^\circ</m>,
-          none of these angles looks to be a right angle in <xref ref="fig_dotp3">Figure</xref>.
+          none of these angles looks to be a right angle in <xref ref="fig_dotp3"/>.
           Such is the case when drawing three-dimensional objects on the page.
         </p>
       </solution>
@@ -662,7 +662,7 @@
       <m>90^\circ</m> angles are <q>nice</q>
       for a variety of reasons,
       so it should seem significant that these angles are all <m>\pi/2</m>.
-      Notice the common feature in each calculation (and also the calculation of <m>\alpha</m> in <xref ref="ex_dotp2">Example</xref>):
+      Notice the common feature in each calculation (and also the calculation of <m>\alpha</m> in <xref ref="ex_dotp2"/>):
       the dot products of each pair of angles was 0.
       We use this as a basis for a definition of the term <em>orthogonal</em>,
       which is essentially synonymous to <em>perpendicular</em>.
@@ -776,12 +776,12 @@
     </example>
 
     <p>
-      An important construction is illustrated in <xref ref="fig_dotpproj">Figure</xref>,
+      An important construction is illustrated in <xref ref="fig_dotpproj"/>,
       where vectors <m>\vec u</m> and <m>\vec v</m> are sketched.
-      In <xref ref="fig_dotpproja">Figure</xref>,
+      In <xref ref="fig_dotpproja"/>,
       a dotted line is drawn from the tip of <m>\vec u</m> to the line containing <m>\vec v</m>,
       where the dotted line is orthogonal to <m>\vec v</m>.
-      In <xref ref="fig_dotpprojb">Figure</xref>,
+      In <xref ref="fig_dotpprojb"/>,
       the dotted line is replaced with the vector <m>\vec z</m> and <m>\vec w</m> is formed,
       parallel to <m>\vec v</m>.
       It is clear by the diagram that <m>\vec u = \vec w+\vec z</m>.
@@ -795,7 +795,7 @@
 
     <p>
       The vectors <m>\vec w</m>,
-      <m>\vec z</m> and <m>\vec u</m> as shown in <xref ref="fig_dotpprojb">Figure</xref> form a right triangle,
+      <m>\vec z</m> and <m>\vec u</m> as shown in <xref ref="fig_dotpprojb"/> form a right triangle,
       where the angle between <m>\vec v</m> and <m>\vec u</m> is labeled <m>\theta</m>.
       We can find <m>\vec w</m> in terms of <m>\vec v</m> and <m>\vec u</m>.
     </p>
@@ -893,9 +893,9 @@
       <m>\vec v/\norm{\vec v}</m> with magnitude <m>\norm{\vec u}\cos(\theta)</m>:
       <md>
         <mrow>\vec w \amp = \Big(\norm{\vec u}\cos(\theta) \Big)\frac{1}{\norm{\vec v}}\vec v.</mrow>
-        <mrow>\amp = \left(\norm{\vec u}\frac{\dotp uv}{\norm{\vec u}\norm{\vec v}}\right)\frac{1}{\norm{\vec v}} \vec v \text{ (Replacing } \cos(\theta) \text{ using } <xref ref="thm_dot_product">Theorem</xref>\text{)}</mrow>
+        <mrow>\amp = \left(\norm{\vec u}\frac{\dotp uv}{\norm{\vec u}\norm{\vec v}}\right)\frac{1}{\norm{\vec v}} \vec v \text{ (Replacing } \cos(\theta) \text{ using } <xref ref="thm_dot_product"/>\text{)}</mrow>
         <mrow>\amp = \frac{\dotp uv}{\norm{\vec v}^2}\vec v.</mrow>
-        <mrow>\amp = \frac{\dotp uv}{\dotp vv}\vec v \text{ (Applying }<xref ref="thm_dot_product_properties">Theorem</xref>\text{)}</mrow>
+        <mrow>\amp = \frac{\dotp uv}{\dotp vv}\vec v \text{ (Applying }<xref ref="thm_dot_product_properties"/>\text{)}</mrow>
       </md>.
     </p>
 
@@ -957,14 +957,14 @@
           <ol>
             <li>
               <p>
-                Applying <xref ref="def_orthogonal_projection">Definition</xref>, we have
+                Applying <xref ref="def_orthogonal_projection"/>, we have
                 <md>
                   <mrow>\proj uv \amp = \frac{\dotp uv}{\dotp vv}\vec v</mrow>
                   <mrow>\amp = \frac{-5}{10}\la 3,1\ra</mrow>
                   <mrow>\amp = \la -\frac32,-\frac12\ra</mrow>
                 </md>.
                 Vectors <m>\vec u</m>, <m>\vec v</m> and
-                <m>\proj uv</m> are sketched in <xref ref="fig_dotp4a">Figure</xref>.
+                <m>\proj uv</m> are sketched in <xref ref="fig_dotp4a"/>.
                 Note how the projection is parallel to <m>\vec v</m>;
                 that is, it lies on the same line through the origin as <m>\vec v</m>,
                 although it points in the opposite direction.
@@ -972,7 +972,7 @@
               </p>
 
               <figure xml:id="fig_dotp4a">
-                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part1">Part</xref> of <xref ref="ex_dotp4">Example</xref></caption>
+                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part1" text="local">Part</xref> of <xref ref="ex_dotp4"/></caption>
                 <image xml:id="img_dotp4a" width="47%">
                   <shortdescription>
                     Graph shows two vectors u and v, and the projection of u on v.
@@ -1023,15 +1023,15 @@
                   <mrow>\amp = \frac{6}{3}\la 1,1,1\ra</mrow>
                   <mrow>\amp = \la 2,2,2\ra</mrow>
                 </md>.
-                These vectors are sketched in <xref ref="figdotp4b_3D">Figure</xref>,
-                and again in <xref ref="figdotp4c_3D">Figure</xref> from a different perspective.
+                These vectors are sketched in <xref ref="figdotp4b_3D"/>,
+                and again in <xref ref="figdotp4c_3D"/> from a different perspective.
                 Because of the nature of graphing these vectors,
-                the sketch in <xref ref="figdotp4b_3D">Figure</xref> makes it difficult to recognize that the drawn projection has the geometric properties it should.
-                The graph shown in <xref ref="figdotp4c_3D">Figure</xref> illustrates these properties better.
+                the sketch in <xref ref="figdotp4b_3D"/> makes it difficult to recognize that the drawn projection has the geometric properties it should.
+                The graph shown in <xref ref="figdotp4c_3D"/> illustrates these properties better.
               </p>
 
               <figure xml:id="fig_dotp4bc">
-                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part2">Part</xref> of <xref ref="ex_dotp4">Example</xref></caption>
+                <caption>Sketching the three vectors in <xref ref="ex_dotp4_part2" text="local">Part</xref> of <xref ref="ex_dotp4"/></caption>
                 <sidebyside widths="47% 47%" margins="0%">
                   <figure xml:id="figdotp4b_3D">
                     <caption/>
@@ -1212,8 +1212,8 @@
     </example>
 
     <p>
-      We can use the properties of the dot product found in <xref ref="thm_dot_product_properties">Theorem</xref>
-      to rearrange the formula found in <xref ref="def_orthogonal_projection">Definition</xref>:
+      We can use the properties of the dot product found in <xref ref="thm_dot_product_properties"/>
+      to rearrange the formula found in <xref ref="def_orthogonal_projection"/>:
       <md>
         <mrow>\proj uv \amp = \frac{\dotp uv}{\dotp vv}\vec v</mrow>
         <mrow>\amp = \frac{\dotp uv}{\norm{\vec v}^2}\vec v</mrow>
@@ -1281,7 +1281,7 @@
     </figure>
 
     <p>
-      Now consider <xref ref="fig_dotpprojc">Figure</xref>
+      Now consider <xref ref="fig_dotpprojc"/>
       where the concept of the orthogonal projection is again illustrated.
       It is clear that
       <men xml:id="eq_orthogproj">
@@ -1343,7 +1343,7 @@
             <li>
               <p>
                 Let <m>\vec u = \la -2,1\ra</m> and
-                <m>\vec v = \la 3,1\ra</m> as in <xref ref="ex_dotp4">Example</xref>.
+                <m>\vec v = \la 3,1\ra</m> as in <xref ref="ex_dotp4"/>.
                 Decompose <m>\vec u</m> as the sum of a vector parallel to <m>\vec v</m> and a vector orthogonal to <m>\vec v</m>.
               </p>
             </li>
@@ -1351,7 +1351,7 @@
             <li>
               <p>
                 Let <m>\vec w =\la 2,1,3\ra</m> and
-                <m>\vec x =\la 1,1,1\ra</m> as in <xref ref="ex_dotp4">Example</xref>.
+                <m>\vec x =\la 1,1,1\ra</m> as in <xref ref="ex_dotp4"/>.
                 Decompose <m>\vec w</m> as the sum of a vector parallel to <m>\vec x</m> and a vector orthogonal to <m>\vec x</m>.
               </p>
             </li>
@@ -1367,7 +1367,7 @@
           <ol>
             <li>
               <p>
-                In <xref ref="ex_dotp4">Example</xref>,
+                In <xref ref="ex_dotp4"/>,
                 we found that <m>\proj uv = \la -1.5,-0.5\ra</m>.
                 Let
                 <me>
@@ -1389,7 +1389,7 @@
 
             <li>
               <p>
-                We found in <xref ref="ex_dotp4">Example</xref>
+                We found in <xref ref="ex_dotp4"/>
                 that <m>\proj wx = \la 2,2,2\ra</m>.
                 Applying the Key Idea, we have:
                 <me>
@@ -1421,15 +1421,15 @@
       <title>Orthogonally decomposing a force vector</title>
       <statement>
         <p>
-          Consider <xref ref="fig_dotp6a">Figure</xref>,
+          Consider <xref ref="fig_dotp6a"/>,
           showing a box weighing 50lb on a ramp that rises 5ft over a span of 20ft.
           Find the components of force,
           and their magnitudes,
-          acting on the box (as sketched in <xref ref="fig_dotp6b">Figure</xref>):
+          acting on the box (as sketched in <xref ref="fig_dotp6b"/>):
         </p>
 
         <figure xml:id="fig_dotp6">
-          <caption>Sketching the ramp and box in <xref ref="ex_dotp6">Example</xref>. Note: <em>The vectors are not drawn to scale.</em></caption>
+          <caption>Sketching the ramp and box in <xref ref="ex_dotp6"/>. Note: <em>The vectors are not drawn to scale.</em></caption>
           <sidebyside widths="47% 47%" margins="0%">
            <figure xml:id="fig_dotp6a">
               <caption/>
@@ -1547,7 +1547,7 @@
             <li>
               <p>
                 To find the component <m>\vec z</m> of gravity orthogonal to the ramp,
-                we use <xref ref="idea_orthog_proj">Key Idea</xref>.
+                we use <xref ref="idea_orthog_proj"/>.
                 <md>
                   <mrow>\vec z \amp = \vec g - \proj gr</mrow>
                   <mrow>\amp = \la \frac{200}{17},-\frac{800}{17}\ra \approx \la 11.76,-47.06\ra</mrow>
@@ -1606,7 +1606,7 @@
     </figure>
 
     <p>
-      Consider <xref ref="fig_dotpwork">Figure</xref>,
+      Consider <xref ref="fig_dotpwork"/>,
       where a force <m>\vec F</m> is being applied to an object moving in the direction of <m>\vec d</m>.
       (The distance the object travels is the magnitude of <m>\vec d</m>.)
       The work done is the amount of force in the direction of <m>\vec d</m>,
@@ -1645,11 +1645,11 @@
       <title>Computing work</title>
       <statement>
         <p>
-          A man slides a box along a ramp that rises 3ft over a distance of 15ft by applying 50lb of force as shown in <xref ref="fig_dotp7">Figure</xref>.
+          A man slides a box along a ramp that rises 3ft over a distance of 15ft by applying 50lb of force as shown in <xref ref="fig_dotp7"/>.
           Compute the work done.
         </p>
         <figure xml:id="fig_dotp7">
-          <caption>Computing work when sliding a box up a ramp in <xref ref="ex_dotp7">Example</xref></caption>
+          <caption>Computing work when sliding a box up a ramp in <xref ref="ex_dotp7"/></caption>
           <!-- START figures/fig_dotp7.tex -->
           <image xml:id="img_dotp7" width="47%">
             <shortdescription>
@@ -2368,8 +2368,7 @@
             one of which is parallel to <m>\vec v</m>
             (or is zero)
             and one of which is orthogonal to <m>\vec v</m>.
-            Note: these are the same pairs of vectors as found in <xref ref="ex_10_03_ex_21">Exercises</xref>
-            <mdash/> <xref ref="ex_10_03_ex_24"/>.
+            Note: these are the same pairs of vectors as found in <xref first="ex_10_03_ex_21" last="ex_10_03_ex_24" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_double_int_polar.ptx
+++ b/ptx/sec_double_int_polar.ptx
@@ -126,12 +126,12 @@
 
   <p>
     Now consider representing a region <m>R</m> with polar coordinates.
-    Consider <xref ref="fig_double_pol_introa">Figure</xref>.
+    Consider <xref ref="fig_double_pol_introa"/>.
     Let <m>R</m> be the region in the first quadrant bounded by the curve.
     We can approximate this region using the natural shape of polar coordinates:
     portions of sectors of circles.
     In the figure, one such region is shaded,
-    shown again in <xref ref="fig_double_pol_introb">Figure</xref>.
+    shown again in <xref ref="fig_double_pol_introb"/>.
   </p>
 
   <p>
@@ -217,7 +217,7 @@
         The bounds of the integral are determined solely by the region <m>R</m> over which we are integrating.
         In this case, it is a disk with boundary <m>x^2+y^2=1</m>.
         We need to find polar bounds for this region.
-        It may help to review <xref ref="sec_polar">Section</xref>;
+        It may help to review <xref ref="sec_polar"/>;
         bounds for this disk are <m>0\leq r\leq 1</m> and <m>0\leq \theta\leq 2\pi</m>.
       </p>
 
@@ -243,7 +243,7 @@
       </p>
 
       <figure xml:id="fig_doublepol1">
-        <caption>Evaluating a double integral with polar coordinates in <xref ref="ex_doublepol1">Example</xref></caption>
+        <caption>Evaluating a double integral with polar coordinates in <xref ref="ex_doublepol1"/></caption>
 
         <!-- START figures/figdoublepol1_3D.asy -->
         <image xml:id="img_doublepol1" width="47%">
@@ -301,7 +301,7 @@
       </figure>
 
       <p>
-        The surface and region <m>R</m> are shown in <xref ref="fig_doublepol1">Figure</xref>.
+        The surface and region <m>R</m> are shown in <xref ref="fig_doublepol1"/>.
       </p>
     </solution>
   </example>
@@ -323,15 +323,15 @@
     <solution>
       <p>
         At first glance,
-        this seems like a very hard volume to compute as the region <m>R</m> (shown in <xref ref="fig_doublepol2a">Figure</xref>) has a hole in it,
+        this seems like a very hard volume to compute as the region <m>R</m> (shown in <xref ref="fig_doublepol2a"/>) has a hole in it,
         cutting out a strange portion of the surface,
-        as shown in <xref ref="fig_doublepol2b_3D">Figure</xref>.
+        as shown in <xref ref="fig_doublepol2b_3D"/>.
         However, by describing <m>R</m> in terms of polar equations,
         the volume is not very difficult to compute.
       </p>
 
       <figure xml:id="fig_doublepol2">
-        <caption>Showing the region <m>R</m> and surface used in <xref ref="ex_doublepol2">Example</xref></caption>
+        <caption>Showing the region <m>R</m> and surface used in <xref ref="ex_doublepol2"/></caption>
         <sidebyside widths="47% 47%" margins="0%">
           <figure xml:id="fig_doublepol2a">
             <caption/>
@@ -512,10 +512,10 @@
       <p>
         Find the volume under the surface given by the graph of
         <m>\ds f(x,y) =\frac1{x^2+y^2+1}</m> over the sector of the circle with radius <m>a</m> centered at the origin in the first quadrant,
-        as shown in <xref ref="fig_doublepol5">Figure</xref>.
+        as shown in <xref ref="fig_doublepol5"/>.
       </p>
       <figure xml:id="fig_doublepol5">
-        <caption>The surface and region <m>R</m> used in <xref ref="ex_doublepol5">Example</xref></caption>
+        <caption>The surface and region <m>R</m> used in <xref ref="ex_doublepol5"/></caption>
 
         <!-- START figures/figdoublepol5_3D.asy -->
         <image xml:id="img_doublepol5" width="47%">
@@ -609,14 +609,14 @@
         <p>
           Previous work has shown that there is finite <em>area</em>
           under <m>\frac{1}{x^2+1}</m> over the entire <m>x</m>-axis.
-          However, <xref ref="ex_doublepol5">Example</xref>
+          However, <xref ref="ex_doublepol5"/>
           shows that there is infinite <em>volume</em>
           under <m>\frac{1}{x^2+y^2+1}</m> over the entire <m>xy</m>-plane.
         </p>
       </aside>
 
       <p>
-        <xref ref="fig_doublepol5">Figure</xref>
+        <xref ref="fig_doublepol5"/>
         shows that <m>f</m> shrinks to near 0 very quickly.
         Regardless, as <m>a</m> grows,
         so does the volume, without bound.
@@ -681,7 +681,7 @@
     <title>Finding the volume of a solid</title>
     <statement>
       <p>
-        A sculptor wants to make a solid bronze cast of the solid shown in <xref ref="fig_doublepol4">Figure</xref>,
+        A sculptor wants to make a solid bronze cast of the solid shown in <xref ref="fig_doublepol4"/>,
         where the base of the solid has boundary,
         in polar coordinates, <m>r=\cos(3\theta)</m>,
         and the top is defined by the plane <m>z=1-x+0.1y</m>.
@@ -689,7 +689,7 @@
       </p>
 
       <figure xml:id="fig_doublepol4">
-        <caption>Visualizing the solid used in <xref ref="ex_doublepol4">Example</xref></caption>
+        <caption>Visualizing the solid used in <xref ref="ex_doublepol4"/></caption>
 
         <!-- START figures/figdoublepol4_3D.asy -->
         <image xml:id="img_doublepol4" width="47%">

--- a/ptx/sec_double_int_volume.ptx
+++ b/ptx/sec_double_int_volume.ptx
@@ -10,7 +10,7 @@
     We formed rectangles that approximated part of the region under the curve with width <m>\dx_i</m>,
     height <m>f(c_i)</m>, and hence with area <m>f(c_i)\dx_i</m>.
     Summing all the rectangle's areas gave an approximation of the definite integral,
-    and <xref ref="thm_riemann_sum">Theorem</xref> stated that
+    and <xref ref="thm_riemann_sum"/> stated that
     <me>
       \int_a^bf(x)\, dx = \lim_{\norm{\Delta x}\to 0}\sum f(c_i)\dx_i
     </me>,
@@ -40,7 +40,7 @@
   </p>
 
   <p>
-    We start by partitioning <m>R</m> into <m>n</m> rectangular subregions as shown in <xref ref="fig_double_introa">Figure</xref>.
+    We start by partitioning <m>R</m> into <m>n</m> rectangular subregions as shown in <xref ref="fig_double_introa"/>.
     For simplicity's sake,
     we let all widths be <m>\dx</m> and all heights be <m>\dy</m>.
     Note that the sum of the areas of the rectangles is not equal to the area of <m>R</m>,
@@ -255,7 +255,7 @@
     The volume of the rectangular solid whose base is the
     <m>i</m>th subregion and whose height is
     <m>f(x_i,y_i)</m> is <m>V_i=f(x_i,y_i)\dx\dy</m>.
-    Such a solid is shown in <xref ref="fig_double_introb_3d">Figure</xref>.
+    Such a solid is shown in <xref ref="fig_double_introb_3d"/>.
     Note how this rectangular solid only approximates the true volume under the surface;
     part of the solid is above the surface and part is below.
   </p>
@@ -298,7 +298,7 @@
       <em>sum</em> of the areas of rectangles over the interval <m>[a,b]</m>.</q>
       The double integral uses two integration symbols to represent a <q>double sum.</q>
       When adding up the volumes of rectangular solids over a partition of a region <m>R</m>,
-      as done in <xref ref="fig_double_intro">Figure</xref>,
+      as done in <xref ref="fig_double_intro"/>,
       one could first add up the volumes across each row
       (one type of sum),
       then add these totals together
@@ -320,7 +320,7 @@
       The summation inside the parenthesis indicates the sum of heights <times/> widths,
       which gives an area;
       multiplying these areas by the thickness <m>\Delta y_j</m> gives a volume.
-      The illustration in <xref ref="fig_double_intro3">Figure</xref>
+      The illustration in <xref ref="fig_double_intro3"/>
       relates to this understanding.
     </p>
   </aside>
@@ -389,14 +389,14 @@
   </p>
 
   <p>
-    Recall <xref ref="thm_volume_by_cross_section">Theorem</xref>
-    in <xref ref="sec_disk">Section</xref>.
+    Recall <xref ref="thm_volume_by_cross_section"/>
+    in <xref ref="sec_disk"/>.
     This stated that if <m>A(x)</m> gives the cross-sectional area of a solid at <m>x</m>,
     then <m>\int_a^b A(x)\, dx</m> gave the volume of that solid over <m>[a,b]</m>.
   </p>
 
   <p>
-    Consider <xref ref="fig_double_intro3">Figure</xref>,
+    Consider <xref ref="fig_double_intro3"/>,
     where a surface <m>z=f(x,y)</m> is drawn over a region <m>R</m>.
     Fixing a particular <m>x</m> value,
     we can consider the area under <m>f</m> over <m>R</m> where <m>x</m> has that fixed value.
@@ -561,11 +561,11 @@
       <p>
         Let <m>f(x,y) = xy+e^y</m>.
         Find the signed volume under <m>f</m> on the region <m>R</m>,
-        which is the rectangle with corners <m>(3,1)</m> and <m>(4,2)</m> pictured in <xref ref="fig_double1">Figure</xref>,
+        which is the rectangle with corners <m>(3,1)</m> and <m>(4,2)</m> pictured in <xref ref="fig_double1"/>,
         using Fubini's Theorem and both orders of integration.
       </p>
       <figure xml:id="fig_double1">
-        <caption>Finding the signed volume under a surface in <xref ref="ex_double1">Example</xref></caption>
+        <caption>Finding the signed volume under a surface in <xref ref="ex_double1"/></caption>
 
         <!-- START figures/figdouble1_3D.asy -->
         <image xml:id="img_double1" width="47%">
@@ -668,10 +668,10 @@
         Evaluate <m>\iint_R \big(3xy-x^2-y^2+6\big)\, dA</m>,
         where <m>R</m> is the triangle bounded by <m>x=0</m>,
         <m>y=0</m> and <m>x/2+y=1</m>,
-        as shown in <xref ref="fig_double2">Figure</xref>.
+        as shown in <xref ref="fig_double2"/>.
       </p>
       <figure xml:id="fig_double2">
-        <caption>Finding the signed volume under the surface in <xref ref="ex_double2">Example</xref></caption>
+        <caption>Finding the signed volume under the surface in <xref ref="ex_double2"/></caption>
 
         <!-- START figures/figdouble2_3D.asy -->
         <image xml:id="img_double2" width="47%">
@@ -850,7 +850,7 @@
             <p>
               Let <m>R</m> be the union of two nonoverlapping regions,
               <m>R = R_1\bigcup R_2</m>
-              (see <xref ref="fig_double_region">Figure</xref>).
+              (see <xref ref="fig_double_region"/>).
               Then
               <me>
                 \iint_R f(x,y)\, dA = \iint_{R_1}f(x,y)\, dA+ \iint_{R_2}f(x,y)\, dA
@@ -906,12 +906,12 @@
       <p>
         Let <m>f(x,y) = \sin(x) \cos(y)</m> and <m>R</m> be the triangle with vertices <m>(-1,0)</m>,
         <m>(1,0)</m> and <m>(0,1)</m>
-        (see <xref ref="fig_double3">Figure</xref>).
+        (see <xref ref="fig_double3"/>).
         Evaluate the double integral <m>\iint_Rf(x,y)\, dA</m>.
       </p>
 
       <figure xml:id="fig_double3">
-        <caption>Finding the signed volume under a surface in <xref ref="ex_double3">Example</xref></caption>
+        <caption>Finding the signed volume under a surface in <xref ref="ex_double3"/></caption>
 
         <!-- START figures/figdouble3_3D.asy -->
         <image xml:id="img_double3" width="47%">
@@ -984,8 +984,8 @@
         If we attempt to integrate using an iterated integral with the order <m>dy\, dx</m>,
         note how there are two upper bounds on <m>R</m> meaning we'll need to use two iterated integrals.
         We would need to split the triangle into two regions along the <m>y</m>-axis,
-        then use <xref ref="thm_double_prop">Theorem</xref>,
-        <xref ref="thm_double_prop_regions">part</xref>.
+        then use <xref ref="thm_double_prop"/>,
+        <xref ref="thm_double_prop_regions" text="local">Part</xref>.
       </p>
 
       <p>
@@ -1015,7 +1015,7 @@
       <p>
         It turns out that over <m>R</m>,
         there is just as much volume above the <m>xy</m>-plane as below
-        (look again at <xref ref="fig_double3">Figure</xref>),
+        (look again at <xref ref="fig_double3"/>),
         giving a final signed volume of 0.
       </p>
     </solution>
@@ -1031,11 +1031,11 @@
       <p>
         Evaluate <m>\iint_R (4-y)\, dA</m>,
         where <m>R</m> is the region bounded by the parabolas <m>y^2=4x</m> and <m>x^2=4y</m>,
-        graphed in <xref ref="fig_double4">Figure</xref>.
+        graphed in <xref ref="fig_double4"/>.
       </p>
 
       <figure xml:id="fig_double4">
-        <caption>Finding the volume under the surface in <xref ref="ex_double4">Example</xref></caption>
+        <caption>Finding the volume under the surface in <xref ref="ex_double4"/></caption>
 
         <!-- START figures/figdouble4_3D.asy -->
         <image xml:id="img_double4" width="47%">
@@ -1119,7 +1119,7 @@
       <p>
         Thus we've found analytically what was easy to approximate graphically:
         the regions intersect at <m>(0,0)</m> and <m>(4,4)</m>,
-        as shown in <xref ref="fig_double4">Figure</xref>.
+        as shown in <xref ref="fig_double4"/>.
       </p>
 
       <p>
@@ -1180,12 +1180,12 @@
         Once again we make a sketch of the region over which we are integrating to facilitate changing the order.
         The bounds on <m>x</m> are from <m>x=y</m> to <m>x=3</m>;
         the bounds on <m>y</m> are from <m>y=0</m> to <m>y=3</m>.
-        These curves are sketched in <xref ref="fig_double6">Figure</xref>,
+        These curves are sketched in <xref ref="fig_double6"/>,
         enclosing the region <m>R</m>.
       </p>
 
       <figure xml:id="fig_double6">
-        <caption>Determining the region <m>R</m> determined by the bounds of integration in <xref ref="ex_double6">Example</xref></caption>
+        <caption>Determining the region <m>R</m> determined by the bounds of integration in <xref ref="ex_double6"/></caption>
         <!-- START figures/fig_double6.tex -->
         <image xml:id="img_double6" width="47%">
           <description></description>
@@ -1232,7 +1232,7 @@
         as given in the original problem.
         The first indefinite integral we need to evaluate is <m>\int e^{-x^2}\, dx</m>;
         we have stated before
-        (see <xref ref="sec_numerical_integration">Section</xref>)
+        (see <xref ref="sec_numerical_integration"/>)
         that this integral cannot be evaluated in terms of elementary functions.
         We are stuck.
       </p>
@@ -1258,12 +1258,12 @@
       <p>
         This last integral is easy to evaluate with substitution,
         giving a final answer of <m>\frac12(1-e^{-9})\approx 0.5</m>.
-        <xref ref="fig_double6b">Figure</xref>
+        <xref ref="fig_double6b"/>
         shows the surface over <m>R</m>.
       </p>
 
       <figure xml:id="fig_double6b">
-        <caption>Showing the surface <m>z=f(x,y)</m> defined in <xref ref="ex_double6">Example</xref> over its region <m>R</m></caption>
+        <caption>Showing the surface <m>z=f(x,y)</m> defined in <xref ref="ex_double6"/> over its region <m>R</m></caption>
 
         <!-- START figures/figdouble6b_3D.asy -->
         <image xml:id="img_double6b" width="47%">
@@ -1339,7 +1339,7 @@
   </figure>
 
   <p>
-    <xref ref="def_av_val">Definition</xref>
+    <xref ref="def_av_val"/>
     defines the average value of a single-variable function <m>f(x)</m> on the interval <m>[a,b]</m> as
     <me>
       \text{ average value of \(f(x)\) on \([a,b]\) }  = \frac1{b-a}\int_a^b f(x)\, dx;
@@ -1370,12 +1370,12 @@
       <p>
         Find the average value of <m>f(x,y) = 4-y</m> over the region <m>R</m>,
         which is bounded by the parabolas <m>y^2=4x</m> and <m>x^2=4y</m>.
-        Note: this is the same function and region as used in <xref ref="ex_double4">Example</xref>.
+        Note: this is the same function and region as used in <xref ref="ex_double4"/>.
       </p>
     </statement>
     <solution>
       <p>
-        In <xref ref="ex_double4">Example</xref> we found
+        In <xref ref="ex_double4"/> we found
         <me>
           \iint_R f(x,y)\, dA = \int_0^4\int_{y^2/4}^{2\sqrt{y}}(4-y)\, dx\, dy = \frac{176}{15}
         </me>.
@@ -1396,13 +1396,13 @@
       </p>
 
       <p>
-        While the surface, as shown in <xref ref="fig_double8">Figure</xref>,
+        While the surface, as shown in <xref ref="fig_double8"/>,
         covers <m>z</m>-values from <m>z=0</m> to <m>z=4</m>,
         the <q>average</q> <m>z</m>-value on <m>R</m> is 2.2.
       </p>
 
       <figure xml:id="fig_double8">
-        <caption>Finding the average value of <m>f</m> in <xref ref="ex_double8">Example</xref></caption>
+        <caption>Finding the average value of <m>f</m> in <xref ref="ex_double8"/></caption>
 
         <!-- START figures/figdouble4_3D.asy -->
         <image xml:id="img_double8" width="47%">
@@ -1486,7 +1486,7 @@
     a flat surface with constant <m>z</m>-value of 1.
     The double integral <m>\iint_R 1\, dA</m> finds the volume,
     under <m>z=1</m>, over <m>R</m>,
-    as shown in <xref ref="fig_double_summary">Figure</xref>.
+    as shown in <xref ref="fig_double_summary"/>.
     Basic geometry tells us that if the base of a general right cylinder has area <m>A</m>,
     its volume is <m>A\cdot h</m>,
     where <m>h</m> is the height.
@@ -2553,8 +2553,8 @@
           <p>
             In the following exercises,
             find the average value of <m>f</m> over the region <m>R</m>.
-            Notice how these functions and regions are related to the iterated integrals given in <xref ref="x13_02_ex_05">Exercises</xref>
-            <mdash/> <xref ref="x13_02_ex_08"/>.
+            Notice how these functions and regions are related to the iterated integrals given in
+            <xref first="x13_02_ex_05" last="x13_02_ex_08" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_fluid_force.ptx
+++ b/ptx/sec_fluid_force.ptx
@@ -58,12 +58,12 @@
               and holds <quantity><mag>10</mag><unit base="foot"/></quantity>
               of a fluid with a weight-density of
               <quantity><mag>50</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
-              (See <xref ref="fig_fluid1a">Figure</xref>.)
+              (See <xref ref="fig_fluid1a"/>.)
               What is the force exerted on the base of the cylinder by the fluid?
             </p>
 
             <figure xml:id="fig_fluid1a">
-              <caption>A cylindrical tank in <xref ref="ex_fluid1">Example</xref></caption>
+              <caption>A cylindrical tank in <xref ref="ex_fluid1"/></caption>
           <!-- START figures/fig_fluid1a.tex -->
               <image xml:id="img_fluid1a" width="33%">
                 <description>
@@ -115,12 +115,12 @@
               The tank holds <quantity><mag>10</mag><unit base="foot"/></quantity>
               of a fluid with a weight-density of
               <quantity><mag>50</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
-              (See <xref ref="fig_fluid1b">Figure</xref>.)
+              (See <xref ref="fig_fluid1b"/>.)
               What is the force exerted on the hatch by the fluid?
             </p>
 
             <figure xml:id="fig_fluid1b">
-              <caption>A rectangular tank in <xref ref="ex_fluid1">Example</xref></caption>
+              <caption>A rectangular tank in <xref ref="ex_fluid1"/></caption>
           <!-- START figures/fig_fluid1b.tex -->
               <image xml:id="img_fluid1b" width="47%">
                 <description>
@@ -209,7 +209,7 @@
         <ol>
           <li>
             <p>
-              Using <xref ref="def_fluid_pressure">Definition</xref>,
+              Using <xref ref="def_fluid_pressure"/>,
               we calculate that the pressure exerted on the cylinder's base is
               <m>w\cdot d = </m><quantity><mag>50</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>
               <times/><quantity><mag>10</mag><unit base="foot"/></quantity><m>=</m><quantity><mag>500</mag><unit base="pound"/><per base="foot" exp="2"/></quantity>.
@@ -261,7 +261,7 @@
   </p>
 
   <p>
-    So consider a vertically oriented plate as shown in <xref ref="fig_fluid_intro1">Figure</xref>
+    So consider a vertically oriented plate as shown in <xref ref="fig_fluid_intro1"/>
     submerged in a fluid with weight-density <m>w</m>.
     What is the total fluid force exerted on this plate?
     We find this force by first approximating the force on small horizontal strips.
@@ -404,7 +404,7 @@
     <title>Finding fluid force</title>
     <statement>
       <p>
-        Consider a thin plate in the shape of an isosceles triangle as shown in <xref ref="fig_fluid2a">Figure</xref>,
+        Consider a thin plate in the shape of an isosceles triangle as shown in <xref ref="fig_fluid2a"/>,
         submerged in water with a weight-density of
         <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
         If the bottom of the plate is <quantity><mag>10</mag><unit base="foot"/></quantity>
@@ -413,7 +413,7 @@
       </p>
 
       <figure xml:id="fig_fluid2a">
-        <caption>A thin plate in the shape of an isosceles triangle in <xref ref="ex_fluid2">Example</xref></caption>
+        <caption>A thin plate in the shape of an isosceles triangle in <xref ref="ex_fluid2"/></caption>
         <!-- START figures/fig_fluid2a.tex -->
         <image xml:id="img_fluid2a" width="30%">
           <description>
@@ -446,7 +446,7 @@
     </statement>
     <solution>
       <p>
-        We approach this problem in two different ways to illustrate the different ways <xref ref="idea_fluid_force">Key Idea</xref> can be implemented.
+        We approach this problem in two different ways to illustrate the different ways <xref ref="idea_fluid_force"/> can be implemented.
         First we will let <m>y=0</m> represent the surface of the water,
         then we will consider an alternate convention.
       </p>
@@ -457,7 +457,7 @@
             <p>
               We let <m>y=0</m> represent the surface of the water;
               therefore the bottom of the plate is at <m>y=-10</m>.
-              We center the triangle on the <m>y</m>-axis as shown in <xref ref="fig_fluid2b">Figure</xref>.
+              We center the triangle on the <m>y</m>-axis as shown in <xref ref="fig_fluid2b"/>.
               The depth of the plate at <m>y</m> is <m>-y</m> as indicated by the Key Idea.
               We now consider the length of the plate at <m>y</m>.
 
@@ -471,7 +471,7 @@
             </p>
 
             <figure xml:id="fig_fluid2b">
-              <caption>Sketching the triangular plate in <xref ref="ex_fluid2">Example</xref> with the convention that the water level is at <m>y=0</m></caption>
+              <caption>Sketching the triangular plate in <xref ref="ex_fluid2"/> with the convention that the water level is at <m>y=0</m></caption>
           <!-- START figures/fig_fluid2b.tex -->
               <image xml:id="img_fluid2b" width="47%">
                 <description>
@@ -545,7 +545,7 @@
               Sometimes it seems easier to orient the thin plate nearer the origin.
               For instance,
               consider the convention that the bottom of the triangular plate is at <m>(0,0)</m>,
-              as shown in <xref ref="fig_fluid2c">Figure</xref>.
+              as shown in <xref ref="fig_fluid2c"/>.
               The equations of the left and right hand sides are easy to find.
               They are <m>y=2x</m> and <m>y=-2x</m>, respectively,
               which we rewrite as <m>x= 1/2y</m> and <m>x=-1/2y</m>.
@@ -553,7 +553,7 @@
             </p>
 
             <figure xml:id="fig_fluid2c">
-              <caption>Sketching the triangular plate in <xref ref="ex_fluid2">Example</xref> with the convention that the base of the triangle is at <m>(0,0)</m></caption>
+              <caption>Sketching the triangular plate in <xref ref="ex_fluid2"/> with the convention that the base of the triangle is at <m>(0,0)</m></caption>
           <!-- START figures/fig_fluid2c.tex -->
               <image xml:id="img_fluid2c" width="47%">
                 <description>
@@ -649,7 +649,7 @@
     <solution>
       <p>
         The car door, as a rectangle,
-        is drawn in <xref ref="fig_fluid3">Figure</xref>.
+        is drawn in <xref ref="fig_fluid3"/>.
         Its length is <m>10/3</m> ft and its height is <quantity><mag>2.25</mag><unit base="foot"/></quantity>.
         We adopt the convention that the top of the door is at the surface of the water,
         both of which are at <m>y=0</m>.
@@ -672,7 +672,7 @@
       </p>
 
       <figure xml:id="fig_fluid3">
-        <caption>Sketching a submerged car door in <xref ref="ex_fluid3">Example</xref></caption>
+        <caption>Sketching a submerged car door in <xref ref="ex_fluid3"/></caption>
         <!-- START figures/fig_fluid3.tex -->
         <image xml:id="img_fluid3" width="47%">
           <description>
@@ -732,7 +732,7 @@
       </p>
 
       <figure xml:id="fig_fluid4">
-        <caption>Measuring the fluid force on an underwater porthole in <xref ref="ex_fluid4">Example</xref></caption>
+        <caption>Measuring the fluid force on an underwater porthole in <xref ref="ex_fluid4"/></caption>
         <!-- START figures/fig_fluid4.tex -->
         <image xml:id="img_fluid4" width="40%">
           <description>
@@ -793,7 +793,7 @@
       <p>
         We place the center of the porthole at the origin,
         meaning the surface of the water is at <m>y=50</m> and the depth function will be <m>d(y)=50-y</m>;
-        see <xref ref="fig_fluid4">Figure</xref>
+        see <xref ref="fig_fluid4"/>
       </p>
 
       <p>

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -225,7 +225,7 @@
       when <m> \fp </m>is <em>increasing.</em>
       That means as one looks at a concave up graph from left to right,
       the slopes of the tangent lines will be increasing.
-      Consider <xref ref="fig_concavity1">Figure</xref>,
+      Consider <xref ref="fig_concavity1"/>,
       where a concave up graph is shown along with some tangent lines.
       Notice how the tangent line on the left is steep,
       downward, corresponding to a lesser
@@ -275,11 +275,11 @@
     <p>
       If a function is decreasing and concave up,
       then its rate of decrease is slowing;
-      it is <q>leveling off.</q> You can see this in the left side of <xref ref="fig_concavity1">Figure</xref>.
+      it is <q>leveling off.</q> You can see this in the left side of <xref ref="fig_concavity1"/>.
       If the function is increasing and concave up,
       then the <em>rate</em> of increase is increasing.
       The function is increasing at a faster and faster rate.
-      You can see this in the right side of <xref ref="fig_concavity1">Figure</xref>.
+      You can see this in the right side of <xref ref="fig_concavity1"/>.
     </p>
 
     <p>
@@ -292,7 +292,7 @@
       when <m> \fp </m>is <em>decreasing.</em>
       That means as one looks at a concave down graph from left to right,
       the slopes of the tangent lines will be decreasing.
-      Consider <xref ref="fig_concavity2">Figure</xref>,
+      Consider <xref ref="fig_concavity2"/>,
       where a concave down graph is shown along with some tangent lines.
       Notice how the tangent line on the left is steep,
       upward, corresponding to a greater
@@ -491,7 +491,7 @@
     </definition>
 
     <p>
-      <xref ref="fig_concavity4">Figure</xref>
+      <xref ref="fig_concavity4"/>
       shows a graph of a function with inflection points labeled.
     </p>
 
@@ -574,7 +574,7 @@
         <p>
           We start by finding <m>\fp(x)=3x^2-3</m> and <m>\fpp(x)=6x</m>.
           To find the inflection points,
-          we use <xref ref="thm_inflection">Theorem</xref>
+          we use <xref ref="thm_inflection"/>
           and find where <m>\fpp(x)=0</m> or where <m> \fpp </m>is undefined.
           We find <m> \fpp </m>is always defined,
           and is <m>0</m> only when <m>x=0</m>.
@@ -594,16 +594,16 @@
         </p>
 
         <p>
-          The number line in <xref ref="fig_concline1">Figure</xref>
+          The number line in <xref ref="fig_concline1"/>
           illustrates the process of determining concavity;
-          <xref ref="fig_conc1">Figure</xref>
+          <xref ref="fig_conc1"/>
           shows a graph of <m>f</m> and <m>\fpp</m>, confirming our results.
           Notice how <m>f</m> is concave down precisely when
           <m>\fpp(x)\lt 0</m> and concave up when <m>\fpp(x)\gt 0</m>.
         </p>
 
         <figure xml:id="fig_concline1">
-          <caption>A number line determining the concavity of <m>f</m> in <xref ref="ex_conc1">Example</xref></caption>
+          <caption>A number line determining the concavity of <m>f</m> in <xref ref="ex_conc1"/></caption>
           <!-- START figures/fig_concline1.tex -->
 
           <image xml:id="img_concline1"  width="47%">
@@ -639,7 +639,7 @@
         </figure>
 
         <figure xml:id="fig_conc1">
-          <caption>A graph of <m>f(x)</m> used in <xref ref="ex_conc1">Example</xref></caption>
+          <caption>A graph of <m>f(x)</m> used in <xref ref="ex_conc1"/></caption>
           <!-- START figures/fig_conc1.tex -->
           <image xml:id="img_conc1" width="47%">
             <shortdescription>
@@ -688,7 +688,7 @@
 
         <p>
           We need to find <m>\fp</m>and <m>\fpp</m>.
-          Using the <xref ref="thm_QuotientRule">Quotient Rule</xref> and simplifying, we find
+          Using the <xref ref="thm_QuotientRule" text="title"/> and simplifying, we find
           <md>
             <mrow>\fp(x)\amp=\frac{-(1+x^2)}{(x^2-1)^2}\amp\fpp(x)\amp= \frac{2x(x^2+3)}{(x^2-1)^3}</mrow>
           </md>.
@@ -712,7 +712,7 @@
         <p>
           The important <m>x</m>-values at which concavity might switch are <m>x=-1</m>,
           <m>x=0</m> and <m>x=1</m>,
-          which split the number line into four intervals as shown in <xref ref="fig_concline2">Figure</xref>.
+          which split the number line into four intervals as shown in <xref ref="fig_concline2"/>.
           We determine the concavity on each.
           Keep in mind that all we are concerned with is the <em>sign</em>
           of <m> \fpp </m>on the interval.
@@ -765,7 +765,7 @@
         </p>
 
         <figure xml:id="fig_concline2">
-          <caption>Number line for <m>f</m> in <xref ref="ex_conc2">Example</xref></caption>
+          <caption>Number line for <m>f</m> in <xref ref="ex_conc2"/></caption>
           
           <!-- START figures/fig_concline2.tex -->
           <image xml:id="img_concline2" width="50%">
@@ -836,14 +836,14 @@
           <m>(1,\infty)</m> and concave down on <m>(-\infty,-1)</m> and <m>(0,1)</m>.
           There is only one point of inflection,
           <m>(0,0)</m>, as <m>f</m> is not defined at <m>x=\pm 1</m>.
-          Our work is confirmed by the graph of <m>f</m> in <xref ref="fig_conc2">Figure</xref>.
+          Our work is confirmed by the graph of <m>f</m> in <xref ref="fig_conc2"/>.
           Notice how <m>f</m> is concave up whenever <m>\fpp</m>is positive,
           and concave down when <m>\fpp</m>is negative.
           The inflection in <m>f</m> occurs where <m>\fpp</m> changes sign.
         </p>
 
         <figure xml:id="fig_conc2">
-          <caption>A graph of <m>f(x)</m> and <m>\fpp(x)</m> in <xref ref="ex_conc2">Example</xref></caption>
+          <caption>A graph of <m>f(x)</m> and <m>\fpp(x)</m> in <xref ref="ex_conc2"/></caption>
           <!-- START figures/fig_conc2.tex -->
           <image xml:id="img_conc2" width="47%">
             <shortdescription>
@@ -906,13 +906,13 @@
         <p>
           The sales of a certain product over a three-year span are modeled by <m>S(t)= t^4-8t^2+20</m>,
           where <m>t</m> is the time in years,
-          shown in <xref ref="fig_conc3">Figure</xref>.
+          shown in <xref ref="fig_conc3"/>.
           Over the first two years, sales are decreasing.
           Find the point at which sales are decreasing at their greatest rate.
         </p>
 
         <figure xml:id="fig_conc3">
-          <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3">Example</xref>, modeling the sale of a product over time</caption>
+          <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3"/>, modeling the sale of a product over time</caption>
           <!-- START figures/fig_conc3.tex -->
           <image xml:id="img_conc3" width="47%">
             <shortdescription>
@@ -968,7 +968,7 @@
         </p>
 
         <p>
-          A graph of <m>S(t)</m> and <m>S'(t)</m> is given in <xref ref="fig_conc3b">Figure</xref>.
+          A graph of <m>S(t)</m> and <m>S'(t)</m> is given in <xref ref="fig_conc3b"/>.
           When <m>S'(t)\lt 0</m>, sales are decreasing;
           note how at <m>t\approx 1.16</m>,
           <m>S'(t)</m> is minimized.
@@ -979,7 +979,7 @@
         </p>
 
         <figure xml:id="fig_conc3b">
-          <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3">Example</xref>, along with <m>S'(t)</m></caption>
+          <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3"/>, along with <m>S'(t)</m></caption>
           <!-- START figures/fig_conc3b.tex -->
           <image xml:id="img_conc3b" width="47%">
             <shortdescription>
@@ -1025,7 +1025,7 @@
       concavity changing is <m>f(x)=x^4</m>.
       At <m>x=0</m>,
       <m>\fpp(x)=0</m> but <m>f</m> is always concave up,
-      as shown in <xref ref="fig_concavity5">Figure</xref>.
+      as shown in <xref ref="fig_concavity5"/>.
     </p>
 
     <figure xml:id="fig_concavity5">
@@ -1066,7 +1066,7 @@
       The following theorem officially states something that is intuitive:
       if a critical value occurs in a region where a function <m>f</m> is concave up,
       then that critical value must correspond to a relative minimum of <m>f</m>, etc.
-      See <xref ref="fig_concavity6">Figure</xref> for a visualization of this.
+      See <xref ref="fig_concavity6"/> for a visualization of this.
     </p>
 
     <figure xml:id="fig_concavity6">
@@ -1188,11 +1188,11 @@
           so there is a local minimum at <m>x=10</m>.
           Evaluating <m>\fpp(-10)=-0.1\lt 0</m>,
           determining a relative maximum at <m>x=-10</m>.
-          These results are confirmed in <xref ref="fig_conc4">Figure</xref>.
+          These results are confirmed in <xref ref="fig_conc4"/>.
         </p>
 
         <figure xml:id="fig_conc4">
-          <caption>A graph of <m>f(x)</m> in <xref ref="ex_conc4">Example</xref>. The second derivative is evaluated at each critical point. When the graph is concave up, the critical point represents a local minimum; when the graph is concave down, the critical point represents a local maximum.</caption>
+          <caption>A graph of <m>f(x)</m> in <xref ref="ex_conc4"/>. The second derivative is evaluated at each critical point. When the graph is concave up, the critical point represents a local minimum; when the graph is concave down, the critical point represents a local maximum.</caption>
           <!-- START figures/fig_conc4.tex -->
           <image xml:id="img_conc4" width="47%">
             <shortdescription>
@@ -1231,7 +1231,7 @@
       We have found intervals of increasing and decreasing,
       intervals where the graph is concave up and down,
       along with the locations of relative extrema and inflection points.
-      In <xref ref="chapter_limits">Chapter</xref>
+      In <xref ref="chapter_limits"/>
       we saw how limits explained asymptotic behavior.
       In the next section we combine all of this information to produce accurate sketches of functions.
     </p>
@@ -1328,7 +1328,7 @@
             A function <m>f(x)</m> is given.
             Graph <m>f</m> and <m>\fpp</m> on the same axes
             (using technology is permitted)
-            and verify <xref ref="thm_concavity">Theorem</xref>.
+            and verify <xref ref="thm_concavity"/>.
           </p>
         </introduction>
 

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -57,13 +57,13 @@
     </definition>
 
     <p>
-      Geometrically, the condition in <xref ref="eqn-concave-up"/>
+      Geometrically, the condition in <xref ref="eqn-concave-up">Equation</xref>
       states that a graph is concave up if the midpoint of the secant line from <m>(a,f(a))</m>
       to <m>(b,f(b))</m> (and hence, the secant line itself) is above the graph <m>y=f(x)</m>.
-      Similarly, <xref ref="eqn-concave-down"/> states that the secant line lies below the graph.
+      Similarly, <xref ref="eqn-concave-down">Equation</xref> states that the secant line lies below the graph.
     </p>
     <p>
-      In order for equality to hold instead of <xref ref="eqn-concave-up"/> or <xref ref="eqn-concave-down"/>,
+      In order for equality to hold instead of <xref ref="eqn-concave-up">Equation</xref> or <xref ref="eqn-concave-down">Equation</xref>,
       the function would have to be of the form <m>f(x)=mx+c</m>,
       in which case the graph is a straight line.
       Straight lines are considered to have <term>no concavity</term>.

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -71,7 +71,7 @@
   </figure>
 
  <p>
-    Consider <xref ref="fig_extreme">Figure</xref>.
+    Consider <xref ref="fig_extreme"/>.
     The function displayed in <xref ref="fig_extreme1"/> has a maximum,
     but no minimum,
     as the interval over which the function is defined is open.
@@ -238,12 +238,12 @@
     <statement>
       <p>
         Consider <m>f(x) = 2x^3-9x^2</m> on <m>I=[-1,5]</m>,
-        as graphed in <xref ref="fig_extval1">Figure</xref>.
+        as graphed in <xref ref="fig_extval1"/>.
         Approximate the extreme values of <m>f</m>.
       </p>
 
       <figure xml:id="fig_extval1">
-        <caption>A graph of <m>f(x) = 2x^3-9x^2</m> as in <xref ref="ex_extval1">Example</xref></caption>
+        <caption>A graph of <m>f(x) = 2x^3-9x^2</m> as in <xref ref="ex_extval1"/></caption>
 
           <!-- START figures/fig_extval1.tex -->
         <image xml:id="img_extval1" width="47%">
@@ -352,7 +352,7 @@
 
     <p>
       As it makes intuitive sense that an absolute maximum is also a relative maximum,
-      <xref ref="def_rel_ext">Definition</xref>
+      <xref ref="def_rel_ext"/>
       allows a relative maximum to occur at an interval's endpoint.
     </p>
   </aside>
@@ -370,13 +370,13 @@
     <statement>
       <p>
         Consider <m>f(x) = (3x^4-4x^3-12x^2+5)/5</m>,
-        as shown in <xref ref="fig_extval2">Figure</xref>.
+        as shown in <xref ref="fig_extval2"/>.
         Approximate the relative extrema of <m>f</m>.
         At each of these points, evaluate <m>\fp</m>.
       </p>
 
       <figure xml:id="fig_extval2">
-        <caption>A graph of <m>f(x) = (3x^4-4x^3-12x^2+5)/5</m> as in <xref ref="ex_extval2">Example</xref></caption>
+        <caption>A graph of <m>f(x) = (3x^4-4x^3-12x^2+5)/5</m> as in <xref ref="ex_extval2"/></caption>
           <!-- START figures/fig_extval2.tex -->
         <image xml:id="img_extval2" width="47%">
           <shortdescription>The graph of a degree 4 function with several critical points.</shortdescription>
@@ -428,12 +428,12 @@
     <statement>
       <p>
         Approximate the relative extrema of <m>f(x) = (x-1)^{2/3}+2</m>,
-        shown in <xref ref="fig_extval3">Figure</xref>.
+        shown in <xref ref="fig_extval3"/>.
         At each of these points, evaluate <m>\fp</m>.
       </p>
 
       <figure xml:id="fig_extval3">
-        <caption>A graph of <m>f(x) = (x-1)^{2/3}+2</m> as in <xref ref="ex_extval3">Example</xref></caption>
+        <caption>A graph of <m>f(x) = (x-1)^{2/3}+2</m> as in <xref ref="ex_extval3"/></caption>
           <!-- START figures/fig_extval3.tex -->
         <image xml:id="img_extval3" width="47%">
           <shortdescription>A graph in the shape of a curved V, with a sharp point at (1,2).</shortdescription>
@@ -540,7 +540,7 @@
     Since <m>\fp(x) = 3x^2</m>,
     it is straightforward to determine that <m>x=0</m> is a critical number of <m>f</m>.
     However, <m>f</m> has no relative extrema,
-    as illustrated in <xref ref="fig_extreme4">Figure</xref>.
+    as illustrated in <xref ref="fig_extreme4"/>.
   </p>
 
   <figure xml:id="fig_extreme4">
@@ -624,11 +624,11 @@
     <statement>
       <p>
         Find the extreme values of <m>f(x) = 2x^3+3x^2-12x</m> on <m>[0,3]</m>,
-        graphed in <xref ref="fig_extval4">Figure</xref>.
+        graphed in <xref ref="fig_extval4"/>.
       </p>
 
       <figure xml:id="fig_extval4">
-        <caption>A graph of <m>f(x) = 2x^3+3x^2-12x</m> on <m>[0,3]</m> as in <xref ref="ex_extval4">Example</xref></caption>
+        <caption>A graph of <m>f(x) = 2x^3+3x^2-12x</m> on <m>[0,3]</m> as in <xref ref="ex_extval4"/></caption>
           <!-- START figures/fig_extval4.tex -->
         <image xml:id="img_extval4" width="47%">
           <shortdescription>A graph of a cubic function on the interval [0,3].</shortdescription>
@@ -660,7 +660,7 @@
     </solution>
     <solution>
       <p>
-        We follow the steps outlined in <xref ref="idea_extrema">Key Idea</xref>.
+        We follow the steps outlined in <xref ref="idea_extrema"/>.
         We first evaluate <m>f</m> at the endpoints:
         <md>
           <mrow>f(0)\amp=0\amp f(3)\amp=45</mrow>
@@ -686,7 +686,7 @@
       </p>
 
       <figure xml:id="table_ext4">
-        <caption>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in <xref ref="ex_extval4">Example</xref></caption>
+        <caption>Finding the extreme values of <m>f(x)= 2x^3+3x^2-12x</m> in <xref ref="ex_extval4"/></caption>
         <tabular>
           <row bottom="medium">
             <cell><m>x</m></cell>
@@ -713,7 +713,7 @@
   <p>
     Note that all this was done without the aid of a graph;
     this work followed an analytic algorithm and did not depend on any visualization.
-    <xref ref="fig_extval4">Figure</xref>
+    <xref ref="fig_extval4"/>
     shows <m>f</m> and we can confirm our answer,
     but it is important to understand that these answers can be found without graphical assistance.
   </p>
@@ -741,7 +741,7 @@
 
       <p>
         Here <m>f</m> is piecewise-defined,
-        but we can still apply <xref ref="idea_extrema">Key Idea</xref>
+        but we can still apply <xref ref="idea_extrema"/>
         as it is continuous on <m>[-4,2]</m>
         (one should check to verify that <m>\lim\limits_{x\to 0}f(x) =f(0)</m>).
       </p>
@@ -791,7 +791,7 @@
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
         <figure xml:id="table_ext5">
-          <caption>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5">Example</xref></caption>
+          <caption>Finding the extreme values of a piecewise-defined function in <xref ref="ex_extval5"/></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -813,7 +813,7 @@
         </figure>
 
         <figure xml:id="fig_extval5">
-          <caption>A graph of <m>f(x)</m> on <m>[-4,2]</m> as in <xref ref="ex_extval5">Example</xref></caption>
+          <caption>A graph of <m>f(x)</m> on <m>[-4,2]</m> as in <xref ref="ex_extval5"/></caption>
             <!-- START figures/fig_extval5.tex -->
           <image xml:id="img_extval5">
             <shortdescription>The graph of a piecewise-defined function on the interval [-4,2]</shortdescription>
@@ -861,7 +861,7 @@
     </solution>
     <solution>
       <p>
-        We again use <xref ref="idea_extrema">Key Idea</xref>.
+        We again use <xref ref="idea_extrema"/>.
         Evaluating <m>f</m> at the endpoints of the interval gives:
         <m>f(-2) = f(2) = \cos(4) \approx -0.6536</m>.
         We now find the critical values of <m>f</m>.
@@ -895,7 +895,7 @@
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
         <figure xml:id="table_ext6">
-          <caption>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6">Example</xref></caption>
+          <caption>Finding the extrema of <m>f(x)= \cos\mathopen{}\left(x^2\right)\mathclose{}</m> in <xref ref="ex_extval6"/></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -925,7 +925,7 @@
         </figure>
 
         <figure xml:id="fig_extval6">
-          <caption>A graph of <m>f(x)=\cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m> as in <xref ref="ex_extval6">Example</xref></caption>
+          <caption>A graph of <m>f(x)=\cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m> as in <xref ref="ex_extval6"/></caption>
             <!-- START figures/fig_extval6.tex -->
           <image xml:id="img_extval6">
             <shortdescription>A graph that resembles a flattened cosine wave for small values of x</shortdescription>
@@ -976,7 +976,7 @@
 
       <sidebyside widths="47% 47%" valign="bottom" margins="0%">
         <figure xml:id="fig_extval7">
-          <caption>A graph of <m>f(x)=\sqrt{1-x^2}</m> on <m>[-1,1]</m> as in <xref ref="ex_extval7">Example</xref></caption>
+          <caption>A graph of <m>f(x)=\sqrt{1-x^2}</m> on <m>[-1,1]</m> as in <xref ref="ex_extval7"/></caption>
             <!-- START figures/fig_extval7.tex -->
           <image xml:id="img_extval7">
             <shortdescription>A semi-circle equivalent to the top half of the unit circle</shortdescription>
@@ -1004,7 +1004,7 @@
         </figure>
 
         <figure xml:id="table_ext7">
-          <caption>Finding the extrema of the half-circle in <xref ref="ex_extval7">Example</xref></caption>
+          <caption>Finding the extrema of the half-circle in <xref ref="ex_extval7"/></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -1048,9 +1048,9 @@
     <p>
       We implicitly found the derivative of <m>x^2+y^2=1</m>,
       the unit circle,
-      in <xref ref="sec_imp_deriv">Section</xref>
-      <xref ref="ex_implicit7">Example</xref> as <m>\lz{y}{x} = -x/y</m>.
-      In <xref ref="ex_extval7">Example</xref>,
+      in <xref ref="sec_imp_deriv"/>
+      <xref ref="ex_implicit7"/> as <m>\lz{y}{x} = -x/y</m>.
+      In <xref ref="ex_extval7"/>,
       half of the unit circle is given as <m>y=f(x) = \sqrt{1-x^2}</m>.
     </p>
 
@@ -1064,12 +1064,12 @@
   <p>
     We have seen that continuous functions on closed intervals always have a maximum and minimum value,
     and we have also developed a technique to find these values.
-    In <xref ref="sec_mvt">Section</xref>,
+    In <xref ref="sec_mvt"/>,
     we further our study of the information we can glean from <q>nice</q>
     functions with the Mean Value Theorem.
     On a closed interval, we can find the
     <em>average rate of change</em> of a function
-    (as we did at the beginning of <xref ref="chapter_derivatives">Chapter</xref>).
+    (as we did at the beginning of <xref ref="chapter_derivatives"/>).
     We will see that differentiable functions always have a point at which their <em>instantaneous</em>
     rate of change is same as the <em>average</em> rate of change.
     This is surprisingly useful, as we'll see.
@@ -1471,7 +1471,7 @@
                 <m>f(x) = <var name="$f"/></m>
               </p>
               <image xml:id="img_03_01_ex_10">
-                <shortdescription>Graph of a sine wave from 0 to 2 pi. The marked points are (pi/2, 1) and (3 pi/2,-1)/</shortdescription>
+                <shortdescription>Graph of a sine wave from 0 to 2 pi. The marked points are (pi/2, 1) and (3 pi/2,-1)</shortdescription>
                 <description>
                   <p>
                     The graph of <m>f(x)=\sin(x)</m> from <m>0</m> to <m>\pi</m>.

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -16,7 +16,7 @@
 
   <p>
     We start with an intuitive concept.
-    Given the graph in <xref ref="fig_incr0">Figure</xref>,
+    Given the graph in <xref ref="fig_incr0"/>,
     where would you say the function is <em>increasing</em>?
     <em>Decreasing</em>?
     Even though we have not defined these terms mathematically,
@@ -124,7 +124,7 @@
     To find such intervals, we again consider secant lines.
     Let <m>f</m> be an increasing,
     differentiable function on an open interval <m>I</m>,
-    such as the one shown in <xref ref="fig_incr00">Figure</xref>,
+    such as the one shown in <xref ref="fig_incr00"/>,
     and let <m>a\lt b</m> be given in <m>I</m>.
     The secant line on the graph of <m>f</m> from <m>x=a</m> to <m>x=b</m> is drawn;
     it has a slope of <m>(f(b)-f(a))/(b-a)</m>.
@@ -189,7 +189,7 @@
   <p>
     We have shown mathematically what may have already been obvious:
     when <m>f</m> is increasing, its secant lines will have a positive slope.
-    Now recall the <xref ref="thm_mvt">Mean Value Theorem</xref>
+    Now recall that the <xref ref="thm_mvt" text="custom">Mean Value Theorem</xref>
     guarantees that there is a number <m>c</m>,
     where <m>a\lt c\lt b</m>, such that
     <me>
@@ -207,7 +207,7 @@
     Our above logic can be summarized as
     <q>If <m>f</m> is increasing,
     then <m>\fp</m> is probably positive.</q>
-    <xref ref="thm_incr_decr">Theorem</xref>
+    <xref ref="thm_incr_decr"/>
     below turns this around by stating
     <q>If <m>\fp</m> is positive,
     then <m>f</m> is increasing.</q>
@@ -289,7 +289,7 @@
             That is, find all <m>c</m> in the domain of <m>f</m> where
             <m>\fp(c) = 0</m> or <m>\fp</m> is not defined.
             (Note: Any values of <m>c</m> <em>not</em>
-              in the domain of <m>f</m> where <m>\fp(c)</m> is undefined should already be marked on your number line from <xref ref="stp_inc_dec1">Step</xref>).
+              in the domain of <m>f</m> where <m>\fp(c)</m> is undefined should already be marked on your number line from <xref ref="stp_inc_dec1" text="local">Step</xref>).
           </p>
         </li>
         <li>
@@ -370,7 +370,7 @@
     <solution>
 
       <p>
-        Since an interval was not specified for us to consider, using <xref ref="idea_incr_decr">Key Idea</xref>,
+        Since an interval was not specified for us to consider, using <xref ref="idea_incr_decr"/>,
         the domain of <m>f</m> is <m>\mathbb{R}</m> or <m>(-\infty,\infty)</m>.
         Next, we find the critical values of <m>f</m>.
         We have <m>\fp(x) = 3x^2+2x-1 = (3x-1)(x+1)</m>,
@@ -383,11 +383,11 @@
         (in this case the <m>(-\infty, \infty)</m>)
         into three subintervals based on the two critical values we just found:
         <m>(-\infty,-1)</m>, <m>(-1,1/3)</m> and <m>(1/3,\infty)</m>.
-        This is shown in <xref ref="fig_incrline1">Figure</xref>.
+        This is shown in <xref ref="fig_incrline1"/>.
       </p>
 
       <figure xml:id="fig_incrline1">
-        <caption>Number line for <m>f</m> in <xref ref="ex_incr1">Example</xref></caption>
+        <caption>Number line for <m>f</m> in <xref ref="ex_incr1"/></caption>
         
         <image xml:id="img_incrline1" width="47%">
           <shortdescription>Number line showing the critical points of f</shortdescription>
@@ -462,11 +462,11 @@
       </p>
 
       <p>
-        <xref ref="fig_incrline1a">Figure</xref> summarizes our work.
+        <xref ref="fig_incrline1a"/> summarizes our work.
       </p>
 
       <figure xml:id="fig_incrline1a">
-        <caption>Completed number line for <m>f</m> in <xref ref="ex_incr1">Example</xref></caption>
+        <caption>Completed number line for <m>f</m> in <xref ref="ex_incr1"/></caption>
         
         <!-- START figures/fig_incrline1.tex -->
         <image xml:id="img_incrline1a" width="47%">
@@ -531,7 +531,7 @@
       </figure>
 
       <p>
-        We can verify our calculations by considering <xref ref="fig_incr1">Figure</xref>,
+        We can verify our calculations by considering <xref ref="fig_incr1"/>,
         where <m>f</m> is graphed.
         The graph also presents <m>\fp</m>;
         note how <m>\fp\gt 0</m> when <m>f</m> is increasing and
@@ -539,7 +539,7 @@
       </p>
 
       <figure xml:id="fig_incr1">
-        <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr1">Example</xref>, showing where <m>f</m> is increasing and decreasing</caption>
+        <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr1"/>, showing where <m>f</m> is increasing and decreasing</caption>
         <!-- START figures/fig_incr1.tex -->
         <image xml:id="img_incr1" width="47%">
           <shortdescription>The graphs of a function and its derivative.</shortdescription>
@@ -622,7 +622,7 @@
   </p>
 
   <p>
-    In <xref ref="sec_extreme_values">Section</xref>
+    In <xref ref="sec_extreme_values"/>
     we learned the definition of relative maxima and minima and found that they occur at critical points.
     We are now learning that functions can switch from increasing to decreasing
     (and vice-versa)
@@ -689,7 +689,7 @@
       For example,
       we can construct a piecewise function where the sign of <m>\fp</m> switches to positive to negative at <m>c</m> and <m>f(c)</m> is
       <em>not</em> a local maximum.
-      This is shown in <xref ref="fig_inc_counter">Figure</xref>.
+      This is shown in <xref ref="fig_inc_counter"/>.
     </p>
 
     <figure xml:id="fig_inc_counter">
@@ -736,7 +736,7 @@
     <statement>
       <p>
         Find the intervals on which <m>f</m> is increasing and decreasing,
-        and use the <xref ref="thm_first_der">First Derivative Test</xref>
+        and use the <xref ref="thm_first_der" text="custom">First Derivative Test</xref>
         to determine the relative extrema of <m>f</m>, where
         <me>
           f(x) = \frac{x^2+3}{x-1}
@@ -764,7 +764,7 @@
       </p>
 
       <p>
-        Using the <xref ref="thm_QuotientRule">Quotient Rule</xref>, we find
+        Using the <xref ref="thm_QuotientRule" text="title"/>, we find
         <me>
           \fp(x) = \frac{x^2-2x-3}{(x-1)^2}
         </me>.
@@ -846,7 +846,7 @@
         <m>(3,\infty)</m> and is decreasing on the intervals <m>(-1,1)</m> and <m>(1,3)</m>.
         Since at <m>x=-1</m>,
         the sign of <m>\fp</m> switched from positive to negative,
-        <xref ref="thm_first_der">Theorem</xref>
+        <xref ref="thm_first_der"/>
         states that <m>f(-1)</m> is a relative maximum of <m>f</m>.
         At <m>x=3</m>,
         the sign of <m>\fp</m> switched from negative to positive,
@@ -936,15 +936,15 @@
       </figure>
 
       <p>
-        This is summarized in the number line shown in <xref ref="fig_incrline2">Figure</xref>.
-        Also, <xref ref="fig_incr2">Figure</xref> shows a graph of <m>f</m>,
+        This is summarized in the number line shown in <xref ref="fig_incrline2"/>.
+        Also, <xref ref="fig_incr2"/> shows a graph of <m>f</m>,
         confirming our calculations.
         This figure also shows <m>\fp</m>,
         again demonstrating that <m>f</m> is increasing when <m>\fp\gt 0</m> and decreasing when <m>\fp\lt 0</m>.
       </p>
 
       <figure xml:id="fig_incr2">
-        <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr2">Example</xref>, showing where <m>f</m> is increasing and decreasing</caption>
+        <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr2"/>, showing where <m>f</m> is increasing and decreasing</caption>
         <!-- START figures/fig_incr2.tex -->
         <image xml:id="img_incr2" width="47%">
           <shortdescription>The graphs of a function and its derivative for the current example.</shortdescription>
@@ -1031,7 +1031,7 @@
         This derivation of <m>\fp</m> shows that
         <m>\fp(x) = 0</m> when <m>x=\pm 1</m> and <m>\fp</m>is not defined when <m>x=0</m>.
         Thus we have three critical values,
-        breaking the number line into four subintervals as shown in <xref ref="fig_incrline3">Figure</xref>.
+        breaking the number line into four subintervals as shown in <xref ref="fig_incrline3"/>.
       </p>
 
       <p>
@@ -1088,7 +1088,7 @@
       </p>
 
       <figure xml:id="fig_incrline3">
-        <caption>Number line for <m>f</m> in <xref ref="ex_incr3">Example</xref></caption>
+        <caption>Number line for <m>f</m> in <xref ref="ex_incr3"/></caption>
         
         <!-- START figures/fig_incrline3.tex -->
         <image xml:id="img_incrline3" width="47%">
@@ -1170,18 +1170,18 @@
         We conclude by stating that <m>f</m> is increasing on the intervals <m>(-1,0)</m> and
         <m>(1,\infty)</m> and decreasing on the intervals <m>(-\infty,-1)</m> and <m>(0,1)</m>.
         The sign of <m>\fp</m><nbsp/>changes from negative to positive around <m>x=-1</m> and <m>x=1</m>,
-        meaning by <xref ref="thm_first_der">Theorem</xref>
+        meaning by <xref ref="thm_first_der"/>
         that <m>f(-1)</m> and <m>f(1)</m> are relative minima of <m>f</m>.
         As the sign of <m>\fp</m> changes from positive to negative at <m>x=0</m>,
         we have a relative maximum at <m>f(0)</m>.
-        <xref ref="fig_incr3">Figure</xref>
+        <xref ref="fig_incr3"/>
         shows a graph of <m>f</m>, confirming our result.
         We also graph <m>\fp</m>,
         highlighting once more that <m>f</m> is increasing when <m>\fp\gt 0</m> and is decreasing when <m>\fp\lt 0</m>.
       </p>
 
       <figure xml:id="fig_incr3">
-        <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr3">Example</xref>, showing where <m>f</m> is increasing and decreasing</caption>
+        <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr3"/>, showing where <m>f</m> is increasing and decreasing</caption>
         <!-- START figures/fig_incr3.tex -->
         <image xml:id="img_incr3" width="47%">
           <description></description>
@@ -1319,7 +1319,7 @@
               Since <m>\fp(x) \gt 1</m>, we know in
               particular that <m>\fp(x) \gt 0</m>,
               so <m>f</m> is increasing by
-              <xref ref="thm_incr_decr">Theorem</xref>.
+              <xref ref="thm_incr_decr"/>.
             </p>
           </solution>
         </webwork>
@@ -1335,7 +1335,7 @@
             A function <m>f(x)</m> is given.
             Graph <m>f</m> and <m>\fp</m> on the same axes
             (using technology is permitted)
-            and verify <xref ref="thm_incr_decr">Theorem</xref>.
+            and verify <xref ref="thm_incr_decr"/>.
           </p>
         </introduction>
 

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -87,7 +87,7 @@
         <md>
           <mrow>f_1(x)\amp=\frac{1}{x^2}\amp f_2(x)\amp= \abs{x}</mrow>
         </md>
-        with <m>a=-1</m> and <m>b=1</m> as shown in <xref ref="fig_mvt1">Figure</xref>.
+        with <m>a=-1</m> and <m>b=1</m> as shown in <xref ref="fig_mvt1"/>.
         Both functions have a value of <m>1</m> at <m>a</m> and <m>b</m>.
         Therefore the slope of the secant line connecting the end points is <m>0</m> in each case.
         But if you look at the plots of each,
@@ -201,7 +201,7 @@
   </theorem>
 
   <p>
-    Note that the reasons that the functions in <xref ref="ex_mvt1">Example</xref>
+    Note that the reasons that the functions in <xref ref="ex_mvt1"/>
     fail are indeed that <m>f_1</m> has a discontinuity on the interval <m>[-1,1]</m> and <m>f_2</m> is not differentiable at the origin.
   </p>
 
@@ -228,7 +228,7 @@
   </figure>
 
   <p>
-    Consider <xref ref="fig_mvt3">Figure</xref>
+    Consider <xref ref="fig_mvt3"/>
     where the graph of a function <m>f</m> is given, where <m>f(a) = f(b)</m>.
     It should make intuitive sense that if <m>f</m> is differentiable
     (and hence, continuous)
@@ -318,7 +318,7 @@
         Assume, without loss of generality,
         that the maximum of <m>f</m> is not found at the endpoints.
         Therefore there is a <m>c</m> in <m>(a,b)</m> such that <m>f(c)</m> is the maximum value of <m>f</m>.
-        By <xref ref="thm_criticalpts">Theorem</xref>,
+        By <xref ref="thm_criticalpts"/>,
         <m>c</m> must be a critical number of <m>f</m>;
         since <m>f</m> is differentiable,
         we have that <m>\fp(c) = 0</m>,
@@ -426,14 +426,14 @@
       <p>
         We have found two values <m>c</m> in <m>[-3,3]</m> where the instantaneous rate of change is equal to the average rate of change;
         the <xref ref="thm_mvt"/> guaranteed at least one.
-        In <xref ref="fig_mvt4">Figure</xref>,
+        In <xref ref="fig_mvt4"/>,
         <m>f</m> is graphed with a line representing the average rate of change;
         the lines tangent to <m>f</m> at <m>x=\pm \sqrt{3}</m> are also given.
         Note how these lines are parallel (<ie/>, have the same slope) to the secant line.
       </p>
 
       <figure xml:id="fig_mvt4">
-        <caption>Demonstrating the Mean Value Theorem in <xref ref="ex_mvt2">Example</xref></caption>
+        <caption>Demonstrating the Mean Value Theorem in <xref ref="ex_mvt2"/></caption>
           <!-- START figures/fig_mvt4.tex -->
         <image xml:id="img_mvt4" width="47%">
           <shortdescription>

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -32,7 +32,7 @@
   </p>
 
   <p>
-    <xref ref="idea_sketch">Key Idea</xref>
+    <xref ref="idea_sketch"/>
     summarizes what we have learned so far that is applicable to sketching graphs of functions and gives a framework for putting that information together.
     It is followed by several examples.
   </p>
@@ -68,7 +68,7 @@
         <li>
           <p>
             Find the location of any vertical asymptotes of <m>f</m>
-            (usually done in conjunction with <xref ref="item-find-domain">Item</xref>).
+            (usually done in conjunction with <xref ref="item-find-domain"/>).
           </p>
         </li>
 
@@ -106,7 +106,7 @@
     <title>Curve sketching</title>
     <statement>
       <p>
-        Use <xref ref="idea_sketch">Key Idea</xref>
+        Use <xref ref="idea_sketch"/>
         to sketch <m>f(x) = 3x^3-10x^2+7x+5</m>.
       </p>
     </statement>
@@ -117,7 +117,7 @@
     <solution>
 
       <p>
-        We follow the steps outlined in <xref ref="idea_sketch">Key Idea</xref>.
+        We follow the steps outlined in <xref ref="idea_sketch"/>.
 
         <ol>
           <li>
@@ -174,7 +174,7 @@
 
             <p>
               We place the values <m>x=(10\pm\sqrt{37})/9</m> and <m>x=10/9</m> on a number line,
-              as shown in <xref ref="fig_sketchline1">Figure</xref>.
+              as shown in <xref ref="fig_sketchline1"/>.
               We mark each subinterval as increasing or decreasing, concave up or down,
               using the techniques used in <xref first="sec_incr_decr" last="sec_concavity">Sections</xref>.
             </p>
@@ -189,12 +189,12 @@
             </p>
 
             <p>
-              We plot the appropriate points on axes as shown in <xref ref="fig_sketch1a">Figure</xref>
+              We plot the appropriate points on axes as shown in <xref ref="fig_sketch1a"/>
               and connect the points with straight lines
               (to show increasing/decreasig behavior).
-              In <xref ref="fig_sketch1b">Figure</xref>
+              In <xref ref="fig_sketch1b"/>
               we adjust these lines to demonstrate the proper concavity.
-              In <xref ref="fig_sketch1c">Figure</xref>
+              In <xref ref="fig_sketch1c"/>
               we show a graph of <m>f</m> drawn with a computer program,
               verifying the accuracy of our sketch.
             </p>
@@ -286,7 +286,7 @@
       </figure>
 
       <figure xml:id="fig_sketch1">
-      <caption>Sketching <m>f</m> in <xref ref="ex_sketch1">Example</xref></caption>
+      <caption>Sketching <m>f</m> in <xref ref="ex_sketch1"/></caption>
         <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
           <figure xml:id="fig_sketch1a">
             <caption/>
@@ -391,7 +391,7 @@
     <solution>
 
       <p>
-        We again follow the steps outlined in <xref ref="idea_sketch">Key Idea</xref>.
+        We again follow the steps outlined in <xref ref="idea_sketch"/>.
       </p>
 
       <p>
@@ -456,7 +456,7 @@
           <li>
             <p>
               We place the values <m>x=1/2</m>,
-              <m>x=-2</m> and <m>x=3</m> on a number line as shown in <xref ref="fig_sketchline2">Figure</xref>.
+              <m>x=-2</m> and <m>x=3</m> on a number line as shown in <xref ref="fig_sketchline2"/>.
               We mark in each interval whether <m>f</m> is increasing or decreasing,
               concave up or down.
               We see that <m>f</m> has a relative maximum at <m>x=1/2</m>;
@@ -473,13 +473,13 @@
             </p>
 
             <p>
-              In <xref ref="fig_sketch2a">Figure</xref>,
+              In <xref ref="fig_sketch2a"/>,
               we plot the points from the number line on a set of axes and connect the points with straight lines to get a general idea of what the function looks like
               (these lines effectively only convey increasing/decreasing information).
-              In <xref ref="fig_sketch2b">Figure</xref>,
+              In <xref ref="fig_sketch2b"/>,
               we adjust the graph with the appropriate concavity.
               We also show <m>f</m> crossing the <m>x</m>-axis at <m>x=-1</m> and <m>x=2</m> and crossing the <m>y</m>-axis at <m>y=1/3</m>.
-              Finally, <xref ref="fig_sketch2c">Figure</xref>
+              Finally, <xref ref="fig_sketch2c"/>
               shows a computer generated graph of <m>f</m>,
               which verifies the accuracy of our sketch.
             </p>
@@ -488,7 +488,7 @@
       </p>
 
       <figure xml:id="fig_sketchline2">
-        <caption>Number line for <m>f</m> in <xref ref="ex_sketch2">Example</xref></caption>
+        <caption>Number line for <m>f</m> in <xref ref="ex_sketch2"/></caption>
         <image xml:id="img_sketchline2" width="67%">
           <shortdescription>Number line showing intervals where f is increasing/decreasing and concave up/down</shortdescription>
           <description>
@@ -554,7 +554,7 @@
       </figure>
 
       <figure xml:id="fig_sketch2">
-        <caption>Sketching <m>f</m> in <xref ref="ex_sketch2">Example</xref></caption>
+        <caption>Sketching <m>f</m> in <xref ref="ex_sketch2"/></caption>
     <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
           <figure xml:id="fig_sketch2a">
             <caption/>
@@ -666,7 +666,7 @@
     </statement>
     <solution>
       <p>
-        We again follow <xref ref="idea_sketch">Key Idea</xref>.
+        We again follow <xref ref="idea_sketch"/>.
       </p>
 
       <p>
@@ -724,7 +724,7 @@
 
           <li>
             <p>
-              We place the critical points and possible points on a number line as shown in <xref ref="fig_sketchline3">Figure</xref>
+              We place the critical points and possible points on a number line as shown in <xref ref="fig_sketchline3"/>
               and mark each interval as increasing/decreasing,
               concave up/down appropriately.
             </p>
@@ -742,15 +742,15 @@
             </p>
 
             <p>
-              In <xref ref="fig_sketch3a">Figure</xref>
+              In <xref ref="fig_sketch3a"/>
               we plot the significant points from the number line as well as the <m>x</m>- and <m>y</m>-intercepts,
               and connect the points with straight lines to get a general impression about the graph
               (this graph only includes increasing/decreasing information).
-              In <xref ref="fig_sketch3b">Figure</xref>,
+              In <xref ref="fig_sketch3b"/>,
               we add concavity, drawing the function so that it is smooth
               (since <m>f</m> is differentiable everywhere,
               there should be no kinks or corners).
-              <xref ref="fig_sketch3c">Figure</xref>
+              <xref ref="fig_sketch3c"/>
               shows a computer generated graph of <m>f</m>, affirming our results.
             </p>
           </li>
@@ -758,7 +758,7 @@
       </p>
 
       <figure xml:id="fig_sketchline3">
-        <caption>Number line for <m>f</m> in Example <xref ref="ex_sketch3">Example</xref></caption>
+        <caption>Number line for <m>f</m> in Example <xref ref="ex_sketch3"/></caption>
           <image xml:id="img_sketchline3" width="90%">
             <shortdescription>Number line showing intervals where f is increasing/decreasing and concave up/down</shortdescription>
             <description>
@@ -853,7 +853,7 @@
         
 
       <figure xml:id="fig_sketch3">
-        <caption>Sketching <m>f</m> in <xref ref="ex_sketch3">Example</xref></caption>
+        <caption>Sketching <m>f</m> in <xref ref="ex_sketch3"/></caption>
         <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
           <figure xml:id="fig_sketch3a">
             <caption/>
@@ -1008,7 +1008,7 @@
   </p>
 
   <p>
-    In <xref ref="fig_sage_sinx">Figure</xref>,
+    In <xref ref="fig_sage_sinx"/>,
     two graph of <m>y=\sin(x)</m> is given,
     generated by <pubtitle>Sage</pubtitle> and <pubtitle>Mathematica</pubtitle>.
     The small points represent each of the places where each <init>CAS</init> sampled the function.
@@ -1077,7 +1077,7 @@
     Again, the goal of this section is not
     <q>How to graph a function when there is no computer to help.</q> Rather,
     the goal is <q>Understand that the shape of the graph of a function is largely determined by understanding the behavior of the function at a few key places.</q>
-    In <xref ref="ex_sketch3">Example</xref>,
+    In <xref ref="ex_sketch3"/>,
     we were able to accurately sketch a complicated graph using only five points and knowledge of asymptotes!
   </p>
 
@@ -1203,7 +1203,7 @@
         <introduction>
           <p>
             In the following exercises,
-            practice using <xref ref="idea_sketch">Key Idea</xref>
+            practice using <xref ref="idea_sketch"/>
             by applying the principles to the given functions with familiar graphs.
           </p>
         </introduction>
@@ -1211,7 +1211,7 @@
         <exercise label="ex-graph-sketch-basic-1">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>f(x) = 2x+4</m>
             </p>
           </statement>
@@ -1225,7 +1225,7 @@
         <exercise label="ex-graph-sketch-basic-2">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>f(x) = -x^2+1</m>
             </p>
           </statement>
@@ -1239,7 +1239,7 @@
         <exercise label="ex-graph-sketch-basic-3">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>f(x) = \sin(x)</m>
             </p>
           </statement>
@@ -1253,7 +1253,7 @@
         <exercise label="ex-graph-sketch-basic-4">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>f(x) = e^x</m>
             </p>
           </statement>
@@ -1267,7 +1267,7 @@
         <exercise label="ex-graph-sketch-basic-5">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \frac{1}{x}</m>
             </p>
           </statement>
@@ -1281,7 +1281,7 @@
         <exercise label="ex-graph-sketch-basic-6">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \frac{1}{x^2}</m>
             </p>
           </statement>
@@ -1298,7 +1298,7 @@
         <introduction>
           <p>
             In the following exercises,
-            sketch a graph of the given function using <xref ref="idea_sketch">Key Idea</xref>.
+            sketch a graph of the given function using <xref ref="idea_sketch"/>.
             Show all work; check your answer with technology.
           </p>
         </introduction>
@@ -1306,7 +1306,7 @@
         <exercise label="ex-graph-sketch-harder-1">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = x^3-2x^2+4x+1</m>
             </p>
           </statement>
@@ -1320,7 +1320,7 @@
         <exercise label="ex-graph-sketch-harder-2">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = -x^3+5x^2-3x+2</m>
             </p>
           </statement>
@@ -1334,7 +1334,7 @@
         <exercise label="ex-graph-sketch-harder-3">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = x^3+3x^2+3x+1</m>
             </p>
           </statement>
@@ -1348,7 +1348,7 @@
         <exercise label="ex-graph-sketch-harder-4">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = x^3-x^2-x+1</m>
             </p>
           </statement>
@@ -1362,7 +1362,7 @@
         <exercise label="ex-graph-sketch-harder-5">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = (x-2)\ln(x-2)</m>
             </p>
           </statement>
@@ -1376,7 +1376,7 @@
         <exercise label="ex-graph-sketch-harder-6">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = (x-2)^2\ln(x-2)</m>
             </p>
           </statement>
@@ -1390,7 +1390,7 @@
         <exercise label="ex-graph-sketch-harder-7">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \frac{x^2-4}{x^2}</m>
             </p>
           </statement>
@@ -1404,7 +1404,7 @@
         <exercise label="ex-graph-sketch-harder-8">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \frac{x^2-4x+3}{x^2-6x+8}</m>
             </p>
           </statement>
@@ -1418,7 +1418,7 @@
         <exercise label="ex-graph-sketch-harder-9">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \frac{x^2-2x+1}{x^2-6x+8}</m>
             </p>
           </statement>
@@ -1432,7 +1432,7 @@
         <exercise label="ex-graph-sketch-harder-10">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = x\sqrt{x+1}</m>
             </p>
           </statement>
@@ -1446,7 +1446,7 @@
         <exercise label="ex-graph-sketch-harder-11">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = x^2e^x</m>
             </p>
           </statement>
@@ -1460,7 +1460,7 @@
         <exercise label="ex-graph-sketch-harder-12">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \sin(x) \cos(x)</m> on <m>[-\pi,\pi]</m>
             </p>
           </statement>
@@ -1474,7 +1474,7 @@
         <exercise label="ex-graph-sketch-harder-13">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = (x-3)^{2/3} + 2</m>
             </p>
           </statement>
@@ -1488,7 +1488,7 @@
         <exercise label="ex-graph-sketch-harder-14">
           <statement>
             <p>
-              Use <xref ref="idea_sketch">Key Idea</xref>
+              Use <xref ref="idea_sketch"/>
               to sketch a graph of <m>\ds f(x) = \frac{(x-1)^{2/3}}{x}</m>
             </p>
           </statement>

--- a/ptx/sec_greensthm.ptx
+++ b/ptx/sec_greensthm.ptx
@@ -81,7 +81,7 @@
 
     <p>
       Let the vector field <m>\vec F = \la 1,0\ra</m> represent the velocity of water as it moves across a smooth surface,
-      depicted in <xref ref="fig_flowfluxintro">Figure</xref>.
+      depicted in <xref ref="fig_flowfluxintro"/>.
       A line integral over <m>C</m> will compute
       <q>how much water is moving
       <em>along</em> the path <m>C</m>.</q>
@@ -108,7 +108,7 @@
       <em>across</em> the path <m>C</m>.</q>
       If a curve represents a filter in flowing water,
       flux measures how much water will pass through the filter.
-      Considering again <xref ref="fig_flowfluxintro">Figure</xref>,
+      Considering again <xref ref="fig_flowfluxintro"/>,
       we see that a screen along <m>C_1</m> will not filter any water as no water passes across that curve.
       Because of the nature of this field,
       <m>C_2</m> and <m>C_3</m> each filter the same amount of water per second.
@@ -118,7 +118,7 @@
       The terms <q>flow</q> and <q>flux</q>
       are used apart from velocity fields, too.
       Flow is measured by <m>\int_C \vec F\cdot d\vec r</m>,
-      which is the same as <m>\int_C \vec F\cdot\vec T\, ds</m> by <xref ref="def_line_integral2">Definition</xref>.
+      which is the same as <m>\int_C \vec F\cdot\vec T\, ds</m> by <xref ref="def_line_integral2"/>.
       That is, flow is a summation of the amount of <m>\vec F</m> that is
       <em>tangent</em> to the curve <m>C</m>.
     </p>
@@ -152,7 +152,7 @@
       (If <m>C</m> is a complicated closed curve,
       it can be difficult to determine what
       <q>counterclockwise</q> means.
-      Consider <xref ref="fig_fluxcounterclockwise">Figure</xref>.
+      Consider <xref ref="fig_fluxcounterclockwise"/>.
       Seeing the curve as a whole, we know which way
       <q>counterclockwise</q> is.
       If we zoom in on point <m>A</m>,
@@ -309,12 +309,12 @@
         <p>
           Curves <m>C_1</m> and <m>C_2</m> each start at <m>(1,0)</m> and end at <m>(0,1)</m>,
           where <m>C_1</m> follows the line <m>y=1-x</m> and <m>C_2</m> follows the unit circle,
-          as shown in <xref ref="fig_flux1">Figure</xref>.
+          as shown in <xref ref="fig_flux1"/>.
           Find the flux across both curves for the vector fields
           <m>\vec F_1 = \la y, -x+1\ra</m> and <m>\vec F_2 = \la -x, 2y-x\ra</m>.
         </p>
         <figure xml:id="fig_flux1">
-          <caption>Illustrating the curves and vector fields in <xref ref="ex_flux1">Example</xref>. In (a) the vector field is <m>\vec F_1</m>, and in (b) the vector field is <m>\vec F_2</m>.</caption>
+          <caption>Illustrating the curves and vector fields in <xref ref="ex_flux1"/>. In (a) the vector field is <m>\vec F_1</m>, and in (b) the vector field is <m>\vec F_2</m>.</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_flux1a">
               <caption/>
@@ -467,7 +467,7 @@
       <solution>
         <p>
           We begin by finding parametrizations of <m>C_1</m> and <m>C_2</m>.
-          As done in <xref ref="ex_livf3">Example</xref>,
+          As done in <xref ref="ex_livf3"/>,
           parametrize <m>C_1</m> by creating the line that starts at <m>(1,0)</m> and moves in the <m>\la -1,1\ra</m> direction:
           <m>\vec r_1(t) = \la 1,0\ra + t\la -1,1\ra = \la 1-t, t\ra</m>,
           for <m>0\leq t\leq 1</m>.
@@ -483,9 +483,9 @@
         </p>
 
         <p>
-          When <m>\vec F = \vec F_1 = \la y, -x+1\ra</m> (as shown in <xref ref="fig_flux1a">Figure</xref>),
+          When <m>\vec F = \vec F_1 = \la y, -x+1\ra</m> (as shown in <xref ref="fig_flux1a"/>),
           over <m>C_1</m> we have <m>M = y =t</m> and <m>N = -x+1 = -(1-t)+1 = t</m>.
-          Using <xref ref="def_flowflux">Definition</xref>, we compute the flux:
+          Using <xref ref="def_flowflux"/>, we compute the flux:
           <md>
             <mrow>\int_{C_1} \vec F\cdot \vec n\, ds \amp  = \int_{C_1} \Big(M\,g'(t) - N\,\fp(t)\Big)\, dt</mrow>
             <mrow>\amp = \int_0^1 \Big( t(1) - t(-1)\Big)\, dt</mrow>
@@ -512,7 +512,7 @@
         </p>
 
         <p>
-          When <m>\vec F = \vec F_2 = \la -x,2y-x\ra</m> (as shown in <xref ref="fig_flux1b">Figure</xref>),
+          When <m>\vec F = \vec F_2 = \la -x,2y-x\ra</m> (as shown in <xref ref="fig_flux1b"/>),
           over <m>C_1</m> we have <m>M = -x = t-1</m> and <m>N = 2y-x = 2t-(1-t) = 3t-1</m>.
           Computing the flux across <m>C_1</m>:
           <md>
@@ -542,10 +542,10 @@
     </example>
 
     <p>
-      In <xref ref="ex_flux1">Example</xref>,
+      In <xref ref="ex_flux1"/>,
       we saw that the flux across the two curves was the same when the vector field was <m>\vec F_1 = \la y, -x+1\ra</m>.
       This is not a coincidence.
-      We show why they are equal in <xref ref="ex_div2">Example</xref>.
+      We show why they are equal in <xref ref="ex_div2"/>.
       In short, the reason is this:
       the divergence of <m>\vec F_1</m> is 0, and when <m>\divv \vec F = 0</m>,
       the flux across any two paths with common beginning and ending points will be the same.
@@ -558,7 +558,7 @@
       Positive flux means most of the field is crossing from left to right;
       negative flux means most of the field is crossing from right to left;
       zero flux means the same amount crosses from each side.
-      When we consider <xref ref="fig_flux1b">Figure</xref>,
+      When we consider <xref ref="fig_flux1b"/>,
       it seems plausible that the same amount of
       <m>\vec F_2</m> was crossing <m>C_1</m> from left to right as from right to left.
     </p>
@@ -610,13 +610,13 @@
         <p>
           Let <m>\vec F =\la -y,x^2+1\ra</m> and let <m>R</m> be the region of the plane bounded by the triangle with vertices <m>(-1,0)</m>,
           <m>(1,0)</m> and <m>(0,2)</m>,
-          shown in <xref ref="fig_green1">Figure</xref>.
+          shown in <xref ref="fig_green1"/>.
           Verify Green's Theorem; that is,
           find the circulation of <m>\vec F</m> around the boundary of <m>R</m> and show that is equal to the double integral of <m>\curl \vec F</m> over <m>R</m>.
         </p>
 
         <figure xml:id="fig_green1">
-          <caption>The vector field and planar region used in <xref ref="ex_green1">Example</xref></caption>
+          <caption>The vector field and planar region used in <xref ref="ex_green1"/></caption>
           <image xml:id="img_green1" width="47%">
             <description></description>
             <asymptote>
@@ -767,12 +767,12 @@
         <p>
           Let <m>\vec F = \la \sin x,\cos y\ra</m> and let <m>R</m> be the region enclosed by the curve <m>C</m> parametrized by
           <m>\vec r(t) = \la 2\cos t+ \frac1{10}\cos(10t),2\sin t+\frac1{10}\sin(10t)\ra</m> on <m>0\leq t\leq 2\pi</m>,
-          as shown in <xref ref="fig_green2">Figure</xref>.
+          as shown in <xref ref="fig_green2"/>.
           Find the circulation around <m>C</m>.
         </p>
 
         <figure xml:id="fig_green2">
-          <caption>The vector field and planar region used in <xref ref="ex_green2">Example</xref></caption>
+          <caption>The vector field and planar region used in <xref ref="ex_green2"/></caption>
           <image xml:id="img_green2" width="47%">
             <description></description>
             <asymptote>
@@ -910,12 +910,12 @@
           Let <m>C</m> be the closed curve parametrized by
           <m>\vrt = \la t-t^3,t^2\ra</m> on <m>-1\leq t\leq 1</m>,
           enclosing the region <m>R</m>,
-          as shown in <xref ref="fig_green3">Figure</xref>.
+          as shown in <xref ref="fig_green3"/>.
           Find the area of <m>R</m>.
         </p>
 
         <figure xml:id="fig_green3">
-          <caption>The region <m>R</m>, whose area is found in <xref ref="ex_green3">Example</xref></caption>
+          <caption>The region <m>R</m>, whose area is found in <xref ref="ex_green3"/></caption>
           <image xml:id="img_green3" width="47%">
             <description></description>
             <latex-image>
@@ -1016,13 +1016,13 @@
         <p>
           Let <m>\vec F = \la x-y,x+y\ra</m>,
           let <m>C</m> be the circle of radius 2 centered at the origin and define <m>R</m> to be the interior of that circle,
-          as shown in <xref ref="fig_div1">Figure</xref>.
+          as shown in <xref ref="fig_div1"/>.
           Verify the Divergence Theorem;
           that is, find the flux across <m>C</m> and show it is equal to the double integral of <m>\divv \vec F</m> over <m>R</m>.
         </p>
 
         <figure xml:id="fig_div1">
-          <caption>The region <m>R</m> used in <xref ref="ex_div1">Example</xref></caption>
+          <caption>The region <m>R</m> used in <xref ref="ex_div1"/></caption>
           <image xml:id="img_div1" width="47%">
             <description></description>
             <asymptote>
@@ -1129,13 +1129,13 @@
           Let <m>\vec F</m> be any field where <m>\divv \vec F = 0</m>,
           and let <m>C_1</m> and <m>C_2</m> be any two nonintersecting paths,
           except that each begin at point <m>A</m> and end at point <m>B</m>
-          (see <xref ref="fig_div2">Figure</xref>).
+          (see <xref ref="fig_div2"/>).
           Show why the flux across <m>C_1</m> and <m>C_2</m> is the same.
         </p>
       </statement>
       <solution>
         <p>
-          By referencing <xref ref="fig_div2">Figure</xref>,
+          By referencing <xref ref="fig_div2"/>,
           we see we can make a closed path <m>C</m> that combines <m>C_1</m> with <m>C_2</m>,
           where <m>C_2</m> is traversed with its opposite orientation.
           We label the enclosed region <m>R</m>.
@@ -1147,12 +1147,12 @@
         </p>
 
         <p>
-          Using the properties and notation given in <xref ref="thm_line_int_properties_vector">Theorem</xref>,
+          Using the properties and notation given in <xref ref="thm_line_int_properties_vector"/>,
           consider:
         </p>
 
         <figure xml:id="fig_div2">
-          <caption>As used in <xref ref="ex_div2">Example</xref>, the vector field has a divergence of 0 and the two paths only intersect at their initial and terminal points.</caption>
+          <caption>As used in <xref ref="ex_div2"/>, the vector field has a divergence of 0 and the two paths only intersect at their initial and terminal points.</caption>
           <image xml:id="img_div2" width="47%">
             <description></description>
             <asymptote>

--- a/ptx/sec_hessian.ptx
+++ b/ptx/sec_hessian.ptx
@@ -3,10 +3,10 @@
   <title>Hessians and the General Second Derivative Test</title>
   <introduction>
     <p>
-      In <xref ref="sec_multi_extreme_values">Section</xref>,
+      In <xref ref="sec_multi_extreme_values"/>,
       we saw that, just as for functions of a single variable
-      (recall <xref ref="sec_extreme_values">Section</xref>), local extreme values occur at critical points.
-      <xref ref="def_multi_critical_point">Definition</xref>
+      (recall <xref ref="sec_extreme_values"/>), local extreme values occur at critical points.
+      <xref ref="def_multi_critical_point"/>
       defined a critical point <m>(a,b)</m> of a function <m>f(x,y)</m>  to be one where the gradient vanishes:
       <me>
         \nabla f(a,b) = \la f_x(a,b),f_y(a,b)\ra = \la 0,0\ra
@@ -15,7 +15,7 @@
 
     <p>
       Given a critical point for a function <m>f</m> of two variables,
-      <xref ref="thm_multi_second_test">Theorem</xref>, the Second Derivative Test,
+      <xref ref="thm_multi_second_test"/>, the Second Derivative Test,
       tells us how to determine whether that critical point corresponds to a local minimum,
       local maximum, or saddle point.
       You might have been left wondering why the second derivative test looks so different in two variables.
@@ -34,7 +34,7 @@
         f(x,y) \approx f(a,b) +\nabla f(a,b)\cdot\langle x-a,y-b\rangle
       </me>
       near a point <m>(a,b)</m> in the domain of <m>f</m>.
-      (Multiplying out the dot product above gives us the differential <m>df</m> defined in <xref ref="def_total_differential">Definition</xref>.)
+      (Multiplying out the dot product above gives us the differential <m>df</m> defined in <xref ref="def_total_differential"/>.)
     </p>
 
     <p>
@@ -124,11 +124,11 @@
 
     <aside>
       <p>
-        We will use the shorthand <m>f(\vec{x})</m> from <xref ref="sec_deriv_matrix">Section</xref> for the function <m>f(x_1,\ldots, x_n)</m>,
+        We will use the shorthand <m>f(\vec{x})</m> from <xref ref="sec_deriv_matrix"/> for the function <m>f(x_1,\ldots, x_n)</m>,
         where <m>\vec{x} = \la x_1,\ldots, x_n\ra</m>.
         We will also write our vectors using angle bracket notation,
         even when we should really write them as column vectors for the purposes of matrix multiplication.
-        Finally, as in <xref ref="sec_deriv_matrix">Section</xref>,
+        Finally, as in <xref ref="sec_deriv_matrix"/>,
         for an <m>n\times n</m> matrix <m>A</m>, we will use the dot product <m>A\cdot \vec{x}</m> to account for this.
       </p>
     </aside>
@@ -138,7 +138,7 @@
       <me>
          \lim_{\vec{x}\to\vec{a}}\frac{R_1(\vec{x})}{\norm{\vec{x}-\vec{a}}}=0
       </me>.
-      Using the terminology from <xref ref="sec_deriv_matrix">Section</xref>,
+      Using the terminology from <xref ref="sec_deriv_matrix"/>,
       we say that <m>f</m> and <m>P_1</m> <q>agree to first order</q>.
       From here we can go on and ask for degree <m>k</m> Taylor polynomials
       <m>P_k(\vec{x})</m> that give a <q><m>k</m>th-order approximation</q> of <m>f</m> near <m>\vec{a}</m>.
@@ -344,7 +344,7 @@
 
     <p>
       Note that <m>\Hess f(\vec{a})</m> is symmetric by Clairaut's theorem
-      (<xref ref="thm_mixed_partial">Theorem</xref>.
+      (<xref ref="thm_mixed_partial"/>.
       The factor of <m>1/2</m> is included for convenience with respect to Taylor's theorem.
       Recall that for a function of one variable, the second-order Taylor polynomial of <m>f</m> about <m>x=a</m> is
       <me>
@@ -435,7 +435,7 @@
     </p>
 
     <p>
-      <xref ref="thm_quadfunction">Theorem</xref> tells us that
+      <xref ref="thm_quadfunction"/> tells us that
       <m>h_{f,\vec{a}}(\vec{x}-\vec{a})\geq M\lVert\vec{x}-\vec{a}\rVert^2</m> for some <m>M</m>,
       and by <xref ref="eq_remainderorder"/>,
       there exists a <m>\delta\gt0</m> such that whenever <m>0\lt \lVert \vec{x}-\vec{a}\rVert\lt \delta</m>,

--- a/ptx/sec_hessian.ptx
+++ b/ptx/sec_hessian.ptx
@@ -428,7 +428,7 @@
       Suppose <m>\vec{a}</m> is a critical point for <m>f</m>,
       and that <m>\Hess f(\vec{a})</m> is positive definite.
       We know that <m>\nabla f(\vec{a})=0</m> at a critical point,
-      so from <xref ref="eq_hesstaylor"/> we get
+      so from <xref ref="eq_hesstaylor">Equation</xref> we get
       <me>
         f(\vec{x})-f(\vec{a}) = h_{f,\vec{a}}(\vec{x}-\vec{a})+R(\vec{a},\vec{x})
       </me>.
@@ -437,7 +437,7 @@
     <p>
       <xref ref="thm_quadfunction"/> tells us that
       <m>h_{f,\vec{a}}(\vec{x}-\vec{a})\geq M\lVert\vec{x}-\vec{a}\rVert^2</m> for some <m>M</m>,
-      and by <xref ref="eq_remainderorder"/>,
+      and by <xref ref="eq_remainderorder">Equation</xref>,
       there exists a <m>\delta\gt0</m> such that whenever <m>0\lt \lVert \vec{x}-\vec{a}\rVert\lt \delta</m>,
       we get <m>\lvert R(\vec{a},\vec{x})\rvert\lt M\lVert \vec{x}-\vec{a}\rVert^2</m>.
       (Take <m>\epsilon=M</m> in the definition of the limit.)

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -18,7 +18,7 @@
       These functions are sometimes referred to as the
       <q>hyperbolic trigonometric functions</q> as there are many,
       many connections between them and the standard trigonometric functions.
-      <xref ref="fig_hfcircle">Figure</xref>
+      <xref ref="fig_hfcircle"/>
       demonstrates one such connection.
       Just as cosine and sine are used to define points on the circle defined by <m>x^2+y^2=1</m>,
       the functions <em>hyperbolic cosine</em> and
@@ -191,15 +191,15 @@
       </p>
     </aside>
     <p>
-      These hyperbolic functions are graphed in <xref ref="fig_hyperbolic1">Figure</xref>
-      and <xref ref="fig_hyperbolic2">Figure</xref>.
+      These hyperbolic functions are graphed in <xref ref="fig_hyperbolic1"/>
+      and <xref ref="fig_hyperbolic2"/>.
     </p>
 
     <p>
-      In the graph of <m>\cosh(x)</m> in <xref ref="fig_hf_cosh">Figure</xref>,
+      In the graph of <m>\cosh(x)</m> in <xref ref="fig_hf_cosh"/>,
       the graphs of <m>e^x/2</m> and
       <m>e^{-x}/2</m> are included with dashed lines.
-      In the graph of <m>\sinh(x)</m> in <xref ref="fig_hf_sinh">Figure</xref>,
+      In the graph of <m>\sinh(x)</m> in <xref ref="fig_hf_sinh"/>,
       the graphs of <m>e^x/2</m> and
       <m>-
       e^{-x}/2</m> are included with dashed lines.
@@ -330,7 +330,7 @@
     </figure>
 
     <p>
-      In Figure <xref ref="fig_hyperbolic2">Figure</xref>,
+      In Figure <xref ref="fig_hyperbolic2"/>,
       notice the domains of <m>\tanh(x)</m> and
       <m>\sech(x)</m> are <m>(-\infty,\infty)</m>,
       whereas both <m>\coth(x)</m> and
@@ -461,7 +461,7 @@
       <title>Exploring properties of hyperbolic functions</title>
       <statement>
         <p>
-          Use <xref ref="def_hyperbolic_functions">Definition</xref>
+          Use <xref ref="def_hyperbolic_functions"/>
           to rewrite the following expressions.
         </p>
 
@@ -491,7 +491,7 @@
             <li xml:id="ex_hf1a">
 
               <p>
-                By <xref ref="def_hyperbolic_functions">Definition</xref>
+                By <xref ref="def_hyperbolic_functions"/>
                 <md>
                   <mrow>\cosh^2(x) -\sinh^2(x) \amp = \left(\frac{e^x+e^{-x}}2\right)^2 -\left(\frac{e^x-e^{-x}}2\right)^2</mrow>
                   <mrow>\amp = \frac{e^{2x}+2e^xe^{-x} + e^{-2x}}4 - \frac{e^{2x}-2e^xe^{-x} + e^{-2x}}4</mrow>
@@ -503,10 +503,10 @@
 
             <li>
               <p>
-                Again, use <xref ref="def_hyperbolic_functions">Definition</xref>
+                Again, use <xref ref="def_hyperbolic_functions"/>
                 <md>
                   <mrow>\tanh^2(x) +\sech^2(x) \amp =\frac{\sinh^2(x) }{\cosh^2(x) } + \frac{1}{\cosh^2(x) }</mrow>
-                  <mrow>\amp= \frac{\sinh^2(x) +1}{\cosh^2(x) }\qquad \text{ Now use identity from } <xref ref="ex_hf1a">Part</xref></mrow>
+                  <mrow>\amp= \frac{\sinh^2(x) +1}{\cosh^2(x) }\qquad \text{ Now use identity from } <xref ref="ex_hf1a" text="local">Part</xref></mrow>
                   <mrow>\amp = \frac{\cosh^2(x) }{\cosh^2(x) } = 1</mrow>
                 </md>.
                 So <m>\tanh^2(x) +\sech^2(x) =1</m>.
@@ -515,7 +515,7 @@
 
             <li>
               <p>
-                Again, use <xref ref="def_hyperbolic_functions">Definition</xref>
+                Again, use <xref ref="def_hyperbolic_functions"/>
                 <md>
                   <mrow>2\cosh(x) \sinh(x) \amp = 2\left(\frac{e^x+e^{-x}}2\right)\left(\frac{e^x-e^{-x}}2\right)</mrow>
                   <mrow>\amp = 2 \cdot\frac{e^{2x} - e^{-2x}}4</mrow>
@@ -527,7 +527,7 @@
 
             <li>
               <p>
-                Again, use <xref ref="def_hyperbolic_functions">Definition</xref>
+                Again, use <xref ref="def_hyperbolic_functions"/>
                 <md>
                   <mrow>\frac{d}{dx}\big(\cosh(x) \big) \amp = \frac{d}{dx}\left(\frac{e^x+e^{-x}}2\right)</mrow>
                   <mrow>\amp = \frac{e^x-e^{-x}}2</mrow>
@@ -539,7 +539,7 @@
 
             <li>
               <p>
-                Apply derivatives to <xref ref="def_hyperbolic_functions">Definition</xref>:
+                Apply derivatives to <xref ref="def_hyperbolic_functions"/>:
                 <md>
                   <mrow>\frac{d}{dx}\big(\sinh(x) \big) \amp = \frac{d}{dx}\left(\frac{e^x-e^{-x}}2\right)</mrow>
                   <mrow>\amp = \frac{e^x+e^{-x}}2</mrow>
@@ -551,7 +551,7 @@
 
             <li>
               <p>
-                Apply derivatives to <xref ref="def_hyperbolic_functions">Definition</xref>:
+                Apply derivatives to <xref ref="def_hyperbolic_functions"/>:
                 <md>
                   <mrow>\frac{d}{dx}\big(\tanh(x) \big) \amp = \frac{d}{dx}\left(\frac{\sinh(x) }{\cosh(x) }\right)</mrow>
                   <mrow>\amp = \frac{\cosh(x) \cosh(x) - \sinh(x) \sinh(x) }{\cosh^2(x) }</mrow>
@@ -568,7 +568,7 @@
 
     <p>
       The following Key Idea summarizes many of the important identities relating to hyperbolic functions.
-      Each can be verified by referring back to <xref ref="def_hyperbolic_functions">Definition</xref>.
+      Each can be verified by referring back to <xref ref="def_hyperbolic_functions"/>.
     </p>
 
     <insight xml:id="idea_hyperbolic_identities">
@@ -643,7 +643,7 @@
     </insight>
 
     <p>
-      We practice using <xref ref="idea_hyperbolic_identities">Key Idea</xref>.
+      We practice using <xref ref="idea_hyperbolic_identities"/>.
     </p>
 
     <example xml:id="ex_hf2">
@@ -676,7 +676,7 @@
                 we have <m>\frac{d}{dx} \big(\cosh(2x) \big) = 2\sinh(2x)</m>.
 
                 Just to demonstrate that it works,
-                let's also use the Basic Identity found in <xref ref="idea_hyperbolic_identities">Key Idea</xref>:
+                let's also use the Basic Identity found in <xref ref="idea_hyperbolic_identities"/>:
                 <m>\cosh(2x) = \cosh^2(x) +\sinh^2(x)</m>.
                 <md>
                   <mrow>\frac{d}{dx}\big(\cosh(2x) \big) \amp = \frac{d}{dx}\big(\cosh^2(x) +\sinh^2(x) \big)</mrow>
@@ -692,8 +692,8 @@
             <li>
               <p>
                 We employ substitution, with <m>u = 7t-3</m> and <m>du = 7dt</m>.
-                Applying <xref ref="idea_linearsub">Key Ideas</xref>
-                and <xref ref="idea_hyperbolic_identities"/> we have:
+                Applying <xref ref="idea_linearsub" text="local">Key Ideas</xref>
+                and <xref ref="idea_hyperbolic_identities" text="local"/> we have:
                 <me>
                   \int \sech^2(7t-3)\,dt = \frac17\tanh(7t-3) + C
                 </me>.
@@ -727,19 +727,19 @@
     <p>
       Just as the inverse trigonometric functions are useful in certain applications,
       the inverse hyperbolic functions are useful with others.
-      <xref ref="fig_hfarccosh">Figure</xref>
+      <xref ref="fig_hfarccosh"/>
       shows restriction on the domain of
       <m>\cosh(x)</m> to make the function one-to-one and the resulting domain and range of its inverse function.
       Since <m>\sinh(x)</m> is already one-to-one,
-      no domain restriction is needed as shown in <xref ref="fig_hfarcsinh"> Figure </xref>.
+      no domain restriction is needed as shown in <xref ref="fig_hfarcsinh"/>.
       Since <m>\sech(x)</m> is not one to one,
       it also needs a restricted domain in order to be invertible.
-      <xref ref="fig_hfarcsecharccsch">Figure</xref>
+      <xref ref="fig_hfarcsecharccsch"/>
       shows the graph of <m>\sech^{-1}(x)</m>.
-      You should carefully compare the graph of this function to the graph given in <xref ref="fig_hf_sech_csch">Figure </xref>
+      You should carefully compare the graph of this function to the graph given in <xref ref="fig_hf_sech_csch"/>
       to see how this inverse was constructed.
       The rest of the hyperbolic functions area already one-to-one and need no domain restrictions.
-      Their graphs are also shown in <xref ref="fig_hfinverse1">Figure</xref>.
+      Their graphs are also shown in <xref ref="fig_hfinverse1"/>.
 
       <idx><h>hyperbolic function</h><h>inverse</h></idx>
 
@@ -747,7 +747,7 @@
 
     <p>
       Because the hyperbolic functions are defined in terms of exponential functions,
-      their inverses can be expressed in terms of logarithms as shown in <xref ref="idea_hyperbolic_log">Key Idea</xref>.
+      their inverses can be expressed in terms of logarithms as shown in <xref ref="idea_hyperbolic_log"/>.
       It is often more convenient to refer to
       <m>\sinh^{-1}(x)</m> than to <m>\ln\big(x+\sqrt{x^2+1}\big)</m>,
       especially when one is working on theory and does not need to compute actual values.
@@ -1093,11 +1093,11 @@
 
     <p>
       The following Key Ideas give the derivatives and integrals relating to the inverse hyperbolic functions.
-      In <xref ref="idea_hyperbolic_inverse_integrals">Key Idea</xref>,
+      In <xref ref="idea_hyperbolic_inverse_integrals"/>,
       both the inverse hyperbolic and logarithmic function representations of the antiderivative are given,
-      based on <xref ref="idea_hyperbolic_log">Key Idea</xref>.
+      based on <xref ref="idea_hyperbolic_log"/>.
       Again, these latter functions are often more useful than the former.
-      Note how inverse hyperbolic functions can be used to solve integrals we used Trigonometric Substitution to solve in <xref ref="sec_trig_sub">Section</xref>.
+      Note how inverse hyperbolic functions can be used to solve integrals we used Trigonometric Substitution to solve in <xref ref="sec_trig_sub"/>.
     </p>
 
     <!-- ToDo: Consider adding an example showing how one of the inverse functions is found using logarithms? -->
@@ -1230,7 +1230,7 @@
           <ol>
             <li>
               <p>
-                Applying <xref ref="idea_hyperbolic_inverse_derivatives">Key Idea</xref> with the Chain Rule gives:
+                Applying <xref ref="idea_hyperbolic_inverse_derivatives"/> with the Chain Rule gives:
                 <me>
                   \frac{d}{dx}\left[\cosh^{-1}\left(\frac{3x-2}5\right)\right] = \frac{1}{\sqrt{\left(\frac{3x-2}5\right)^2-1}}\cdot\frac35
                 </me>.
@@ -1241,7 +1241,7 @@
               <p>
                 Multiplying the numerator and denominator by <m>(-1)</m> gives:
                 <m>\ds \int \frac{1}{x^2-1}\, dx = \int \frac{-1}{1-x^2}\, dx</m>.
-                The second integral can be solved with a direct application of item #3 from <xref ref="idea_hyperbolic_inverse_integrals">Key Idea</xref>,
+                The second integral can be solved with a direct application of item #3 from <xref ref="idea_hyperbolic_inverse_integrals"/>,
                 with <m>a=1</m>.
                 Thus
                 <mdn>
@@ -1252,9 +1252,9 @@
                   <mrow number="no">\amp =-\frac12\ln\abs{\frac{x+1}{x-1}}+C</mrow>
                   <mrow xml:id="eq_hf3">\amp =\frac12\ln\abs{\frac{x-1}{x+1}}+C</mrow>
                 </mdn>.
-                We should note that this exact problem was solved at the beginning of <xref ref="sec_partial_fraction">Section</xref>.
+                We should note that this exact problem was solved at the beginning of <xref ref="sec_partial_fraction"/>.
                 In that example the answer was given as <m>\frac12\ln\abs{x-1}-\frac12\ln\abs{x+1}+C</m>.
-                Note that this is equivalent to the answer given in <xref ref="eq_hf3">Equation</xref>,
+                Note that this is equivalent to the answer given in <xref ref="eq_hf3"/>,
                 as <m>\ln(a/b) = \ln(a) - \ln(b)</m>.
               </p>
             </li>
@@ -1262,7 +1262,7 @@
             <li>
               <p>
                 This requires a substitution,
-                then item #2 of <xref ref="idea_hyperbolic_inverse_integrals">Key Idea</xref> can be applied.
+                then item #2 of <xref ref="idea_hyperbolic_inverse_integrals"/> can be applied.
 
                 Let <m>u = 3x</m>, hence <m>du = 3dx</m>.
                 We have
@@ -1292,7 +1292,7 @@
     <p>
       Do not view this section as containing a source of information to be memorized,
       but rather as a reference for future problem solving.
-      <xref ref="idea_hyperbolic_inverse_integrals">Key Idea</xref>
+      <xref ref="idea_hyperbolic_inverse_integrals"/>
       contains perhaps the most useful information.
       Know the integration forms it helps evaluate and understand how to use the inverse hyperbolic answer and the logarithmic answer.
     </p>
@@ -1300,7 +1300,7 @@
     <p>
       The next section takes a brief break from demonstrating new integration techniques.
       It instead demonstrates a technique of evaluating limits that return indeterminate forms.
-      This technique will be useful in <xref ref="sec_improper_integration">Section</xref>,
+      This technique will be useful in <xref ref="sec_improper_integration"/>,
       where limits will arise in the evaluation of certain definite integrals.
     </p>
   </subsection>
@@ -1316,7 +1316,7 @@
 
             <statement>
               <p>
-                In <xref ref="idea_hyperbolic_identities">Key Idea</xref>,
+                In <xref ref="idea_hyperbolic_identities"/>,
                 the equation <m>\ds \int \tanh(x) \, dx = \ln(\cosh(x) )+C</m> is given.
                 Why is <q><m>\ln\abs{\cosh(x) }</m></q>
                 not used <mdash/> <ie/>, why are absolute values not necessary?
@@ -1342,7 +1342,7 @@
             <statement>
               <p>
                 The hyperbolic functions are used to define points on the right hand portion of the hyperbola <m>x^2-y^2=1</m>,
-                as shown in <xref ref="fig_hfcircle">Figure</xref>.
+                as shown in <xref ref="fig_hfcircle"/>.
                 How can we use the hyperbolic functions to define points on the left hand portion of the hyperbola?
               </p>
 
@@ -1365,8 +1365,8 @@
         <introduction>
           <p>
             In the following exercises,
-            verify the given identity using <xref ref="def_hyperbolic_functions">Definition</xref>,
-            as done in <xref ref="ex_hf1">Example</xref>.
+            verify the given identity using <xref ref="def_hyperbolic_functions"/>,
+            as done in <xref ref="ex_hf1"/>.
           </p>
         </introduction>
   <!-- Exercise 3 -->

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -692,8 +692,8 @@
             <li>
               <p>
                 We employ substitution, with <m>u = 7t-3</m> and <m>du = 7dt</m>.
-                Applying <xref ref="idea_linearsub" text="local">Key Ideas</xref>
-                and <xref ref="idea_hyperbolic_identities" text="local"/> we have:
+                Applying <xref ref="idea_linearsub" text="global">Key Ideas</xref>
+                and <xref ref="idea_hyperbolic_identities" text="global"/> we have:
                 <me>
                   \int \sech^2(7t-3)\,dt = \frac17\tanh(7t-3) + C
                 </me>.
@@ -1254,7 +1254,7 @@
                 </mdn>.
                 We should note that this exact problem was solved at the beginning of <xref ref="sec_partial_fraction"/>.
                 In that example the answer was given as <m>\frac12\ln\abs{x-1}-\frac12\ln\abs{x+1}+C</m>.
-                Note that this is equivalent to the answer given in <xref ref="eq_hf3"/>,
+                Note that this is equivalent to the answer given in <xref ref="eq_hf3">Equation</xref>,
                 as <m>\ln(a/b) = \ln(a) - \ln(b)</m>.
               </p>
             </li>

--- a/ptx/sec_improper_integration.ptx
+++ b/ptx/sec_improper_integration.ptx
@@ -18,7 +18,7 @@
 
     <p>
       Notice how the integrand is <m>1/(1+x^2)</m> in each integral
-      (which is sketched in <xref ref="fig_improper1">Figure</xref>).
+      (which is sketched in <xref ref="fig_improper1"/>).
       As the upper bound gets larger,
       one would expect the <q>area under the curve</q> would also grow.
       While the definite integrals do increase in value as the upper bound grows,
@@ -204,11 +204,11 @@
                   <mrow>\amp = 1</mrow>
                 </md>.
 
-                A graph of the area defined by this integral is given in <xref ref="fig_impint1a">Figure</xref>.
+                A graph of the area defined by this integral is given in <xref ref="fig_impint1a"/>.
               </p>
 
               <figure xml:id="fig_impint1a">
-                <caption>A graph of <m>f(x) = \frac{1}{x^2}</m> in <xref ref="ex_impint1">Example</xref></caption>
+                <caption>A graph of <m>f(x) = \frac{1}{x^2}</m> in <xref ref="ex_impint1"/></caption>
             <!-- START figures/fig_eximpint1a.tex -->
                 <image xml:id="img_impint1a" width="47%">
                   <shortdescription>
@@ -262,14 +262,14 @@
 
                 The limit does not exist,
                 hence the improper integral <m>\ds\int_1^\infty\frac1x\, dx</m> diverges.
-                Compare the graphs in <xref ref="fig_impint1a">Figures</xref>
-                and <xref ref="fig_impint1b"/>;
+                Compare the graphs in <xref ref="fig_impint1a" text="global">Figures</xref>
+                and <xref ref="fig_impint1b" text="global"/>;
                 notice how the graph of <m>f(x) = 1/x</m> is noticeably larger.
                 This difference is enough to cause the improper integral to diverge.
               </p>
 
               <figure xml:id="fig_impint1b">
-                <caption>A graph of <m>f(x) = \frac{1}{x}</m> in <xref ref="ex_impint1">Example</xref></caption>
+                <caption>A graph of <m>f(x) = \frac{1}{x}</m> in <xref ref="ex_impint1"/></caption>
             <!-- START figures/fig_eximpint1b.tex -->
                 <image xml:id="img_impint1b" width="47%">
                   <shortdescription>
@@ -320,11 +320,11 @@
                   <mrow>\amp = 1</mrow>
                 </md>.
 
-                A graph of the area defined by this integral is given in <xref ref="fig_impint1c">Figure</xref>.
+                A graph of the area defined by this integral is given in <xref ref="fig_impint1c"/>.
               </p>
 
               <figure xml:id="fig_impint1c">
-                <caption>A graph of <m>f(x) = e^x</m> in <xref ref="ex_impint1">Example</xref></caption>
+                <caption>A graph of <m>f(x) = e^x</m> in <xref ref="ex_impint1"/></caption>
             <!-- START figures/fig_eximpint1c.tex -->
                 <image xml:id="img_impint1c" width="47%">
                   <shortdescription>
@@ -370,7 +370,7 @@
 
             <li>
               <p>
-                We will need to break this into two improper integrals and choose a value of <m>c</m> as in part 3 of <xref ref="def_imp_int1">Definition</xref>.
+                We will need to break this into two improper integrals and choose a value of <m>c</m> as in part 3 of <xref ref="def_imp_int1"/>.
                 Any value of <m>c</m> is fine;
                 we choose <m>c=0</m>.
                 <md>
@@ -382,11 +382,11 @@
                   <intertext>Each	limit exists, hence the original integral converges and has value:</intertext>
                   <mrow>\amp = \pi</mrow>
                 </md>.
-                A graph of the area defined by this integral is given in <xref ref="fig_impint1d">Figure</xref>.
+                A graph of the area defined by this integral is given in <xref ref="fig_impint1d"/>.
               </p>
 
               <figure xml:id="fig_impint1d">
-                <caption>A graph of <m>f(x) = \frac{1}{1+x^2}</m> in <xref ref="ex_impint1">Example</xref></caption>
+                <caption>A graph of <m>f(x) = \frac{1}{1+x^2}</m> in <xref ref="ex_impint1"/></caption>
             <!-- START figures/fig_eximpint1d.tex -->
                 <image xml:id="img_impint1d" width="47%">
                   <shortdescription>
@@ -462,7 +462,7 @@
         </p>
 
         <figure xml:id="fig_impint2">
-          <caption>A graph of <m>f(x) = \frac{\ln(x) }{x^2}</m> in <xref ref="ex_impint2">Example</xref></caption>
+          <caption>A graph of <m>f(x) = \frac{\ln(x) }{x^2}</m> in <xref ref="ex_impint2"/></caption>
           <!-- START figures/fig_eximpint2.tex -->
           <image xml:id="img_impint2" width="47%">
             <shortdescription>
@@ -573,7 +573,7 @@
           <ol>
             <li>
               <p>
-                A graph of <m>f(x) = 1/\sqrt{x}</m> is given in <xref ref="fig_impint3">Figure</xref>.
+                A graph of <m>f(x) = 1/\sqrt{x}</m> is given in <xref ref="fig_impint3"/>.
                 Notice that <m>f</m> has a vertical asymptote at <m>x=0</m>;
                 in some sense,
                 we are trying to compute the area of a region that has no <q>top.</q>
@@ -589,7 +589,7 @@
               </p>
                 <aside>
                   <p>
-                    In <xref ref="def_imp_int2">Definition</xref>,
+                    In <xref ref="def_imp_int2"/>,
                     <m>c</m> can be one of the endpoints
                     (<m>a</m> or <m>b</m>).
                     In that case,
@@ -599,7 +599,7 @@
 
 
               <figure xml:id="fig_impint3">
-                <caption>A graph of <m>f(x)=\frac{1}{\sqrt{x}}</m> in <xref ref="ex_impint3">Example</xref></caption>
+                <caption>A graph of <m>f(x)=\frac{1}{\sqrt{x}}</m> in <xref ref="ex_impint3"/></caption>
             <!-- START figures/fig_impint3.tex -->
                 <image xml:id="img_impint3" width="47%">
                   <shortdescription>
@@ -645,7 +645,7 @@
             <li>
               <p>
                 The function <m>f(x) = 1/x^2</m> has a vertical asymptote at <m>x=0</m>,
-                as shown in <xref ref="fig_impint3b">Figure</xref>,
+                as shown in <xref ref="fig_impint3b"/>,
                 so this integral is an improper integral.
                 Let's eschew using limits for a moment and proceed without recognizing the improper nature of the integral.
                 This leads to:
@@ -657,7 +657,7 @@
               </p>
 
               <figure xml:id="fig_impint3b">
-                <caption>A graph of <m>f(x)=\frac{1}{x^2}</m> in <xref ref="ex_impint3">Example</xref></caption>
+                <caption>A graph of <m>f(x)=\frac{1}{x^2}</m> in <xref ref="ex_impint3"/></caption>
             <!-- START figures/fig_impint3b.tex -->
                 <image xml:id="img_impint3b" width="47%">
                   <shortdescription>
@@ -707,7 +707,7 @@
                 yet the area is supposedly negative!
                 Why does our answer not match our intuition?
                 To answer this,
-                evaluate the integral using <xref ref="def_imp_int2">Definition</xref>.
+                evaluate the integral using <xref ref="def_imp_int2"/>.
                 <md>
                   <mrow>\int_{-1}^1\frac1{x^2}\, dx \amp = \lim_{t\to0^-}\int_{-1}^t \frac1{x^2}\, dx + \lim_{t\to0^+}\int_t^1\frac1{x^2}\, dx</mrow>
                   <mrow>\amp = \lim_{t\to0^-}-\frac1x\Big|_{-1}^t + \lim_{t\to0^+}-\frac1x\Big|_t^1</mrow>
@@ -767,7 +767,7 @@
         </p>
 
         <figure xml:id="fig_impint4">
-          <caption>Plotting functions of the form <m>1/x^p</m> in <xref ref="ex_impint4">Example</xref></caption>
+          <caption>Plotting functions of the form <m>1/x^p</m> in <xref ref="ex_impint4"/></caption>
           <!-- START figures/fig_impint4.tex -->
           <image xml:id="img_impint4" width="47%">
             <shortdescription>
@@ -818,12 +818,12 @@
           Our analysis shows that if <m>p \gt 1</m>,
           then <m>\ds\int_1^\infty \frac1{x^p}\, dx</m> converges.
           When <m>p\lt 1</m> the improper integral diverges;
-          we showed in <xref ref="ex_impint1">Example</xref>
+          we showed in <xref ref="ex_impint1"/>
           that when <m>p=1</m> the integral also diverges.
         </p>
 
         <p>
-          <xref ref="fig_impint4">Figure</xref>
+          <xref ref="fig_impint4"/>
           graphs <m>y=1/x</m> with a dashed line,
           along with graphs of <m>y=1/x^p</m>, <m>p\lt 1</m>,
           and <m>y=1/x^q</m>, <m>q \gt 1</m>.
@@ -833,7 +833,7 @@
     </example>
 
     <p>
-      The result of <xref ref="ex_impint4">Example</xref>
+      The result of <xref ref="ex_impint4"/>
       provides an important tool in determining the convergence of other integrals.
       A similar result is proved in the exercises about improper integrals of the form <m>\ds \int_0^1\frac1{x^p}\, dx</m>.
       These results are summarized in the following Key Idea.
@@ -869,7 +869,7 @@
     <aside>
       <p>
         We used the upper and lower bound of <q>1</q>
-        in <xref ref="idea_impint1">Key Idea</xref> for convenience.
+        in <xref ref="idea_impint1"/> for convenience.
         It can be replaced by any <m>a</m> where <m>a \gt 0</m>.
       </p>
     </aside>
@@ -934,15 +934,15 @@
                 The function <m>f(x) = e^{-x^2}</m> does not have an antiderivative expressible in terms of elementary functions,
                 so we cannot integrate directly.
                 It is comparable to <m>g(x)=1/x^2</m>,
-                and as demonstrated in <xref ref="fig_impint5">Figure</xref>,
+                and as demonstrated in <xref ref="fig_impint5"/>,
                 <m>e^{-x^2} \lt 1/x^2</m> on <m>[1,\infty)</m>.
-                We know from <xref ref="idea_impint1">Key Idea</xref>
+                We know from <xref ref="idea_impint1"/>
                 that <m>\ds \int_1^\infty \frac{1}{x^2}\, dx</m> converges,
                 hence <m>\ds\int_1^\infty e^{-x^2}\, dx</m> also converges.
               </p>
 
               <figure xml:id="fig_impint5">
-                <caption>Graphs of <m>f(x) = e^{-x^2}</m> and <m>f(x)= 1/x^2</m> in <xref ref="ex_impint5">Example</xref></caption>
+                <caption>Graphs of <m>f(x) = e^{-x^2}</m> and <m>f(x)= 1/x^2</m> in <xref ref="ex_impint5"/></caption>
             <!-- START figures/fig_impint5.tex -->
                 <image xml:id="img_impint5" width="47%">
                   <shortdescription>
@@ -989,7 +989,7 @@
               <p>
                 Note that for large values of <m>x</m>,
                 <m>\ds \frac{1}{\sqrt{x^2-x}} \approx \frac{1}{\sqrt{x^2}} =\frac{1}{x}</m>.
-                We know from <xref ref="idea_impint1">Key Idea</xref>
+                We know from <xref ref="idea_impint1"/>
                 and the subsequent note that  <m>\ds \int_3^\infty \frac1x\, dx</m> diverges,
                 so we seek to compare the original integrand to <m>1/x</m>.
 
@@ -999,14 +999,14 @@
                 <me>
                   \frac1x \lt  \frac1{\sqrt{x^2-x}}
                 </me>.
-                Using <xref ref="thm_impint_comparison">Theorem</xref>,
+                Using <xref ref="thm_impint_comparison"/>,
                 we conclude that since <m>\ds\int_3^\infty\frac1x\, dx</m> diverges,
                 <m>\ds\int_3^\infty\frac1{\sqrt{x^2-x}}\, dx</m> diverges as well.
-                <xref ref="fig_impint5b">Figure</xref> illustrates this.
+                <xref ref="fig_impint5b"/> illustrates this.
               </p>
 
               <figure xml:id="fig_impint5b">
-                <caption>Graphs of <m>f(x) = 1/\sqrt{x^2-x}</m> and <m>f(x)= 1/x</m> in <xref ref="ex_impint5">Example</xref></caption>
+                <caption>Graphs of <m>f(x) = 1/\sqrt{x^2-x}</m> and <m>f(x)= 1/x</m> in <xref ref="ex_impint5"/></caption>
             <!-- START figures/fig_impint5b.tex -->
                 <image xml:id="img_impint5b" width="47%">
                   <shortdescription>
@@ -1065,7 +1065,7 @@
       were replaced with a <q><m>+2x+5</m></q>?
       That is, what can we say about the convergence of <m>\ds \int_3^\infty\frac{1}{\sqrt{x^2+2x+5}}\, dx</m>?
       We have <m>\ds \frac{1}{x}  \gt  \frac1{\sqrt{x^2+2x+5}}</m>,
-      so we cannot use <xref ref="thm_impint_comparison">Theorem</xref>.
+      so we cannot use <xref ref="thm_impint_comparison"/>.
     </p>
 
     <p>
@@ -1146,14 +1146,14 @@
           <m>\ds\frac{1}{\sqrt{x^2+2x+5}}</m><nbsp/>looks very much like <m>\ds\frac1x</m>.
           Since we know that <m>\ds\int_3^{\infty} \frac1x\, dx</m><nbsp/>diverges,
           by the Limit Comparison Test we know that <m>\ds\int_3^\infty\frac{1}{\sqrt{x^2+2x+5}}\, dx</m><nbsp/>also diverges.
-          <xref ref="fig_impint6">Figure</xref>
+          <xref ref="fig_impint6"/>
           graphs <m>f(x)=1/\sqrt{x^2+2x+5}</m> and <m>f(x)=1/x</m>,
           illustrating that as <m>x</m> gets large,
           the functions become indistinguishable.
         </p>
 
         <figure xml:id="fig_impint6">
-          <caption>Graphing <m>f(x)=\frac{1}{\sqrt{x^2+2x+5}}</m> and <m>f(x)=\frac1x</m> in <xref ref="ex_impint6">Example</xref></caption>
+          <caption>Graphing <m>f(x)=\frac{1}{\sqrt{x^2+2x+5}}</m> and <m>f(x)=\frac1x</m> in <xref ref="ex_impint6"/></caption>
           <!-- START figures/fig_impint6.tex -->
           <image xml:id="img_impint6" width="47%">
             <shortdescription>

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -180,7 +180,7 @@
     </p>
 
     <p>
-      From Equation <xref ref="eq_integral_testc"/> we can make the following two statements:
+      From <xref ref="eq_integral_testc">Equation</xref> we can make the following two statements:
     </p>
 
     <p>

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -4,11 +4,11 @@
   <introduction>
     <p>
       Knowing whether or not a series converges is very important,
-      especially when we discuss Power Series in <xref ref="sec_power_series">Section</xref>.
-      <xref ref="thm_geom_series">Theorems</xref>
-      and <xref ref="thm_pseries"/>
+      especially when we discuss Power Series in <xref ref="sec_power_series"/>.
+      <xref ref="thm_geom_series" text="global">Theorems</xref>
+      and <xref ref="thm_pseries" text="global"/>
       give criteria for when Geometric and <m>p</m>-series converge,
-      and <xref ref="thm_series_nth_term">Theorem</xref>
+      and <xref ref="thm_series_nth_term"/>
       gives a quick test to determine if a series diverges.
       There are many important series whose convergence cannot be determined by these theorems, though,
       so we introduce a set of tests that allow us to handle a broad range of series.
@@ -19,7 +19,7 @@
   <subsection>
     <title>Integral Test</title>
     <p>
-      We stated in <xref ref="sec_sequences">Section</xref>
+      We stated in <xref ref="sec_sequences"/>
       that a sequence <m>\{a_n\}</m> is a function <m>a(n)</m> whose domain is <m>\mathN</m>,
       the set of natural numbers.
       If we can extend <m>a(n)</m> to <m>\mathbb{R}</m>,
@@ -47,7 +47,7 @@
 
     <aside>
       <p>
-        <xref ref="thm_integral_test">Theorem</xref>
+        <xref ref="thm_integral_test"/>
         does not state that the integral and the summation have the same value.
       </p>
     </aside>
@@ -58,7 +58,7 @@
     </figure>
     <p>
       We can demonstrate the truth of the Integral Test with two simple graphs.
-      In <xref ref="fig_integral_test_a">Figure</xref>,
+      In <xref ref="fig_integral_test_a"/>,
       the height of each rectangle is
       <m>a(n)=a_n</m> for <m>n=1,2,\ldots</m>,
       and clearly the rectangles enclose more area than the area under <m>y=a(x)</m>.
@@ -160,7 +160,7 @@
     </figure>
 
     <p>
-      In <xref ref="fig_integral_test_b">Figure</xref>,
+      In <xref ref="fig_integral_test_b"/>,
       we draw rectangles under <m>y=a(x)</m> with the Right-Hand rule,
       starting with <m>n=2</m>.
       This time, the area of the rectangles is less than the area under <m>y=a(x)</m>,
@@ -203,7 +203,7 @@
 
     <p>
       Therefore the series and integral either both converge or both diverge.
-      <xref ref="thm_series_behavior">Theorem</xref>
+      <xref ref="thm_series_behavior"/>
       allows us to extend this theorem to series where <m>a(n)</m> is positive and decreasing on <m>[b,\infty)</m> for some <m>b \gt 1</m>.
       A formal proof of the <xref ref="thm_integral_test" text="title"/> is shown below.
     </p>
@@ -223,7 +223,7 @@
           <li>
             <p>
               Suppose that <m>\int_1^{\infty}a(x)\, dx</m> diverges.
-              Using <xref ref="fig_integral_test_a">Figure</xref>,
+              Using <xref ref="fig_integral_test_a"/>,
               we can say that <m>S_n=\sum_{i=1}^{n}a_i\gt \int_1^{n+1}a(x)\, dx</m>.
               If we let <m>n \to \infty</m> in this inequality,
               we know that <m>\int_1^{n+1}a(x)\, dx</m> will get arbitrarily large as <m>n \to \infty</m> (since
@@ -238,13 +238,13 @@
             <p>
               Now suppose that <m>\int_1^{\infty}a(x)\, dx</m> converges to <m>M</m>,
               where <m>M</m> is some positive, finite number.
-              Using <xref ref="fig_integral_test_b">Figure</xref>,
+              Using <xref ref="fig_integral_test_b"/>,
               we can say that <m>0 \lt S_n=\sum_{i=1}^{n}a_i \lt \int_1^{\infty} a(x)\, dx=M</m>.
               Therefore our sequence of partial sums, <m>S_n</m> is bounded.
               Furthermore,
               <m>S_n</m> is a monotonically increasing sequence since all of the terms <m>a_n</m> are positive.
               Since <m>S_n</m> is both bounded and monotonic,
-              <m>S_n</m> converges by <xref ref="thm_converge_bounded" text="title"/> and by <xref ref="def_series">Definition</xref>,
+              <m>S_n</m> converges by <xref ref="thm_converge_bounded" text="title"/> and by <xref ref="def_series"/>,
               the series <m>\infser a_n</m> converges as well.
             </p>
           </li>
@@ -258,7 +258,7 @@
         <p>
           Determine the convergence of
           <m>\ds\infser \frac{\ln(n) }{n^2}</m>. (The terms of the sequence
-          <m>\{a_n\} = \{\ln(n) /n^2\}</m> and the <m>n</m>th partial sums are given in <xref ref="fig_itest1">Figure</xref>.)
+          <m>\{a_n\} = \{\ln(n) /n^2\}</m> and the <m>n</m>th partial sums are given in <xref ref="fig_itest1"/>.)
         </p>
       </statement>
       <solution component="video">
@@ -267,7 +267,7 @@
       </solution>
       <solution>
         <p>
-          <xref ref="fig_itest1">Figure</xref>
+          <xref ref="fig_itest1"/>
           implies that <m>a(n) = (\ln(n) )/n^2</m> is positive and decreasing on <m>[2,\infty)</m>.
           We can determine this analytically, too.
           We know <m>a(n)</m> is positive as both <m>\ln(n)</m> and <m>n^2</m> are positive on <m>[2,\infty)</m>.
@@ -280,7 +280,7 @@
         </p>
 
         <figure xml:id="fig_itest1">
-          <caption>Plotting the sequence and series in <xref ref="ex_itest1">Example</xref></caption>
+          <caption>Plotting the sequence and series in <xref ref="ex_itest1"/></caption>
           <!-- START figures/fig_itest1.tex -->
           <image xml:id="img_itest1" width="47%">
             <shortdescription>Scatter plots of the sequence used in this example, and the corresponding sequence of partial sums.</shortdescription>
@@ -350,7 +350,7 @@
     </example>
 
     <p>
-      <xref ref="thm_pseries">Theorem</xref>
+      <xref ref="thm_pseries"/>
       was given without justification,
       stating that the general <m>p</m>-series
       <m>\ds \infser \frac 1{(an+b)^p}</m> converges if, and only if,
@@ -360,7 +360,7 @@
     </p>
 
     <example xml:id="ex_itest2">
-      <title>Using the Integral Test to establish <xref ref="thm_pseries">Theorem</xref></title>
+      <title>Using the Integral Test to establish <xref ref="thm_pseries"/></title>
       <statement>
         <p>
           Let <m>a, b</m> be real numbers such that <m>a\neq 0</m> and <m>an+b\gt 0</m> for all <m>n\geq 1</m>.
@@ -388,7 +388,7 @@
           This limit converges if,
           and only if, <m>p \gt 1</m> so that <m>1-p \lt 0</m>.
           It is easy to show that the integral also diverges in the case of <m>p=1</m>.
-          (This result is similar to the work preceding <xref ref="idea_impint1">Key Idea</xref>.)
+          (This result is similar to the work preceding <xref ref="idea_impint1"/>.)
         </p>
 
         <p>
@@ -502,7 +502,7 @@
       </p>
 
       <p>
-        Because of <xref ref="thm_series_behavior">Theorem</xref>,
+        Because of <xref ref="thm_series_behavior"/>,
         any theorem that relies on a positive sequence still holds true when <m>a_n \gt 0</m> for all but a finite number of values of <m>n</m>.
             <idx><h>sequence</h><h>positive</h></idx>
       </p>
@@ -537,7 +537,7 @@
           Since <m>3^n \lt 3^n+n^2</m>,
           <m>\ds \frac1{3^n} \gt  \frac1{3^n+n^2}</m> for all <m>n\geq1</m>.
           The series <m>\ds\infser \frac{1}{3^n}</m> is a convergent geometric series;
-          by <xref ref="thm_series_direct_compare">Theorem</xref>,
+          by <xref ref="thm_series_direct_compare"/>,
           <m>\ds \infser \frac1{3^n+n^2}</m> converges.
         </p>
       </solution>
@@ -582,7 +582,7 @@
 
     <p>
       Consider <m>\ds\infser \frac1{n+\ln(n) }</m>.
-      It is very similar to the divergent series given in <xref ref="ex_dct2">Example</xref>.
+      It is very similar to the divergent series given in <xref ref="ex_dct2"/>.
       We suspect that it also diverges,
       as <m>\ds \frac 1n \approx \frac1{n+\ln(n) }</m> for large <m>n</m>.
       However, the inequality that we naturally want to use
@@ -650,7 +650,7 @@
     </theorem>
 
     <p>
-      <xref ref="thm_series_limit_compare">Theorem</xref>
+      <xref ref="thm_series_limit_compare"/>
       is most useful when the convergence of the series from <m>\{b_n\}</m> is known and we are trying to determine the convergence of the series from <m>\{a_n\}</m>.
     </p>
 
@@ -705,7 +705,7 @@
       </solution>
       <solution>
         <p>
-          This series is similar to the one in <xref ref="ex_dct1">Example</xref>,
+          This series is similar to the one in <xref ref="ex_dct1"/>,
           but now we are considering <q><m>3^n-n^2</m></q>
           instead of <q><m>3^n+n^2</m>.</q>
           This difference makes applying the Direct Comparison Test difficult.
@@ -763,7 +763,7 @@
         </p>
 
         <p>
-          <xref ref="thm_series_limit_compare">Theorem</xref>
+          <xref ref="thm_series_limit_compare"/>
           part (3) only applies when <m>\ds\infser b_n</m> diverges;
           in our case, it converges.
           Ultimately, our test has not revealed anything about the convergence of our series.

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -3,7 +3,7 @@
   <title>Iterated Integrals and Area</title>
   <introduction>
     <p>
-      In <xref ref="sec_partial_derivatives">Section</xref>
+      In <xref ref="sec_partial_derivatives"/>
       we found that it was useful to differentiate functions of several variables with respect to one variable,
       while treating all the other variables as constants or coefficients.
       We can integrate functions of several variables in a similar way.
@@ -122,7 +122,7 @@
       <solution>
         <p>
           We follow a standard <q>order of operations</q>
-          and perform the operations inside parentheses first (which is the integral evaluated in <xref ref="ex_iterated2">Example</xref>.)
+          and perform the operations inside parentheses first (which is the integral evaluated in <xref ref="ex_iterated2"/>.)
           <md>
             <mrow>\int_1^2\left(\int_1^x\big(5x^3y^{-3}+6y^2\big)\, dy\right)\, dx \amp = \int_1^2 \left(\left[\frac{5x^3y^{-2}}{-2}+\frac{6y^3}{3}\right]\Bigg|_1^x\right)\, dx</mrow>
             <mrow>\amp = \int_1^2 \left(\frac92x^3-\frac52x-2\right)\, dx</mrow>
@@ -216,8 +216,8 @@
     <p>
       Consider the plane region <m>R</m> bounded by
       <m>a\leq x\leq b</m> and <m>g_1(x)\leq y\leq g_2(x)</m>,
-      shown in <xref ref="fig_iterated_intro">Figure</xref>.
-      We learned in <xref ref="sec_ABC">Section</xref>
+      shown in <xref ref="fig_iterated_intro"/>.
+      We learned in <xref ref="sec_ABC"/>
       that the area of <m>R</m> is given by
           <idx><h>integration</h><h>area</h></idx>
       <me>
@@ -279,7 +279,7 @@
     <p>
       A region <m>R</m> could also be defined by
       <m>c\leq y\leq d</m> and <m>h_1(y)\leq x\leq h_2(y)</m>,
-      as shown in <xref ref="fig_iterated_intro2">Figure</xref>.
+      as shown in <xref ref="fig_iterated_intro2"/>.
       Using a process similar to that above, we have
       <me>
         \text{ the area of } R = \int_c^d\int_{h_1(y)}^{h_2(y)} \, dx\, dy
@@ -371,10 +371,10 @@
       <statement>
         <p>
           Find the area <m>A</m> of the rectangle with corners <m>(-1,1)</m> and <m>(3,3)</m>,
-          as shown in <xref ref="fig_iterated4">Figure</xref>.
+          as shown in <xref ref="fig_iterated4"/>.
         </p>
         <figure xml:id="fig_iterated4">
-          <caption>Calculating the area of a rectangle with an iterated integral in <xref ref="ex_iterated4">Example</xref></caption>
+          <caption>Calculating the area of a rectangle with an iterated integral in <xref ref="ex_iterated4"/></caption>
           <!-- START figures/fig_iterated4.tex -->
           <image xml:id="img_iterated4" width="47%">
             <description></description>
@@ -436,11 +436,11 @@
         <p>
           Find the area <m>A</m> of the triangle with vertices at <m>(1,1)</m>,
           <m>(3,1)</m> and <m>(5,5)</m>,
-          as shown in <xref ref="fig_iterated5">Figure</xref>.
+          as shown in <xref ref="fig_iterated5"/>.
         </p>
 
         <figure xml:id="fig_iterated5">
-          <caption>Calculating the area of a triangle with iterated integrals in <xref ref="ex_iterated5">Example</xref></caption>
+          <caption>Calculating the area of a triangle with iterated integrals in <xref ref="ex_iterated5"/></caption>
           <!-- START figures/fig_iterated5.tex -->
           <image xml:id="img_iterated5" width="47%">
             <description></description>
@@ -515,11 +515,11 @@
       <statement>
         <p>
           Find the area of the region enclosed by <m>y=2x</m> and <m>y=x^2</m>,
-          as shown in <xref ref="fig_iterated6">Figure</xref>.
+          as shown in <xref ref="fig_iterated6"/>.
         </p>
 
         <figure xml:id="fig_iterated6">
-          <caption>Calculating the area of a plane region with iterated integrals in <xref ref="ex_iterated6">Example</xref></caption>
+          <caption>Calculating the area of a plane region with iterated integrals in <xref ref="ex_iterated6"/></caption>
           <!-- START figures/fig_iterated6.tex -->
           <image xml:id="img_iterated6" width="47%">
             <description></description>
@@ -591,7 +591,7 @@
     <p>
       The simplest of all cases is when both integrals are bound by constants.
       The region described by these bounds is a rectangle
-      (see <xref ref="ex_iterated4">Example</xref>),
+      (see <xref ref="ex_iterated4"/>),
       and so:
       <me>
         \int_a^b\int_c^d 1\, dy\, dx = \int_c^d\int_a^b1\, dx\, dy
@@ -626,12 +626,12 @@
           <m>x</m> is bounded by 0 and 6.
           We plot these four curves: <m>y=0</m>, <m>y=x/3</m>,
           <m>x=0</m> and <m>x=6</m> to find the region described by the bounds.
-          <xref ref="fig_double5">Figure</xref> shows these curves,
+          <xref ref="fig_double5"/> shows these curves,
           indicating that <m>R</m> is a triangle.
         </p>
 
         <figure xml:id="fig_double5">
-          <caption>Sketching the region <m>R</m> described by the iterated integral in <xref ref="ex_double5">Example</xref></caption>
+          <caption>Sketching the region <m>R</m> described by the iterated integral in <xref ref="ex_double5"/></caption>
           <!-- START figures/fig_double5.tex -->
           <image xml:id="img_double5" width="47%">
             <description></description>
@@ -687,11 +687,11 @@
           <m>x</m> is bounded below and above (<ie/>, to the left and right) by <m>x=y^2/4</m> and <m>x=(y+4)/2</m> respectively,
           and <m>y</m> is bounded between 0 and 4.
           Graphing the previous curves,
-          we find the region <m>R</m> to be that shown in <xref ref="fig_double7">Figure</xref>.
+          we find the region <m>R</m> to be that shown in <xref ref="fig_double7"/>.
         </p>
 
         <figure xml:id="fig_double7">
-          <caption>Drawing the region determined by the bounds of integration in <xref ref="ex_double7">Example</xref></caption>
+          <caption>Drawing the region determined by the bounds of integration in <xref ref="ex_double7"/></caption>
           <!-- START figures/fig_double7.tex -->
           <image xml:id="img_double7" width="47%">
             <description></description>

--- a/ptx/sec_lagrange.ptx
+++ b/ptx/sec_lagrange.ptx
@@ -2,8 +2,8 @@
 <section xml:id="sec-multi_extreme_further">
 	<title>Constrained Optimization and Lagrange Multipliers</title>
 	<p>
-		Let us continue our discussion of constrained optimization begun in <xref ref="sec_multi_extreme_values">Section</xref>.
-		<xref ref="thm_extreme_val3">Theorem</xref> tells us that the Extreme Value Theorem extends to functions of two variables;
+		Let us continue our discussion of constrained optimization begun in <xref ref="sec_multi_extreme_values"/>.
+		<xref ref="thm_extreme_val3"/> tells us that the Extreme Value Theorem extends to functions of two variables;
 		in fact, this is true for a function of any number of variables:
 		if a real-valued function <m>f</m> is continuous on a closed, bounded subset of <m>\mathbb{R}^n</m>,
 		then it is guaranteed to have an absolute maximum and minimum.
@@ -12,7 +12,7 @@
 	<p>
 		However, as the number of variables increases,
 		the job of finding these absolute extrema becomes more and more complicated.
-		We saw one approach in <xref ref="sec_multi_extreme_values">Section</xref>:
+		We saw one approach in <xref ref="sec_multi_extreme_values"/>:
 		given a continuous function on a closed, bounded region <m>D</m>,
 		we first consider critical values on the interior of <m>D</m>.
 		We then restrict our function <m>f</m> to points on the boundary of <m>D</m>,
@@ -21,7 +21,7 @@
 
 	<p>
 		In many cases, this approach is best accomplished by parametrizing the boundary.
-		We learned how to define parametric curves in the plane in <xref ref="sec_param_eqs">Section</xref>.
+		We learned how to define parametric curves in the plane in <xref ref="sec_param_eqs"/>.
 	</p>
 
 
@@ -55,7 +55,7 @@
 
 			<p>
 				We learned how to find the extreme values of such a function back in our first course in calculus:
-				see <xref ref="sec_extreme_values">Section</xref>. We have <m>h(0)=h(2\pi)=-12</m>, and
+				see <xref ref="sec_extreme_values"/>. We have <m>h(0)=h(2\pi)=-12</m>, and
 				<me>
 				  h'(t) = -8\cos t\sin t+16\sin t-24\sin t\cos t = 16\sin t (1-2\cos t)
 				</me>.
@@ -107,7 +107,7 @@
 	<p>
 		This tells us that the gradient <m>\nabla f</m> should be orthogonal to the constraint curve <m>g(x,y)=c</m> at the point <m>(x_0,y_0)=(x(t_0),y(t_0))</m>.
 		But we know another gradient that is orthogonal to this curve: <m>\nabla g</m>!
-		Recall from <xref ref="thm_gradient">Theorem</xref> that <m>\nabla g(x,y)</m> is always orthogonal to the level curve <m>g(x,y)=c</m> at points along the curve.
+		Recall from <xref ref="thm_gradient"/> that <m>\nabla g(x,y)</m> is always orthogonal to the level curve <m>g(x,y)=c</m> at points along the curve.
 	</p>
 
 	<p>
@@ -166,7 +166,7 @@
 		Note that there are two possibilities: either <m>\lambda=0</m>,
 		in which case <m>(x_0,y_0)</m> is a critical point of <m>f</m>, or <m>\lambda\neq 0</m>,
 		in which case the level curve of <m>f</m> that passes through <m>(x_0,y_0)</m> must be <em>tangent</em> to the curve <m>g(x,y)=c</m> at that point.
-		Putting <xref ref="thm_lagrange_multipliers">Theorem</xref> to use is a matter of solving a system of equations.
+		Putting <xref ref="thm_lagrange_multipliers"/> to use is a matter of solving a system of equations.
 	</p>
 
 	<insight xml:id="idea_lagrange_multipliers">
@@ -192,7 +192,7 @@
 	  </statement>
 	  <solution>
 			<p>
-				This is the same problem as <xref ref="ex_optimize_param_bound">Example</xref>,
+				This is the same problem as <xref ref="ex_optimize_param_bound"/>,
 				but this time, we will attempt to solve it using the method of Lagrange multipliers.
 				Again, since <m>\nabla f(x,y) = \la 2x-8,-6y\ra</m>,
 				the only critical point for <m>f</m> is outside the given disc.
@@ -252,7 +252,7 @@
 	</p>
 
 	<figure xml:id="fig_lagrange1">
-		<caption>The constraint curve and several level curves in <xref ref="ex_lagrange1">Example</xref></caption>
+		<caption>The constraint curve and several level curves in <xref ref="ex_lagrange1"/></caption>
 		<image xml:id="img_lagrange1" width="47%">
 		  <latex-image>
 		    \begin{tikzpicture}
@@ -281,7 +281,7 @@
 	</figure>
 
 	<p>
-		Consider <xref ref="fig_lagrange1">Figure</xref>.
+		Consider <xref ref="fig_lagrange1"/>.
 		The constraint curve <m>x^2+y^2=4</m> is the dashed circle.
 		We also see the three level curves (solid) that were obtained as solutions to the Lagrange multiplier equations:
 	</p>
@@ -328,12 +328,12 @@
 	</p>
 
 	<p>
-		In <xref ref="fig_lagrange1">Figure</xref>,
+		In <xref ref="fig_lagrange1"/>,
 		you can imagine that increasing or decreasing the value of <m>c</m> has the effect of shifting the level curve one way or the other,
 		until it <em>just</em> touches the circle. Any bigger than the maximum,
 		or smaller than the minimum, and the curves no longer intersect.
 		Of course, saying that the curves <q>just touch</q> amounts to saying that they are tangent at their point of intersection,
-		just as <xref ref="thm_lagrange_multipliers">Theorem</xref> predicts.
+		just as <xref ref="thm_lagrange_multipliers"/> predicts.
 	</p>
 
 	<example xml:id="ex_lagrange2">
@@ -384,7 +384,7 @@
 	</example>
 
 	<figure xml:id="fig_lagrange2">
-		<caption>The constraint and some level curves in <xref ref="ex_lagrange2">Example</xref></caption>
+		<caption>The constraint and some level curves in <xref ref="ex_lagrange2"/></caption>
 		<image xml:id="img_lagrange2" width="47%">
 		  <latex-image>
 		    \begin{tikzpicture}
@@ -516,9 +516,9 @@
 		But more practically, the method of Lagrange multipliers is useful because it is easy to program into a computer:
 		we simply provide the function and the constraint(s), and the computer solves the resulting equations.
 		There is no need for the same degree of problem-solving employed when we first tackled optimization problems in one variable,
-		back in <xref ref="chapter_deriv_apps">Chapter</xref>.
+		back in <xref ref="chapter_deriv_apps"/>.
 		To emphasize this, we consider one more example:
-		a reprise of one of the optimization problems from <xref ref="sec_optimization">Section</xref>.
+		a reprise of one of the optimization problems from <xref ref="sec_optimization"/>.
 	</p>
 
 	<example xml:id="ex_lagrange4">
@@ -530,7 +530,7 @@
 	  </statement>
 	  <solution>
 			<p>
-				This was one of the exercises at the end of <xref ref="sec_optimization">Section</xref>.
+				This was one of the exercises at the end of <xref ref="sec_optimization"/>.
 				The surface area of a cylinder of radius <m>r</m> and height <m>h</m> is given by
 				<me>
 				  s(r,h) = 2r^2+2\pi rh
@@ -539,9 +539,9 @@
 			</p>
 
 			<p>
-				In <xref ref="sec_optimization">Section</xref>,
+				In <xref ref="sec_optimization"/>,
 				our next step would have been to solve the constraint equation for one of the two variables (likely <m>h</m> ) in terms of the other,
-				so we could rewrite <m>s(r,h)</m> as a function of one variable and apply the techniques of <xref ref="sec_extreme_values">Section</xref>.
+				so we could rewrite <m>s(r,h)</m> as a function of one variable and apply the techniques of <xref ref="sec_extreme_values"/>.
 			</p>
 
 			<p>
@@ -565,7 +565,7 @@
 				  \pi r^2 h = 2r^2 = 206
 				</me>,
 				so <m>r=\sqrt[3]{103}\approx 4.688</m>, and <m>h=2\sqrt[3]{103}/\pi  \approx 2.984</m>.
-				This is, of course, the same result you would have found if you did this exercise back in <xref ref="sec_optimization">Section</xref>.
+				This is, of course, the same result you would have found if you did this exercise back in <xref ref="sec_optimization"/>.
 			</p>
 		</solution>
 	</example>

--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -133,7 +133,7 @@
           <ol>
             <li>
               <p>
-                We proved this limit is 1 in <xref ref="ex_limit_sinx_prove">Example</xref> using the Squeeze Theorem.
+                We proved this limit is 1 in <xref ref="ex_limit_sinx_prove"/> using the Squeeze Theorem.
                 Here we use l'Hospital's Rule to show its power.
                 <me>
                   \lim_{x\to0}\frac{\sin(x) }x \stackrel{\,\text{ by LHR }  \,}{=} \lim_{x\to0} \frac{\cos(x) }{1}=1
@@ -262,7 +262,7 @@
           <ol>
             <li>
               <p>
-                We can evaluate this limit already using <xref ref="thm_lim_rational_fn_at_infty">Theorem</xref>;
+                We can evaluate this limit already using <xref ref="thm_lim_rational_fn_at_infty"/>;
                 the answer is 3/4.
                 We apply l'Hospital's Rule to demonstrate its applicability.
                 <me>
@@ -460,7 +460,7 @@
           <ol>
             <li>
               <p>
-                This is equivalent to a special limit given in <xref ref="thm_special_limits">Theorem</xref>;
+                This is equivalent to a special limit given in <xref ref="thm_special_limits"/>;
                 these limits have important applications within mathematics and finance.
                 Note that the exponent approaches <m>\infty</m> while the base approaches 1, leading to the indeterminate form <m>1^\infty</m>.
                 Let <m>f(x) = (1+1/x)^x</m>;
@@ -476,7 +476,7 @@
                   <mrow>\amp = 1</mrow>
                 </md>.
                 Thus <m>\lim\limits_{x\to\infty} \ln\big(f(x)\big) = 1</m>.
-                We return to the original limit and apply <xref ref="idea_LHR_power">Key Idea</xref>.
+                We return to the original limit and apply <xref ref="idea_LHR_power"/>.
                 <me>
                   \lim_{x\to\infty}\left(1+\frac1x\right)^x = \lim_{x\to\infty} f(x) =  \lim_{x\to\infty}e^{\ln(f(x))} = e^1 = e
                 </me>.
@@ -497,12 +497,12 @@
                   <mrow>\amp = 0</mrow>
                 </md>.
                 Thus <m>\lim\limits_{x\to0^+} \ln\big(f(x)\big) =0</m>.
-                We return to the original limit and apply <xref ref="idea_LHR_power">Key Idea</xref>.
+                We return to the original limit and apply <xref ref="idea_LHR_power"/>.
                 <me>
                   \lim_{x\to0^+} x^x = \lim_{x\to0^+} f(x) = \lim_{x\to0^+} e^{\ln(f(x))} = e^0 = 1
                 </me>.
                 This result is supported by the graph of
-                <m>f(x)=x^x</m> given in <xref ref="fig_LHR4">Figure</xref>.
+                <m>f(x)=x^x</m> given in <xref ref="fig_LHR4"/>.
               </p>
                 <figure xml:id="fig_LHR4">
                   <caption>A graph of <m>f(x)=x^x</m> supporting the fact that as <m>x\to 0^+</m>, <m>f(x)\to 1</m></caption>

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -3,7 +3,7 @@
   <title>Finding Limits Analytically</title>
 
   <p>
-    In <xref ref="sec_limit_intro">Section</xref>
+    In <xref ref="sec_limit_intro"/>
     we explored the concept of the limit without a strict definition,
     meaning we could only make approximations.
     In the previous section we gave the definition of the limit and demonstrated how to use it to verify our approximations were correct.
@@ -212,10 +212,10 @@
   </example>
 
   <p>
-    <xref ref="polynomial-limit-example">Part</xref>
+    <xref ref="polynomial-limit-example" text="local">Part</xref>
     of the previous example demonstrates how the limit of a quadratic polynomial
     can be determined using the properties of
-    <xref ref="thm_limit_algebra">Theorem</xref>.
+    <xref ref="thm_limit_algebra"/>.
     Not only that, recognize that
     <me>
       \lim_{x\to 2} p(x) = 9 = p(2);
@@ -269,7 +269,7 @@
     <title>Finding a limit of a rational function</title>
     <statement>
       <p>
-        Using <xref ref="thm_poly_rat">Theorem</xref>, find
+        Using <xref ref="thm_poly_rat"/>, find
         <me>
           \lim_{x\to -1} \frac{3x^2-5x+1}{x^4-x^2+3}
         </me>.
@@ -277,7 +277,7 @@
     </statement>
     <solution>
       <p>
-        Using <xref ref="thm_poly_rat">Theorem</xref>, we can quickly state that
+        Using <xref ref="thm_poly_rat"/>, we can quickly state that
         <md>
           <mrow>\lim_{x\to -1}\frac{3x^2-5x+1}{x^4-x^2+3} \amp = \frac{3(-1)^2-5(-1)+1}{(-1)^4-(-1)^2+3}</mrow>
           <mrow>\amp = \frac{9}{3} =3</mrow>
@@ -287,7 +287,7 @@
   </example>
 
   <p>
-    It was likely frustrating in <xref ref="sec_limit_def">Section</xref>
+    It was likely frustrating in <xref ref="sec_limit_def"/>
     to do a lot of work with <m>\varepsilon</m> and <m>\delta</m> to prove that
     <me>
       \lim_{x\to 2} x^2 = 4
@@ -296,14 +296,14 @@
     The previous theorems state that many functions behave in such an
     <q>obvious</q> fashion,
     as demonstrated by the rational function in
-    <xref ref="ex_limit_rat">Example</xref>.
+    <xref ref="ex_limit_rat"/>.
   </p>
 
   <p>
     Polynomial and rational functions are not the only functions to behave in such a predictable way.
     The following theorem gives a list of functions whose behavior is particularly
     <q>nice</q> in terms of limits.
-    In <xref ref="sec_continuity">Section</xref>,
+    In <xref ref="sec_continuity"/>,
     we will give a formal name to these functions that behave <q>nicely.</q>
   </p>
 
@@ -372,7 +372,7 @@
           <li>
             <p>
               This is a straightforward application of
-              <xref ref="thm_lim_continuous">Theorem</xref>:
+              <xref ref="thm_lim_continuous"/>:
               <m>\lim\limits_{x\to \pi} \cos(x) = \cos(\pi) = -1</m>.
             </p>
           </li>
@@ -380,7 +380,7 @@
             <p>
               We can approach this in at least two ways.
               First, by directly applying
-              <xref ref="thm_lim_continuous">Theorem</xref>, we have:
+              <xref ref="thm_lim_continuous"/>, we have:
               <me>
                 \lim_{x\to 3} \left(\sec^2(x) - \tan^2(x)\right) = \sec^2(3)-\tan^2(3)
               </me>.
@@ -402,7 +402,7 @@
           <li>
             <p>
               Applying the <xref ref="product-limit-rule" text="title"/> rule and
-              <xref ref="thm_lim_continuous">Theorem</xref> gives
+              <xref ref="thm_lim_continuous"/> gives
               <me>
                 \lim\limits_{x\to \pi/2} \cos(x)\sin(x) = \cos(\pi/2)\sin(\pi/2) = 0\cdot 1 = 0
               </me>.
@@ -418,7 +418,7 @@
 
             <p>
               We can also use the <xref ref="composition-limit-rule" text="title"/> rule.
-              Using <xref ref="thm_lim_continuous">Theorem</xref>,
+              Using <xref ref="thm_lim_continuous"/>,
               we have <m>\lim\limits_{x\to 1}\ln(x) = \ln(1) = 0</m> and
               <m>\lim_{x\to 0} e^x= e^0=1</m>,
               satisfying the conditions of the
@@ -433,7 +433,7 @@
 
           <li>
             <p>
-              We encountered this limit in <xref ref="sec_limit_intro">Section</xref>.
+              We encountered this limit in <xref ref="sec_limit_intro"/>.
               Applying our theorems, we attempt to find the limit as
               <me>
                 \lim_{x\to 0}\frac{\sin(x)}{x}\rightarrow \frac{\sin(0) }{0}
@@ -476,7 +476,7 @@
     and <m>g</m> is always <q>squeezed</q> between them,
     then <m>g</m> must have the same limit as well.
     That is what the Squeeze Theorem states.
-    This is illustrated in <xref ref="fig-squeeze-theorem">Figure</xref>.
+    This is illustrated in <xref ref="fig-squeeze-theorem"/>.
   </p>
   <figure xml:id="fig-squeeze-theorem">
     <caption>An illustration of the Squeeze Theorem</caption>
@@ -592,7 +592,7 @@
         We begin by considering the unit circle.
         Each point on the unit circle has coordinates
         <m>(\cos(\theta),\sin(\theta))</m> for some angle <m>\theta</m> as shown in
-        <xref ref="fig_squeeze_sinx">Figure</xref>.
+        <xref ref="fig_squeeze_sinx"/>.
         Using similar triangles,
         we can extend the line from the origin through the point to the point
         <m>(1,\tan(\theta))</m>, as shown.
@@ -650,7 +650,7 @@
       </figure>
 
       <p>
-        <xref ref="fig_squeeze_sinx">Figure</xref>
+        <xref ref="fig_squeeze_sinx"/>
         shows three regions have been constructed in the first quadrant,
         two triangles and a sector of a circle,
         which are also drawn below.
@@ -658,7 +658,7 @@
         the area of the sector is <m>\theta/2</m>;
         the area of the triangle contained inside the sector is
         <m>\frac{1}{2}\sin(\theta)</m>.
-        It is then clear from <xref ref="fig_squeeze1">Figure</xref> that
+        It is then clear from <xref ref="fig_squeeze1"/> that
         <me>
           \frac{\tan(\theta)}{2}\geq\frac{\theta}{2}\geq\frac{\sin(\theta)}{2}
         </me>.
@@ -817,7 +817,7 @@
   </figure>
 
   <p>
-    Two notes about the <xref ref="ex_limit_sinx_prove">Example</xref> are worth mentioning.
+    Two notes about the <xref ref="ex_limit_sinx_prove"/> are worth mentioning.
     First, one might be discouraged by this application,
     thinking <q>I would <em>never</em>
     have come up with that on my own.
@@ -892,7 +892,7 @@
   </p>
 
   <p>
-    The special limits stated in <xref ref="thm_special_limits">Theorem </xref>
+    The special limits stated in <xref ref="thm_special_limits"/>
     are called <em>indeterminate forms</em>;
 
     <idx><h>limit</h><h>indeterminate form</h></idx>
@@ -900,7 +900,7 @@
     in this case they are of the form <m>0/0</m>,
     except the third limit, which is of a different form.
     You'll learn techniques to find these limits exactly using calculus in
-    <xref ref="sec_lhopitals_rule">Section</xref>.
+    <xref ref="sec_lhopitals_rule"/>.
   </p>
 
   <p>
@@ -919,7 +919,7 @@
     </statement>
     <solution>
       <p>
-        We begin by attempting to apply <xref ref="thm_poly_rat">Theorem</xref>
+        We begin by attempting to apply <xref ref="thm_poly_rat"/>
         and substituting <m>1</m> for <m>x</m> in the quotient.
         This gives:
         <me>
@@ -931,7 +931,7 @@
 
       <p>
         By graphing the function,
-        as in <xref ref="fig_limitxplus1">Figure</xref>,
+        as in <xref ref="fig_limitxplus1"/>,
         we see that the function seems to be linear,
         implying that the limit should be easy to evaluate.
         Recognize that the numerator of our quotient can be factored:
@@ -948,7 +948,7 @@
       </p>
 
       <figure xml:id="fig_limitxplus1">
-        <caption>Graphing <m>f</m> in <xref ref="ex_limit_onept">Example</xref> to understand a limit</caption>
+        <caption>Graphing <m>f</m> in <xref ref="ex_limit_onept"/> to understand a limit</caption>
         <!-- START figures/figLimitXplus1.tex -->
         <image xml:id="img_limitxplus1" width="47%">
           <description>
@@ -997,7 +997,7 @@
   </example>
 
   <p>
-    The key to <xref ref="ex_limit_onept">Example</xref>
+    The key to <xref ref="ex_limit_onept"/>
     is that the functions <m>y=(x^2-1)/(x-1)</m> and <m>y=x+1</m> are identical except at <m>x=1</m>.
     Since limits describe a value the function is approaching,
     not the value the function actually attains,
@@ -1025,12 +1025,12 @@
     <m>\lim\limits_{x\to c} \frac{g(x)}{f(x)}</m> returns <q>0/0</q>,
     then <m>(x-c)</m> is a factor of both <m>g(x)</m> and <m>f(x)</m>.
     One can then use algebra to factor this binomial out,
-    cancel, then apply <xref ref="thm_limit_allbut1">Theorem</xref>.
+    cancel, then apply <xref ref="thm_limit_allbut1"/>.
     We demonstrate this once more.
   </p>
 
   <example xml:id="ex_limit_allbut1">
-    <title>Evaluating a limit using <xref ref="thm_limit_allbut1">Theorem</xref></title>
+    <title>Evaluating a limit using <xref ref="thm_limit_allbut1"/></title>
     <statement>
       <p>
         Evaluate
@@ -1045,7 +1045,7 @@
     </solution>
     <solution>
       <p>
-        We attempt to apply <xref ref="thm_poly_rat">Theorem</xref>
+        We attempt to apply <xref ref="thm_poly_rat"/>
         by substituting <m>3</m> for <m>x</m>.
         This returns the familiar indeterminate form of <q>0/0</q>.
         Since the numerator and denominator are each polynomials,
@@ -1059,7 +1059,7 @@
           \frac{x^3-2 x^2-5 x+6}{2 x^3+3 x^2-32 x+15} = \frac{(x-3)\left(x^2+x-2\right)}{(x-3)\left(2 x^2+9 x-5\right)}
         </me>.
         We can cancel the <m>(x-3)</m> factors as long as <m>x\neq 3</m>.
-        Using <xref ref="thm_limit_allbut1">Theorem</xref> we conclude:
+        Using <xref ref="thm_limit_allbut1"/> we conclude:
         <md>
           <mrow>\lim_{x\to 3} \frac{x^3-2 x^2-5 x+6}{2 x^3+3 x^2-32 x+15} \amp = \lim_{x\to 3}\frac{(x-3)\left(x^2+x-2\right)}{(x-3)\left(2 x^2+9 x-5\right)}</mrow>
           <mrow>\amp =\lim_{x\to 3} \frac{x^2+x-2}{2 x^2+9 x-5}</mrow>
@@ -1098,7 +1098,7 @@
           <mrow>\amp= \frac{x-9}{(x-9)(\sqrt{x}+3)}</mrow>
         </md>
         We can cancel the <m>(x-9)</m> factors as long as <m>x\neq 9</m>.
-        Using <xref ref="thm_limit_allbut1">Theorem</xref> we conclude:
+        Using <xref ref="thm_limit_allbut1"/> we conclude:
         <md>
           <mrow>\lim_{x\to 9} \frac{\sqrt{x}-3}{x-9} \amp =\lim_{x\to 9} \frac{x-9}{(x-9)\left(\sqrt{x}+3\right)}</mrow>
           <mrow>\amp = \lim_{x\to 9 }\frac{1}{\sqrt{x}+3}</mrow>
@@ -1113,7 +1113,7 @@
 
   <p>
     We end this section by revisiting a limit first seen in
-    <xref ref="sec_limit_intro">Section</xref>,
+    <xref ref="sec_limit_intro"/>,
     a limit of a difference quotient.
     Let <m>f(x) = -1.5x^2+11.5x</m>;
     we approximated the limit
@@ -1132,7 +1132,7 @@
     <solution>
       <p>
         Since <m>f</m> is a polynomial,
-        our first attempt should be to employ <xref ref="thm_poly_rat">Theorem</xref>
+        our first attempt should be to employ <xref ref="thm_poly_rat"/>
         and substitute <m>0</m> for <m>h</m>.
         However, we see that this gives us <q><m>0/0</m>.</q>
         Knowing that we have a rational function hints that some algebra will help.
@@ -1142,8 +1142,8 @@
           <mrow>\amp =\lim_{h\to 0}\frac{-1.5(1+2h+h^2) + 11.5+11.5h - 10}{h}</mrow>
           <mrow>\amp =\lim_{h\to 0}\frac{-1.5h^2 +8.5h}{h}</mrow>
           <mrow>\amp =\lim_{h\to 0}\frac{h(-1.5h+8.5)}h</mrow>
-          <mrow>\amp =\lim_{h\to 0}(-1.5h+8.5)  \quad (\text{using } <xref ref="thm_limit_allbut1">Theorem</xref>, \text{ as } h\neq 0  )</mrow>
-          <mrow>\amp =8.5  \quad (\text{using } <xref ref="thm_poly_rat">Theorem</xref>  )</mrow>
+          <mrow>\amp =\lim_{h\to 0}(-1.5h+8.5)  \quad (\text{using } <xref ref="thm_limit_allbut1"/>, \text{ as } h\neq 0  )</mrow>
+          <mrow>\amp =8.5  \quad (\text{using } <xref ref="thm_poly_rat"/>  )</mrow>
         </md>
         This matches our previous approximation.
       </p>
@@ -1153,10 +1153,10 @@
   <p>
     This section contains several valuable tools for evaluating limits.
     One of the main results of this section is
-    <xref ref="thm_lim_continuous">Theorem</xref>;
+    <xref ref="thm_lim_continuous"/>;
     it states that many functions that we use regularly behave in a very nice,
     predictable way.
-    In <xref ref="sec_continuity">Section</xref>
+    In <xref ref="sec_continuity"/>
     we give a name to this nice behavior;
     we label such functions as <term>continuous</term>.
     Defining that term will require us to look again at what a limit is and what causes limits to not exist.
@@ -2389,7 +2389,7 @@
       <exercisegroup cols="2" xml:id="exset-limit-analytically-challenge">
         <introduction>
           <p>
-            The following exercises challenge your understanding of limits but can be evaluated using the knowledge gained in <xref ref="sec_limit_analytically">Section</xref>.
+            The following exercises challenge your understanding of limits but can be evaluated using the knowledge gained in <xref ref="sec_limit_analytically"/>.
           </p>
         </introduction>
 
@@ -2501,7 +2501,7 @@
             </statement>
             <solution>
               <p>
-                Apply Part 1 of <xref ref="thm_limit_algebra">Theorem</xref>.
+                Apply Part 1 of <xref ref="thm_limit_algebra"/>.
               </p>
             </solution>
           </task>
@@ -2517,7 +2517,7 @@
             </statement>
             <solution>
               <p>
-                Apply <xref ref="thm_limit_allbut1">Theorem</xref>;
+                Apply <xref ref="thm_limit_allbut1"/>;
                 <m>g(x)=\frac{x}{x}</m> is the same as <m>g(x)=1</m> everywhere except at <m>x=0</m>.
                 Thus <m>\lim\limits_{x\to0}g(x)=\lim_{x\to0}1=1</m>.
               </p>
@@ -2545,7 +2545,7 @@
           <task label="ex-limit-analytically-challenge-5d">
             <statement>
               <p>
-                Explain why the previous statement does not violate the Composition Rule of <xref ref="thm_limit_algebra">Theorem</xref>.
+                Explain why the previous statement does not violate the Composition Rule of <xref ref="thm_limit_algebra"/>.
               </p>
               <p>
                 <var form="essay"/>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -95,12 +95,12 @@
     <title>Finding intervals of continuity</title>
     <statement>
       <p>
-        Let <m>f</m> be defined as shown in <xref ref="fig_continuous1">Figure</xref>.
+        Let <m>f</m> be defined as shown in <xref ref="fig_continuous1"/>.
         Give the interval(s) on which <m>f</m> is continuous.
       </p>
 
       <figure xml:id="fig_continuous1">
-        <caption>A graph of <m>f</m> in <xref ref="ex_contint1">Example</xref></caption>
+        <caption>A graph of <m>f</m> in <xref ref="ex_contint1"/></caption>
         <!-- START figures/fig_continuous1.tex -->
         <image xml:id="img_continuous1" width="47%">
           <description>
@@ -167,7 +167,7 @@
       <aside xml:id="aside-limit-continuous-intervals">
         <p>
           Our definition of continuity (currently) only applies to open intervals.
-          After <xref ref="def_closed_continuity">Definition</xref>,
+          After <xref ref="def_closed_continuity"/>,
           we'll be able to say that <m>f</m> is continuous on <m>[0,1)</m> and
           <m>(1,3]</m>.
         </p>
@@ -188,7 +188,7 @@
         returns the largest integer smaller than, or equal to,
         the input <m>x</m>. (For example,
         <m>f(\pi) = \lfloor \pi \rfloor = 3</m>.) The graph of <m>f</m> in
-        <xref ref="fig_continuous2">Figure</xref>
+        <xref ref="fig_continuous2"/>
         demonstrates why this is often called a <q>step function.</q>
       </p>
 
@@ -197,7 +197,7 @@
       </p>
 
       <figure xml:id="fig_continuous2">
-        <caption>A graph of the step function in <xref ref="ex_contint2">Example</xref></caption>
+        <caption>A graph of the step function in <xref ref="ex_contint2"/></caption>
         <!-- START figures/fig_continuous2.tex -->
         <image xml:id="img_continuous2" width="47%">
           <description>
@@ -349,14 +349,14 @@
 
   <p>
     If the domain of <m>f</m> includes values less than <m>a</m>,
-    we say that <xref ref="def_right_continuity">Item</xref> in <xref ref="def_closed_continuity"/>
+    we say that <xref ref="def_right_continuity" text="local">Item</xref> in <xref ref="def_closed_continuity"/>
     indicates that <m>f</m> is <term>continuous from the right</term> at <m>a</m>.
     But if <m>f</m> is undefined for <m>x\lt a</m>,
     we can say that <m>f</m> is continuous at <m>a</m> without ambiguity.
   </p>
 
   <p>
-    Similarly, <xref ref="def_left_continuity">Item</xref> indcates that <m>f</m>
+    Similarly, <xref ref="def_left_continuity" text="local">Item</xref> indcates that <m>f</m>
     is <term>continuous from the left</term> at <m>b</m>,
     and if <m>f</m> is not defined for <m>x\gt b</m>,
     we can simply say that <m>f</m> is continuous at <m>b</m>.
@@ -371,10 +371,10 @@
 
   <p>
     Using this new definition,
-    we can adjust our answer in <xref ref="ex_contint1">Example</xref>
+    we can adjust our answer in <xref ref="ex_contint1"/>
     by stating that <m>f</m> is continuous on <m>[0,1)</m> and <m>(1,3]</m>,
     as mentioned in that example.
-    We can also revisit <xref ref="ex_contint2">Example</xref>
+    We can also revisit <xref ref="ex_contint2"/>
     and state that the floor function is continuous on the following half-open intervals
     <me>
       \ldots, [-2,-1), [-1,0), [0,1), [1,2), \ldots
@@ -449,7 +449,7 @@
             <p>
               The domain of <m>f(x) = 1/x</m> is <m>(-\infty,0) \cup (0,\infty)</m>.
               As it is a rational function,
-              we apply <xref ref="thm_poly_rat">Theorem</xref>
+              we apply <xref ref="thm_poly_rat"/>
               to recognize that <m>f</m> is continuous on all of its domain.
             </p>
           </li>
@@ -457,14 +457,14 @@
             <p>
               The domain of <m>f(x) = \sin(x)</m> is all real numbers,
               or <m>(-\infty,\infty)</m>.
-              Applying <xref ref="thm_lim_continuous">Theorem</xref>
+              Applying <xref ref="thm_lim_continuous"/>
               shows that <m>\sin(x)</m> is continuous everywhere.
             </p>
           </li>
           <li>
             <p>
               The domain of <m>f(x) = \sqrt{x}</m> is <m>[0,\infty)</m>.
-              Applying <xref ref="thm_lim_continuous">Theorem</xref>
+              Applying <xref ref="thm_lim_continuous"/>
               shows that <m>f(x) = \sqrt{x}</m> is continuous on its domain of
               <m>[0,\infty)</m>.
             </p>
@@ -472,8 +472,8 @@
           <li>
             <p>
               The domain of <m>f(x) = \sqrt{1-x^2}</m> is <m>[-1,1]</m>.
-              Applying <xref ref="thm_limit_algebra">Theorems</xref>
-              and <xref ref="thm_lim_continuous"/>
+              Applying <xref ref="thm_limit_algebra" text="global">Theorems</xref>
+              and <xref ref="thm_lim_continuous" text="global"/>
               shows that <m>f</m> is continuous on all of its domain,
               <m>[-1,1]</m>.
             </p>
@@ -504,10 +504,10 @@
   <p>
     Continuity is inherently tied to the properties of limits.
     Because of this,
-    the properties of limits found in <xref ref="thm_limit_algebra">Theorems</xref>
-    and <xref ref="thm_poly_rat"/> apply to continuity as well.
+    the properties of limits found in <xref ref="thm_limit_algebra" text="global">Theorems</xref>
+    and <xref ref="thm_poly_rat" text="global"/> apply to continuity as well.
     Further, now knowing the definition of continuity we can re-read
-    <xref ref="thm_lim_continuous">Theorem</xref>
+    <xref ref="thm_lim_continuous"/>
     as giving a list of functions that are continuous on their domains.
     The following theorem states how continuous functions can be combined to form other continuous functions,
     followed by a theorem which formally lists functions that we know are continuous on their domains.
@@ -707,8 +707,8 @@
 
       <p>
         We examine each in turn,
-        applying <xref ref="thm_continuity_algebra">Theorems</xref>
-        and <xref ref="thm_continuous_functions"/> as appropriate.
+        applying <xref ref="thm_continuity_algebra" text="global">Theorems</xref>
+        and <xref ref="thm_continuous_functions" text="global"/> as appropriate.
       </p>
 
       <figure xml:id="fig_continuous3">
@@ -753,7 +753,7 @@
               <m>f</m> is continuous on <m>[1,5]</m>,
               the intersection of these two intervals.
               A graph of <m>f</m> is given in
-              <xref ref="fig_continuous3">Figure</xref>.
+              <xref ref="fig_continuous3"/>.
             </p>
           </li>
           <li>
@@ -765,7 +765,7 @@
           </li>
           <li>
             <p>
-              <xref ref="thm_continuous_functions">Theorem</xref>
+              <xref ref="thm_continuous_functions"/>
               states that <m>f(x) = \tan(x)</m> is continuous <em>on its domain</em>.
               Its domain includes all real numbers except odd multiples of <m>\pi/2</m>.
               Thus the intervals on which <m>f(x) = \tan(x)</m> is continuous are
@@ -869,7 +869,7 @@
           <p>
             Infinite discontinuities are most easily understood
             in terms of <em>infinite limits</em>, which are
-            discussed in <xref ref="sec_limits_infty">Section</xref>.
+            discussed in <xref ref="sec_limits_infty"/>.
           </p>
         </li>
       </ol>
@@ -1160,7 +1160,7 @@
       <solution>
         <p>
           Consider the graph of <m>f(x) = x-\cos(x)</m>,
-          shown in <xref ref="fig_xminuscosx">Figure</xref>.
+          shown in <xref ref="fig_xminuscosx"/>.
           It is clear that the graph crosses the <m>x</m>-axis somewhere near <m>x=0.8</m>.
           To start the Bisection Method,
           pick an interval that contains <m>0.8</m>.
@@ -1357,7 +1357,7 @@
     </p>
 
     <p>
-      In <xref ref="sec_newton">Section</xref>
+      In <xref ref="sec_newton"/>
       another equation solving method will be introduced, called Newton's Method.
       In many cases, Newton's Method is much faster.
       It relies on more advanced mathematics, though,

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -228,7 +228,7 @@
           <mrow>\implies-1.75\lt x-4\lt1.75\lt2.25</mrow>
         </md>
         Therefore we can have <m>\delta \leq 1.75</m>.
-        See <xref ref="fig_choose_e_d">Figure</xref>.
+        See <xref ref="fig_choose_e_d"/>.
       </p>
 
       <figure xml:id="fig_choose_e_d">
@@ -526,7 +526,7 @@
           <mrow>\abs{x-2}\amp\lt\frac{\varepsilon}{5}\amp\amp\text{(Our choice of } \delta\text{)}</mrow>
           <mrow>\abs{x-2}\cdot\abs{x+2}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{5}\amp\amp\text{(Multiply by }\abs{x+2}\text{)}</mrow>
           <mrow>\abs{x^2-4}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{5}\amp\amp\text{(Simplify left side)}</mrow>
-          <mrow>\abs{x^2-4}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{\abs{x+2}}\amp\amp\text{(}<xref ref="eq_limit1">Inequality</xref>, \delta \lt 1\text{)}</mrow>
+          <mrow>\abs{x^2-4}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{\abs{x+2}}\amp\amp\text{(}<xref ref="eq_limit1" text="local">Inequality</xref>, \delta \lt 1\text{)}</mrow>
           <mrow>\abs{x^2-4}\amp\lt\varepsilon</mrow>
         </md>
       </p>
@@ -542,7 +542,7 @@
       <p>
         We have also picked <m>\delta</m> to be smaller than <q>necessary.</q>
         We could get by with a slightly larger <m>\delta</m>,
-        as shown in <xref ref="fig_limit_eover5">Figure</xref>.
+        as shown in <xref ref="fig_limit_eover5"/>.
         The outer lines show the boundaries defined by our choice of <m>\varepsilon</m>.
         The inner lines show the boundaries defined by setting <m>\delta = \varepsilon/5</m>.
         Note how these dotted lines are within the dashed lines.
@@ -552,7 +552,7 @@
       </p>
 
       <figure xml:id="fig_limit_eover5">
-        <caption>Choosing <m>\delta = \varepsilon/5</m> in <xref ref="ex_compute_lim2">Example</xref></caption>
+        <caption>Choosing <m>\delta = \varepsilon/5</m> in <xref ref="ex_compute_lim2"/></caption>
         <!-- START figures/fig_limit_proof2a.tex -->
         <image xml:id="img_limit_eover5" width="47%">
           <description>
@@ -631,7 +631,7 @@
         Then <m>\abs{x-2} \lt \delta</m> implies
         <m>\abs{x^2 - 4}\lt\varepsilon</m> (<ie/><nbsp/><m>\abs{y-4}\lt\varepsilon</m>) as desired.
         This shows that <m>\lim_{x\to 2} x^2 = 4</m>.
-        <xref ref="fig_limit_eover5">Figure</xref>
+        <xref ref="fig_limit_eover5"/>
         gives a visualization of this;
         by restricting <m>x</m> to values within <m>\delta = \varepsilon/5</m> of <m>2</m>,
         we see that <m>f(x)</m> is within <m>\varepsilon</m> of <m>4</m>.
@@ -739,7 +739,7 @@
       </p>
 
       <p>
-        In <xref ref="eq_lim4">Inequality</xref>,
+        In <xref ref="eq_lim4" text="local">Inequality</xref>,
         we wanted <m>\abs{x-1}\lt \varepsilon/\abs{x^2+x-1}</m>.
         The above shows that given any <m>x</m> in <m>[0,2]</m>,
         we know that
@@ -764,7 +764,7 @@
         <md>
           <mrow>\abs{x-1} \amp \lt  \delta</mrow>
           <mrow>\abs{x-1} \amp \lt  \frac{\varepsilon}{5}</mrow>
-          <mrow>\abs{x-1} \amp \lt  \frac{\varepsilon}{\abs{x^2+x-1}} \amp\amp  \text{(}<xref ref="eq_lim5">Inequality</xref>, x\text{ near 1)}</mrow>
+          <mrow>\abs{x-1} \amp \lt  \frac{\varepsilon}{\abs{x^2+x-1}} \amp\amp  \text{(}<xref ref="eq_lim5" text="local">Inequality</xref>, x\text{ near 1)}</mrow>
           <mrow>\abs{x-1}\cdot \abs{x^2+x-1} \amp \lt  \varepsilon</mrow>
           <mrow>\abs{x^3-2x+1} \amp \lt  \varepsilon</mrow>
           <mrow>\abs{(x^3-2x)-(-1)} \amp \lt \varepsilon</mrow>
@@ -864,7 +864,7 @@
     As an added benefit, this shows that in fact the function
     <m>f(x)=e^x</m> is <em>continuous</em>
     at all values of <m>x</m>,
-    an important concept we will define in <xref ref="sec_continuity">Section</xref>.
+    an important concept we will define in <xref ref="sec_continuity"/>.
   </p>
 
   <p>
@@ -875,16 +875,16 @@
     It is very difficult to prove,
     using the techniques given above,
     that <m>\lim_{x\to 0}\frac{\sin(x)}{x} = 1</m>,
-    as we approximated in <xref ref="sec_limit_intro">Section</xref>.
+    as we approximated in <xref ref="sec_limit_intro"/>.
   </p>
   <p>
     There is hope.
-    <xref ref="sec_limit_analytically">Section</xref>
+    <xref ref="sec_limit_analytically"/>
     shows how one can evaluate complicated limits using certain basic limits as building blocks.
     While limits are an incredibly important part of calculus
     (and hence much of higher mathematics),
     rarely are limits evaluated using the definition.
-    Rather, the techniques of <xref ref="sec_limit_analytically">Section</xref> are employed.
+    Rather, the techniques of <xref ref="sec_limit_analytically"/> are employed.
   </p>
 
   <exercises>

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -526,7 +526,7 @@
           <mrow>\abs{x-2}\amp\lt\frac{\varepsilon}{5}\amp\amp\text{(Our choice of } \delta\text{)}</mrow>
           <mrow>\abs{x-2}\cdot\abs{x+2}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{5}\amp\amp\text{(Multiply by }\abs{x+2}\text{)}</mrow>
           <mrow>\abs{x^2-4}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{5}\amp\amp\text{(Simplify left side)}</mrow>
-          <mrow>\abs{x^2-4}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{\abs{x+2}}\amp\amp\text{(}<xref ref="eq_limit1" text="local">Inequality</xref>, \delta \lt 1\text{)}</mrow>
+          <mrow>\abs{x^2-4}\amp\lt\abs{x+2}\cdot\frac{\varepsilon}{\abs{x+2}}\amp\amp\text{(}<xref ref="eq_limit1" text="global">Inequality</xref>, \delta \lt 1\text{)}</mrow>
           <mrow>\abs{x^2-4}\amp\lt\varepsilon</mrow>
         </md>
       </p>
@@ -739,7 +739,7 @@
       </p>
 
       <p>
-        In <xref ref="eq_lim4" text="local">Inequality</xref>,
+        In <xref ref="eq_lim4" text="global">Inequality</xref>,
         we wanted <m>\abs{x-1}\lt \varepsilon/\abs{x^2+x-1}</m>.
         The above shows that given any <m>x</m> in <m>[0,2]</m>,
         we know that
@@ -764,7 +764,7 @@
         <md>
           <mrow>\abs{x-1} \amp \lt  \delta</mrow>
           <mrow>\abs{x-1} \amp \lt  \frac{\varepsilon}{5}</mrow>
-          <mrow>\abs{x-1} \amp \lt  \frac{\varepsilon}{\abs{x^2+x-1}} \amp\amp  \text{(}<xref ref="eq_lim5" text="local">Inequality</xref>, x\text{ near 1)}</mrow>
+          <mrow>\abs{x-1} \amp \lt  \frac{\varepsilon}{\abs{x^2+x-1}} \amp\amp  \text{(}<xref ref="eq_lim5" text="global">Inequality</xref>, x\text{ near 1)}</mrow>
           <mrow>\abs{x-1}\cdot \abs{x^2+x-1} \amp \lt  \varepsilon</mrow>
           <mrow>\abs{x^3-2x+1} \amp \lt  \varepsilon</mrow>
           <mrow>\abs{(x^3-2x)-(-1)} \amp \lt \varepsilon</mrow>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -3,7 +3,7 @@
   <title>Limits Involving Infinity</title>
   <introduction>
     <p>
-      In <xref ref="def_limit">Definition</xref>
+      In <xref ref="def_limit"/>
       we stated that in the equation <m>\lim_{x\to c}f(x) = L</m>,
       both <m>c</m> and <m>L</m> were numbers.
       In this section we relax that definition a bit by considering situations when it makes sense to let <m>c</m> and/or <m>L</m> be <q>infinity.</q>
@@ -11,7 +11,7 @@
 
     <p>
       As a motivating example, consider <m>f(x) = 1/x^2</m>,
-      as shown in <xref ref="fig_oneoverxsquared">Figure</xref>.
+      as shown in <xref ref="fig_oneoverxsquared"/>.
       Note how, as <m>x</m> approaches 0, <m>f(x)</m> grows very,
       very large<mdash/>in fact, it grows without bound.
       It seems appropriate, and descriptive, to state that
@@ -116,8 +116,8 @@
 
     <p>
       The first definition is similar to the
-      <m>\varepsilon</m>-<m>\delta</m> definition in <xref ref="def_limit">Definition</xref>
-      from <xref ref="sec_limit_def">Section</xref>.
+      <m>\varepsilon</m>-<m>\delta</m> definition in <xref ref="def_limit"/>
+      from <xref ref="sec_limit_def"/>.
       In that definition, given any (small) value <m>\varepsilon</m>,
       if we let <m>x</m> get close enough to <m>c</m>
       (within <m>\delta</m> units of <m>c</m>)
@@ -186,7 +186,7 @@
               <p>
                 The term <em>left- (or,
                 right-) hand limit of <m>f</m> at c is negative infinity</em>
-                is defined in a manner similar to <xref ref="def_limit_of_infinity">Definition</xref>.
+                is defined in a manner similar to <xref ref="def_limit_of_infinity"/>.
               </p>
             </li>
           </ul>
@@ -198,11 +198,11 @@
       <title>Evaluating limits involving infinity</title>
       <statement>
         <p>
-          Find <m>\lim\limits_{x\to 1}\frac1{(x-1)^2}</m> as shown in <xref ref="fig_inflim1">Figure</xref>.
+          Find <m>\lim\limits_{x\to 1}\frac1{(x-1)^2}</m> as shown in <xref ref="fig_inflim1"/>.
         </p>
 
         <figure xml:id="fig_inflim1">
-          <caption>Observing infinite limit as <m>x\to 1</m> in <xref ref="ex_inflim1">Example</xref></caption>
+          <caption>Observing infinite limit as <m>x\to 1</m> in <xref ref="ex_inflim1"/></caption>
           <!-- START figures/fig_nolimit2.tex -->
           <image xml:id="img_inflim1" width="47%">
             <description>
@@ -243,8 +243,8 @@
       <solution>
 
         <p>
-          In <xref ref="ex_no_limit2">Example</xref>
-          of <xref ref="sec_limit_intro">Section</xref>,
+          In <xref ref="ex_no_limit2"/>
+          of <xref ref="sec_limit_intro"/>,
           by inspecting values of <m>x</m> close to <m>1</m> we concluded that this limit does not exist.
           That is, it cannot equal any real number.
           But the limit could be infinite.
@@ -254,7 +254,7 @@
           A similar thing happens on the other side of <m>1</m>.
           From the graph and the numeric information,
           we could state <m>\lim_{x \to 1}1/(x-1)^2=\infty</m>.
-          We can prove this by using <xref ref="def_limit_of_infinity">Definition</xref>
+          We can prove this by using <xref ref="def_limit_of_infinity"/>
         </p>
 
         <p>
@@ -278,7 +278,7 @@
       <statement>
         <p>
           Find <m>\lim\limits_{x\to 0}\frac1x</m>,
-          as shown in <xref ref="fig_oneoverx">Figure</xref>.
+          as shown in <xref ref="fig_oneoverx"/>.
         </p>
       </statement>
       <solution component="video">
@@ -394,7 +394,7 @@
           In the case of the given function,
           the denominator is <m>0</m> at <m>x=\pm 2</m>.
           Substituting in values of <m>x</m> close to <m>2</m> and <m>-2</m> seems to indicate that the function tends toward <m>\infty</m> or <m>-\infty</m> at those points.
-          We can graphically confirm this by looking at <xref ref="fig_multipleasymptotes">Figure</xref>.
+          We can graphically confirm this by looking at <xref ref="fig_multipleasymptotes"/>.
           Thus the vertical asymptotes are at <m>x=\pm2</m>.
         </p>
 
@@ -457,7 +457,7 @@
       However, just because the denominator is <m>0</m> at a certain point does not mean there is a vertical asymptote there.
       For instance,
       <m>f(x)=(x^2-1)/(x-1)</m> does not have a vertical asymptote at <m>x=1</m>,
-      as shown in <xref ref="fig_noasy">Figure</xref>.
+      as shown in <xref ref="fig_noasy"/>.
       While the denominator does get small near <m>x=1</m>,
       the numerator gets small too,
       matching the denominator step for step.
@@ -512,7 +512,7 @@
       We found that <m>\lim_{x\to0}\frac{\sin(x) }{x}=1</m>;
       <ie/>, there is no vertical asymptote.
       No simple algebraic cancellation makes this fact obvious;
-      we used the <xref ref="thm_sqz"/> in <xref ref="sec_limit_analytically">Section</xref> to prove this.
+      we used the <xref ref="thm_sqz" text="title"/> in <xref ref="sec_limit_analytically"/> to prove this.
     </p>
 
     <p>
@@ -560,7 +560,7 @@
       (such as factoring and canceling),
       it may involve using trigonometric identities or logarithm rules,
       or it may require a tool such as the <xref text="title" ref="thm_sqz"/>.
-      In <xref ref="sec_lhopitals_rule">Section</xref>
+      In <xref ref="sec_lhopitals_rule"/>
       we will learn yet another technique called L'Hospital's Rule that provides another way to handle indeterminate forms.
     </p>
 
@@ -649,7 +649,7 @@
     <p>
       We can also define limits such as
       <m>\lim_{x\to\infty}f(x)=\infty</m> by combining this definition with
-      <xref ref="def_limit_of_infinity">Definition</xref>.
+      <xref ref="def_limit_of_infinity"/>.
     </p>
 
     <example xml:id="ex_hzasy1">
@@ -677,7 +677,7 @@
         </p>
 
         <figure xml:id="fig_hzasy1">
-          <caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1">Example</xref></caption>
+          <caption>Using a graph and a table to approximate a horizontal asymptote in <xref ref="ex_hzasy1"/></caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
             <figure xml:id="fig_hzasy1a"><caption/>
               <image xml:id="img_hzasy1a">
@@ -762,19 +762,19 @@
 
     <p>
       Horizontal asymptotes can take on a variety of forms.
-      <xref ref="fig_hzasya">Figure</xref>
+      <xref ref="fig_hzasya"/>
       shows that <m>f(x) = x/(x^2+1)</m> has a horizontal asymptote of <m>y=0</m>,
       where <m>0</m> is approached from both above and below.
     </p>
 
     <p>
-      <xref ref="fig_hzasyb">Figure</xref>
+      <xref ref="fig_hzasyb"/>
       shows that <m>f(x) =x/\sqrt{x^2+1}</m> has two horizontal asymptotes;
       one at <m>y=1</m> and the other at <m>y=-1</m>.
     </p>
 
     <p>
-      <xref ref="fig_hzasyc">Figure</xref>
+      <xref ref="fig_hzasyc"/>
       shows that <m>f(x) = \sin(x)/x</m> has even more interesting behavior than at just <m>x=0</m>;
       as <m>x</m> approaches <m>\pm\infty</m>,
       <m>f(x)</m> approaches <m>0</m>,
@@ -1012,7 +1012,7 @@
       <statement>
         <p>
           Confirm analytically that <m>y=1</m> is the horizontal asymptote of <m>f(x) = \frac{x^2}{x^2+4}</m>,
-          as approximated in <xref ref="ex_hzasy1">Example</xref>.
+          as approximated in <xref ref="ex_hzasy1"/>.
         </p>
       </statement>
       <solution component="video">
@@ -1022,7 +1022,7 @@
       <solution>
 
         <p>
-          Before using <xref ref="thm_lim_rational_fn_at_infty">Theorem</xref>,
+          Before using <xref ref="thm_lim_rational_fn_at_infty"/>,
           let's use the technique of evaluating limits at infinity of rational functions that led to that theorem.
           The largest power of <m>x</m> in <m>f</m> is <m>2</m>,
           so divide the numerator and denominator of <m>f</m> by <m>x^2</m>,
@@ -1036,7 +1036,7 @@
         </p>
 
         <p>
-          We can also use <xref ref="thm_lim_rational_fn_at_infty">Theorem</xref> directly;
+          We can also use <xref ref="thm_lim_rational_fn_at_infty"/> directly;
           in this case <m>n=m</m> so the limit is the ratio of the leading coefficients of the numerator and denominator,
           <ie/>, 1/1 = 1.
         </p>
@@ -1047,7 +1047,7 @@
       <title>Finding limits of rational functions</title>
       <statement>
         <p>
-          Use <xref ref="thm_lim_rational_fn_at_infty">Theorem</xref>
+          Use <xref ref="thm_lim_rational_fn_at_infty"/>
           to evaluate each of the following limits.
           <ol cols="2">
             <li><m>\lim_{x\to-\infty}\dfrac{x^2+2x-1}{x^3+1}</m></li>
@@ -1063,7 +1063,7 @@
               <p>
                 The highest power of <m>x</m> is in the denominator.
                 Therefore, the limit is <m>0</m>;
-                see <xref ref="fig_hzasy3a">Figure</xref>.
+                see <xref ref="fig_hzasy3a"/>.
               </p>
             </li>
             <li>
@@ -1072,7 +1072,7 @@
                 which occurs in both the numerator and denominator.
                 The limit is therefore the ratio of the coefficients of <m>x^2</m>,
                 which is <m>-1/3</m>.
-                See <xref ref="fig_hzasy3b">Figure</xref>.
+                See <xref ref="fig_hzasy3b"/>.
               </p>
             </li>
             <li>
@@ -1084,14 +1084,14 @@
                 The expression in the limit will behave like
                 <m>x^2/(-x) = -x</m> for large values of <m>x</m>.
                 Therefore, the limit is <m>-\infty</m>.
-                See <xref ref="fig_hzasy3c">Figure</xref>.
+                See <xref ref="fig_hzasy3c"/>.
               </p>
             </li>
           </ol>
         </p>
 
         <figure xml:id="fig_hzasy3">
-          <caption>Visualizing the functions in <xref ref="ex_hzasy3">Example</xref></caption>
+          <caption>Visualizing the functions in <xref ref="ex_hzasy3"/></caption>
           <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
             <figure xml:id="fig_hzasy3a">
               <caption/>
@@ -1202,7 +1202,7 @@
       long run behavior using <q>dominant terms</q> of <m>f(x)</m>.
       For instance,
       consider again <m>\lim_{x\to\pm\infty}\frac{x}{\sqrt{x^2+1}}</m>,
-      graphed in <xref ref="fig_hzasyb">Figure</xref>.
+      graphed in <xref ref="fig_hzasyb"/>.
       The dominant terms are <m>x</m> in the numerator and <m>\sqrt{x^2}</m> in the denominator.
       When <m>x</m> is very large, <m>x^2+1 \approx x^2</m>.
       Thus
@@ -1223,7 +1223,7 @@
       <statement>
         <p>
           Confirm analytically that <m>y=1</m> and <m>y=-1</m> are the horizontal asymptote of <m>\lim_{x\to\pm\infty}\frac{x}{\sqrt{x^2+1}}</m>,
-          as graphed in <xref ref="fig_hzasyb">Figure</xref>.
+          as graphed in <xref ref="fig_hzasyb"/>.
         </p>
       </statement>
       <solution>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -24,7 +24,7 @@
       the answer does not seem difficult to find.
       One might think first to look at a graph of this function to approximate the appropriate
       <m>y</m> values.
-      Consider <xref ref="fig_zoom_sinx_over_x">Figure</xref>,
+      Consider <xref ref="fig_zoom_sinx_over_x"/>,
       where <m>y = \frac{\sin(x) }{x}</m> is graphed.
       For values of <m>x</m> near 1, it seems that <m>y</m> takes on values near <m>0.85</m>.
       In fact, when <m>x=1</m>, then <m>y=\frac{\sin(1) }{1} \approx 0.84</m>,
@@ -112,7 +112,7 @@
       When <m>x</m> is near <m>0</m>, what value
       (if any)
       is <m>y</m> near?
-      By considering <xref ref="fig_sinx_over_x">Figure</xref>,
+      By considering <xref ref="fig_sinx_over_x"/>,
       one can see that it seems that <m>y</m> takes on values near <m>1</m>.
       But what happens when <m>x=0</m>?
       We have
@@ -367,7 +367,7 @@
 
         <sidebyside widths="47% 47%" margins="0%" valign="bottom">
           <figure xml:id="fig_limit1">
-            <caption>Graphically approximating a limit in <xref ref="ex_limit1">Example</xref></caption>
+            <caption>Graphically approximating a limit in <xref ref="ex_limit1"/></caption>
             <!-- START figures/fig_limit1.tex -->
             <image xml:id="img_limit1">
               <description>
@@ -406,7 +406,7 @@
           </figure>
 
           <figure xml:id="table_limit1">
-            <caption>Numerically approximating a limit in <xref ref="ex_limit1">Example</xref></caption>
+            <caption>Numerically approximating a limit in <xref ref="ex_limit1"/></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -481,7 +481,7 @@
       Graphs are useful since they give a visual understanding concerning the behavior of a function.
       Sometimes a function may act <q>erratically</q>
       near certain <m>x</m> values which is hard to discern numerically but very plain graphically
-      (see <xref ref="ex_no_limit3">Example</xref>).
+      (see <xref ref="ex_no_limit3"/>).
       Since graphing utilities are very accessible,
       it makes sense to make proper use of them.
     </p>
@@ -493,7 +493,7 @@
       Include enough so that a trend is clear, and use values
       (when possible)
       both less than and greater than the value in question.
-      In <xref ref="ex_limit1">Example</xref>,
+      In <xref ref="ex_limit1"/>,
       we used both values less than and greater than <m>3</m>.
       Had we used just <m>x=3.001</m>,
       we might have been tempted to conclude that the limit had a value of <m>0.3</m>.
@@ -524,7 +524,7 @@
           <m>x=0</m> to approximate the limit.
           Note that this is a piecewise defined function,
           so it behaves differently on either side of <m>0</m>.
-          <xref ref="fig_limit2">Figure</xref> shows a graph of <m>f(x)</m>,
+          <xref ref="fig_limit2"/> shows a graph of <m>f(x)</m>,
           and on either side of <m>0</m> it seems the <m>y</m> values approach <m>1</m>.
           Note that <m>f(0)</m> is not actually defined,
           as indicated in the graph with the open circle.
@@ -532,7 +532,7 @@
 
         <sidebyside widths="47% 47%" margins="0%" valign="bottom">
           <figure xml:id="fig_limit2">
-            <caption>Graphically approximating a limit in <xref ref="ex_limit2">Example</xref></caption>
+            <caption>Graphically approximating a limit in <xref ref="ex_limit2"/></caption>
             <!-- START figures/fig_limit2.tex -->
             <image xml:id="img_limit2">
               <description>
@@ -568,7 +568,7 @@
           </figure>
 
           <figure xml:id="table_limit2">
-            <caption>Numerically approximating a limit in <xref ref="ex_limit2">Example</xref></caption>
+            <caption>Numerically approximating a limit in <xref ref="ex_limit2"/></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -603,7 +603,7 @@
         </sidebyside>
 
         <p>
-          <xref ref="table_limit2">Figure</xref>
+          <xref ref="table_limit2"/>
           shows values of <m>f(x)</m> for values of <m>x</m> near <m>0</m>.
           It is clear that as <m>x</m> takes on values very near <m>0</m>,
           <m>f(x)</m> takes on values very near <m>1</m>.
@@ -692,7 +692,7 @@
 
         <sidebyside widths="47% 47%" margins="0%" valign="bottom">
           <figure xml:id="fig_nolimit1">
-            <caption>Observing no limit as <m>x\to 1</m> in <xref ref="ex_no_limit1">Example</xref></caption>
+            <caption>Observing no limit as <m>x\to 1</m> in <xref ref="ex_no_limit1"/></caption>
             <!-- START figures/fig_nolimit1.tex -->
             <image xml:id="img_nolimit1">
               <description>
@@ -728,7 +728,7 @@
           </figure>
 
           <figure xml:id="table_nolimit1">
-            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1">Example</xref></caption>
+            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit1"/></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -782,7 +782,7 @@
 
         <sidebyside widths="47% 47%" margins="0%" valign="bottom">
           <figure xml:id="fig_nolimit2">
-            <caption>Observing no limit as <m>x\to 1</m> in <xref ref="ex_no_limit2">Example</xref></caption>
+            <caption>Observing no limit as <m>x\to 1</m> in <xref ref="ex_no_limit2"/></caption>
             <!-- START figures/fig_nolimit2.tex -->
             <image xml:id="img_nolimit2">
               <description>
@@ -816,7 +816,7 @@
           </figure>
 
           <figure xml:id="table_nolimit2">
-            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2">Example</xref></caption>
+            <caption>Values of <m>f(x)</m> near <m>x=1</m> in <xref ref="ex_no_limit2"/></caption>
             <tabular>
               <row bottom="medium">
                 <cell><m>x</m></cell>
@@ -888,7 +888,7 @@
       <solution>
 
         <p>
-          Two graphs of <m>f(x) = \sin(1/x)</m> are given in <xref ref="fig_nolimit3">Figure</xref>.
+          Two graphs of <m>f(x) = \sin(1/x)</m> are given in <xref ref="fig_nolimit3"/>.
           <xref ref="fig_nolimit3a"/>
           shows <m>f(x)</m> on the interval <m>[-1,1]</m>;
           notice how <m>f(x)</m> seems to oscillate near <m>x=0</m>.
@@ -905,7 +905,7 @@
         </p>
 
         <figure xml:id="fig_nolimit3">
-          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref></caption>
+          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_nolimit3a">
               <caption/>
@@ -1063,7 +1063,7 @@
         </figure>
 
         <figure xml:id="table_nolimit3c">
-          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3">Example</xref></caption>
+          <caption>Observing that <m>f(x)=\sin(1/x)</m> has no limit as <m>x\to0</m> in <xref ref="ex_no_limit3"/></caption>
           <tabular>
             <row bottom="medium">
               <cell><m>x</m></cell>
@@ -1169,7 +1169,7 @@
       given two points on the graph of <m>f</m>,
       we are finding the slope of the <em>secant line</em>
       through those two points.
-      See <xref ref="fig_diffquot1">Figure</xref>.
+      See <xref ref="fig_diffquot1"/>.
     </p>
 
     <figure xml:id="fig_diffquot1">
@@ -1237,7 +1237,7 @@
       For small values of <m>h</m>,
       <ie/>, values of <m>h</m> close to <m>0</m>,
       we get average velocities over very short time periods and compute secant lines over small intervals.
-      See <xref ref="fig_diff_quot_smallh">Figure</xref>.
+      See <xref ref="fig_diff_quot_smallh"/>.
       This leads us to wonder what the limit of the difference quotient is as
       <m>h</m> approaches <m>0</m>.
       That is,

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -7,7 +7,7 @@
     approximating their values graphically and numerically.
     Next came the rigorous definition of the limit,
     along with an admittedly tedious method for evaluating them.
-    <xref ref="sec_limit_analytically">Section</xref> gave us tools
+    <xref ref="sec_limit_analytically"/> gave us tools
     (which we call theorems)
     that allow us to compute limits with greater ease.
     Chief among the results were the facts that polynomials and
@@ -17,7 +17,7 @@
     In this section we rigorously define what we mean by <q>nicely.</q>
   </p>
   <p>
-    In <xref ref="sec_limit_intro">Section</xref>
+    In <xref ref="sec_limit_intro"/>
     we saw three ways in which limits of functions can fail to exist:
     <ol>
       <li xml:id="lim_DNE_lr">
@@ -43,7 +43,7 @@
     In this section we explore in depth the concepts behind
     <xref ref="lim_DNE_lr"/> by introducing the <em>one-sided limit</em>.
     We begin with formal definitions that are very similar to the
-    definition of the limit given in <xref ref="sec_limit_def">Section</xref>,
+    definition of the limit given in <xref ref="sec_limit_def"/>,
     but the notation is slightly different and <q><m>x\neq c</m></q>
     is replaced with either <q><m>x\lt c</m></q> or <q><m>x \gt c</m>.</q>
   </p>
@@ -144,7 +144,7 @@
                          x \amp 0\leq x\leq 1 \\
                          3-x \amp 1\lt x\lt 2
                        \end{cases}</m>,
-        as shown in <xref ref="fig_onesided1">Figure</xref>.
+        as shown in <xref ref="fig_onesided1"/>.
         Find each of the following:
 
         <ol cols="2" marker="a">
@@ -176,7 +176,7 @@
       </p>
 
       <figure xml:id="fig_onesided1">
-        <caption>A graph of <m>f</m> in <xref ref="ex_onesidea">Example</xref></caption>
+        <caption>A graph of <m>f</m> in <xref ref="ex_onesidea"/></caption>
         <!-- START figures/fig_one_sidedlimit1.tex -->
         <image xml:id="img_onesided1" width="47%">
           <description>
@@ -277,7 +277,7 @@
             <p>
               <em>The</em> limit of <m>f</m> as <m>x</m> approaches
               <m>1</m> does not exist, as discussed in
-              <xref ref="sec_limit_intro">Section</xref>.
+              <xref ref="sec_limit_intro"/>.
               The function does not approach one particular value,
               but two different values from the left and the right.
             </p>
@@ -362,7 +362,7 @@
   </p>
 
   <p>
-    One thing to consider in <xref ref="ex_onesidea">Examples</xref>-<xref ref="ex_onesided"/>
+    One thing to consider in <xref first="ex_onesidea" last="ex_onesided" text="global">Examples</xref>
     is that the value of the function may/may not be equal to the value(s)
     of its left/right-hand limits, even when these limits agree.
   </p>
@@ -376,7 +376,7 @@
                        (x-2)^2 \amp 1\lt x\lt 2
                     \end{cases}</m>
                    .
-        <!-- as shown in <xref ref="fig_onesidedb">Figure</xref>.-->
+        <!-- as shown in <xref ref="fig_onesidedb"/>.-->
         Evaluate the following:
         <ol cols="2" marker="a">
           <li>
@@ -528,11 +528,11 @@
       </p>
 
       <p>
-        We can confirm our analytic result by consulting the graph of <m>f</m> shown in <xref ref="fig_onesidedb">Figure</xref>.
+        We can confirm our analytic result by consulting the graph of <m>f</m> shown in <xref ref="fig_onesidedb"/>.
         Note the open circles on the graph at <m>x=0</m>, <m>1</m> and <m>2</m>, where <m>f</m> is not defined.
       </p>
       <figure xml:id="fig_onesidedb">
-        <caption>A graph of <m>f</m> from <xref ref="ex_onesideb">Example</xref></caption>
+        <caption>A graph of <m>f</m> from <xref ref="ex_onesideb"/></caption>
         <!-- START figures/fig_one_sidedlimit2.tex -->
         <image xml:id="img_onesidedb" width="47%">
           <description>
@@ -580,7 +580,7 @@
     <statement>
       <p>
         Let <m>f(x) =\begin{cases} (x-1)^2 \amp 0\leq x\leq 2, x\neq 1\\ 1 \amp x=1
-        \end{cases}</m> as shown in <xref ref="fig_onesidedc">Figure</xref>.
+        \end{cases}</m> as shown in <xref ref="fig_onesidedc"/>.
         Evaluate the following:
         <ol cols="2" marker="a">
           <li>
@@ -599,12 +599,12 @@
       </p>
 
       <figure xml:id="fig_onesidedc">
-        <caption>Graphing <m>f</m> in <xref ref="ex_onesidec">Example</xref></caption>
+        <caption>Graphing <m>f</m> in <xref ref="ex_onesidec"/></caption>
         <!-- START figures/fig_one_sidedlimit3.tex -->
         <image xml:id="img_onesidedc" width="47%">
           <description>
             <p>
-              The graph of <m>f(x)</m> in <xref ref="ex_onesidec">Example</xref>.
+              The graph of <m>f(x)</m> in <xref ref="ex_onesidec"/>.
               The graph is a parabola, opening upward, plotted from
               <m>(0, 1)</m> to <m>(2, 1)</m>, with its vertex at <m>(1,0)</m>. 
               However, there is a hole in the graph at the vertex, indicated by a hollow dot. 
@@ -657,7 +657,7 @@
     <statement>
       <p>
         Let <m>f(x) = \begin{cases} x^2 \amp 0\leq x\leq 1 \\ 2-x \amp 1\lt x\leq 2
-        \end{cases}</m> as shown in <xref ref="fig_onesidedd">Figure</xref>.
+        \end{cases}</m> as shown in <xref ref="fig_onesidedd"/>.
         Evaluate the following:
         <ol cols="2" marker="a">
           <li>
@@ -676,7 +676,7 @@
       </p>
 
       <figure xml:id="fig_onesidedd">
-        <caption>Graphing <m>f</m> in <xref ref="ex_onesided">Example</xref></caption>
+        <caption>Graphing <m>f</m> in <xref ref="ex_onesided"/></caption>
         <!-- START figures/fig_one_sidedlimit4.tex -->
         <image xml:id="img_onesidedd" width="47%">
           <description>
@@ -732,7 +732,7 @@
   </example>
 
   <p>
-    In <xref ref="ex_onesidea">Examples</xref>-<xref ref="ex_onesided"/>
+    In <xref first="ex_onesidea" last="ex_onesided" text="global">Examples</xref>
     we were asked to find both <m>\lim_{x\to 1}f(x)</m> and <m>f(1)</m>.
     Consider the following table:
   </p>
@@ -744,32 +744,32 @@
       <cell><m>f(1)</m></cell>
     </row>
     <row>
-      <cell><xref ref="ex_onesidea">Example</xref></cell>
+      <cell><xref ref="ex_onesidea"/></cell>
       <cell>does not exist</cell>
       <cell><m>1</m></cell>
     </row>
     <row>
-      <cell><xref ref="ex_onesideb">Example</xref></cell>
+      <cell><xref ref="ex_onesideb"/></cell>
       <cell><m>1</m></cell>
       <cell>not defined</cell>
     </row>
     <row>
-      <cell><xref ref="ex_onesidec">Example</xref></cell>
+      <cell><xref ref="ex_onesidec"/></cell>
       <cell><m>0</m></cell>
       <cell><m>1</m></cell>
     </row>
     <row>
-      <cell><xref ref="ex_onesided">Example</xref></cell>
+      <cell><xref ref="ex_onesided"/></cell>
       <cell><m>1</m></cell>
       <cell><m>1</m></cell>
     </row>
   </tabular>
 
   <p>
-    Only in <xref ref="ex_onesided">Example</xref>
+    Only in <xref ref="ex_onesided"/>
     do both the function and the limit exist and agree.
     This seems <q>nice;</q> in fact,
-    it seems <q>normal.</q> This is in fact an important situation which we explore in <xref ref="sec_continuity">Section</xref>
+    it seems <q>normal.</q> This is in fact an important situation which we explore in <xref ref="sec_continuity"/>
     entitled <q>Continuity.</q> In short,
     a <term>continuous function</term>
     is one in which when a function approaches a value as <m>x\to c</m> (<ie/>, when <m>\lim_{x\to c} f(x) = L</m>),

--- a/ptx/sec_line_int_intro.ptx
+++ b/ptx/sec_line_int_intro.ptx
@@ -303,7 +303,7 @@
 
     <p>
       All this leads us to a definition.
-      The integral found in <xref ref="eq_line0" text="local">Equation</xref>
+      The integral found in <xref ref="eq_line0" text="global">Equation</xref>
       is called a <em>line integral</em>.
       We formally define it below, but note that the definition is very abstract.
       On one hand,
@@ -389,7 +389,7 @@
 
     <p>
       In <xref ref="sec_curvature"/>,
-      we defined the arc-length parameter in <xref ref="eq_vvfarc" text="local">Equation</xref> as
+      we defined the arc-length parameter in <xref ref="eq_vvfarc" text="global">Equation</xref> as
       <me>
         s(t) = \int_0^t \norm{\vec r\,'(u)}\, du
       </me>.

--- a/ptx/sec_line_int_intro.ptx
+++ b/ptx/sec_line_int_intro.ptx
@@ -16,7 +16,7 @@
       <video youtube="ponQzAg7V3I" label="vid-veccalc-lineint-intro"/>
     </figure>
     <p>
-      Consider the surface and curve shown in <xref ref="fig_line_integral_intro1a_3D">Figure</xref>.
+      Consider the surface and curve shown in <xref ref="fig_line_integral_intro1a_3D"/>.
       The surface is given by <m>f(x,y)=1-\cos(x)\sin(y)</m>.
       The dashed curve lies in the <m>xy</m>-plane and is the familiar <m>y=x^2</m> parabola from <m>-1\leq x\leq1</m>;
       we'll call this curve <m>C</m>.
@@ -28,7 +28,7 @@
       what is the area that lies below the curve drawn with the solid line?
       In other words,
       what is the area of the region above <m>C</m> and under the the surface <m>z=f(x,y)</m>?
-      This region is shown in <xref ref="fig_line_integral_intro1b_3D">Figure</xref>.
+      This region is shown in <xref ref="fig_line_integral_intro1b_3D"/>.
     </p>
 
     <p>
@@ -237,7 +237,7 @@
     </figure>
 
     <p>
-      In <xref ref="fig_line_integral_intro1c_3D">Figure</xref>,
+      In <xref ref="fig_line_integral_intro1c_3D"/>,
       four rectangles have been drawn over the curve <m>C</m>.
       The bottom corners of each rectangle lie on <m>C</m>,
       and each rectangle has a height given by the function <m>f(x,y)</m> for some <m>(x,y)</m> pair along <m>C</m> between the rectangle's bottom corners.
@@ -269,7 +269,7 @@
       the width was a small change in <m>x</m>: <m>dx</m>.
       That will not suffice in this context.
       Rather, each width of a rectangle is actually approximating the arc length of a small portion of <m>C</m>.
-      In <xref ref="sec_curvature">Section</xref>,
+      In <xref ref="sec_curvature"/>,
       we used <m>s</m> to represent the arc-length parameter of a curve.
       A small amount of arc length will thus be represented by <m>ds</m>.
     </p>
@@ -303,7 +303,7 @@
 
     <p>
       All this leads us to a definition.
-      The integral found in <xref ref="eq_line0">Equation</xref>
+      The integral found in <xref ref="eq_line0" text="local">Equation</xref>
       is called a <em>line integral</em>.
       We formally define it below, but note that the definition is very abstract.
       On one hand,
@@ -335,10 +335,10 @@
 
     <aside>
       <p>
-        <em>Note:</em> <xref ref="def_line_integral1">Definition</xref>
+        <em>Note:</em> <xref ref="def_line_integral1"/>
         uses the term <em>scalar field</em>
         which has not yet been defined.
-        Its meaning is discussed in the paragraph preceding <xref ref="def_line_integral2">Definition</xref>
+        Its meaning is discussed in the paragraph preceding <xref ref="def_line_integral2"/>
         when it is compared to a <em>vector field</em>.
       </p>
     </aside>
@@ -388,8 +388,8 @@
     </p>
 
     <p>
-      In <xref ref="sec_curvature">Section</xref>,
-      we defined the arc-length parameter in <xref ref="eq_vvfarc">Equation</xref> as
+      In <xref ref="sec_curvature"/>,
+      we defined the arc-length parameter in <xref ref="eq_vvfarc" text="local">Equation</xref> as
       <me>
         s(t) = \int_0^t \norm{\vec r\,'(u)}\, du
       </me>.
@@ -456,7 +456,7 @@
 
     <p>
       To be clear,
-      the first point of <xref ref="thm_line1">Theorem</xref>
+      the first point of <xref ref="thm_line1"/>
       can be used to find the area under a surface
       <m>z=f(x,y)</m> and above a curve <m>C</m>.
       We will later give an understanding of the line integral when <m>C</m> is a curve in space.
@@ -473,10 +473,10 @@
           Find the area under the surface
           <m>f(x,y) =\cos(x)+\sin(y)+2</m> over the curve <m>C</m>,
           which is the segment of the line <m>y=2x+1</m> on <m>-1\leq x\leq 1</m>,
-          as shown in <xref ref="fig_linescalarfield2">Figure</xref>.
+          as shown in <xref ref="fig_linescalarfield2"/>.
         </p>
         <figure xml:id="fig_linescalarfield2">
-          <caption>Finding area under a curve in <xref ref="ex_linescalarfield2">Example</xref></caption>
+          <caption>Finding area under a curve in <xref ref="ex_linescalarfield2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_linescalarfield2a_3D">
               <caption/>
@@ -637,10 +637,10 @@
       <statement>
         <p>
           Find the area over the unit circle in the <m>xy</m>-plane and under the graph of <m>f(x,y) = x^2-y^2+3</m>,
-          shown in <xref ref="fig_linescalarfield3">Figure</xref>.
+          shown in <xref ref="fig_linescalarfield3"/>.
         </p>
         <figure xml:id="fig_linescalarfield3">
-          <caption>Finding area under a curve in <xref ref="ex_linescalarfield3">Example</xref></caption>
+          <caption>Finding area under a curve in <xref ref="ex_linescalarfield3"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_linescalarfield3a_3D">
               <caption/>
@@ -830,10 +830,10 @@
         <p>
           Find the area above the <m>xy</m>-plane and below the helix parametrized by <m>\vrt = \langle \cos t,2\sin t,t/\pi\rangle</m>,
           for <m>0\leq t\leq 2\pi</m>,
-          as shown in <xref ref="fig_linescalarfield4">Figure</xref>.
+          as shown in <xref ref="fig_linescalarfield4"/>.
         </p>
         <figure xml:id="fig_linescalarfield4">
-          <caption>Finding area under a curve in <xref ref="ex_linescalarfield4">Example</xref></caption>
+          <caption>Finding area under a curve in <xref ref="ex_linescalarfield4"/></caption>
           <image xml:id="img_linescalarfield4_3D" width="47%">
             <description></description>
             <asymptote>
@@ -942,7 +942,7 @@
     <p>
       One property in particular of line integrals is worth noting.
       If <m>C</m> is a curve composed of subcurves <m>C_1</m> and <m>C_2</m>,
-      where they share only one point in common (see <xref ref="fig_line_int_propa">Figure</xref>,
+      where they share only one point in common (see <xref ref="fig_line_int_propa"/>,
       then the line integral over <m>C</m> is the sum of the line integrals over <m>C_1</m> and <m>C_2</m>:
       <me>
         \int_Cf(s)\, ds = \int_{C_1}f(s)\, ds+\int_{C_2}f(s)\, ds
@@ -1011,7 +1011,7 @@
 
     <p>
       This property allows us to evaluate line integrals over some curves <m>C</m> that are not smooth.
-      Note how in <xref ref="fig_line_int_propb">Figure</xref> the curve is not smooth at <m>D</m>,
+      Note how in <xref ref="fig_line_int_propb"/> the curve is not smooth at <m>D</m>,
       so by our definition of the line integral we cannot evaluate <m>\int_C f(s)ds</m>.
       However, one can evaluate line integrals over <m>C_1</m> and <m>C_2</m> and their sum will be the desired quantity.
     </p>
@@ -1087,7 +1087,7 @@
     </p>
 
     <p>
-      By taking the limit as the length of the segments approaches 0, we have the definition of the line integral as seen in <xref ref="def_line_integral1">Definition</xref>.
+      By taking the limit as the length of the segments approaches 0, we have the definition of the line integral as seen in <xref ref="def_line_integral1"/>.
       When learning of the line integral,
       we let <m>f(s)</m> represent a height;
       now we let <m>f(s) = \delta(s)</m> represent a density.
@@ -1098,7 +1098,7 @@
       (As a reminder,
       the center of mass can be a useful piece of information as objects rotate about that center.)
       We give the relevant formulas in the next definition, followed by an example.
-      Note the similarities between this definition and <xref ref="def_mass_3d">Definition</xref>,
+      Note the similarities between this definition and <xref ref="def_mass_3d"/>,
       which gives similar properties of solids in space.
     </p>
 
@@ -1161,13 +1161,13 @@
           <m>0\leq t\leq 2\pi</m>.
           The density of the wire is determined by its position in space:
           <m>\delta(x,y,z) = y+z</m> gm/cm.
-          The wire is shown in <xref ref="fig_linescalarfield6">Figure</xref>,
+          The wire is shown in <xref ref="fig_linescalarfield6"/>,
           where a light color indicates low density and a dark color represents high density.
           Find the mass and center of mass of the wire.
         </p>
 
         <figure xml:id="fig_linescalarfield6">
-          <caption>Finding the mass of a thin wire in <xref ref="ex_linescalarfield6">Example</xref></caption>
+          <caption>Finding the mass of a thin wire in <xref ref="ex_linescalarfield6"/></caption>
           <image xml:id="img_linescalarfield6" width="47%">
             <description></description>
             <asymptote>
@@ -1265,7 +1265,7 @@
           <me>
             (\overline{x},\overline{y},\overline{z}) = \left(\frac{M_{yz}}M, \frac{M_{xz}}M,\frac{M_{xy}}M\right) \approx (1,1.25,1.20)
           </me>,
-          as indicated by the dot in <xref ref="fig_linescalarfield6">Figure</xref>.
+          as indicated by the dot in <xref ref="fig_linescalarfield6"/>.
           Note how in this example,
           the curve <m>C</m> is <q>centered</q>
           about the point <m>(1,1,1)</m>,
@@ -1332,7 +1332,7 @@
       <exercise label="TaC-line-int-intro-3">
         <statement>
           <p>
-            Why are most line integrals evaluated using <xref ref="thm_line1">Key Idea</xref> instead of <q>directly</q>
+            Why are most line integrals evaluated using <xref ref="thm_line1"/> instead of <q>directly</q>
             as <m>\int_C f(s)\, ds</m>?
           </p>
         </statement>

--- a/ptx/sec_line_int_vf.ptx
+++ b/ptx/sec_line_int_vf.ptx
@@ -113,7 +113,7 @@
       the right-hand side simply becomes <m>\int_C f(s)\, ds</m>,
       and we can use the techniques of that section to evaluate the integral.
       We combine those techniques,
-      along with parts of Equation <xref ref="eq_line_integral"/>,
+      along with parts of <xref ref="eq_line_integral">Equation</xref>,
       to clearly state how to evaluate a line integral over a vector field in the following Key Idea.
     </p>
 

--- a/ptx/sec_line_int_vf.ptx
+++ b/ptx/sec_line_int_vf.ptx
@@ -27,7 +27,7 @@
     </figure>
 
     <p>
-      Assume as we did in <xref ref="sec_line_int_intro">Section</xref>
+      Assume as we did in <xref ref="sec_line_int_intro"/>
       that <m>C</m> can be parametrized by the arc length parameter <m>s</m>.
       Over a short piece of the curve with length <m>ds</m>,
       the curve is approximately straight and our force is approximately constant.
@@ -57,7 +57,7 @@
       (largely because the arc length parameter is so difficult to work with).
       To compute actual work,
       we need to parametrize <m>C</m> with another parameter <m>t</m> via a vector-valued function <m>\vec r(t)</m>.
-      As stated in <xref ref="sec_line_int_intro">Section</xref>,
+      As stated in <xref ref="sec_line_int_intro"/>,
       <m>ds = \norm{\vrp(t)}\, dt</m>,
       and recall that <m>\vec T = \vrp(t)/\norm{\vrp(t)}</m>.
       Thus
@@ -74,7 +74,7 @@
     <p>
       These integrals are known as <em>line integrals over vector fields</em>.
       By contrast,
-      the line integrals we dealt with in <xref ref="sec_line_int_intro">Section</xref>
+      the line integrals we dealt with in <xref ref="sec_line_int_intro"/>
       are sometimes referred to as <em>line integrals over scalar fields</em>.
           <idx><h>line integral</h><h>over scalar field</h></idx>
       Just as a vector field is defined by a function that returns a vector,
@@ -106,9 +106,9 @@
     </definition>
 
     <p>
-      In <xref ref="def_line_integral2">Definition</xref>,
+      In <xref ref="def_line_integral2"/>,
       note how the dot product <m>\vec F \cdot \vec T</m> is just a scalar.
-      Therefore, this new line integral is really just a special kind of line integral found in <xref ref="sec_line_int_intro">Section</xref>;
+      Therefore, this new line integral is really just a special kind of line integral found in <xref ref="sec_line_int_intro"/>;
       letting <m>f(s) = \vec F(s)\cdot \vec T(s)</m>,
       the right-hand side simply becomes <m>\int_C f(s)\, ds</m>,
       and we can use the techniques of that section to evaluate the integral.
@@ -169,12 +169,12 @@
           Two particles move from <m>(0,0)</m> to <m>(1,1)</m> under the influence of the force field <m>\vec F = \langle x, x+y\rangle</m>.
           One particle follows <m>C_1</m>, the line <m>y=x</m>;
           the other follows <m>C_2</m>,
-          the curve <m>y=x^4</m>, as shown in <xref ref="fig_livf1">Figure</xref>.
+          the curve <m>y=x^4</m>, as shown in <xref ref="fig_livf1"/>.
           Force is measured in newtons and distance is measured in meters.
           Find the work performed by each particle.
         </p>
         <figure xml:id="fig_livf1">
-          <caption>Paths through a vector field in <xref ref="ex_livf1">Example</xref></caption>
+          <caption>Paths through a vector field in <xref ref="ex_livf1"/></caption>
           <image xml:id="img_livf1" width="47%">
             <description></description>
             <asymptote>
@@ -305,12 +305,12 @@
           the parabola defined by <m>y = 2x^2-1</m>.
           The other particle moves along the curve <m>C_2</m>,
           the bottom half of the circle defined by <m>x^2+(y-1)^2=1</m>,
-          as shown in <xref ref="fig_livf2">Figure</xref>.
+          as shown in <xref ref="fig_livf2"/>.
           Force is measured in pounds and distances are measured in feet.
           Find the work performed by moving each particle along its path.
         </p>
         <figure xml:id="fig_livf2">
-          <caption>Paths through a vector field in <xref ref="ex_livf2">Example</xref></caption>
+          <caption>Paths through a vector field in <xref ref="ex_livf2"/></caption>
           <image xml:id="img_livf2" width="47%">
             <description></description>
             <asymptote>
@@ -509,12 +509,12 @@
           Let <m>\vec F = \la 3(y-1/2),1\ra</m> and let <m>C</m> be the path that starts at <m>(0,0)</m>,
           goes to <m>(1,1)</m> along the curve <m>y=x^3</m>,
           then returns to <m>(0,0)</m> along the line <m>y=x</m>,
-          as shown in <xref ref="fig_livf3">Figure</xref>.
+          as shown in <xref ref="fig_livf3"/>.
           Evaluate <m>\oint_C \vec F\cdot d\vec r</m>.
         </p>
 
         <figure xml:id="fig_livf3">
-          <caption>The vector field and curve in <xref ref="ex_livf3">Example</xref></caption>
+          <caption>The vector field and curve in <xref ref="ex_livf3"/></caption>
           <image xml:id="img_livf3" width="47%">
             <description></description>
             <asymptote>
@@ -603,12 +603,12 @@
           there are 2 <q>direct</q> methods to choose from when parametrizing <m>C_2</m>.
           The parametrization <m>\vec r_2(t)=\la t,t\ra</m>,
           <m>0\leq t\leq 1</m> traces the correct line segment but with the wrong orientation.
-          Using Property 3 of <xref ref="thm_line_int_properties_vector">Theorem</xref>,
+          Using Property 3 of <xref ref="thm_line_int_properties_vector"/>,
           we can use this parametrization and negate the result.
         </p>
 
         <p>
-          Another choice is to use the techniques of <xref ref="sec_lines">Section</xref>
+          Another choice is to use the techniques of <xref ref="sec_lines"/>
           to create the line with the orientation we desire.
           We wish to start at <m>( 1,1)</m> and travel in the
           <m>\vec d = \la -1,-1\ra</m> direction for one length of <m>\vec d</m>,
@@ -636,7 +636,7 @@
           If we interpret this integral as computing work,
           the negative work implies that the motion is mostly <em>against</em>
           the direction of the force,
-          which seems plausible when we look at <xref ref="fig_livf3">Figure</xref>.
+          which seems plausible when we look at <xref ref="fig_livf3"/>.
         </p>
       </solution>
     </example>
@@ -652,12 +652,12 @@
         <p>
           Let <m>\vec F = \la -y, x, 1\ra</m>,
           and let <m>C</m> be the portion of the helix given by <m>\vrt = \langle \cos t,\sin t, t/(2\pi)\rangle</m> on <m>[0,2\pi]</m>,
-          as shown in <xref ref="fig_livf4">Figure</xref>.
+          as shown in <xref ref="fig_livf4"/>.
           Evaluate <m>\int_C\vec F\cdot d\vec r</m>.
         </p>
 
         <figure xml:id="fig_livf4">
-          <caption>The graph of <m>\vec r(t)</m> in <xref ref="ex_livf4">Example</xref></caption>
+          <caption>The graph of <m>\vec r(t)</m> in <xref ref="ex_livf4"/></caption>
           <image xml:id="img_livf4_3D" width="47%">
             <description></description>
             <asymptote>
@@ -803,7 +803,7 @@
       A region in the plane is <em>connected</em>
           <idx><h>connected</h></idx>
       if any two points in the region can be joined by a piecewise smooth curve that lies entirely in the region.
-      In <xref ref="fig_simply_connected_plane">Figure</xref>,
+      In <xref ref="fig_simply_connected_plane"/>,
       sets <m>R_1</m> and <m>R_2</m> are connected;
       set <m>R_3</m> is not connected,
       though it is composed of two connected subregions.
@@ -815,7 +815,7 @@
           <idx><h>connected</h><h>simply</h></idx>
       if every simple closed curve that lies entirely in the region can be continuously deformed (shrunk) to a single point without leaving the region. (A curve is <em>simple</em>
           <idx><h>simple curve</h></idx>
-      if it does not cross itself.) In <xref ref="fig_simply_connected_plane">Figure</xref>,
+      if it does not cross itself.) In <xref ref="fig_simply_connected_plane"/>,
       only set <m>R_1</m> is simply connected.
       Region <m>R_2</m> is not simply connected as any closed curve that goes around the <q>hole</q>
       in <m>R_2</m> cannot be continuously shrunk to a single point.
@@ -828,14 +828,14 @@
       We have applied these terms to regions of the plane,
       but they can be extended intuitively to domains in space
       (and hyperspace).
-      In <xref ref="fig_simply_connected_spacea_3D">Figure</xref>,
+      In <xref ref="fig_simply_connected_spacea_3D"/>,
       the domain bounded by the sphere
       (at left)
       and the domain with a subsphere removed
       (at right)
       are both simply connected.
       Any simple closed path that lies entirely within these domains can be continuously deformed into a single point.
-      In <xref ref="fig_simply_connected_spacea_3D">Figure</xref>,
+      In <xref ref="fig_simply_connected_spacea_3D"/>,
       neither domain is simply connected.
       A left, the ball has a hole that extends its length and the pictured closed path cannot be deformed to a point.
       At right, two paths are illustrated on the torus that cannot be shrunk to a point.
@@ -1050,7 +1050,7 @@
     </figure>
 
     <p>
-      Recall how in <xref ref="ex_livf2">Example</xref>
+      Recall how in <xref ref="ex_livf2"/>
       particles moved from <m>A = (-1,1)</m> to
       <m>B = (1,1)</m> along two different paths,
       wherein the same amount of work was performed along each path.
@@ -1115,7 +1115,7 @@
       Consider the surface defined by <m>z = f(x,y) = xy</m>.
       We can compute the gradient of this function:
       <m>\nabla f = \la f_x, f_y\ra = \la y, x\ra</m>.
-      Note that this is the field from <xref ref="ex_livf2">Example</xref>,
+      Note that this is the field from <xref ref="ex_livf2"/>,
       which we have claimed is conservative.
       We will soon give a theorem that states that a field <m>\vec F</m> is conservative if,
       and only if,
@@ -1181,7 +1181,7 @@
     </theorem>
 
     <p>
-      Once again considering <xref ref="ex_livf2">Example</xref>,
+      Once again considering <xref ref="ex_livf2"/>,
       we have <m>A = (-1,1)</m>,
       <m>B = (1,1)</m> and <m>\vec F = \la y,x\ra</m>.
       In that example,
@@ -1317,7 +1317,7 @@
     </theorem>
 
     <p>
-      In <xref ref="ex_livf5">Example</xref>,
+      In <xref ref="ex_livf5"/>,
       we showed that <m>\vec F =\langle 3x^2y+2x,x^3+1\rangle</m> is conservative by finding a potential function for <m>\vec F</m>.
       Using the above theorem,
       we can show that <m>\vec F</m> is conservative much more easily by computing its curl:
@@ -1624,7 +1624,7 @@
               <li>
                 <p>
                   Evaluate <m>\ds\int_C \vec F\cdot d\vec r</m> directly,
-                  <ie/>, using <xref ref="idea_line2">Key Idea</xref>.
+                  <ie/>, using <xref ref="idea_line2"/>.
                 </p>
               </li>
 
@@ -1801,7 +1801,7 @@
       <exercise label="ex-line-int-vector-conservative-5">
         <statement>
           <p>
-            Prove part of <xref ref="thm_conservative_field_curl">Theorem</xref>:
+            Prove part of <xref ref="thm_conservative_field_curl"/>:
             let <m>\vec F =\langle M,N,P\rangle</m> be a conservative vector field.
             Show that <m>\curl \vec F = 0</m>.
           </p>
@@ -1817,7 +1817,7 @@
 
           <p>
             Note that <m>\curl \vec F = \langle P_y - N_z, M_z-P_x, N_x-M_y \rangle = \langle f_{zy} - f_{yz}, f_{xz} - f_{zx}, f_{yx} - f_{xy}\rangle</m>, which,
-            by <xref ref="thm_mixed_partial">Theorem</xref>,
+            by <xref ref="thm_mixed_partial"/>,
             is <m>\langle 0,0,0\rangle</m>.
           </p>
         </solution>

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -42,7 +42,7 @@
       we can start at <m>\vec p</m> and move in a direction parallel to <m>\vec d</m>.
       For instance,
       starting at <m>\vec p</m> and traveling one length of <m>\vec d</m> places one at another point on the line.
-      Consider <xref ref="fig_lines_intro">Figure</xref>
+      Consider <xref ref="fig_lines_intro"/>
       where certain points along the line are indicated.
     </p>
 
@@ -247,7 +247,7 @@
       <statement>
         <p>
           Give all three equations,
-          as given in <xref ref="def_lines">Definition</xref>,
+          as given in <xref ref="def_lines"/>,
           of the line through <m>P = (2,3,1)</m> in the direction of <m>\vec d = \la -1,1,2\ra</m>.
           Does the point <m>Q=(-1,6,6)</m> lie on this line?
         </p>
@@ -291,7 +291,7 @@
         </p>
 
         <figure xml:id="fig_lines1">
-          <caption>Graphing a line in <xref ref="ex_lines1">Example</xref></caption>
+          <caption>Graphing a line in <xref ref="ex_lines1"/></caption>
 
           <!-- START figures/figlines1_3D.asy -->
           <image xml:id="img_lines1" width="47%">
@@ -346,14 +346,14 @@
           one can immediately find the corresponding point on the line.
           These forms are good when calculating with a computer;
           most software programs easily handle equations in these formats. (For instance,
-          the graphics program that made <xref ref="fig_lines1">Figure</xref>
+          the graphics program that made <xref ref="fig_lines1"/>
           can be given the input <q><c>(2-t,3+t,1+2*t)</c></q>
           for <m>-1\leq t\leq 3</m>.).
         </p>
 
         <p>
           Does the point <m>Q = (-1,6,6)</m> lie on the line?
-          The graph in <xref ref="fig_lines1">Figure</xref>
+          The graph in <xref ref="fig_lines1"/>
           makes it clear that it does not.
           We can answer this question without the graph using any of the three equation forms.
           Of the three,
@@ -402,7 +402,7 @@
         </p>
 
         <figure xml:id="fig_lines6">
-          <caption>A graph of the line in <xref ref="ex_lines6">Example</xref></caption>
+          <caption>A graph of the line in <xref ref="ex_lines6"/></caption>
 
           <!-- START figures/figlines6_3D.asy -->
           <image xml:id="img_lines6" width="47%">
@@ -452,11 +452,11 @@
         </figure>
 
         <p>
-          A graph of the points and line are given in <xref ref="fig_lines6">Figure</xref>.
+          A graph of the points and line are given in <xref ref="fig_lines6"/>.
           Note how in the given parametrization of the line,
           <m>t=0</m> corresponds to the point <m>P</m>,
           and <m>t=1</m> corresponds to the point <m>Q</m>.
-          This relates to the understanding of the vector equation of a line described in <xref ref="fig_lines_eq">Figure</xref>.
+          This relates to the understanding of the vector equation of a line described in <xref ref="fig_lines_eq"/>.
           The parametric equations <q>start</q> at the point <m>P</m>,
           and <m>t</m> determines how far in the direction of <m>\overrightarrow{PQ}</m> to travel.
           When <m>t=0</m>, we travel 0 lengths of <m>\overrightarrow{PQ}</m>;
@@ -548,12 +548,12 @@
           It should be clear that <m>\vec d_1</m> and <m>\vec d_2</m> are not parallel,
           hence <m>\ell_1</m> and <m>\ell_2</m> are not the same line,
           nor are they parallel.
-          <xref ref="fig_lines2">Figure</xref> verifies this fact
+          <xref ref="fig_lines2"/> verifies this fact
           (where the points and directions indicated by the equations of each line are identified).
         </p>
 
         <figure xml:id="fig_lines2">
-          <caption>Sketching the lines from <xref ref="ex_lines2">Example</xref></caption>
+          <caption>Sketching the lines from <xref ref="ex_lines2"/></caption>
 
           <!-- START figures/figlines2_3D.asy -->
           <image xml:id="img_lines2" width="47%">
@@ -729,7 +729,7 @@
         </p>
 
         <figure xml:id="fig_lines3">
-          <caption>Graphing the lines in <xref ref="ex_lines3">Example</xref></caption>
+          <caption>Graphing the lines in <xref ref="ex_lines3"/></caption>
 
           <!-- START figures/figlines3_3D.asy -->
           <image xml:id="img_lines3" width="47%">
@@ -791,7 +791,7 @@
           The point <m>P_1</m> lies on both lines,
           so we conclude they are the same line,
           just parametrized differently.
-          <xref ref="fig_lines3">Figure</xref>
+          <xref ref="fig_lines3"/>
           graphs this line along with the points and vectors described by the parametric equations.
           Note how <m>\vec d_1</m> and <m>\vec d_2</m> are parallel,
           though point in opposite directions
@@ -809,7 +809,7 @@
       (Here we use the standard definition of <q>distance,</q>
       <ie/>, the length of the shortest line segment from the point to the line.)
       Identifying <m>\vec p</m> with the point <m>P</m>,
-      <xref ref="fig_lines_dist1">Figure</xref>
+      <xref ref="fig_lines_dist1"/>
       will help establish a general method of computing this distance <m>h</m>.
     </p>
 
@@ -859,7 +859,7 @@
       which we define as the length of the shortest line segment that connects the two lines
       (an argument from geometry shows that this line segments is perpendicular to both lines).
       Let lines <m>\vec\ell_1(t) = \vec p_1 + t\vec d_1</m> and <m>\vec\ell_2(t) = \vec p_2 + t\vec d_2</m> be given,
-      as shown in <xref ref="fig_lines_dist2">Figure</xref>.
+      as shown in <xref ref="fig_lines_dist2"/>.
       To find the direction orthogonal to both <m>\vec d_1</m> and <m>\vec d_2</m>,
       we take the cross product:
       <m>\vec c = \vec d_1\times \vec d_2</m>.
@@ -1035,7 +1035,7 @@
           <m>P=(1,-1,1)</m> that lies on the line,
           hence <m>\overrightarrow{PQ} = \la 0,2,2\ra</m>.
           The equation also gives <m>\vec d= \la 2,3,1\ra</m>.
-          Following <xref ref="idea_line_distance">Key Idea</xref>,
+          Following <xref ref="idea_line_distance"/>,
           we have the distance as
           <md>
             <mrow>h \amp = \frac{\norm{\overrightarrow{PQ}\times \vec d}}{\vnorm{d}}</mrow>
@@ -1067,7 +1067,7 @@
       </solution>
       <solution>
         <p>
-          These are the sames lines as given in <xref ref="ex_lines2">Example</xref>,
+          These are the sames lines as given in <xref ref="ex_lines2"/>,
           where we showed them to be skew.
           The equations allow us to identify the following points and vectors:
           <me>
@@ -1079,7 +1079,7 @@
         </p>
 
         <p>
-          From <xref ref="idea_line_distance">Key Idea</xref>
+          From <xref ref="idea_line_distance"/>
           we have the distance <m>h</m> between the two lines is
           <md>
             <mrow>h \amp = \frac{\abs{\overrightarrow{P_1P_2}\cdot \vec c}}{\vnorm c}</mrow>
@@ -2365,7 +2365,7 @@
 
         <introduction>
           <p>
-            The following exercises explore special cases of the distance formulas found in <xref ref="idea_line_distance">Key Idea</xref>.
+            The following exercises explore special cases of the distance formulas found in <xref ref="idea_line_distance"/>.
           </p>
         </introduction>
 
@@ -2403,7 +2403,7 @@
               </statement>
               <solution>
                 <p>
-                  (Note: this solution is easier once one has studied <xref ref="sec_planes">Section</xref>.) Since the two lines intersect,
+                  (Note: this solution is easier once one has studied <xref ref="sec_planes"/>.) Since the two lines intersect,
                   we can state <m>P_2= P_1 + a\vec d_1+b\vec d_2</m> for some scalars <m>a</m> and <m>b</m>.
                   (Here we abuse notation slightly and add points to vectors.)
                   Thus <m>\overrightarrow{P_1P_2} = a\vec d_1+b\vec d_2</m>.

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -110,7 +110,7 @@
 
     <p>
       In many ways, this is <em>not</em> a new concept.
-      Compare Equation <xref ref="eq_lines1"/> to the familiar
+      Compare <xref ref="eq_lines1">Equation</xref> to the familiar
       <q><m>y=mx+b</m></q> equation of a line:
     </p>
 
@@ -149,7 +149,7 @@
     </p>
 
     <p>
-      Equation <xref ref="eq_lines1"/> is an example of a
+      <xref ref="eq_lines1">Equation</xref> is an example of a
       <em>vector-valued function</em>;
       the input of the function is a real number and the output is a vector.
       We will cover vector-valued functions extensively in the next chapter.

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -21,7 +21,7 @@
     </p>
 
     <p>
-      Consider <xref ref="fig_mchain_intro">Figure</xref>
+      Consider <xref ref="fig_mchain_intro"/>
       in which a surface <m>z=f(x,y)</m> is drawn,
       along with a dashed curve in the <m>xy</m>-plane.
       Restricting <m>f</m> to just the points on this circle gives the curve shown on the surface (<ie/>,
@@ -133,7 +133,7 @@
     </theorem>
 
     <p>
-      The Chain Rule of <xref ref="sec_chainrule">Section</xref>
+      The Chain Rule of <xref ref="sec_chainrule"/>
       states that
       <me>
         \frac{d}{dx}\Big(f\big(g(x)\big)\Big) = \fp\big(g(x)\big)g'(x)
@@ -143,7 +143,7 @@
         \frac{df}{dx} = \frac{df}{dt}\frac{dt}{dx};
       </me>
       recall that the derivative notation is deliberately chosen to reflect their fraction-like properties.
-      A similar effect is seen in <xref ref="thm_multi_chain">Theorem</xref>.
+      A similar effect is seen in <xref ref="thm_multi_chain"/>.
       In the second line of equations,
       one can think of the <m>dx</m> and <m>\partial x</m> as
       <q>sort of</q> canceling out,
@@ -152,7 +152,7 @@
 
     <p>
       Notice, too,
-      the third line of equations in <xref ref="thm_multi_chain">Theorem</xref>.
+      the third line of equations in <xref ref="thm_multi_chain"/>.
       The vector <m>\langle\,f_x,f_y\rangle</m> contains information about the surface (terrain);
       the vector <m>\langle x',y'\rangle</m> can represent velocity.
       In the context measuring the rate of elevation change of the off-road vehicle,
@@ -178,7 +178,7 @@
       </statement>
       <solution>
         <p>
-          Following <xref ref="thm_multi_chain">Theorem</xref>, we find
+          Following <xref ref="thm_multi_chain"/>, we find
           <me>
             f_x(x,y) = 2xy+1,\qquad f_y(x,y) = x^2,\qquad \frac{dx}{dt} = \cos(t) ,\qquad \frac{dy}{dt}= 5e^{5t}
           </me>.
@@ -310,7 +310,7 @@
         </p>
 
         <figure xml:id="fig_mchain2">
-          <caption>Plotting the path of a particle on a surface in <xref ref="ex_mchain2">Example</xref></caption>
+          <caption>Plotting the path of a particle on a surface in <xref ref="ex_mchain2"/></caption>
 
           <!-- START figures/figmchain2_3D.asy -->
           <image xml:id="img_mchain2" width="47%">
@@ -374,7 +374,7 @@
           When <m>t=0</m>, <m>x=1</m> and <m>y=0</m>.
           Thus <m>\ds\frac{dz}{dt} = -(2)(0)+ (-1)(1) = -1</m>.
           When <m>t=0</m>, the particle is moving down,
-          as shown in <xref ref="fig_mchain2">Figure</xref>.
+          as shown in <xref ref="fig_mchain2"/>.
         </p>
 
         <p>
@@ -393,7 +393,7 @@
           We can use the First Derivative Test to find that on <m>[0,2\pi]</m>,
           <m>z</m> has reaches its absolute minimum at <m>t=\pi/4</m> and <m>5\pi/4</m>;
           it reaches its absolute maximum at <m>t=3\pi/4</m> and <m>7\pi/4</m>,
-          as shown in <xref ref="fig_mchain2">Figure</xref>.
+          as shown in <xref ref="fig_mchain2"/>.
         </p>
       </solution>
     </example>
@@ -456,7 +456,7 @@
       </statement>
       <solution>
         <p>
-          Following <xref ref="thm_multi_chain2">Theorem</xref>,
+          Following <xref ref="thm_multi_chain2"/>,
           we compute the following partial derivatives:
           <me>
             \frac{\partial f}{\partial x} = 2xy+1\qquad\qquad \frac{\partial f}{\partial y} = x^2
@@ -497,7 +497,7 @@
       </statement>
       <solution>
         <p>
-          Following <xref ref="thm_multi_chain2">Theorem</xref>,
+          Following <xref ref="thm_multi_chain2"/>,
           we compute the following partial derivatives:
           <md>
             <mrow>\frac{\partial f}{\partial x} \amp = y \amp \frac{\partial f}{\partial y} \amp = x \amp \frac{\partial f}{\partial z} \amp = 2z</mrow>
@@ -524,7 +524,7 @@
     </example>
 
     <!-- <figure xml:id="vid-multi-chain-general" component="video">
-      <caption>Illustrating the chain rule, and interpreting as matrix multiplication (see <xref ref="sec_deriv_matrix">Section</xref>)</caption>
+      <caption>Illustrating the chain rule, and interpreting as matrix multiplication (see <xref ref="sec_deriv_matrix"/>)</caption>
       <video youtube="7jtaSujep7g" label="vid-multi-chain-general"/>
     </figure> -->
   </subsection>
@@ -532,7 +532,7 @@
   <subsection xml:id="subsec-implicit-diff">
     <title>Implicit Differentiation</title>
     <p>
-      We studied finding <m>\frac{dy}{dx}</m> when <m>y</m> is given as an implicit function of <m>x</m> in detail in <xref ref="sec_imp_deriv">Section</xref>.
+      We studied finding <m>\frac{dy}{dx}</m> when <m>y</m> is given as an implicit function of <m>x</m> in detail in <xref ref="sec_imp_deriv"/>.
       We find here that the Multivariable Chain Rule gives a simpler method of finding <m>\frac{dy}{dx}</m>.
     </p>
 
@@ -598,8 +598,8 @@
     </theorem>
 
     <p>
-      We practice using <xref ref="thm_implicit_deriv_chain">Theorem</xref>
-      by applying it to a problem from <xref ref="sec_imp_deriv">Section</xref>.
+      We practice using <xref ref="thm_implicit_deriv_chain"/>
+      by applying it to a problem from <xref ref="sec_imp_deriv"/>.
     </p>
 
     <example xml:id="ex_mchain5">
@@ -608,8 +608,8 @@
         <p>
           Given the implicitly defined function <m>\sin(x^2y^2)+y^3=x+y</m>,
           find <m>y'</m>.
-          Note: this is the same problem as given in <xref ref="ex_implicit5">Example</xref>
-          of <xref ref="sec_imp_deriv">Section</xref>,
+          Note: this is the same problem as given in <xref ref="ex_implicit5"/>
+          of <xref ref="sec_imp_deriv"/>,
           where the solution took about a full page to find.
         </p>
       </statement>
@@ -617,7 +617,7 @@
         <p>
           Let <m>f(x,y) = \sin(x^2y^2)+y^3-x-y</m>;
           the implicitly defined function above is equivalent to <m>f(x,y)=0</m>.
-          We find <m>\frac{dy}{dx}</m> by applying <xref ref="thm_implicit_deriv_chain">Theorem</xref>.
+          We find <m>\frac{dy}{dx}</m> by applying <xref ref="thm_implicit_deriv_chain"/>.
           We find
           <md>
             <mrow>f_x(x,y) \amp = 2xy^2\cos(x^2y^2)-1</mrow>
@@ -627,7 +627,7 @@
           <me>
             \frac{dy}{dx} = -\frac{2xy^2\cos(x^2y^2)-1}{2x^2y\cos(x^2y^2)+3y^2-1}
           </me>,
-          which matches our solution from <xref ref="ex_implicit5">Example</xref>.
+          which matches our solution from <xref ref="ex_implicit5"/>.
         </p>
       </solution>
     </example>
@@ -753,7 +753,7 @@
     </example>
 
     <p>
-      In <xref ref="sec_partial_derivatives">Section</xref>
+      In <xref ref="sec_partial_derivatives"/>
       we learned how partial derivatives give certain instantaneous rate of change information about a function <m>f(x,y)</m>.
       In that section,
       we measured the rate of change of <m>f</m> by holding one variable constant and letting the other vary
@@ -764,7 +764,7 @@
     <p>
       What if we want to move in a direction that is not parallel to a coordinate axis?
       Can we still measure instantaneous rates of change?
-      Yes; we find out how in <xref ref="sec_directional_derivative">Section</xref>.
+      Yes; we find out how in <xref ref="sec_directional_derivative"/>.
       In doing so,
       we'll see how the Multivariable Chain Rule informs our understanding of these
       <em>directional derivatives</em>.
@@ -1137,7 +1137,7 @@
             In the following exercises,
             functions <m>z=f(x,y)</m>, <m>x=g(t)</m> and <m>y=h(t)</m> are given.
             Find the values of <m>t</m> where <m>\frac{dz}{dt}=0</m>.
-            Note: these are the same surfaces/curves as found in <xref first="x12_08_ex_07" last="x12_08_ex_08">Exercises</xref>.
+            Note: these are the same surfaces/curves as found in <xref first="x12_08_ex_07" last="x12_08_ex_08" text="local">Exercises</xref>.
           </p>
         </introduction>
 
@@ -1630,7 +1630,7 @@
         <introduction>
           <p>
             The given equation defines <m>y</m> implicitly as a function of <m>x</m>.
-            Find <m>\lz{y}{x}</m> using Implicit Differentiation and <xref ref="thm_implicit_deriv_chain">Theorem</xref>.
+            Find <m>\lz{y}{x}</m> using Implicit Differentiation and <xref ref="thm_implicit_deriv_chain"/>.
           </p>
         </introduction>
 

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -562,7 +562,7 @@
       (in our example, <m>z=3</m>),
       <m>\frac{dz}{dx} = 0</m>.
       We also know <m>\frac{dx}{dx} = 1</m>.
-      Equation <xref ref="eq_mchain1"/> becomes
+      <xref ref="eq_mchain1">Equation</xref> becomes
       <mdn>
         <mrow number="no">0 \amp = \frac{\partial z}{\partial x}(1) + \frac{\partial z}{\partial y}\frac{dy}{dx}  \Rightarrow</mrow>
         <mrow number="no">\frac{dy}{dx} \amp = -\frac{\partial z}{\partial x}\Big/\frac{\partial z}{\partial y}</mrow>
@@ -571,7 +571,7 @@
     </p>
 
     <p>
-      Note how our solution for <m>\frac{dy}{dx}</m> in Equation <xref ref="eq_mchain2"/> is just the partial derivative of <m>z</m> with respect to <m>x</m>,
+      Note how our solution for <m>\frac{dy}{dx}</m> in <xref ref="eq_mchain2">Equation</xref> is just the partial derivative of <m>z</m> with respect to <m>x</m>,
       divided by the partial derivative of <m>z</m> with respect to <m>y</m>,
       all multiplied by <m>(-1)</m>.
     </p>
@@ -709,7 +709,7 @@
           We will use the first method for the <m>x</m> derivative, and the second for <m>y</m>.
         </p>
         <p>
-          We first take the partial derivative of both sides of <xref ref="eqn-implicit-three"/> with respect to <m>x</m>:
+          We first take the partial derivative of both sides of <xref ref="eqn-implicit-three">Equation</xref> with respect to <m>x</m>:
           <md>
             <mrow>\frac{\partial}{\partial x}(x^2yz^3-\sin(x-3z)+4xy^2-3yz) \amp = 0</mrow>
             <mrow>2xyz^3 + x^2y(3z^2)\plz{z}{x}-\cos(x-3z)\left(1-3\plz{z}{x}\right)+4y^2-3y\plz{z}{x} \amp = 0</mrow>

--- a/ptx/sec_multi_derivative_matrix.ptx
+++ b/ptx/sec_multi_derivative_matrix.ptx
@@ -4,8 +4,8 @@
   <introduction>
     <p>
       We defined what it means for a real-valued function of two variables to be
-      <em>differentiable</em> in Definition <xref ref="def_multi_differentiability">Definition</xref>
-      in <xref ref="sec_total_differential">Section</xref>.
+      <em>differentiable</em> in Definition <xref ref="def_multi_differentiability"/>
+      in <xref ref="sec_total_differential"/>.
     </p>
 
     <p>
@@ -32,7 +32,7 @@
 
     <p>
       One might be tempted at first to simply mimic the definition of the derivative from
-      <xref ref="chapter_derivatives">Chapter</xref>, but we quickly run into trouble,
+      <xref ref="chapter_derivatives"/>, but we quickly run into trouble,
       for a reason that is immediately obvious.
     </p>
 
@@ -62,7 +62,7 @@
       Indeed, if <m>\vec{h} = h\vec{i}</m> or <m>h\vec{j}</m>, we get a partial derivative,
       and for any unit vector <m>\vec{u}</m>, setting <m>\vec{h}=h\vec{u}</m>
       gives us a directional derivative, and we know from
-      <xref ref="sec_directional_derivative">Section</xref>
+      <xref ref="sec_directional_derivative"/>
       that a directional derivative depends on <m>\vec{u}</m>.
       It seems this approach is doomed to failure. What can we try instead?
     </p>
@@ -77,7 +77,7 @@
     <title>The Definition of the Derivative</title>
     <p>
       The key to generalizing the definition of the derivative given in
-      <xref ref="def_derivative_at_a_point">Definition</xref> in <xref ref="chapter_derivatives">Chapter</xref>
+      <xref ref="def_derivative_at_a_point"/> in <xref ref="chapter_derivatives"/>
        is remembering the following essential property of the derivative:
        the derivative <m>\fp(a)</m> is used to compute the <em>best linear approximation</em> to <m>f</m> at <m>a</m>.
        Indeed, the <em>linearization</em> of <m>f</m> at <m>a</m> is the linear function
@@ -158,7 +158,7 @@
         To avoid confusion between the meaning of <em>linear function</em> in Calculus,
         and <em>linear transformation</em> in Linear Algebra,
         we will use <m>\ell</m> to denote the former, and <m>T</m> to denote the latter.
-        Notice that if <m>\vec{b}=\vec{0}</m> in <xref ref="def_gen_linear">Definition</xref>,
+        Notice that if <m>\vec{b}=\vec{0}</m> in <xref ref="def_gen_linear"/>,
         then a linear function <em>is</em> a linear transformation.
       </p>
     </aside>
@@ -211,8 +211,8 @@
     <p>
       This definition is going to take a lot of unpacking.
       First of all, what is this function <m>\ell</m>? How do we compute it?
-      Does this definition include <xref ref="def_multi_differentiability">Definition</xref>
-      from <xref ref="sec_total_differential">Section</xref> as a special case?
+      Does this definition include <xref ref="def_multi_differentiability"/>
+      from <xref ref="sec_total_differential"/> as a special case?
       What about differentiability for vector-valued functions of one variable,
       or real-valued functions of one variable?
     </p>
@@ -254,7 +254,7 @@
     </p>
 
     <p>
-      In <xref ref="sec_total_differential">Section</xref>,
+      In <xref ref="sec_total_differential"/>,
       we saw that differentiability means that the difference
       <m>\ddz = f(x+dx,y+dy) - f(x,y)</m> can be approximated by the differential
       <m>dz = f_x(x,y)\,dx+f_y(x,y)\,dy</m>.
@@ -327,7 +327,7 @@
     </aside>
 
     <p>
-      For real-valued functions, <xref ref="def_general_differentiability">Definition</xref> becomes the following:
+      For real-valued functions, <xref ref="def_general_differentiability"/> becomes the following:
     </p>
 
     <definition xml:id="def_real_differentiability">
@@ -434,8 +434,8 @@
     </aside>
 
     <p>
-      Let's return to <m>n=2</m> and <xref ref="def_multi_differentiability">Definition</xref>
-      from <xref ref="sec_total_differential">Section</xref>.
+      Let's return to <m>n=2</m> and <xref ref="def_multi_differentiability"/>
+      from <xref ref="sec_total_differential"/>.
       If we write <m>\vec{h} = \langle dx, dy\rangle</m>,
       then <m>f(\vec{a}+\vec{h})-f(\vec{a}) = \ddz</m>, and <m>\nabla f(\vec{a})\cdot \vec{h} = dz</m>,
       and Equation <xref ref="eq_deriv_with_h"/> becomes
@@ -443,19 +443,19 @@
         \lim_{\vec{h}\to\vec{0}}\frac{\lvert \ddz-dz\rvert}{\norm{\vec{h}}} = \lim_{\vec{h}\to\vec{0}}\frac{\lvert E_x\,dx+E_y\,dz\rvert}{\norm{\langle dx,dy\rangle}} = 0
       </me>,
       which is another way of saying that the error terms <m>E_x,E_y</m> must vanish as <m>dx</m> and <m>dy</m> approach zero.
-      Success! <xref ref="def_general_differentiability">Definition</xref>
-      is indeed a generalization of <xref ref="def_multi_differentiability">Definition</xref>.
+      Success! <xref ref="def_general_differentiability"/>
+      is indeed a generalization of <xref ref="def_multi_differentiability"/>.
     </p>
 
     <p>
-      Note that we've also generalized <xref ref="def_derivative_at_a_point">Definition</xref>
+      Note that we've also generalized <xref ref="def_derivative_at_a_point"/>
       for functions of one variable as well: Equation <xref ref="eq_deriv_with_h"/> becomes
       <me>
         \lim_{h\to 0}\left\lvert \frac{f(a+h)-f(a)}{h}-f'(a)\right\rvert = 0
       </me>,
       which is just another way of re-writing the usual definition of the derivative.
-      In fact, we've also generalized <xref ref="def_vvf_derivative">Definition</xref>
-      from <xref ref="chap_vvf">Chapter</xref> for differentiability of vector-valued functions:
+      In fact, we've also generalized <xref ref="def_vvf_derivative"/>
+      from <xref ref="chap_vvf"/> for differentiability of vector-valued functions:
       all we have to do is write our vector-valued function as a column matrix.
     </p>
 
@@ -521,7 +521,7 @@
   <subsection xml:id="subsec-deriv-matrix">
     <title>Vector-valued functions of several variables</title>
     <p>
-      Let us now consider <xref ref="def_general_differentiability">Definition</xref>
+      Let us now consider <xref ref="def_general_differentiability"/>
       for general functions <m>f:D\subseteq \mathbb{R}^n\to \mathbb{R}^m</m>.
       If <m>f</m> is differentiable at <m>\vec{a}</m>, then we must have
       <me>
@@ -583,7 +583,7 @@
          \lim_{t\to 0}\left\lvert\frac{f(a_1+t,a_2,\ldots, a_n)-f(a_1,a_2,\ldots, a_n)}{t} - \langle c_{11}, c_{21}, \ldots, c_{m1}\rangle\right\rvert = 0
       </me>.
       Since <m>\langle c_{11}, c_{21}, \ldots, c_{m1}\rangle</m> is a constant vector,
-      from differentiability of <m>f</m>, together with <xref ref="def_general_differentiability">Definition</xref>, we get
+      from differentiability of <m>f</m>, together with <xref ref="def_general_differentiability"/>, we get
       <me>
         \lim_{t\to 0}\frac{f(a_1+t,a_2,\ldots, a_n)-f(a_1,a_2,\ldots, a_n)}{t} = \langle c_{11}, c_{21}, \ldots, c_{m1}\rangle
       </me>.
@@ -646,7 +646,7 @@
       This definition also accounts for parametric curves, viewed as vector-valued functions of one variable.
       If <m>\mathbf{r}:\mathbb{R}\to \mathbb{R}^n</m> defines a parametric curve,
       then the derivative <m>\mathbf{r}'(t) = \begin{bmatrix}x_1'(t)\\x_2'(t)\\\vdots \\x_n'(t)\end{bmatrix}</m>
-      as introduced in <xref ref="chap_vvf">Chapter</xref> is the same as the one obtained using this definition.
+      as introduced in <xref ref="chap_vvf"/> is the same as the one obtained using this definition.
     </p>
   </subsection>
 
@@ -669,7 +669,7 @@
     </p>
 
     <p>
-      In <xref ref="sec_multi_chain">Section</xref> we saw that in several variables,
+      In <xref ref="sec_multi_chain"/> we saw that in several variables,
       the Chain Rule comes in various flavours, depending on the number of variables involved in each function being composed.
       If we think of derivatives in terms of the Jacobian matrix,
       then each of these flavours says exactly the same thing as the original Chain Rule above!
@@ -704,14 +704,14 @@
         <p>
           Let <m>f:U\subseteq \mathbb{R}^3\to\mathbb{R}</m> be a differentiable function of three variables,
           and let <m>\vec{r}(t) = \la x(t),y(t),z(t)\ra</m> be a vector-valued function of one variable.
-          Use <xref ref="thm_gen_gen_chain">Theorem</xref> to determine a formula for the derivative of
+          Use <xref ref="thm_gen_gen_chain"/> to determine a formula for the derivative of
           <m>h(t) = f(\vec{r}(t))</m>.
         </p>
       </statement>
       <solution>
         <p>
-          We already know what this derivative should look like from <xref ref="sec_multi_chain">Section</xref>.
-          The point is to confirm that this is a special case of <xref ref="thm_gen_gen_chain">Theorem</xref>.
+          We already know what this derivative should look like from <xref ref="sec_multi_chain"/>.
+          The point is to confirm that this is a special case of <xref ref="thm_gen_gen_chain"/>.
           The Jacobian matrix of <m>f</m> is a <m>1\times 3</m> matrix and Jacobian matrix of
           <m>\vec{r}</m> is a <m>3\times 1</m> matrix. They are given, respectively, by
           <me>
@@ -722,7 +722,7 @@
         </p>
 
         <p>
-          <xref ref="thm_gen_gen_chain">Theorem</xref> then gives us
+          <xref ref="thm_gen_gen_chain"/> then gives us
           <me>
             h'(t) = Df(\vec{r}(t))D\vec{r}(t) = f_x(\vec{r(t)})x'(t)+f_y(\vec{r(t)})y'(t)+f_z(\vec{r(t)})z'(t)
           </me>,
@@ -743,7 +743,7 @@
           <me>
             g(u,v)=(x(u,v),y(u,v))
           </me>.
-          Given <m>h = f\circ g</m>, use <xref ref="thm_gen_gen_chain">Theorem</xref>
+          Given <m>h = f\circ g</m>, use <xref ref="thm_gen_gen_chain"/>
           to determine <m>h_u</m> and <m>h_v</m>.
         </p>
       </statement>
@@ -766,7 +766,7 @@
             <mrow>\frac{\partial h}{\partial u} \amp = \frac{\partial f}{\partial x}\frac{\partial x}{\partial u}+\frac{\partial f}{\partial y}\frac{\partial y}{\partial u}</mrow>
             <mrow>\frac{\partial h}{\partial v} \amp = \frac{\partial f}{\partial x}\frac{\partial x}{\partial v}+\frac{\partial f}{\partial y}\frac{\partial y}{\partial v}</mrow>
           </md>.
-          Again, this reproduces another instance of the Chain Rule from <xref ref="sec_multi_chain">Section</xref>.
+          Again, this reproduces another instance of the Chain Rule from <xref ref="sec_multi_chain"/>.
         </p>
       </solution>
     </example>
@@ -774,7 +774,7 @@
     <p>
       With additional experimentation, you will find that every instance of the
       Chain Rule you have previously encountered can be interpreted as a special case of
-      <xref ref="thm_gen_gen_chain">Theorem</xref>.
+      <xref ref="thm_gen_gen_chain"/>.
       Moreover, a slight shift in interpretation makes this version of the Chain Rule even more obvious!
       (There's another detour coming, but stick with us.)
     </p>
@@ -905,8 +905,8 @@
       This turns out to be an extremely powerful way of looking at derivatives and the Chain Rule.
       You may want to keep this in mind in later sections,
       such as when we consider change of variables in multiple integrals at the end of
-      <xref ref="chapter_mult_int">Chapter</xref>,
-      and when we define integrals over curves and surfaces in <xref ref="chapter_vector_calc">Chapter</xref>.
+      <xref ref="chapter_mult_int"/>,
+      and when we define integrals over curves and surfaces in <xref ref="chapter_vector_calc"/>.
       We won't use this language when we get there, but many of the results in those sections
       (for example, the formula for surface area of a parametric surface)
       can be understood according to the two principles we have just seen:

--- a/ptx/sec_multi_derivative_matrix.ptx
+++ b/ptx/sec_multi_derivative_matrix.ptx
@@ -235,7 +235,7 @@
     <p>
       This should ring some bells:
       the form of <m>\ell</m> is very similar to that of the linearization given for a function of one variable in
-      <xref ref="eq_linearization"/> above,
+      <xref ref="eq_linearization">Equation</xref> above,
       with the matrix <m>M</m> playing the role of <m>\fp(a)</m>.
       Perhaps this matrix is the derivative we seek?
     </p>
@@ -312,7 +312,7 @@
     </p>
 
     <p>
-      Compare this with Equation <xref ref="eq_gen_linear"/> above.
+      Compare this with <xref ref="eq_gen_linear">Equation</xref> above.
       It seems that the gradient <m>\nabla f (\vec{a})</m> is our matrix <m>M</m> in this case:
       for a real-valued function, <m>m=1</m>, so we expect a <m>1\times n</m> row matrix,
       and the gradient certainly can be interpreted to fit that description.
@@ -438,7 +438,7 @@
       from <xref ref="sec_total_differential"/>.
       If we write <m>\vec{h} = \langle dx, dy\rangle</m>,
       then <m>f(\vec{a}+\vec{h})-f(\vec{a}) = \ddz</m>, and <m>\nabla f(\vec{a})\cdot \vec{h} = dz</m>,
-      and Equation <xref ref="eq_deriv_with_h"/> becomes
+      and <xref ref="eq_deriv_with_h">Equation</xref> becomes
       <me>
         \lim_{\vec{h}\to\vec{0}}\frac{\lvert \ddz-dz\rvert}{\norm{\vec{h}}} = \lim_{\vec{h}\to\vec{0}}\frac{\lvert E_x\,dx+E_y\,dz\rvert}{\norm{\langle dx,dy\rangle}} = 0
       </me>,
@@ -449,7 +449,7 @@
 
     <p>
       Note that we've also generalized <xref ref="def_derivative_at_a_point"/>
-      for functions of one variable as well: Equation <xref ref="eq_deriv_with_h"/> becomes
+      for functions of one variable as well: <xref ref="eq_deriv_with_h">Equation</xref> becomes
       <me>
         \lim_{h\to 0}\left\lvert \frac{f(a+h)-f(a)}{h}-f'(a)\right\rvert = 0
       </me>,
@@ -533,7 +533,7 @@
     </p>
 
     <p>
-      We saw in Equation <xref ref="eq_gen_linear"/> above that <m>T</m> must have the form of a linear approximation:
+      We saw in <xref ref="eq_gen_linear">Equation</xref> above that <m>T</m> must have the form of a linear approximation:
       <me>
         \ell(\vec{x})=L_{\vec{a}}(\vec{x}) = f(\vec{a})+M\cdot (\vec{x}-\vec{a})
       </me>.

--- a/ptx/sec_multi_extreme_values.ptx
+++ b/ptx/sec_multi_extreme_values.ptx
@@ -66,7 +66,7 @@
     <p>
       If <m>f</m> has a relative or absolute maximum at <m>(x_0,y_0)</m>,
       it means every curve on the graph of <m>f</m> through <m>(x_0,y_0,f(x_0,y_0))</m> will also have a relative or absolute maximum at <m>P</m>.
-      Recalling what we learned in <xref ref="sec_extreme_values">Section</xref>,
+      Recalling what we learned in <xref ref="sec_extreme_values"/>,
       the slopes of the tangent lines to these curves at <m>P</m> must be 0 or undefined.
       Since directional derivatives are computed using <m>f_x</m> and <m>f_y</m>,
       we are led to the following definition and theorem.
@@ -154,7 +154,7 @@
         </p>
 
         <figure xml:id="fig_multi_extreme1">
-          <caption>The surface in <xref ref="ex_multi_extreme1">Example</xref> with its absolute minimum indicated</caption>
+          <caption>The surface in <xref ref="ex_multi_extreme1"/> with its absolute minimum indicated</caption>
 
           <!-- START figures/figmulti_extreme1_3D.asy -->
           <image xml:id="img_multi_extreme1" width="47%">
@@ -205,7 +205,7 @@
         </figure>
 
         <p>
-          The graph in <xref ref="fig_multi_extreme1">Figure</xref>
+          The graph in <xref ref="fig_multi_extreme1"/>
           shows <m>f</m> along with this critical point.
           It is clear from the graph that this is a relative minimum;
           further consideration of the function shows that this is actually the absolute minimum.
@@ -240,7 +240,7 @@
         </p>
 
         <figure xml:id="fig_multi_extreme2">
-          <caption>The surface in <xref ref="ex_multi_extreme2">Example</xref> with its absolute maximum indicated</caption>
+          <caption>The surface in <xref ref="ex_multi_extreme2"/> with its absolute maximum indicated</caption>
 
           <!-- START figures/figmulti_extreme2_3D.asy -->
           <image xml:id="img_multi_extreme2" width="47%">
@@ -291,7 +291,7 @@
         </figure>
 
         <p>
-          The graph of <m>f</m> is plotted in <xref ref="fig_multi_extreme2">Figure</xref>
+          The graph of <m>f</m> is plotted in <xref ref="fig_multi_extreme2"/>
           along with the point <m>(0,0,2)</m>.
           The graph shows that this point is the absolute maximum of <m>f</m>.
         </p>
@@ -337,11 +337,11 @@
           We have two critical points:
           <m>(-1,2)</m> and <m>(1,2)</m>.
           To determine if they correspond to a relative maximum or minimum,
-          we consider the graph of <m>f</m> in <xref ref="fig_multi_extreme3">Figure</xref>.
+          we consider the graph of <m>f</m> in <xref ref="fig_multi_extreme3"/>.
         </p>
 
         <figure xml:id="fig_multi_extreme3">
-          <caption>The surface in <xref ref="ex_multi_extreme3">Example</xref> with both critical points marked</caption>
+          <caption>The surface in <xref ref="ex_multi_extreme3"/> with both critical points marked</caption>
 
           <!-- START figures/figmulti_extreme3_3D.asy -->
           <image xml:id="img_multi_extreme3" width="47%">
@@ -431,7 +431,7 @@
     </p>
 
     <p>
-      Before <xref ref="ex_multi_extreme3">Example</xref>
+      Before <xref ref="ex_multi_extreme3"/>
       we mentioned the need for a test to differentiate between relative maxima and minima.
       We now recognize that our test also needs to account for saddle points.
       To do so, we consider the second partial derivatives of <m>f</m>.
@@ -483,7 +483,7 @@
     <p>
       To account for this, consider <m>D = f_{xx}f_{yy}-f_{xy}f_{yx}</m>.
       Since <m>f_{xy}</m> and <m>f_{yx}</m> are equal when continuous
-      (refer back to <xref ref="thm_mixed_partial">Theorem</xref>),
+      (refer back to <xref ref="thm_mixed_partial"/>),
       we can rewrite this as <m>D = f_{xx}f_{yy}-f_{xy}^{\,2}</m>.
       <m>D</m> can be used to test whether the concavity at a point changes depending on direction.
       If <m>D \gt 0</m>,
@@ -557,7 +557,7 @@
       <title>Using the Second Derivative Test</title>
       <statement>
         <p>
-          Let <m>f(x,y) = x^3-3x-y^2+4y</m> as in <xref ref="ex_multi_extreme3">Example</xref>.
+          Let <m>f(x,y) = x^3-3x-y^2+4y</m> as in <xref ref="ex_multi_extreme3"/>.
           Determine whether the function has a relative minimum, maximum,
           or saddle point at each critical point.
         </p>
@@ -678,7 +678,7 @@
         </p>
 
         <figure xml:id="fig_multi_extreme5">
-          <caption>Graphing <m>f</m> from <xref ref="ex_multi_extreme5">Example</xref> and its relative extrema</caption>
+          <caption>Graphing <m>f</m> from <xref ref="ex_multi_extreme5"/> and its relative extrema</caption>
 
           <!-- START figures/figmulti_extreme5_3D.asy -->
           <image xml:id="img_multi_extreme5" width="47%">
@@ -729,7 +729,7 @@
         </figure>
 
         <p>
-          <xref ref="fig_multi_extreme5">Figure</xref>
+          <xref ref="fig_multi_extreme5"/>
           shows a graph of <m>f</m> and the three critical points.
           Note how this function does not vary much near the critical points <mdash/> that is,
           visually it is difficult to determine whether a point is a saddle point or relative minimum
@@ -749,7 +749,7 @@
     <title>Constrained Optimization</title>
     <p>
       When optimizing functions of one variable such as <m>y=f(x)</m>,
-      we made use of <xref ref="thm_extreme_val">Theorem</xref>,
+      we made use of <xref ref="thm_extreme_val"/>,
       the Extreme Value Theorem, that said that over a closed interval <m>I=[a,b]</m>,
       a continuous function has both a maximum and minimum value.
       To find these maximum and minimum values,
@@ -793,14 +793,14 @@
       <solution>
         <p>
           It can help to see a graph of <m>f</m> along with the set <m>S</m>.
-          In <xref ref="fig_conopt1a_3D">Figure</xref> the triangle defining <m>S</m> is shown in the <m>xy</m>-plane in a dashed line.
+          In <xref ref="fig_conopt1a_3D"/> the triangle defining <m>S</m> is shown in the <m>xy</m>-plane in a dashed line.
           Above it is the graph of <m>f</m>;
           we are only concerned with the portion of the surface <m>z=f(x,y)</m> enclosed by the
           <q>triangle</q>.
         </p>
 
         <figure xml:id="fig_conopt1">
-          <caption>Plotting the graph of <m>f</m> along with the restricted domain <m>S</m> in <xref ref="ex_conopt1">Example</xref></caption>
+          <caption>Plotting the graph of <m>f</m> along with the restricted domain <m>S</m> in <xref ref="ex_conopt1"/></caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
             <figure xml:id="fig_conopt1a_3D">
               <caption/>
@@ -906,7 +906,7 @@
         <p>
           We now find the maximum and minimum values that <m>f</m> attains along the boundary of <m>S</m>, that is,
           along the edges of the triangle.
-          In <xref ref="fig_conopt1b">Figure</xref> we see the triangle sketched in the plane with the equations of the lines forming its edges labeled.
+          In <xref ref="fig_conopt1b"/> we see the triangle sketched in the plane with the equations of the lines forming its edges labeled.
         </p>
 
         <p>
@@ -1002,7 +1002,7 @@
         </p>
 
         <figure xml:id="fig_conopt1bX">
-          <caption>The graph of <m>f</m> along with important points along the boundary of <m>S</m> and the interior  in <xref ref="ex_conopt1">Example</xref></caption>
+          <caption>The graph of <m>f</m> along with important points along the boundary of <m>S</m> and the interior  in <xref ref="ex_conopt1"/></caption>
           <!-- START figures/figconopt1c_3D.asy -->
           <image xml:id="img_conopt1bX" width="47%">
             <description></description>
@@ -1068,7 +1068,7 @@
 
         <p>
           We have evaluated <m>f</m> at a total of 7 different places,
-          all shown in <xref ref="fig_conopt1b">Figure</xref>.
+          all shown in <xref ref="fig_conopt1b"/>.
           We checked each vertex of the triangle twice,
           as each showed up as the endpoint of an interval twice.
           Of all the <m>z</m>-values found,
@@ -1230,7 +1230,7 @@
         </figure>
 
         <p>
-          The volume function <m>V(w,\ell)</m> is shown in <xref ref="fig_conopt2">Figure</xref>
+          The volume function <m>V(w,\ell)</m> is shown in <xref ref="fig_conopt2"/>
           along with the constraint <m>\ell = 130-4w</m>.
           As done previously,
           the constraint is drawn dashed in the <m>xy</m>-plane and also along the graph of the function.
@@ -1271,7 +1271,7 @@
             <statement>
               <p>
                 True or False?
-                <xref ref="thm_multi_critical_point">Theorem</xref>
+                <xref ref="thm_multi_critical_point"/>
                 states that if <m>f</m> has a critical point at <m>P</m>,
                 then <m>f</m> has a relative extrema at <m>P</m>.
                 <var name="$false" form="popup"/>

--- a/ptx/sec_multi_intro.ptx
+++ b/ptx/sec_multi_intro.ptx
@@ -95,14 +95,14 @@
         </p>
 
         <p>
-          The above equation describes an ellipse and its interior as shown in <xref ref="fig_multi2">Figure</xref>.
+          The above equation describes an ellipse and its interior as shown in <xref ref="fig_multi2"/>.
           We can represent the domain <m>D</m> graphically with the figure;
           in set notation,
           we can write <m>D = \{(x,y)|\,\frac{x^2}9+\frac{y^2}4 \leq 1\}</m>.
         </p>
 
         <figure xml:id="fig_multi2">
-          <caption>Illustrating the domain of <m>f(x,y)</m> in <xref ref="ex_multi2">Example</xref></caption>
+          <caption>Illustrating the domain of <m>f(x,y)</m> in <xref ref="ex_multi2"/></caption>
           <!-- START figures/fig_multi2.tex -->
           <image xml:id="img_multi2" width="47%">
             <description></description>
@@ -256,11 +256,11 @@
 
     <p>
       One can begin sketching a graph by plotting points, but this has limitations.
-      Consider <xref ref="fig_multigraph_introa_3D">Figure</xref> where 25 points have been plotted of <m>f(x,y) = \frac1{x^2+y^2+1}</m>.
+      Consider <xref ref="fig_multigraph_introa_3D"/> where 25 points have been plotted of <m>f(x,y) = \frac1{x^2+y^2+1}</m>.
       More points have been plotted than one would reasonably want to do by hand,
       yet it is not clear at all what the graph of the function looks like.
       Technology allows us to plot lots of points,
-      connect adjacent points with lines and add shading to create a graph like <xref ref="fig_multigraph_introb_3D">Figure</xref> which does a far better job of illustrating the behavior of <m>f</m>.
+      connect adjacent points with lines and add shading to create a graph like <xref ref="fig_multigraph_introb_3D"/> which does a far better job of illustrating the behavior of <m>f</m>.
     </p>
 
     <p>
@@ -281,7 +281,7 @@
           <idx><h>level curves</h></idx>
           <idx><h>contour lines</h></idx>
       Topographical maps,
-      like the one shown in <xref ref="fig_topomap">Figure</xref>,
+      like the one shown in <xref ref="fig_topomap"/>,
       represent the surface of Earth by indicating points with the same elevation with <em>contour lines</em>.
       The elevations marked are equally spaced;
       in this example,
@@ -369,14 +369,14 @@
         </p>
 
         <p>
-          The level curves are shown in <xref ref="fig_levelcurves1a">Figure</xref>.
+          The level curves are shown in <xref ref="fig_levelcurves1a"/>.
           Note how the level curves for <m>c=0</m> and <m>c=0.2</m> are very,
           very close together:
           this indicates that <m>f</m> is growing rapidly along those curves.
         </p>
 
         <figure xml:id="fig_levelcurves1">
-          <caption>Graphing the level curves in <xref ref="ex_levelcurve1">Example</xref></caption>
+          <caption>Graphing the level curves in <xref ref="ex_levelcurve1"/></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_levelcurves1a">
               <caption/>
@@ -480,7 +480,7 @@
         </figure>
 
         <p>
-          In <xref ref="fig_levelcurves1b_3D">Figure</xref>,
+          In <xref ref="fig_levelcurves1b_3D"/>,
           the curves are drawn on a graph of <m>f</m> in space.
           Note how the elevations are evenly spaced.
           Near the level curves of <m>c=0</m> and <m>c=0.2</m> we can see that <m>f</m> indeed is growing quickly.
@@ -507,7 +507,7 @@
           </md>,
           a circle centered at <m>\big(1/(2c),1/(2c)\big)</m> with radius <m>\sqrt{1/(2c^2)-1}</m>,
           where <m>\abs{c}\lt 1/\sqrt{2}</m>.
-          The level curves for <m>c=\pm 0.2,\,\pm 0.4</m> and <m>\pm0.6</m> are sketched in <xref ref="fig_levelcurves2a">Figure</xref>.
+          The level curves for <m>c=\pm 0.2,\,\pm 0.4</m> and <m>\pm0.6</m> are sketched in <xref ref="fig_levelcurves2a"/>.
           To help illustrate <q>elevation,</q>
           we use thicker lines for <m>c</m> values near 0, and dashed lines indicate where <m>c\lt 0</m>.
         </p>
@@ -518,12 +518,12 @@
         </p>
 
         <p>
-          In <xref ref="fig_levelcurves2b_3D">Figure</xref> we see a graph of the surface.
-          Note how the <m>y</m>-axis is pointing away from the viewer to more closely resemble the orientation of the level curves in <xref ref="fig_levelcurves2a">Figure</xref>.
+          In <xref ref="fig_levelcurves2b_3D"/> we see a graph of the surface.
+          Note how the <m>y</m>-axis is pointing away from the viewer to more closely resemble the orientation of the level curves in <xref ref="fig_levelcurves2a"/>.
         </p>
 
         <figure xml:id="fig_levelcurves2">
-          <caption>Graphing the level curves in <xref ref="ex_levelcurves2">Example</xref></caption>
+          <caption>Graphing the level curves in <xref ref="ex_levelcurves2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_levelcurves2a">
               <caption/>
@@ -668,7 +668,7 @@
     </definition>
 
     <p>
-      Note how this definition closely resembles that of <xref ref="def_multi2">Definition</xref>.
+      Note how this definition closely resembles that of <xref ref="def_multi2"/>.
     </p>
 
     <example xml:id="ex_multi3">
@@ -781,7 +781,7 @@
         </p>
 
         <figure xml:id="fig_multi4">
-          <caption>A table of <m>c</m> values and the corresponding radius <m>r</m> of the spheres of constant value in <xref ref="ex_multi4">Example</xref></caption>
+          <caption>A table of <m>c</m> values and the corresponding radius <m>r</m> of the spheres of constant value in <xref ref="ex_multi4"/></caption>
           <tabular>
             <row>
               <cell><m>c</m></cell>
@@ -1503,8 +1503,8 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Compare the level curves of <xref ref="x12_01_ex_21">Exercises</xref>
-                  and <xref ref="x12_01_ex_22"/>.
+                  Compare the level curves of <xref ref="x12_01_ex_21" text="local">Exercises</xref>
+                  and <xref ref="x12_01_ex_22" text="local"/>.
                   How are they similar, and how are they different?
                   Each surface is a quadric surface;
                   describe how the level curves are consistent with what we know about each surface.

--- a/ptx/sec_multi_limit.ptx
+++ b/ptx/sec_multi_limit.ptx
@@ -78,7 +78,7 @@
     </definition>
 
     <p>
-      <xref ref="fig_multilimit_intro">Figure</xref>
+      <xref ref="fig_multilimit_intro"/>
       shows several sets in the <m>xy</m>-plane.
       In each set,
       point <m>P_1</m> lies on the boundary of the set as all open disks centered there contain both points in,
@@ -200,10 +200,10 @@
     </figure>
 
     <p>
-      The set depicted in <xref ref="fig_multilimit_introa">Figure</xref> is a closed set as it contains all of its boundary points.
-      The set in <xref ref="fig_multilimit_introb">Figure</xref> is open, for all of its points are interior points
+      The set depicted in <xref ref="fig_multilimit_introa"/> is a closed set as it contains all of its boundary points.
+      The set in <xref ref="fig_multilimit_introb"/> is open, for all of its points are interior points
       (or, equivalently, it does not contain any of its boundary points).
-      The set in <xref ref="fig_multilimit_introc">Figure</xref> is neither open nor closed as it contains some of its boundary points.
+      The set in <xref ref="fig_multilimit_introc"/> is neither open nor closed as it contains some of its boundary points.
     </p>
 
     <example xml:id="ex_multilimit1">
@@ -216,7 +216,7 @@
       </statement>
       <solution>
         <p>
-          This domain of this function was found in <xref ref="ex_multi2">Example</xref>
+          This domain of this function was found in <xref ref="ex_multi2"/>
           to be <m>D = \{(x,y)\,|\,\frac{x^2}9+\frac{y^2}4\leq 1\}</m>,
           the region <em>bounded</em> by the ellipse <m>\frac{x^2}9+\frac{y^2}4=1</m>.
           Since the region includes the boundary
@@ -244,7 +244,7 @@
         </p>
 
         <figure xml:id="fig_multilimit2">
-          <caption>Sketching the domain of the function in <xref ref="ex_multilimit2">Example</xref></caption>
+          <caption>Sketching the domain of the function in <xref ref="ex_multilimit2"/></caption>
           <!-- START figures/fig_multilimit2.tex -->
           <image xml:id="img_multilimit2" width="47%">
             <description></description>
@@ -274,7 +274,7 @@
         </figure>
 
         <p>
-          The domain is sketched in <xref ref="fig_multilimit2">Figure</xref>.
+          The domain is sketched in <xref ref="fig_multilimit2"/>.
           Note how we can draw an open disk around any point in the domain that lies entirely inside the domain,
           and also note how the only boundary points of the domain are the points on the line <m>y=x</m>.
           We conclude the domain is an open set.
@@ -348,8 +348,8 @@
     </definition>
 
     <p>
-      The concept behind <xref ref="def_multilimit">Definition</xref>
-      is sketched in <xref ref="fig_multilimitdef">Figure</xref>.
+      The concept behind <xref ref="def_multilimit"/>
+      is sketched in <xref ref="fig_multilimitdef"/>.
       Given <m>\varepsilon \gt 0</m>,
       find <m>\delta \gt 0</m> such that if <m>(x,y)</m> is any point in the open disk centered at
       <m>(x_0,y_0)</m> in the <m>xy</m>-plane with radius <m>\delta</m>,
@@ -508,9 +508,9 @@
 
     <p>
       This theorem,
-      combined with <xref ref="thm_poly_rat">Theorems</xref>
-      and <xref ref="thm_lim_continuous"/>
-      of <xref ref="sec_limit_analytically">Section</xref>,
+      combined with <xref ref="thm_poly_rat" text="global">Theorems</xref>
+      and <xref ref="thm_lim_continuous" text="global"/>
+      of <xref ref="sec_limit_analytically"/>,
       allows us to evaluate many limits.
     </p>
 
@@ -693,7 +693,7 @@
         </p>
 
         <p>
-          To prove the limit is 0, we apply <xref ref="def_multilimit">Definition</xref>.
+          To prove the limit is 0, we apply <xref ref="def_multilimit"/>.
           Let <m>\varepsilon  \gt 0</m> be given.
           We want to find <m>\delta  \gt 0</m> such that if <m>\sqrt{(x-0)^2+(y-0)^2} \lt \delta</m>,
           then <m>\abs{f(x,y)-0} \lt \varepsilon</m>.
@@ -730,7 +730,7 @@
   <subsection>
     <title>Continuity</title>
     <p>
-      <xref ref="def_continuous">Definition</xref>
+      <xref ref="def_continuous"/>
       defines what it means for a function of one variable to be continuous.
       In brief, it meant that the graph of the function did not have breaks, holes,
       jumps, etc.
@@ -809,14 +809,14 @@
 
         <p>
           The second limit does not contain <m>y</m>.
-          By <xref ref="thm_special_limits">Theorem</xref> we can say
+          By <xref ref="thm_special_limits"/> we can say
           <me>
             \lim_{(x,y)\to (0,0)} \frac{\sin(x) }{x} = \lim_{x\to 0} \frac{\sin(x) }{x} = 1
           </me>.
         </p>
 
         <p>
-          Finally, <xref ref="thm_multi_limit_algebra">Theorem</xref>
+          Finally, <xref ref="thm_multi_limit_algebra"/>
           of this section states that we can combine these two limits as follows:
           <md>
             <mrow>\lim_{(x,y)\to (0,0)} \frac{\cos(y) \sin(x) }{x} \amp = \lim_{(x,y)\to (0,0)} (\cos(y) )\left(\frac{\sin(x) }{x}\right)</mrow>
@@ -837,12 +837,12 @@
           when <m>x=0</m>,
           a similar analysis shows that the limit is <m>\cos(y)</m>.
           Thus we can say that <m>f</m> is continuous everywhere.
-          A graph of <m>f</m> is given in <xref ref="fig_multicont1">Figure</xref>.
+          A graph of <m>f</m> is given in <xref ref="fig_multicont1"/>.
           Notice how it has no breaks, jumps, etc.
         </p>
 
         <figure xml:id="fig_multicont1">
-          <caption>A graph of <m>f(x,y)</m> in <xref ref="ex_multicont1">Example</xref></caption>
+          <caption>A graph of <m>f(x,y)</m> in <xref ref="ex_multicont1"/></caption>
 
           <!-- START figures/figmulticont1_3D.asy -->
           <image xml:id="img_multicont1" width="47%">
@@ -899,7 +899,7 @@
     </example>
 
     <p>
-      The following theorem is very similar to <xref ref="thm_continuity_algebra">Theorem</xref>,
+      The following theorem is very similar to <xref ref="thm_continuity_algebra"/>,
       giving us ways to combine continuous functions to create other continuous functions.
     </p>
 
@@ -976,15 +976,15 @@
       </statement>
       <solution>
         <p>
-          We will apply both <xref ref="thm_continuity_algebra">Theorems</xref>
-          and <xref ref="thm_multi_continuous_prop"/>.
+          We will apply both <xref ref="thm_continuity_algebra" text="global">Theorems</xref>
+          and <xref ref="thm_multi_continuous_prop" text="global"/>.
           Let <m>f_1(x,y) = x^2</m>.
           Since <m>y</m> is not actually used in the function,
           and polynomials are continuous
-          (by <xref ref="thm_continuity_algebra">Theorem</xref>),
+          (by <xref ref="thm_continuity_algebra"/>),
           we conclude <m>f_1</m> is continuous everywhere.
           A similar statement can be made about <m>f_2(x,y) = \cos(y)</m>.
-          Part 3 of <xref ref="thm_multi_continuous_prop">Theorem</xref>
+          Part 3 of <xref ref="thm_multi_continuous_prop"/>
           states that <m>f_3=f_1\cdot f_2</m> is continuous everywhere,
           and Part 7 of the theorem states the composition of sine with <m>f_3</m> is continuous:
           that is, <m>\sin(f_3) = \sin(x^2\cos(y) )</m> is continuous everywhere.
@@ -1000,8 +1000,8 @@
       (or more)
       variables.
       We cover the key concepts here;
-      some terms from <xref ref="def_open">Definitions</xref>
-      and <xref ref="def_multi_continuous"/>
+      some terms from <xref ref="def_open" text="global">Definitions</xref>
+      and <xref ref="def_multi_continuous" text="global"/>
       are not redefined but their analogous meanings should be clear to the reader.
     </p>
 
@@ -1063,7 +1063,7 @@
 
     <p>
       These definitions can also be extended naturally to apply to functions of four or more variables.
-      <xref ref="thm_multi_continuous_prop">Theorem</xref>
+      <xref ref="thm_multi_continuous_prop"/>
       also applies to function of three or more variables,
       allowing us to say that the function
       <me>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -1004,7 +1004,7 @@
 
         <p>
           This is not a new method of approximation.
-          Compare the right hand expression for <m>z</m> in Equation <xref ref="eq_tpl7"/> to the total differential:
+          Compare the right hand expression for <m>z</m> in <xref ref="eq_tpl7">Equation</xref> to the total differential:
           <me>
             dz = f_xdx + f_ydy  \text{ and }   z = \underbrace{\underbrace{2}_{f_x}\underbrace{(x-3)}_{dx}+\underbrace{-1/2}_{f_y}\underbrace{(y+1)}_{dy}}_{dz}+4
           </me>.

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -21,7 +21,7 @@
     </p>
 
     <p>
-      In <xref ref="subsec-tangent-plane">Section</xref> we introduced the concept of the tangent plane,
+      In <xref ref="subsec-tangent-plane"/> we introduced the concept of the tangent plane,
       which could be thought of as consisting of all possible lines tangent to the surface at a given point.
       In this section, we explore this idea in more detail.
     </p>
@@ -94,7 +94,7 @@
     </figure>
 
     <p>
-      In <xref ref="fig_space_tangent_intro">Figure</xref>
+      In <xref ref="fig_space_tangent_intro"/>
       we see lines that are tangent to curves in space.
       Since each curve lies on a surface,
       it makes sense to say that the lines are also tangent to the surface.
@@ -155,7 +155,7 @@
     </p>
 
     <p>
-      <xref ref="def_directional_tangent_line">Definition</xref>
+      <xref ref="def_directional_tangent_line"/>
       leads to the following parametric equations of directional tangent lines:
     </p>
 
@@ -203,11 +203,11 @@
         </p>
 
         <p>
-          The two lines are shown with the surface in <xref ref="fig_partial4a_3D">Figure</xref>.
+          The two lines are shown with the surface in <xref ref="fig_partial4a_3D"/>.
         </p>
 
         <figure xml:id="fig_partial4">
-          <caption>A surface and directional tangent lines in <xref ref="ex_tpl1">Example</xref></caption>
+          <caption>A surface and directional tangent lines in <xref ref="ex_tpl1"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_partial4a_3D">
               <caption/>
@@ -347,7 +347,7 @@
         </p>
 
         <p>
-          The curve through <m>(\pi/2,\pi/2,0)</m> in the direction of <m>\vec v</m> is shown in <xref ref="fig_partial4b_3D">Figure</xref> along with <m>\ell_{\vec u}(t)</m>.
+          The curve through <m>(\pi/2,\pi/2,0)</m> in the direction of <m>\vec v</m> is shown in <xref ref="fig_partial4b_3D"/> along with <m>\ell_{\vec u}(t)</m>.
         </p>
       </solution>
     </example>
@@ -386,14 +386,14 @@
         </p>
 
         <p>
-          <xref ref="fig_tpl2">Figure</xref>
+          <xref ref="fig_tpl2"/>
           shows a graph of <m>f</m> and the point <m>(1,1,2)</m>.
           Note that this point comes at the top of a <q>hill,</q>
           and therefore every tangent line through this point will have a <q>slope</q> of 0.
         </p>
 
         <figure xml:id="fig_tpl2">
-          <caption>Graphing <m>f</m> in <xref ref="ex_tpl2">Example</xref></caption>
+          <caption>Graphing <m>f</m> in <xref ref="ex_tpl2"/></caption>
 
           <!-- START figures/figtpl2_3D.asy -->
           <image xml:id="img_tpl2" width="47%">
@@ -483,7 +483,7 @@
 
     <p>
       Let <m>z=f(x,y)</m> be a differentiable function of two variables.
-      By <xref ref="def_directional_tangent_line">Definition</xref>,
+      By <xref ref="def_directional_tangent_line"/>,
       at <m>(x_0,y_0)</m>,
       <m>\ell_x(t)</m> is a line parallel to the vector <m>\vec d_x=\la 1,0,f_x(x_0,y_0)\ra</m> and
       <m>\ell_y(t)</m> is a line parallel to <m>\vec d_y=\la 0,1,f_y(x_0,y_0)\ra</m>.
@@ -562,7 +562,7 @@
           We find <m>z_x(x,y) = -2x</m> and <m>z_y(x,y) = -2y</m>;
           at <m>(0,1)</m>, we have <m>z_x = 0</m> and <m>z_y = -2</m>.
           We take the direction of the normal line,
-          following <xref ref="def_normal_line_space">Definition</xref>,
+          following <xref ref="def_normal_line_space"/>,
           to be <m>\vec n=\la 0,-2,-1\ra</m>.
           The line with this direction going through the point <m>(0,1,1)</m> is
           <me>
@@ -572,7 +572,7 @@
         </p>
 
         <figure xml:id="fig_tpl3">
-          <caption>Graphing a surface with a normal line  from <xref ref="ex_tpl3">Example</xref></caption>
+          <caption>Graphing a surface with a normal line  from <xref ref="ex_tpl3"/></caption>
 
           <!-- START figures/figtpl3_3D.asy -->
           <image xml:id="img_tpl3" width="47%">
@@ -647,7 +647,7 @@
         <p>
           The surface <m>z=-x^2-y^2+2</m>,
           along with the found normal line,
-          is graphed in <xref ref="fig_tpl3">Figure</xref>.
+          is graphed in <xref ref="fig_tpl3"/>.
         </p>
       </solution>
     </example>
@@ -675,7 +675,7 @@
       </statement>
       <solution>
         <p>
-          This surface is used in <xref ref="ex_tpl2">Example</xref>,
+          This surface is used in <xref ref="ex_tpl2"/>,
           so we know that at <m>(x,y)</m>,
           the direction of the normal line will be <m>\vec d_n = \la -2x,-2y,-1\ra</m>.
           A point <m>P</m> on the surface will have coordinates <m>(x,y,2-x^2-y^2)</m>,
@@ -776,7 +776,7 @@
         </p>
 
         <figure xml:id="fig_tpl5">
-          <caption>Graphing the surface in <xref ref="ex_tpl5">Example</xref> along with points 4 units from the surface</caption>
+          <caption>Graphing the surface in <xref ref="ex_tpl5"/> along with points 4 units from the surface</caption>
 
           <!-- START figures/figtpl5_3D.asy -->
           <image xml:id="img_tpl5" width="47%">
@@ -853,14 +853,14 @@
       With <m>a=f_x(x_0,y_0)</m>,
       <m>b=f_y(x_0,y_0)</m> and <m>P = \big(x_0,y_0,f(x_0,y_0)\big)</m>,
       the vector <m>\vec n=\la a,b,-1\ra</m> is orthogonal to <m>f</m> at <m>P</m>.
-      (See <xref ref="def-tangent-plane">Definition</xref>.)
+      (See <xref ref="def-tangent-plane"/>.)
       The plane through <m>P</m> with normal vector <m>\vec n</m> is therefore
       <em>tangent</em> to <m>f</m> at <m>P</m>.
     </p>
 
     <aside>
       <p>
-        When we introduced the tangent plane in <xref ref="sec_partial_derivatives">Section</xref>,
+        When we introduced the tangent plane in <xref ref="sec_partial_derivatives"/>,
         we computed the normal vector to be <m>\vec{n}=\la -f_x(x_0,y_0),-f_y(x_0,y_0),1\ra</m>.
         Here, for convenience, we take the negative of this vector,
         and use <m>\vec{n}=\la f_x(x_0,y_0),f_y(x_0,y_0),-1\ra</m>.
@@ -898,7 +898,7 @@
       </statement>
       <solution>
         <p>
-          Note that this is the same surface and point used in <xref ref="ex_tpl3">Example</xref>.
+          Note that this is the same surface and point used in <xref ref="ex_tpl3"/>.
           There we found <m>\vec n = \la 0,-2,-1\ra</m> and <m>P = (0,1,1)</m>.
           Therefore the equation of the tangent plane is
           <me>
@@ -907,7 +907,7 @@
         </p>
 
         <figure xml:id="fig_tpl6">
-          <caption>Graphing a surface with  tangent plane from <xref ref="ex_tpl6">Example</xref></caption>
+          <caption>Graphing a surface with  tangent plane from <xref ref="ex_tpl6"/></caption>
 
           <!-- START figures/figtpl6_3D.asy -->
           <image xml:id="img_tpl6" width="47%">
@@ -971,7 +971,7 @@
         </figure>
 
         <p>
-          The surface <m>z=-x^2-y^2+2</m> and tangent plane are graphed in <xref ref="fig_tpl6">Figure</xref>.
+          The surface <m>z=-x^2-y^2+2</m> and tangent plane are graphed in <xref ref="fig_tpl6"/>.
         </p>
       </solution>
     </example>
@@ -1192,7 +1192,7 @@
         </figure>
 
         <p>
-          The ellipsoid and tangent plane are graphed in <xref ref="fig_tpl8">Figure</xref>.
+          The ellipsoid and tangent plane are graphed in <xref ref="fig_tpl8"/>.
         </p>
       </solution>
     </example>
@@ -1651,8 +1651,7 @@
           <p>
             A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find the equation of the normal line to <m>z=f(x,y)</m> at <m>P</m>.
-            Note: these are the same functions as in <xref ref="x12_06_ex_05">Exercises</xref>
-            <mdash/> <xref ref="x12_06_ex_08"/>.
+            Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08" text="local">Exercises</xref>.
           </p>
         </introduction>
 
@@ -1834,7 +1833,7 @@
           <p>
             A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find the two points that are <m>2</m> units from the surface <m>z=f(x,y)</m> at <m>P</m>.
-            Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
+            Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08" text="local">Exercises</xref>.
           </p>
         </introduction>
 
@@ -1914,7 +1913,7 @@
           <p>
             A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find an equation of the tangent plane to <m>z=f(x,y)</m> at <m>P</m>.
-            Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08">Exercises</xref>.
+            Note: these are the same functions as in <xref first="x12_06_ex_05" last="x12_06_ex_08" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_newton.ptx
+++ b/ptx/sec_newton.ptx
@@ -10,7 +10,7 @@
     there are methods that can give us <em>approximate</em>
     solutions to equations like these.
     These methods can usually give an approximation correct to as many decimal places as we like.
-    In <xref ref="sec_continuity">Section</xref>
+    In <xref ref="sec_continuity"/>
     we learned about the Bisection Method.
     This section focuses on another technique
     (which generally works faster),
@@ -27,13 +27,13 @@
   <p>
     We start Newton's Method with an initial guess about roughly where the root is.
     Call this <m>x_0</m>.
-    (See <xref ref="fig_newt1a">Figure</xref>.)
+    (See <xref ref="fig_newt1a"/>.)
     Draw the tangent line to the graph at
     <m>(x_0,f(x_0))</m> and see where it meets the <m>x</m>-axis.
     Call this point <m>x_1</m>.
     Then repeat the process <mdash/> draw the tangent line to the graph at
     <m>(x_1, f(x_1))</m> and see where it meets the <m>x</m>-axis.
-    (See <xref ref="fig_newt1b">Figure</xref>.)
+    (See <xref ref="fig_newt1b"/>.)
     Call this point <m>x_2</m>.
     Repeat the process again to get <m>x_3</m>, <m>x_4</m>, etc.
     This sequence of points will often converge rather quickly to a root of <m>f</m>.
@@ -254,7 +254,7 @@
       <p>
         To begin, we compute <m>\fp(x)=3x^2-2x</m>.
         Then we apply the Newton's Method algorithm,
-        outlined in <xref ref="idea_Newton">Key Idea</xref>.
+        outlined in <xref ref="idea_Newton"/>.
         <ul marker="" cols="2">
           <li>
             <p>
@@ -310,7 +310,7 @@
       </p>
 
       <p>
-        A graph of <m>f(x)</m> is given in <xref ref="fig_newt2">Figure</xref>.
+        A graph of <m>f(x)</m> is given in <xref ref="fig_newt2"/>.
         We can see from the graph that our initial approximation of <m>x_0=1</m> was not particularly accurate;
         a closer guess would have been <m>x_0=1.5</m>.
         Our choice was based on ease of initial calculation,
@@ -318,7 +318,7 @@
       </p>
 
       <figure xml:id="fig_newt2">
-        <caption>A graph of <m>f(x) = x^3-x^2-1</m> in <xref ref="ex_newt2">Example</xref></caption>
+        <caption>A graph of <m>f(x) = x^3-x^2-1</m> in <xref ref="ex_newt2"/></caption>
         <image xml:id="img_newt2" width="47%">
           <shortdescription> 
             A cubic graph features a curve with two turning points.
@@ -397,7 +397,7 @@
         Written this way, we are finding a root of <m>f(x)=\cos(x) -x</m>.
         We compute <m>\fp(x)=-\sin(x) - 1</m>.
         Next we need a starting value, <m>x_0</m>.
-        Consider <xref ref="fig_newt3">Figure</xref>,
+        Consider <xref ref="fig_newt3"/>,
         where <m>f(x) = \cos(x) -x</m> is graphed.
         It seems that <m>x_0=0.75</m> is pretty close to the root,
         so we will use that as our <m>x_0</m>. (The figure also shows the graphs of <m>y=\cos(x)</m> and <m>y=x</m>.
@@ -515,10 +515,10 @@
       Generally, the closer to the actual root the initial guess is,
       the better.
       However, some initial guesses should be avoided.
-      For instance, consider <xref ref="ex_newt2">Example</xref>
+      For instance, consider <xref ref="ex_newt2"/>
       where we sought the root to <m>f(x) = x^3-x^2-1</m>.
       Choosing <m>x_0=0</m> would have been a particularly poor choice.
-      Consider <xref ref="fig_newt2a">Figure</xref>,
+      Consider <xref ref="fig_newt2a"/>,
       where <m>f(x)</m> is graphed along with its tangent line at <m>x=0</m>.
       Since <m>\fp(0)=0</m>,
       the tangent line is horizontal and does not intersect the <m>x</m>-axis.
@@ -576,14 +576,14 @@
     <p>
       It is also possible for Newton's Method to not converge while each successive approximation is well defined.
       Consider <m>f(x) = x^{1/3}</m>,
-      as shown in <xref ref="fig_newt4">Figure</xref>.
+      as shown in <xref ref="fig_newt4"/>.
       It is clear that the root is <m>x=0</m>,
       but let's approximate this with <m>x_0=0.1</m>.
-      <xref ref="fig_newt4a">Figure</xref>
+      <xref ref="fig_newt4a"/>
       shows graphically the calculation of <m>x_1</m>;
       notice how it is farther from the root than <m>x_0</m>.
-      <xref ref="fig_newt4b">Figure</xref>
-      and <xref ref="fig_newt4c">Figure</xref>
+      <xref ref="fig_newt4b"/>
+      and <xref ref="fig_newt4c"/>
       show the calculation of <m>x_2</m> and <m>x_3</m>,
       which are even farther away;
       our successive approximations are getting worse.

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -52,7 +52,7 @@
         <li><m>\int_{-\frac{\pi}{4}}^{\frac{\pi}{2}} \sin(x^3) \, dx</m>,</li>
         <li><m>\int_{0.5}^{4\pi} \frac{\sin(x)}{x} \, dx</m>,</li>
       </ul>
-      as pictured in <xref ref="fig_numerical1">Figure</xref>.
+      as pictured in <xref ref="fig_numerical1"/>.
     </p>
 
     <figure xml:id="fig_numerical1">
@@ -180,7 +180,7 @@
   <subsection>
     <title>The Left and Right Hand Rule Methods</title>
     <p>
-      In <xref ref="sec_riemann">Section</xref>
+      In <xref ref="sec_riemann"/>
       we addressed the problem of evaluating definite integrals by approximating the area under the curve using rectangles.
       We revisit those ideas here before introducing other methods of approximating definite integrals.
           <idx><h>numerical integration</h><h>Left/Right Hand Rule</h></idx>
@@ -202,7 +202,7 @@
     </p>
 
     <p>
-      <xref ref="idea_riemann">Key Idea</xref>
+      <xref ref="idea_riemann"/>
       states that to use the Left Hand Rule we use the summation
       <m>\ds \sum_{i=1}^n f(x_{i-1})\dx</m> and to use the Right Hand Rule we use <m>\ds \sum_{i=1}^n f(x_{i})\dx</m>.
       We review the use of these rules in the context of examples.
@@ -245,7 +245,7 @@
         </p>
 
         <figure xml:id="fig_num1">
-          <caption>Approximating <m>\int_0^1e^{-x^2}\, dx</m> in <xref ref="ex_num1">Example</xref></caption>
+          <caption>Approximating <m>\int_0^1e^{-x^2}\, dx</m> in <xref ref="ex_num1"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
 
       <!-- START figures/fig_num1b.tex -->
@@ -330,13 +330,13 @@
       </figure>
 
         <p>
-          <xref ref="fig_num1">Figure</xref>
+          <xref ref="fig_num1"/>
           shows the rectangles used in each method to approximate the definite integral.
           These graphs show that in this particular case,
           the Left Hand Rule is an over approximation and the Right Hand Rule is an under approximation.
           To get a better approximation,
           we could use more rectangles,
-          as we did in <xref ref="sec_riemann">Section</xref>.
+          as we did in <xref ref="sec_riemann"/>.
           We could also average the Left and Right Hand Rule results together, giving
           <me>
             \frac{0.8076 + 0.6812}{2} = 0.7444
@@ -375,7 +375,7 @@
         </p>
 
         <figure xml:id="fig_num2a">
-          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2">Example</xref></caption>
+          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2"/></caption>
           <tabular>
             <row>
               <cell><m>x_i</m></cell>
@@ -486,7 +486,7 @@
         </p>
 
         <figure xml:id="fig_num2">
-          <caption>Approximating <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2">Example</xref></caption>
+          <caption>Approximating <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
 
           <!-- START figures/fig_num2b.tex -->
@@ -584,7 +584,7 @@
           The actual answer, accurate to 4 places after the decimal,
           is 0.4609.
           Our approximations were once again fairly good.
-          The rectangles used in each approximation are shown in <xref ref="fig_num2b">Figure</xref>.
+          The rectangles used in each approximation are shown in <xref ref="fig_num2b"/>.
           It is clear from the graphs that using more rectangles
           (and hence, narrower rectangles)
           should result in a more accurate approximation.
@@ -596,10 +596,10 @@
   <subsection>
     <title>The Trapezoidal Rule</title>
     <p>
-      In <xref ref="ex_num1">Example</xref>
+      In <xref ref="ex_num1"/>
       we approximated the value of
       <m>\ds \int_0^1 e^{-x^2}\, dx</m> with 5 rectangles of equal width.
-      <xref ref="fig_num1">Figure</xref>
+      <xref ref="fig_num1"/>
       shows the rectangles used in the Left and Right Hand Rules.
       These graphs clearly show that rectangles do not match the shape of the graph all that well,
       and that accurate approximations will only come by using lots of rectangles.
@@ -611,7 +611,7 @@
     <p>
       Instead of using rectangles to approximate the area,
       we can instead use <em>trapezoids.</em>
-      In <xref ref="fig_num3a">Figure</xref>,
+      In <xref ref="fig_num3a"/>,
       we show the region under <m>f(x) = e^{-x^2}</m> on <m>[0,1]</m> approximated
       with 5 trapezoids of equal width;
       the top <q>corners</q> of each trapezoid lies on the graph of <m>f(x)</m>.
@@ -663,7 +663,7 @@
     </figure>
 
     <p>
-      The formula for the area of a trapezoid is given in <xref ref="fig_trapezoid">Figure</xref>.
+      The formula for the area of a trapezoid is given in <xref ref="fig_trapezoid"/>.
       We approximate <m>\int_0^1 e^{-x^2}\, dx</m> with these trapezoids in the following example.
     </p>
 
@@ -817,7 +817,7 @@
       <title>Using the Trapezoidal Rule</title>
       <statement>
         <p>
-          Revisit <xref ref="ex_num2">Example</xref>
+          Revisit <xref ref="ex_num2"/>
           and approximate <m>\ds\int_{-\frac{\pi}{4}}^{\frac{\pi}{2}} \sin(x^3)\, dx</m> using the Trapezoidal Rule and 10 equally spaced subintervals.
         </p>
       </statement>
@@ -954,7 +954,7 @@
       <title>Using the Midpoint Rule</title>
       <statement>
         <p>
-          Revisit <xref ref="ex_num4">Example</xref>
+          Revisit <xref ref="ex_num4"/>
           and approximate <m>\ds\int_{-\frac{\pi}{4}}^{\frac{\pi}{2}} \sin(x^3)\, dx</m> using the Midpoint Rule and 10 equally spaced subintervals.
         </p>
       </statement>
@@ -970,7 +970,7 @@
         </p>
 
         <figure xml:id="fig_num4_2">
-          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num4_2 ">Example</xref></caption>
+          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num4_2 "/></caption>
           <tabular>
             <row>
               <cell><m>\overline{x_i}</m></cell>
@@ -1127,7 +1127,7 @@
     <!-- Embedded doesn't really fit in an aside. Use a link.-->
     <aside>
       <p>
-        While it's not <em>hard</em> to show the results of <xref ref="eq_simpsons">Equation</xref>,
+        While it's not <em>hard</em> to show the results of <xref ref="eq_simpsons" text="local">Equation</xref>,
         it's also not exactly easy.
         This video might help:
         <!-- <figure xml:id="video-simpsons-rule" component="video"> -->
@@ -1139,7 +1139,7 @@
     </aside>
     <!--<video youtube="uc4xJsi99bk"/>-->
     <p>
-      Consider <xref ref="fig_numsimpsons">Figure</xref>.
+      Consider <xref ref="fig_numsimpsons"/>.
       A function <m>f</m> goes through the 3 points shown and the parabola <m>g</m> that also goes through those points is graphed with a dashed line.
       Using our equation from above, we know exactly that
       <me>
@@ -1218,7 +1218,7 @@
     </p>
 
     <p>
-      <xref ref="fig_simpsons2">Figure</xref>
+      <xref ref="fig_simpsons2"/>
       illustrates how the area calculated by Simpson's Rule approximates
       <m>\int_0^5 f(x)\, dx</m> for the function <m>f(x)=\sin(\pi x)</m>.
       In this case, <m>8</m> subintervals were used,
@@ -1405,7 +1405,7 @@
         </p>
 
         <p>
-          Recall in <xref ref="ex_num1">Example</xref>
+          Recall in <xref ref="ex_num1"/>
           we stated that the correct answer,
           accurate to 4 places after the decimal, was 0.7468.
           Our approximation with Simpson's Rule, with 4 subintervals,
@@ -1413,7 +1413,7 @@
         </p>
 
         <p>
-          <xref ref="fig_num5b">Figure</xref>
+          <xref ref="fig_num5b"/>
           shows <m>f(x) = e^{-x^2}</m> along with its approximating parabolas,
           demonstrating how good our approximation is.
           The approximating curves are nearly indistinguishable from the actual function.
@@ -1437,7 +1437,7 @@
         </p>
 
         <figure xml:id="fig_num6a">
-          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6">Example</xref></caption>
+          <caption>Values used to approximate <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6"/></caption>
           <tabular>
             <row bottom="minor">
               <cell><m>x_i</m></cell>
@@ -1500,7 +1500,7 @@
         </p>
 
         <figure xml:id="fig_num6b">
-          <caption>Approximating <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6">Example</xref> with Simpson's Rule and 10 equally spaced intervals</caption>
+          <caption>Approximating <m>\int_{-\frac{\pi}4}^{\frac{\pi}2}\sin(x^3)\, dx</m> in <xref ref="ex_num6"/> with Simpson's Rule and 10 equally spaced intervals</caption>
           <!-- START figures/fig_num6b.tex -->
           <image xml:id="img_num6b" width="47%">
           <shortdescription>Approximating the integral of sin(x^3) using Simpson's rule</shortdescription>
@@ -1564,7 +1564,7 @@
           Recall that the actual value,
           accurate to 3 decimal places, is 0.4609.
           Our approximation is within one <m>1/100</m>th of the correct value.
-          The graph in <xref ref="fig_num6b">Figure</xref>
+          The graph in <xref ref="fig_num6b"/>
           shows how closely the parabolas match the shape of the graph.
         </p>
       </solution>
@@ -1663,7 +1663,7 @@
       These are good questions, and their answers are educational.
       In the examples, <em>the</em> right answer was never computed.
       Rather, an approximation accurate to a certain number of places after the decimal was given.
-      In <xref ref="ex_num1">Example</xref>,
+      In <xref ref="ex_num1"/>,
       we do not know the <em>exact</em> answer,
       but we know it starts with <m>0.7468</m>.
       These more accurate approximations were computed using numerical integration but with more precision (<ie/>, more subintervals and the help of a computer).
@@ -1697,7 +1697,7 @@
       then one knows that the correct answer is between 1.48 and 1.68.
       By using lots of subintervals,
       one can get an approximation as accurate as one likes.
-      <xref ref="thm_numerical_error">Theorem</xref> states what these bounds are.
+      <xref ref="thm_numerical_error"/> states what these bounds are.
     </p>
 
     <theorem xml:id="thm_numerical_error">
@@ -1782,9 +1782,9 @@
     </p>
 
     <p>
-      We revisit <xref ref="ex_num3">Examples</xref>
-      and <xref ref="ex_num5"/>
-      and compute the error bounds using <xref ref="thm_numerical_error">Theorem</xref> in the following example.
+      We revisit <xref ref="ex_num3" text="global">Examples</xref>
+      and <xref ref="ex_num5" text="global"/>
+      and compute the error bounds using <xref ref="thm_numerical_error"/> in the following example.
     </p>
 
     <example xml:id="ex_num7">
@@ -1809,13 +1809,13 @@
         </p>
 
         <p>
-          <xref ref="fig_num7a">Figure</xref>
+          <xref ref="fig_num7a"/>
           shows a graph of <m>\fpp(x)</m> on <m>[0,1]</m>.
           It is clear that the largest value of <m>\fpp</m>, in absolute value, is 2.
         </p>
 
         <figure xml:id="fig_num7a">
-          <caption>Graphing <m>\fpp(x)</m> in <xref ref="ex_num7">Example</xref> to help establish error bounds</caption>
+          <caption>Graphing <m>\fpp(x)</m> in <xref ref="ex_num7"/> to help establish error bounds</caption>
           <!-- START figures/fig_num7a.tex -->
           <image xml:id="img_num7a" width="47%">
           <shortdescription>Shows the double derivative of f.</shortdescription>
@@ -1846,7 +1846,7 @@
         </figure>
 
         <p>
-          Thus we let <m>K=2</m> and apply the error formula from <xref ref="thm_numerical_error">Theorem</xref>.
+          Thus we let <m>K=2</m> and apply the error formula from <xref ref="thm_numerical_error"/>.
           <me>
             E_T \leq \frac{(1-0)^3}{12\cdot 5^2}\cdot 2 = 0.00\overline{6}
           </me>.
@@ -1859,14 +1859,14 @@
 
         <p>
           Our error estimation formula states that our approximation of 0.7444 found in
-          <xref ref="ex_num3">Example</xref> is within 0.0067 of the correct answer.
+          <xref ref="ex_num3"/> is within 0.0067 of the correct answer.
           Hence we know that the actual value is within
           <m>[0.7444-0.0067, 0.7444+0.0067]=[0.7377,0.7511].</m> So:
           <me>
             0.7377 \leq \int_0^1e^{-x^2}\, dx \leq 0.7511
           </me>
           But we can do better than this with the Midpoint Rule since its error is at most half of the error of the Trapezoidal Rule.
-          Our error estimate formula state that our approximate of <m>0.7480</m> found in <xref ref="ex_num3_2">Example</xref>
+          Our error estimate formula state that our approximate of <m>0.7480</m> found in <xref ref="ex_num3_2"/>
           is within <m>0.0034</m> of the correct answer.
           Hence Hence we know that the actual value is within <m>[0.7480-0.0034, 0.7480+0.0033]=[0.7447,0.7513]</m>.
         </p>
@@ -1874,7 +1874,7 @@
         <p>
           We had earlier stated the actual answer,
           correct to 4 decimal places, to be 0.7468,
-          affirming the validity of <xref ref="thm_numerical_error">Theorem</xref>.
+          affirming the validity of <xref ref="thm_numerical_error"/>.
         </p>
 
         <p>
@@ -1889,17 +1889,17 @@
         </p>
 
         <p>
-          <xref ref="fig_num7b">Figure</xref>
+          <xref ref="fig_num7b"/>
           shows a graph of <m>f^{(4)}(x)</m> on <m>[0,1]</m>.
           It is clear that the largest value of <m>f^{(4)}</m>, in absolute value, is 12.
-          Thus we let <m>K=12</m> and apply the error formula from <xref ref="thm_numerical_error">Theorem</xref>.
+          Thus we let <m>K=12</m> and apply the error formula from <xref ref="thm_numerical_error"/>.
           <me>
             E_s =\leq \frac{(1-0)^5}{180\cdot 4^4}\cdot 12 = 0.00026
           </me>.
         </p>
 
         <figure xml:id="fig_num7b">
-          <caption>Graphing <m>f^{(4)}(x)</m> in <xref ref="ex_num7">Example</xref> to help establish error bounds</caption>
+          <caption>Graphing <m>f^{(4)}(x)</m> in <xref ref="ex_num7"/> to help establish error bounds</caption>
           <!-- START figures/fig_num7b.tex -->
           <image xml:id="img_num7b" width="47%">
           <shortdescription>Graphing the fourth derivative of f to help establish error bounds.</shortdescription>
@@ -1933,7 +1933,7 @@
 
         <p>
           Our error estimation formula states that our approximation of
-          <m>0.7468\overline{3}</m> found in <xref ref="ex_num5">Example</xref>
+          <m>0.7468\overline{3}</m> found in <xref ref="ex_num5"/>
           is within <m>0.00026</m> of the correct answer,
           hence we know that the correct answer is in the interval <m>[0.74683-0.00026 , 0.74683 + 0.00026]=[0.74657,0.74709].</m> So:
           <me>
@@ -1942,7 +1942,7 @@
         </p>
 
         <p>
-          Once again we affirm the validity of <xref ref="thm_numerical_error">Theorem</xref>
+          Once again we affirm the validity of <xref ref="thm_numerical_error"/>
           since the answer to 4 decimal places is actually <m>0.7468</m>.
         </p>
       </solution>
@@ -1969,7 +1969,7 @@
           Approximate the distance they traveled.
         </p>
         <figure xml:id="fig_num8">
-          <caption>Speed data collected at 30 second intervals for <xref ref="ex_num8">Example</xref></caption>
+          <caption>Speed data collected at 30 second intervals for <xref ref="ex_num8"/></caption>
           <tabular>
             <row>
               <cell>Time</cell><cell>Speed</cell>

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -1127,7 +1127,7 @@
     <!-- Embedded doesn't really fit in an aside. Use a link.-->
     <aside>
       <p>
-        While it's not <em>hard</em> to show the results of <xref ref="eq_simpsons" text="local">Equation</xref>,
+        While it's not <em>hard</em> to show the results of <xref ref="eq_simpsons" text="global">Equation</xref>,
         it's also not exactly easy.
         This video might help:
         <!-- <figure xml:id="video-simpsons-rule" component="video"> -->
@@ -1206,7 +1206,7 @@
       subdivide <m>[a,b]</m> into <m>n</m> subintervals,
       where <m>n</m> is even and each subinterval has width <m>\dx = (b-a)/n</m>.
       We approximate <m>f</m> with <m>n/2</m> parabolic curves,
-      using Equation <xref ref="eq_simpsons"/> to compute the area under these parabolas.
+      using <xref ref="eq_simpsons">Equation</xref> to compute the area under these parabolas.
       Adding up these areas gives the formula:
       <me>
         \int_a^b f(x) \, dx \approx \frac{\dx}3\Big[f(x_0)+4f(x_1)+2f(x_2)+4f(x_3)+\ldots+2f(x_{n-2})+4f(x_{n-1})+f(x_{n})\Big]

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -9,7 +9,7 @@
 
 
   <p>
-    In <xref ref="sec_extreme_values">Section</xref>
+    In <xref ref="sec_extreme_values"/>
     we learned about extreme values <mdash/> the largest and smallest values a
     function attains on an interval.
     We motivated our interest in such values by discussing how it made sense to
@@ -47,7 +47,7 @@
 
       <p>
         It helps to make a sketch of the situation.
-        Our enclosure is sketched twice in <xref ref="fig_opt1b">Figure</xref>,
+        Our enclosure is sketched twice in <xref ref="fig_opt1b"/>,
         either with treetop grass and nice fence boards or as a simple rectangle.
         Either way, drawing a rectangle forces us to realize that we need to
         know the dimensions of this rectangle so we can create an area function
@@ -56,7 +56,7 @@
       </p>
 
       <figure xml:id="fig_opt1b">
-        <caption>A sketch of the enclosure in <xref ref="ex_opt1">Example</xref>.
+        <caption>A sketch of the enclosure in <xref ref="ex_opt1"/>.
       </caption>
         <sidebyside widths="47% 47%" margins="0%">
           <image xml:id="img_opt1b">
@@ -173,7 +173,7 @@
         This function only makes sense when <m>0\leq x \leq 50</m>,
         otherwise we get negative values of area.
         So we find the extreme values of <m>A(x)</m> on the interval
-        <m>[0,50]</m> using <xref ref="idea_extrema">Key Idea</xref>.
+        <m>[0,50]</m> using <xref ref="idea_extrema"/>.
       </p>
 
       <p>
@@ -292,7 +292,7 @@
   </insight>
 
   <p>
-    We will use <xref ref="idea_optimization">Key Idea</xref> in a variety of
+    We will use <xref ref="idea_optimization"/> in a variety of
     examples.
   </p>
 
@@ -317,7 +317,7 @@
 
       <p>
         We will follow the steps outlined by
-        <xref ref="idea_optimization">Key Idea</xref>.
+        <xref ref="idea_optimization"/>.
       </p>
 
       <p>
@@ -326,7 +326,7 @@
             <p>
               We are maximizing <em>area</em>.
               A sketch of the region will help;
-              <xref ref="fig_opt2a">Figure</xref>
+              <xref ref="fig_opt2a"/>
               gives two sketches of the proposed enclosed area.
               A key feature of the sketches is to acknowledge that one side is
               not fenced.
@@ -334,7 +334,7 @@
 
             <figure xml:id="fig_opt2a">
               <caption>A sketch of the enclosure in
-                <xref ref="ex_opt2">Example</xref></caption>
+                <xref ref="ex_opt2"/></caption>
               <sidebyside widths="47% 47%" margins="0%">
                 <image xml:id="img_opt2a">
                   <shortdescription>
@@ -429,7 +429,7 @@
               </me>.
               The perimeter is our constraint equation.
               Note how this is a different equation for perimeter than in
-              <xref ref="ex_opt1">Example</xref>,
+              <xref ref="ex_opt1"/>,
               since one of the sides does not need to be fenced.
             </p>
           </li>
@@ -505,7 +505,7 @@
       <p>
         A power line needs to be run from a power station located on the beach
         to an offshore facility.
-        <xref ref="fig_opt3b">Figure</xref>
+        <xref ref="fig_opt3b"/>
         shows the distances between the power station to the facility.
       </p>
 
@@ -520,7 +520,7 @@
 
       <figure xml:id="fig_opt3b">
         <caption>Running a power line from the power station to an offshore
-          facility with minimal cost in <xref ref="ex_opt3">Example</xref></caption>
+          facility with minimal cost in <xref ref="ex_opt3"/></caption>
         <image xml:id="img_opt3b" width="47%">
           <shortdescription>
             a power line is ran from the power station to an offshore facility.
@@ -570,7 +570,7 @@
 
       <p>
         We will follow the strategy of
-        <xref ref="idea_optimization">Key Idea</xref> implicitly,
+        <xref ref="idea_optimization"/> implicitly,
         without specifically numbering steps.
       </p>
 
@@ -599,11 +599,11 @@
         Recognizing that the underwater distance can be measured as the
         hypotenuse of a right triangle,
         we choose to label the distances as shown in
-        <xref ref="fig_opt3c">Figure</xref>.
+        <xref ref="fig_opt3c"/>.
       </p>
 
       <figure xml:id="fig_opt3c">
-        <caption>Labeling unknown distances in <xref ref="ex_opt3">Example</xref></caption>
+        <caption>Labeling unknown distances in <xref ref="ex_opt3"/></caption>
         <image xml:id="img_opt3c" width="47%">
           <shortdescription>
             A power line is ran from the power station to an offshore facility with the distance run along 
@@ -741,7 +741,7 @@
 
 
   <p>
-    <xref ref="sec_differentials">Section</xref>
+    <xref ref="sec_differentials"/>
     introduces our final application of the derivative:
     <em>differentials</em>.
     Given <m>y=f(x)</m>,
@@ -1211,7 +1211,7 @@
           <statement>
             <p>
               A power line is to be run to an offshore facility in the manner
-              described in <xref ref="ex_opt3">Example</xref>.
+              described in <xref ref="ex_opt3"/>.
               The offshore facility is <m><var name="$x"/></m> miles at sea and
               <m><var name="$y"/></m> miles along the shoreline from the power plant.
               It costs <m><var name="$yC"/></m> per mile to lay a power line underground and
@@ -1261,7 +1261,7 @@
           <statement>
             <p>
               A power line is to be run to an offshore facility in the manner
-              described in <xref ref="ex_opt3">Example</xref>.
+              described in <xref ref="ex_opt3"/>.
               The offshore facility is <m><var name="$x"/></m> miles at sea and
               <m><var name="$y"/></m> miles along the shoreline from the power plant.
               It costs <m><var name="$yC"/></m> per mile to lay a power line underground and
@@ -1312,7 +1312,7 @@
             <p>
               How far along the shore should the dog run to minimize the
               time it takes to get to the stick? (Hint: the figure from
-              <xref ref="ex_opt3">Example</xref> can be useful.)
+              <xref ref="ex_opt3"/> can be useful.)
             </p>
             <p>
               <var name="$zU" width="20"/>

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -169,11 +169,11 @@
               </p>
 
               <p>
-                This is illustrated in <xref ref="fig_parcalc1">Figure</xref>.
+                This is illustrated in <xref ref="fig_parcalc1"/>.
               </p>
 
               <figure xml:id="fig_parcalc1">
-                <caption>Graphing tangent and normal lines in <xref ref="ex_parcalc1">Example</xref></caption>
+                <caption>Graphing tangent and normal lines in <xref ref="ex_parcalc1"/></caption>
               <!-- START figures/fig_parcalc1.tex -->
                 <image xml:id="img_parcalc1" width="47%">
                   <shortdescription>Plot of a parametric curve and its tangent and normal lines at one point.</shortdescription>
@@ -243,7 +243,7 @@
                 </me>.
                 The point on <m>C</m> corresponding to <m>t=0.6</m> is <m>(2.2,2.96)</m>.
                 The tangent line at that point is <m>x=2.2</m>.
-                The points where the tangent lines are vertical and horizontal are indicated on the graph in <xref ref="fig_parcalc1">Figure</xref>.
+                The points where the tangent lines are vertical and horizontal are indicated on the graph in <xref ref="fig_parcalc1"/>.
               </p>
             </li>
           </ol>
@@ -281,7 +281,7 @@
           <ol>
             <li>
               <p>
-                We compute the derivative following <xref ref="idea_dydxpar">Key Idea</xref>:
+                We compute the derivative following <xref ref="idea_dydxpar"/>:
                 <me>
                   \frac{dy}{dx} = \frac{g'(t)}{\fp(t)} = -\frac{\cos(t) }{\sin(t) }
                 </me>.
@@ -304,7 +304,7 @@
                 </md>,
                 as long as <m>\cos(t_0) \neq 0</m>.
                 It is an important fact to recognize that the normal lines to a circle pass through its center,
-                as illustrated in <xref ref="fig_parcalc2">Figure</xref>.
+                as illustrated in <xref ref="fig_parcalc2"/>.
                 Stated in another way,
                 any line that passes through the center of a circle intersects the circle at right angles.
               </p>
@@ -361,7 +361,7 @@
         <p>
           Find the equation of the tangent line to the astroid <m>x=\cos^3(t)</m>,
           <m>y=\sin^3(t)</m> at <m>t=0</m>,
-          shown in <xref ref="fig_parcalc3">Figure</xref>.
+          shown in <xref ref="fig_parcalc3"/>.
         </p>
         <figure xml:id="fig_parcalc3">
           <caption>A graph of an astroid</caption>
@@ -501,7 +501,7 @@
       <statement>
         <p>
           Let <m>x=5t^2-6t+4</m> and
-          <m>y=t^2+6t-1</m> as in <xref ref="ex_parcalc1">Example</xref>.
+          <m>y=t^2+6t-1</m> as in <xref ref="ex_parcalc1"/>.
           Determine the <m>t</m>-intervals on which the graph is concave up/down.
         </p>
       </statement>
@@ -513,11 +513,11 @@
         <p>
           Concavity is determined by the second derivative of <m>y</m> with respect to <m>x</m>,
           <m>\frac{d^2y}{dx^2}</m>,
-          so we compute that here following <xref ref="idea_second_der_par">Key Idea</xref>.
+          so we compute that here following <xref ref="idea_second_der_par"/>.
         </p>
 
         <p>
-          In <xref ref="ex_parcalc1">Example</xref>,
+          In <xref ref="ex_parcalc1"/>,
           we found <m>\ds\frac{dy}{dx} = \frac{2t+6}{10t-6}</m> and <m>\fp(t) = 10t-6</m>.
           So:
           <md>
@@ -529,7 +529,7 @@
         </p>
 
         <figure xml:id="fig_parcalc4">
-          <caption>Graphing the parametric equations in <xref ref="ex_parcalc4">Example</xref> to demonstrate concavity</caption>
+          <caption>Graphing the parametric equations in <xref ref="ex_parcalc4"/> to demonstrate concavity</caption>
           <!-- START figures/fig_parcalc4.tex -->
           <image xml:id="img_parcalc4" width="47%">
             <shortdescription>Sketch of a parametric curve illustrating concavity.</shortdescription>
@@ -582,7 +582,7 @@
           As the numerator of <m>\ds -\frac{9}{(5t-3)^3}</m> is never 0, <m>\frac{d^2y}{dx^2} \neq 0</m> for all <m>t</m>.
           It is undefined when <m>5t-3=0</m>;
           that is, when <m>t= 3/5</m>.
-          Following the work established in <xref ref="sec_concavity">Section</xref>,
+          Following the work established in <xref ref="sec_concavity"/>,
           we look at values of <m>t</m> greater/less than <m>3/5</m> on a number line:
         </p>
 
@@ -615,14 +615,14 @@
         </image>
 
         <p>
-          Reviewing <xref ref="ex_parcalc1">Example</xref>,
+          Reviewing <xref ref="ex_parcalc1"/>,
           we see that when <m>t=3/5=0.6</m>,
           the graph of the parametric equations has a vertical tangent line.
           This point is also a point of inflection for the graph,
-          illustrated in <xref ref="fig_parcalc4">Figure</xref>.
+          illustrated in <xref ref="fig_parcalc4"/>.
         </p>
         <p xml:id="vidint-planecurves-parcalc-sketch" component="video">
-          The video in <xref ref="vid-planecurves-parcalc-sketch">Figure</xref>
+          The video in <xref ref="vid-planecurves-parcalc-sketch"/>
           shows how this information can be used to sketch the curve by hand.
         </p>
 
@@ -659,7 +659,7 @@
         </p>
 
         <p>
-          In <xref ref="fig_parcalc5a">Figure</xref> we see a plot of the second derivative.
+          In <xref ref="fig_parcalc5a"/> we see a plot of the second derivative.
           It shows that it has zeros at approximately <m>t=0.5,\,3.5,\,6.5,\,9.5,\,12.5</m> and <m>16</m>.
           These approximations are not very good,
           made only by looking at the graph.
@@ -671,13 +671,13 @@
         </p>
 
         <p>
-          The corresponding points have been plotted on the graph of the parametric equations in <xref ref="fig_parcalc5b">Figure</xref>.
+          The corresponding points have been plotted on the graph of the parametric equations in <xref ref="fig_parcalc5b"/>.
           Note how most occur near the <m>x</m>-axis,
           but not exactly on the axis.
         </p>
 
         <figure xml:id="fig_parcalc5">
-          <caption>In (a), a graph of <m>\frac{d^2y}{dx^2}</m>, showing where it is approximately 0. In (b), graph of the parametric equations in <xref ref="ex_parcalc5">Example</xref> along with the points of inflection</caption>
+          <caption>In (a), a graph of <m>\frac{d^2y}{dx^2}</m>, showing where it is approximately 0. In (b), graph of the parametric equations in <xref ref="ex_parcalc5"/> along with the points of inflection</caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
             <figure xml:id="fig_parcalc5a">
               <caption/>
@@ -773,7 +773,7 @@
       <video youtube="57F7ZspP0lU" label="vid-planecurves-parcalc-arclength"/>
     </figure>
     <p>
-      Recall in <xref ref="sec_arc_length">Section</xref>
+      Recall in <xref ref="sec_arc_length"/>
       we found the arc length of the graph of a function,
       from <m>x=a</m> to <m>x=b</m>, to be
       <me>
@@ -829,9 +829,9 @@
 
     <aside>
       <p>
-        <em>Note:</em> <xref ref="thm_arc_length_parametric">Theorem</xref>
+        <em>Note:</em> <xref ref="thm_arc_length_parametric"/>
         makes use of differentiability on closed intervals,
-        just as was done in <xref ref="sec_arc_length">Section</xref>.
+        just as was done in <xref ref="sec_arc_length"/>.
       </p>
     </aside>
     <p>
@@ -854,7 +854,7 @@
       </solution>
       <solution>
         <p>
-          By direct application of <xref ref="thm_arc_length_parametric">Theorem</xref>, we have
+          By direct application of <xref ref="thm_arc_length_parametric"/>, we have
           <md>
             <mrow>L \amp = \int_0^{3\pi/2} \sqrt{(-3\sin(t) )^2 +(3\cos(t) )^2} \, dt.</mrow>
             <intertext>Apply the Pythagorean Theorem.</intertext>
@@ -877,11 +877,11 @@
       <statement>
         <p>
           The graph of the parametric equations <m>x=t(t^2-1)</m>,
-          <m>y=t^2-1</m> crosses itself as shown in <xref ref="fig_parcalc7">Figure</xref>,
+          <m>y=t^2-1</m> crosses itself as shown in <xref ref="fig_parcalc7"/>,
           forming a <q>teardrop.</q> Find the arc length of the teardrop.
         </p>
         <figure xml:id="fig_parcalc7">
-          <caption>A graph of the parametric equations in <xref ref="ex_parcalc7">Example</xref>, where the arc length of the teardrop is calculated</caption>
+          <caption>A graph of the parametric equations in <xref ref="ex_parcalc7"/>, where the arc length of the teardrop is calculated</caption>
           <!-- START figures/fig_parcalc7.tex -->
           <image xml:id="img_parcalc7" width="47%">
             <shortdescription>Graph of a "teardrop" curve that intersects itself at the origin.</shortdescription>
@@ -922,7 +922,7 @@
           We can see by the parametrizations of <m>x</m> and <m>y</m> that when <m>t=\pm 1</m>,
           <m>x=0</m> and <m>y=0</m>.
           This means we'll integrate from <m>t=-1</m> to <m>t=1</m>.
-          Applying <xref ref="thm_arc_length_parametric">Theorem</xref>, we have
+          Applying <xref ref="thm_arc_length_parametric"/>, we have
           <md>
             <mrow>L   \amp = \int_{-1}^1\sqrt{(3t^2-1)^2+(2t)^2}\, dt</mrow>
             <mrow>\amp =  \int_{-1}^1 \sqrt{9t^4-2t^2+1} \, dt</mrow>
@@ -946,8 +946,8 @@
     <title>Surface Area of a Solid of Revolution</title>
     <p>
       Related to the formula for finding arc length is the formula for finding surface area.
-      We can adapt the formula found in <xref ref="thm_surface_area">Theorem</xref>
-      from <xref ref="sec_arc_length">Section</xref>
+      We can adapt the formula found in <xref ref="thm_surface_area"/>
+      from <xref ref="sec_arc_length"/>
       in a similar way as done to produce the formula for arc length done before.
     </p>
 
@@ -993,12 +993,12 @@
       <statement>
         <p>
           Consider the teardrop shape formed by the parametric equations <m>x=t(t^2-1)</m>,
-          <m>y=t^2-1</m> as seen in <xref ref="ex_parcalc7">Example</xref>.
+          <m>y=t^2-1</m> as seen in <xref ref="ex_parcalc7"/>.
           Find the surface area if this shape is rotated about the <m>x</m>-axis,
-          as shown in <xref ref="fig_parcalc8">Figure</xref>.
+          as shown in <xref ref="fig_parcalc8"/>.
         </p>
         <figure xml:id="fig_parcalc8">
-          <caption>Rotating a teardrop shape about the <m>x</m>-axis in <xref ref="ex_parcalc8">Example</xref></caption>
+          <caption>Rotating a teardrop shape about the <m>x</m>-axis in <xref ref="ex_parcalc8"/></caption>
 
           <!-- START figures/figparcalc8_3D.asy -->
           <image xml:id="img_parcalc8" width="47%">
@@ -1060,7 +1060,7 @@
       <solution>
         <p>
           The teardrop shape is formed between <m>t=-1</m> and <m>t=1</m>.
-          Using <xref ref="thm_surface_area_parametric">Theorem</xref>,
+          Using <xref ref="thm_surface_area_parametric"/>,
           we see we need for <m>g(t)\geq 0</m> on <m>[-1,1]</m>,
           and this is not the case.
           To fix this, we simplify replace <m>g(t)</m> with <m>-g(t)</m>,
@@ -1122,7 +1122,7 @@
             <statement>
               <p>
                 Given parametric equations <m>x=f(t)</m> and <m>y=g(t)</m>,
-                the derivative <m>\frac{dy}{dx}</m> as given in <xref ref="idea_dydxpar">Key Idea</xref> is a function of <fillin/>?
+                the derivative <m>\frac{dy}{dx}</m> as given in <xref ref="idea_dydxpar"/> is a function of <fillin/>?
               </p>
             </statement>
             <solution>
@@ -1454,8 +1454,7 @@
         <introduction>
           <p>
             Find the <m>t</m>-values where the curve defined by the given parametric equations has a horizontal tangent line.
-            Note: these are the same equations as in <xref ref="ex_09_03_ex_05">Exercises</xref>
-            <mdash/> <xref ref="ex_09_03_ex_12"/>.
+            Note: these are the same equations as in <xref first="ex_09_03_ex_05" last="ex_09_03_ex_12" text="local">Exercises</xref>.
           </p>
         </introduction>
 
@@ -1751,8 +1750,7 @@
             For the given parametric equations for a curve,
             find <m>\frac{d^2y}{dx^2}</m>,
             then determine the intervals on which the graph of the curve is concave up/down.
-            Note: these are the same equations as in <xref ref="ex_09_03_ex_05">Exercises</xref>
-            <mdash/> <xref ref="ex_09_03_ex_12"/>.
+            Note: these are the same equations as in <xref first="ex_09_03_ex_05" last="ex_09_03_ex_12" text="local">Exercises</xref>.
           </p>
         </introduction>
 

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -179,7 +179,7 @@
         </p>
 
         <p>
-          The points <m>(x,y)</m> from the table are plotted in <xref ref="fig_pareq1b">Figure</xref>.
+          The points <m>(x,y)</m> from the table are plotted in <xref ref="fig_pareq1b"/>.
           The points have been connected with a smooth curve.
           Each point has been labeled with its corresponding <m>t</m>-value.
           These values, along with the two arrows along the curve,
@@ -188,7 +188,7 @@
         </p>
 
         <figure xml:id="fig_pareq1">
-          <caption>A table of values of the parametric equations in <xref ref="ex_pareq1">Example</xref> along with a sketch of their graph</caption>
+          <caption>A table of values of the parametric equations in <xref ref="ex_pareq1"/> along with a sketch of their graph</caption>
           <sidebyside valign="bottom" widths="47% 47%">
             <figure xml:id="fig_pareq1a"><caption/>
               <tabular>
@@ -303,7 +303,7 @@
         </p>
 
         <figure xml:id="fig_pareq2">
-          <caption>A table of values of the parametric equations in <xref ref="ex_pareq2">Example</xref> along with a sketch of their graph</caption>
+          <caption>A table of values of the parametric equations in <xref ref="ex_pareq2"/> along with a sketch of their graph</caption>
           <sidebyside valign="bottom" widths="47% 47%">
             <figure xml:id="fig_pareq2a"><caption/>
               <tabular>
@@ -393,19 +393,19 @@
         </figure>
 
         <p>
-          It is not difficult to show that the curves in <xref ref="ex_pareq1">Examples</xref>
-          and <xref ref="ex_pareq2"/>
+          It is not difficult to show that the curves in <xref ref="ex_pareq1" text="global">Examples</xref>
+          and <xref ref="ex_pareq2" text="global"/>
           are portions of the same parabola.
           While the <em>parabola</em> is the same,
           the <em>curves</em> are different.
-          In <xref ref="ex_pareq1">Example</xref>,
+          In <xref ref="ex_pareq1"/>,
           if we let <m>t</m> vary over all real numbers,
           we'd obtain the entire parabola.
           In this example,
           letting <m>t</m> vary over all real numbers would still produce the same graph;
           this portion of the parabola would be traced,
           and re-traced, infinitely many times.
-          The orientation shown in <xref ref="fig_pareq2">Figure</xref>
+          The orientation shown in <xref ref="fig_pareq2"/>
           shows the orientation on <m>[0,\pi]</m>,
           but this orientation is reversed on <m>[\pi,2\pi]</m>.
         </p>
@@ -433,8 +433,8 @@
       A smaller <m>t</m>-step plots more points,
       making for a smoother graph
       (but may take longer).
-      In <xref ref="fig_pareq1">Figure</xref>, the <m>t</m>-step is 1;
-      in <xref ref="fig_pareq2">Figure</xref>,
+      In <xref ref="fig_pareq1"/>, the <m>t</m>-step is 1;
+      in <xref ref="fig_pareq2"/>,
       the <m>t</m>-step is <m>\pi/4</m>.
     </p>
 
@@ -460,7 +460,7 @@
       </statement>
       <solution>
         <p>
-          The graph of the parametric equations is given in <xref ref="fig_pareq3a">Figure</xref>.
+          The graph of the parametric equations is given in <xref ref="fig_pareq3a"/>.
           It is a parabola with a axis of symmetry along the line <m>y=x</m>;
           the vertex is at <m>(0,0)</m>.
         </p>
@@ -475,12 +475,12 @@
           <m>y = t^2-t-2</m>.
           Thus our parametric equations for the shifted graph are <m>x=t^2+t+3</m>,
           <m>y=t^2-t-2</m>.
-          This is graphed in <xref ref="fig_pareq3a">Figure</xref>.
+          This is graphed in <xref ref="fig_pareq3a"/>.
           Notice how the vertex is now at <m>(3,-2)</m>.
         </p>
 
         <figure xml:id="fig_pareq3">
-          <caption>Illustrating how to shift graphs in <xref ref="ex_pareq3">Example</xref></caption>
+          <caption>Illustrating how to shift graphs in <xref ref="ex_pareq3"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_pareq3a">
               <caption/>
@@ -587,13 +587,13 @@
       <solution>
         <p>
           Using the methods developed in this section,
-          we again plot points and graph the parametric equations as shown in <xref ref="fig_pareq4">Figure</xref>.
+          we again plot points and graph the parametric equations as shown in <xref ref="fig_pareq4"/>.
           It appears that the graph crosses itself at the point <m>(2,6)</m>,
           but we'll need to analytically determine this.
         </p>
 
         <figure xml:id="fig_pareq4">
-          <caption>A graph of the parametric equations from <xref ref="ex_pareq4">Example</xref></caption>
+          <caption>A graph of the parametric equations from <xref ref="ex_pareq4"/></caption>
           <!-- START figures/fig_pareq4.tex -->
           <image xml:id="img_pareq4" width="47%">
             <shortdescription>Plot of a more complicated parametric curve that has a self-intersection.</shortdescription>
@@ -751,11 +751,11 @@
           2 seconds into the flight the object is at the point <m>\big(x(2),y(2)\big) = \big(64,128\big)</m>.
           That is, it has traveled horizontally <quantity><mag>64</mag><unit base="foot"/></quantity>
           and is at a height of <quantity><mag>128</mag><unit base="foot"/></quantity>,
-          as shown in <xref ref="fig_pareq6">Figure</xref>.
+          as shown in <xref ref="fig_pareq6"/>.
         </p>
 
         <figure xml:id="fig_pareq6">
-          <caption>Graphing projectile motion in <xref ref="ex_pareq6">Example</xref></caption>
+          <caption>Graphing projectile motion in <xref ref="ex_pareq6"/></caption>
           <!-- START figures/fig_pareq6.tex -->
           <image xml:id="img_pareq6" width="47%">
             <shortdescription>A parabolic arc describing the motion of a projectile fired up and to the right from the origin.</shortdescription>
@@ -840,7 +840,7 @@
         </p>
 
         <figure xml:id="fig_pareq7">
-          <caption>Graphing parametric and rectangular equations for a graph in <xref ref="ex_pareq7">Example</xref></caption>
+          <caption>Graphing parametric and rectangular equations for a graph in <xref ref="ex_pareq7"/></caption>
           <!-- START figures/fig_pareq7.tex -->
           <image xml:id="img_pareq7" width="47%">
             <shortdescription>A graph of two overlapping lines illustrating rectangular and parametric descriptions of a curve.</shortdescription>
@@ -904,7 +904,7 @@
         </p>
 
         <p>
-          The graphs of these functions is given in <xref ref="fig_pareq7">Figure</xref>.
+          The graphs of these functions is given in <xref ref="fig_pareq7"/>.
           The portion of the graph defined by the parametric equations is given in a thick line;
           the graph defined by <m>y=1-x</m> with unrestricted domain is given in a thin line.
         </p>
@@ -944,7 +944,7 @@
         </p>
 
         <figure xml:id="fig_pareq8">
-          <caption>Graphing the parametric equations <m>x=4\cos(t) +3</m>, <m>y=2\sin(t) +1</m> in <xref ref="ex_pareq8">Example</xref></caption>
+          <caption>Graphing the parametric equations <m>x=4\cos(t) +3</m>, <m>y=2\sin(t) +1</m> in <xref ref="ex_pareq8"/></caption>
           <!-- START figures/fig_pareq8.tex -->
           <image xml:id="img_pareq8" width="47%">
             <shortdescription>Graph of the ellipse obtained from the parametric equations in this example.</shortdescription>
@@ -976,7 +976,7 @@
 
         <p>
           This final equation should look familiar <mdash/> it is the equation of an ellipse!
-          <xref ref="fig_pareq8">Figure</xref>
+          <xref ref="fig_pareq8"/>
           plots the parametric equations,
           demonstrating that the graph is indeed of an ellipse with a horizontal major axis and center at <m>(3,1)</m>.
         </p>
@@ -1031,7 +1031,7 @@
   <subsection>
     <title>Special Curves</title>
     <p>
-      <xref ref="fig_pareq_special">Figure</xref>
+      <xref ref="fig_pareq_special"/>
       gives a small gallery of <q>interesting</q> and <q>famous</q>
       curves along with parametric equations that produce them.
       Interested readers can begin learning more about these curves through internet searches.
@@ -1265,12 +1265,12 @@
           We see at <m>t=2</m> both <m>x'</m> and <m>y'</m> are 0;
           thus <m>C</m> is not smooth at <m>t=2</m>,
           corresponding to the point <m>(1,4)</m>.
-          The curve is graphed in <xref ref="fig_pareq9">Figure</xref>,
+          The curve is graphed in <xref ref="fig_pareq9"/>,
           illustrating the cusp at <m>(1,4)</m>.
         </p>
 
         <figure xml:id="fig_pareq9">
-          <caption>Graphing the curve in <xref ref="ex_pareq9">Example</xref>; note it is not smooth at <m>(1,4)</m></caption>
+          <caption>Graphing the curve in <xref ref="ex_pareq9"/>; note it is not smooth at <m>(1,4)</m></caption>
           <!-- START figures/fig_pareq9.tex -->
           <image xml:id="img_pareq9" width="47%">
             <shortdescription>Plot of a parametric curve with a sharp cusp.</shortdescription>

--- a/ptx/sec_parametric_surfaces.ptx
+++ b/ptx/sec_parametric_surfaces.ptx
@@ -135,7 +135,7 @@
       <idx><h>Möbius band</h></idx>
 
       It is enlightening to examine a classic non-orientable surface:
-      the Möbius band, shown in <xref ref="fig_mobius">Figure</xref>.
+      the Möbius band, shown in <xref ref="fig_mobius"/>.
       Vectors normal to the surface are given,
       starting at the point indicated in the figure.
       These normal vectors <q>vary continuously</q>
@@ -276,11 +276,11 @@
           In this instance,
           we have <m>\vec r(u,v) = \langle u,v,u^2+2v^2\rangle</m>,
           for <m>-3\leq u\leq 3</m>, <m>-1\leq v\leq 1</m>.
-          This surface is graphed in <xref ref="fig_parsurf1">Figure</xref>.
+          This surface is graphed in <xref ref="fig_parsurf1"/>.
         </p>
 
         <figure xml:id="fig_parsurf1">
-          <caption>The surface parametrized in <xref ref="ex_parsurf1">Example</xref></caption>
+          <caption>The surface parametrized in <xref ref="ex_parsurf1"/></caption>
           <image xml:id="img_parsurf1" width="47%">
             <description></description>
             <asymptote>
@@ -363,7 +363,7 @@
         </p>
 
         <figure xml:id="fig_parsurf2">
-          <caption>The surface parametrized in <xref ref="ex_parsurf2">Example</xref></caption>
+          <caption>The surface parametrized in <xref ref="ex_parsurf2"/></caption>
           <image xml:id="fig_parsurf2_3D" width="47%">
             <description></description>
             <asymptote>
@@ -431,7 +431,7 @@
         <p>
           Thus <m>\vec r(u,v) = \langle 2v\cos u,2v\sin u,4v^2\cos^2u+8v^2\sin^2u\rangle</m>,
           <m>0\leq u\leq 2\pi</m>, <m>0\leq v\leq 1</m>,
-          which is graphed in <xref ref="fig_parsurf2">Figure</xref>.
+          which is graphed in <xref ref="fig_parsurf2"/>.
           The way that this graphic was generated highlights how the surface was parametrized.
           When viewing from above, one can see lines emanating from the origin;
           they represent different values of <m>u</m> as <m>u</m> sweeps from an angle of 0 up to <m>2\pi</m>.
@@ -442,8 +442,8 @@
     </example>
 
     <p>
-      <xref ref="ex_parsurf1">Examples</xref>
-      and <xref ref="ex_parsurf2"/>
+      <xref ref="ex_parsurf1" text="global">Examples</xref>
+      and <xref ref="ex_parsurf2" text="global"/>
       demonstrate an important principle when parametrizing surfaces given in the form
       <m>z=f(x,y)</m> over a region <m>R</m>:
       if one can determine <m>x</m> and <m>y</m> in terms of <m>u</m> and <m>v</m>,
@@ -454,7 +454,7 @@
       In the following two examples,
       we parametrize the same surface over triangular regions.
       Each will use <m>v</m> as a <q>scaling factor</q>
-      as done in <xref ref="ex_parsurf2">Example</xref>.
+      as done in <xref ref="ex_parsurf2"/>.
     </p>
 
     <example xml:id="ex_parsurf3">
@@ -462,10 +462,10 @@
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the triangular region <m>R</m> enclosed by the coordinate axes and the line <m>y=2-2x/3</m>,
-          as shown in <xref ref="fig_parsurf3a">Figure</xref>.
+          as shown in <xref ref="fig_parsurf3a"/>.
         </p>
         <figure xml:id="fig_parsurf3">
-          <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf3">Example</xref></caption>
+          <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf3"/></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_parsurf3a">
               <caption/>
@@ -575,7 +575,7 @@
           we have <m>\vec r(u,v) = \langle u, v(2-2u/3),
           u^2+2\big(v(2-2u/3)\big)^2\rangle</m>,
           <m>0\leq u\leq 3</m>, <m>0\leq v\leq 1</m>.
-          This surface is graphed in <xref ref="fig_parsurf3b_3D">Figure</xref>.
+          This surface is graphed in <xref ref="fig_parsurf3b_3D"/>.
           Again, when one looks from above,
           we can see the scaling effects of <m>v</m>:
           the series of lines that run to the point <m>(3,0)</m> each represent a different value of <m>v</m>.
@@ -599,10 +599,10 @@
       <statement>
         <p>
           Parametrize the surface <m>z=x^2+2y^2</m> over the triangular region <m>R</m> enclosed by the lines <m>y=3-2x/3</m>,
-          <m>y=1</m> and <m>x=0</m> as shown in <xref ref="fig_parsurf4a">Figure</xref>.
+          <m>y=1</m> and <m>x=0</m> as shown in <xref ref="fig_parsurf4a"/>.
         </p>
         <figure xml:id="fig_parsurf4">
-          <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf4">Example</xref></caption>
+          <caption>Part (a) shows a graph of the region <m>R</m>, and part (b) shows the surface over <m>R</m>, as defined in <xref ref="ex_parsurf4"/></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_parsurf4a">
               <caption/>
@@ -714,7 +714,7 @@
         </p>
 
         <p>
-          The surface is graphed in <xref ref="fig_parsurf4b_3D">Figure</xref>.
+          The surface is graphed in <xref ref="fig_parsurf4b_3D"/>.
         </p>
       </solution>
     </example>
@@ -722,7 +722,7 @@
     <p>
       Given a surface of the form <m>z=f(x,y)</m>,
       one can often determine a parametrization of the surface over a region <m>R</m> in a manner similar to determining bounds of integration over a region <m>R</m>.
-      Using the techniques of <xref ref="sec_iterated_integrals">Section</xref>,
+      Using the techniques of <xref ref="sec_iterated_integrals"/>,
       suppose a region <m>R</m> can be described by <m>a\leq x\leq b</m>,
       <m>g_1(x) \leq y\leq g_2(x)</m>,
       <ie/>, the area of <m>R</m> can be found using the iterated integral
@@ -744,9 +744,9 @@
 
     <p>
       As a specific example,
-      consider the triangular region <m>R</m> from <xref ref="ex_parsurf4">Example</xref>,
-      shown in <xref ref="fig_parsurf4a">Figure</xref>.
-      Using the techniques of <xref ref="sec_iterated_integrals">Section</xref>,
+      consider the triangular region <m>R</m> from <xref ref="ex_parsurf4"/>,
+      shown in <xref ref="fig_parsurf4a"/>.
+      Using the techniques of <xref ref="sec_iterated_integrals"/>,
       we can find the area of <m>R</m> as
       <me>
         \int_0^3\int_1^{3-2x/3} dy\, dx
@@ -793,10 +793,10 @@
         <p>
           Find a parametrization of the cylinder <m>x^2 + z^2/4=1</m>,
           where <m>-1\leq y\leq 2</m>,
-          as shown in <xref ref="fig_parsurf5">Figure</xref>.
+          as shown in <xref ref="fig_parsurf5"/>.
         </p>
         <figure xml:id="fig_parsurf5">
-          <caption>The cylinder parametrized in <xref ref="ex_parsurf5">Example</xref></caption>
+          <caption>The cylinder parametrized in <xref ref="ex_parsurf5"/></caption>
           <image xml:id="img_parsurf5_3D" width="47%">
             <description></description>
             <asymptote>
@@ -855,7 +855,7 @@
           The equation <m>x^2+z^2/4=1</m> can be envisioned to describe an ellipse in the <m>xz</m>-plane;
           as the equation lacks a <m>y</m>-term,
           the equation describes a cylinder
-          (recall <xref ref="def_cylinder">Definition</xref>)
+          (recall <xref ref="def_cylinder"/>)
           that extends without bound parallel to the <m>y</m>-axis.
           This ellipse has a vertical major axis of length 4, a horizontal minor axis of length 2, and is centered at the origin.
           We can parametrize this ellipse using sines and cosines;
@@ -885,10 +885,10 @@
         <p>
           Find a parametrization of the elliptic cone <m>z^2 = \frac{x^2}{4}+\frac{y^2}{9}</m>,
           where <m>-2\leq z\leq 3</m>,
-          as shown in <xref ref="fig_parsurf6a">Figure</xref>.
+          as shown in <xref ref="fig_parsurf6a"/>.
         </p>
         <figure xml:id="fig_parsurf6a">
-          <caption>The elliptic cone as described in  <xref ref="ex_parsurf6">Example</xref></caption>
+          <caption>The elliptic cone as described in  <xref ref="ex_parsurf6"/></caption>
           <image xml:id="img_parsurf6a" width="47%">
             <description></description>
             <asymptote>
@@ -965,7 +965,7 @@
           When <m>v</m> takes on negative values,
           the radii of the cross-sectional ellipses become <q>negative,</q>
           which can lead to some surprising results.
-          Consider <xref ref="fig_parsurf6b_3D">Figure</xref>,
+          Consider <xref ref="fig_parsurf6b_3D"/>,
           where the cone is graphed for <m>0\leq u\leq \pi</m>.
           Because <m>v</m> is negative below the <m>xy</m>-plane,
           the radii of the cross-sectional ellipses are negative,
@@ -973,7 +973,7 @@
         </p>
 
         <figure xml:id="fig_parsurf6b_3D">
-          <caption>The elliptic cone as described in  <xref ref="ex_parsurf6">Example</xref> with restricted domain</caption>
+          <caption>The elliptic cone as described in  <xref ref="ex_parsurf6"/> with restricted domain</caption>
           <image xml:id="img_parsurf6b_3D" width="47%">
             <description></description>
             <asymptote>
@@ -1034,10 +1034,10 @@
       <statement>
         <p>
           Find a parametrization of the ellipsoid
-          <m>\frac{x^2}{25}+y^2+\frac{z^2}{4}=1</m> as shown in <xref ref="fig_parsurf7a_3D">Figure</xref>.
+          <m>\frac{x^2}{25}+y^2+\frac{z^2}{4}=1</m> as shown in <xref ref="fig_parsurf7a_3D"/>.
         </p>
         <figure xml:id="fig_parsurf7">
-          <caption>An ellipsoid in (a), drawn again in (b) with its domain restricted, as described in  <xref ref="ex_parsurf7">Example</xref></caption>
+          <caption>An ellipsoid in (a), drawn again in (b) with its domain restricted, as described in  <xref ref="ex_parsurf7"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_parsurf7a_3D">
               <caption/>
@@ -1138,8 +1138,8 @@
       </statement>
       <solution>
         <p>
-          Recall <xref ref="idea_unit_vectors">Key Idea</xref>
-          from <xref ref="sec_vector_intro">Section</xref>,
+          Recall <xref ref="idea_unit_vectors"/>
+          from <xref ref="sec_vector_intro"/>,
           which states that all unit vectors in space have the form
           <m>\langle \sin\theta\cos\varphi,\sin\theta\sin\varphi,\cos\theta\rangle</m> for some angles <m>\theta</m> and <m>\varphi</m>.
           If we choose our angles appropriately,
@@ -1180,7 +1180,7 @@
         </p>
 
         <p>
-          In <xref ref="fig_parsurf7b_3D">Figure</xref>,
+          In <xref ref="fig_parsurf7b_3D"/>,
           the ellipsoid is graphed on <m>\frac{\pi}{4}\leq u\leq \frac{2\pi}{3}</m>,
           <m>\frac{\pi}4\leq v\leq \frac{3\pi}2</m> to demonstrate how each variable affects the surface.
         </p>
@@ -1226,14 +1226,14 @@
     </p>
 
     <p>
-      In <xref ref="sec_surface_area">Section</xref>
+      In <xref ref="sec_surface_area"/>
       we used the area of a plane to approximate the surface area of a small portion of a surface.
       We will do the same here.
     </p>
 
     <p>
       Let <m>R</m> be the region of the <m>u</m>-<m>v</m> plane bounded by <m>a\leq u\leq b</m>,
-      <m>c\leq v\leq d</m> as shown in <xref ref="fig_parsurfareaa">Figure</xref>.
+      <m>c\leq v\leq d</m> as shown in <xref ref="fig_parsurfareaa"/>.
       Partition <m>R</m> into rectangles of width
       <m>\Delta u = \frac{b-a}n</m> and height <m>\Delta v = \frac{d-c}n</m>,
       for some <m>n</m>.
@@ -1246,7 +1246,7 @@
       <m>P = \vec r(u_0,v_0)</m> on the surface <m>\surfaceS</m>, and the rectangle with corners <m>p</m>,
       <m>m</m> and <m>q</m> maps to some region
       (probably not rectangular)
-      on the surface as shown in <xref ref="fig_parsurfareab_3D">Figure</xref>,
+      on the surface as shown in <xref ref="fig_parsurfareab_3D"/>,
       where <m>M = \vec r(m)</m> and <m>Q = \vec r(q)</m>.
       We wish to approximate the surface area of this mapped region.
     </p>
@@ -1254,7 +1254,7 @@
     <p>
       Let <m>\vec u = M-P</m> and <m>\vec v = Q-P</m>.
       These two vectors form a parallelogram,
-      illustrated in <xref ref="fig_parsurfareac_3D">Figure</xref>,
+      illustrated in <xref ref="fig_parsurfareac_3D"/>,
       whose area <em>approximates</em>
       the surface area we seek.
       In this particular illustration,
@@ -1489,7 +1489,7 @@
     </figure>
 
     <p>
-      From <xref ref="sec_cross_product">Section</xref>
+      From <xref ref="sec_cross_product"/>
       we know the area of this parallelogram is <m>\snorm{\vec u\times \vec v}</m>.
       If we repeat this approximation process for each rectangle in the partition of <m>R</m>,
       we can sum the areas of all the parallelograms to get an approximation of the surface area <m>S</m>:
@@ -1574,16 +1574,16 @@
       <title>Finding the surface area of a parametrized surface</title>
       <statement>
         <p>
-          Using the parametrization found in <xref ref="ex_parsurf2">Example</xref>,
+          Using the parametrization found in <xref ref="ex_parsurf2"/>,
           find the surface area of <m>z=x^2+2y^2</m> over the circular disk of radius 2, centered at the origin.
         </p>
       </statement>
       <solution>
         <p>
-          In <xref ref="ex_parsurf2">Example</xref>,
+          In <xref ref="ex_parsurf2"/>,
           we parametrized the surface as <m>\vec r(u,v) = \la 2v\cos u, 2v\sin u, 4v^2\cos^2u+8v^2\sin^2u\ra</m>,
           for <m>0\leq u\leq 2\pi</m>, <m>0\leq v\leq 1</m>.
-          To find the surface area using <xref ref="thm_par_surface_area">Theorem</xref>,
+          To find the surface area using <xref ref="thm_par_surface_area"/>,
           we need <m>\snorm{\vec r_u\times\vec r_v}</m>.
           We find:
           <md>
@@ -1616,7 +1616,7 @@
     </figure>
 
     <p>
-      In <xref ref="sec_line_int_intro">Section</xref>,
+      In <xref ref="sec_line_int_intro"/>,
       we recalled the arc length differential <m>ds=\snorm{\vrp(t)}dt</m>.
       In subsequent sections, we used that differential,
       but in most applications the <q><m>\snorm{\vrp(t)}</m></q>

--- a/ptx/sec_partial_derivatives.ptx
+++ b/ptx/sec_partial_derivatives.ptx
@@ -22,9 +22,9 @@
     <title>First-order partial derivatives</title>
     <p>
       Consider the function <m>f(x,y) = x^2+2y^2</m>,
-      as graphed in <xref ref="fig_partialintroa_3D">Figure</xref>.
+      as graphed in <xref ref="fig_partialintroa_3D"/>.
       By fixing <m>y=2</m>,
-      we focus our attention to all points on the surface where the <m>y</m>-value is 2, shown in both <xref ref="fig_partialintroa_3D">Figure</xref> and <xref ref="fig_partialintrob_3D">Figure</xref>.
+      we focus our attention to all points on the surface where the <m>y</m>-value is 2, shown in both <xref ref="fig_partialintroa_3D"/> and <xref ref="fig_partialintrob_3D"/>.
       These points form a curve in the plane <m>y=2</m>:
       <m>z = f(x,2) = x^2+8</m> which defines <m>z</m> as a function of just one variable.
       We can take the derivative of <m>z</m> with respect to <m>x</m> along this curve and find equations of tangent lines, etc.
@@ -202,7 +202,7 @@
       </statement>
       <solution>
         <p>
-          Using <xref ref="def_partial_derivative">Definition</xref>, we have:
+          Using <xref ref="def_partial_derivative"/>, we have:
           <md>
             <mrow>f_x(x,y) \amp = \lim_{h\to 0} \frac{f(x+h,y) - f(x,y)}{h}</mrow>
             <mrow>\amp = \lim_{h\to 0} \frac{(x+h)^2y+2(x+h)+y^3 - (x^2y+2x+y^3)}{h}</mrow>
@@ -220,7 +220,7 @@
     </example>
 
     <p>
-      <xref ref="ex_partial1">Example</xref>
+      <xref ref="ex_partial1"/>
       found a partial derivative using the formal,
       limit-based definition.
       Using limits is not necessary, though,
@@ -388,7 +388,7 @@
 
         <p>
           Consider <m>f_x(2,1)=-3</m>,
-          along with <xref ref="fig_partial3a_3D">Figure</xref>.
+          along with <xref ref="fig_partial3a_3D"/>.
           If one <q>stands</q> on the surface at the point
           <m>(2,1,7.5)</m> and moves parallel to the <m>x</m>-axis (<ie/>, only the <m>x</m>-value changes,
           not the <m>y</m>-value),
@@ -516,7 +516,7 @@
 
         <p>
           Now consider <m>f_y(2,1)=1</m>,
-          illustrated in <xref ref="fig_partial3b_3D">Figure</xref>.
+          illustrated in <xref ref="fig_partial3b_3D"/>.
           Moving along the curve drawn on the surface,
           <ie/>, parallel to the <m>y</m>-axis and not changing the <m>x</m>-values,
           increases the <m>z</m>-value instantaneously at a rate of 1.
@@ -535,7 +535,7 @@
     <title>Tangent Planes</title>
     <p>
       Another way to interpret partial derivatives is in terms of the <em>tangent plane</em>.
-      Consider the graph of a function <m>f(x,y)</m>, such as the one in <xref ref="fig_partialintro">Figure</xref>.
+      Consider the graph of a function <m>f(x,y)</m>, such as the one in <xref ref="fig_partialintro"/>.
       Setting <m>x=a</m>, <m>y=b</m> defines a point <m>(a,b,f(a,b))</m> on the graph.
       Through the point <m>(a,b)</m>, we have the lines <m>x=a+s, y=b</m>, and <m>x=a, y=b+t</m>,
       parallel to the <m>x</m> and <m>y</m> axes, respectively (where <m>s,t</m> are parameters).
@@ -557,7 +557,7 @@
       they are <m>1</m> and <m>0</m>, respectively.
       To find the third component of the derivative,
       notice that in <m>\vec{r}_1(s)</m> we vary the <m>x</m>-component of <m>f</m> while holding the <m>y</m>-component constant.
-      Using the Chain Rule and <xref ref="def_partial_derivative">Definition</xref>,
+      Using the Chain Rule and <xref ref="def_partial_derivative"/>,
       we find that the third component is <m>f_x(a+s,b)</m>. Altogether, we have
 			<me>
 			\vec{r}_1'(s) = \la 1,0,f_x(a+s,b)\ra
@@ -570,7 +570,7 @@
       <me>
         \vec{w}=\vec{r}_2'(0) = \la 0,1,f_y(a,b)\ra
       </me>.
-      From <xref ref="sec_vvf_calc">Section</xref>,
+      From <xref ref="sec_vvf_calc"/>,
       we know that <m>\vec{r}_1'(0)</m> defines a tangent vector to the curve <m>\vec{r}_1(s)</m> when <m>s=0</m>,
       and similarly, <m>\vec{r}_2'(0)</m> defines a tangent vector to the curve <m>\vec{r}_2(t)</m> when <m>t=0</m>.
     </p>
@@ -580,7 +580,7 @@
       which lie on our surface, should also be considered tangent to that surface.
       The vectors <m>\vec{v}</m> and <m>\vec{w}</m> are therefore tangent to <m>z=f(x,y)</m> at <m>(a,b,f(a,b))</m>,
       and they are definitely not parallel.
-      From <xref ref="sec_planes">Section</xref> we know that any two non-parallel vectors at a point define a plane through that point.
+      From <xref ref="sec_planes"/> we know that any two non-parallel vectors at a point define a plane through that point.
       We also know that taking the cross product of these two vectors gives us a normal vector:
       the cross product gives us
       <me>
@@ -710,7 +710,7 @@
     </p>
     <aside>
       <p>
-        The terms in <xref ref="def_second_partial">Definition</xref> all depend on limits,
+        The terms in <xref ref="def_second_partial"/> all depend on limits,
         so each definition comes with the caveat
         <q>where the limit exists.</q>
       </p>
@@ -808,7 +808,7 @@
     </figure>
 
     <p>
-      Notice how in each of the three functions in <xref ref="ex_partial6">Example</xref>,
+      Notice how in each of the three functions in <xref ref="ex_partial6"/>,
       <m>f_{xy} = f_{yx}</m>.
       Due to the complexity of the examples,
       this likely is not a coincidence.
@@ -922,12 +922,12 @@
           at this point in the direction of <m>y</m> is <m>-3/2</m>:
           if one moves from this point parallel to the <m>y</m>-axis,
           the instantaneous rate of change will be <m>-3/2</m>.
-          These tangents lines are graphed in <xref ref="fig_partial7a_3D">Figure</xref> and <xref ref="fig_partial7b_3D">Figure</xref>,
+          These tangents lines are graphed in <xref ref="fig_partial7a_3D"/> and <xref ref="fig_partial7b_3D"/>,
           respectively, where the tangent lines are drawn in a solid line.
         </p>
 
         <figure xml:id="fig_partial7">
-          <caption>Understanding the second partial derivatives in <xref ref="ex_partial7">Example</xref></caption>
+          <caption>Understanding the second partial derivatives in <xref ref="ex_partial7"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_partial7a_3D">
               <caption/>
@@ -1066,7 +1066,7 @@
         </figure>
 
         <p>
-          Now consider only <xref ref="fig_partial7a_3D">Figure</xref>.
+          Now consider only <xref ref="fig_partial7a_3D"/>.
           Three directed tangent lines are drawn
           (two are dashed),
           each in the direction of <m>x</m>;
@@ -1082,7 +1082,7 @@
         <p>
           Since <m>f_{xy}=f_{yx}</m>,
           we also expect <m>f_y</m> to increase as <m>x</m> increases.
-          Consider <xref ref="fig_partial7b_3D">Figure</xref> where again three directed tangent lines are drawn,
+          Consider <xref ref="fig_partial7b_3D"/> where again three directed tangent lines are drawn,
           this time each in the direction of <m>y</m> with slopes determined by <m>f_y</m>.
           As <m>x</m> increases, the slopes become less steep
           (closer to 0).
@@ -1094,12 +1094,12 @@
           Thus far we have a visual understanding of <m>f_x</m>,
           <m>f_y</m>, and <m>f_{xy}=f_{yx}</m>.
           We now interpret <m>f_{xx}</m> and <m>f_{yy}</m>.
-          In <xref ref="fig_partial7a_3D">Figure</xref>,
+          In <xref ref="fig_partial7a_3D"/>,
           we see a curve drawn where <m>x</m> is held constant at <m>x=-1/2</m>:
           only <m>y</m> varies.
           This curve is clearly concave down,
           corresponding to the fact that <m>f_{yy}\lt 0</m>.
-          In part <xref ref="fig_partial7b_3D">Figure</xref> of the figure,
+          In part <xref ref="fig_partial7b_3D"/> of the figure,
           we see a similar curve where <m>y</m> is constant and only <m>x</m> varies.
           This curve is concave up, corresponding to the fact that <m>f_{xx} \gt 0</m>.
         </p>
@@ -1285,7 +1285,7 @@
     <p>
       This can be useful at times.
       Had we known this,
-      the second part of <xref ref="ex_partial9">Example</xref>
+      the second part of <xref ref="ex_partial9"/>
       would have been much simpler to compute.
       Instead of computing <m>f_{xyz}</m> in the <m>x</m>,
       <m>y</m> then <m>z</m> orders,
@@ -1306,7 +1306,7 @@
       What if we move in the direction given by the vector <m>\la 2,1\ra</m>?
       Can we measure that rate of change?
       The answer is, of course, yes, we can.
-      This is the topic of <xref ref="sec_directional_derivative">Section</xref>.
+      This is the topic of <xref ref="sec_directional_derivative"/>.
       First, we need to define what it means for a function of two variables to be
       <em>differentiable.</em>
     </p>

--- a/ptx/sec_partial_fraction.ptx
+++ b/ptx/sec_partial_fraction.ptx
@@ -381,7 +381,7 @@
 
       <aside>
         <p>
-          <xref ref="eq_pf3" text="local">Equation</xref>
+          <xref ref="eq_pf3" text="global">Equation</xref>
           offers a direct route to finding the values of <m>A</m>,
           <m>B</m> and <m>C</m>.
           Since the equation holds for all values of <m>x</m>,

--- a/ptx/sec_partial_fraction.ptx
+++ b/ptx/sec_partial_fraction.ptx
@@ -122,7 +122,7 @@
   </aside>
   <p>
     The following examples will demonstrate how to put this Key Idea into practice.
-    <xref ref="ex_pf1">Example</xref>
+    <xref ref="ex_pf1"/>
     stresses the decomposition aspect of the Key Idea.
   </p>
 
@@ -271,7 +271,7 @@
     There is another method for finding the partial fraction decomposition called the
     <q>Heaviside</q> method,
     named after Oliver Heaviside.
-    We show a variation of this process using the same example as in <xref ref="ex_pf1">Example</xref>.
+    We show a variation of this process using the same example as in <xref ref="ex_pf1"/>.
   </p>
 
   <example xml:id="ex_pf2b">
@@ -287,7 +287,7 @@
     </solution>
     <solution>
       <p>
-        As we saw in <xref ref="ex_pf2">Example</xref>,
+        As we saw in <xref ref="ex_pf2"/>,
         <me>
           \frac{1}{x^2-1} = \frac{A}{x-1} + \frac{B}{x+1}
         </me>.
@@ -329,7 +329,7 @@
       </p>
 
       <p>
-        Thus as in <xref ref="ex_pf1">Example </xref>, we get
+        Thus as in <xref ref="ex_pf1"/>, we get
         <me>
           \frac{1}{x^2-1} = \frac{1/2}{x-1}-\frac{1/2}{x+1}
         </me>.
@@ -356,7 +356,7 @@
 
       <p>
         We decompose the integrand as follows,
-        as described by <xref ref="idea_partial_fraction">Key Idea</xref>:
+        as described by <xref ref="idea_partial_fraction"/>:
         <me>
           \frac{1}{(x-1)(x+2)^2} = \frac{A}{x-1} + \frac{B}{x+2} + \frac{C}{(x+2)^2}
         </me>.
@@ -381,7 +381,7 @@
 
       <aside>
         <p>
-          <xref ref="eq_pf3">Equation</xref>
+          <xref ref="eq_pf3" text="local">Equation</xref>
           offers a direct route to finding the values of <m>A</m>,
           <m>B</m> and <m>C</m>.
           Since the equation holds for all values of <m>x</m>,
@@ -432,7 +432,7 @@
 
       <p>
         Each can be integrated with a simple substitution with <m>u=x-1</m> or <m>u=x+2</m>
-        (or by directly applying <xref ref="idea_linearsub">Key Idea</xref>
+        (or by directly applying <xref ref="idea_linearsub"/>
         as the denominators are linear functions).
         The end result is
         <me>
@@ -466,7 +466,7 @@
     </solution>
     <solution>
       <p>
-        <xref ref="idea_partial_fraction">Key Idea</xref>
+        <xref ref="idea_partial_fraction"/>
         presumes that the degree of the numerator is less than the degree of the denominator.
         Since this is not the case here,
         we begin by using polynomial division to reduce the degree of the numerator.
@@ -477,7 +477,7 @@
       </p>
 
       <p>
-        Using <xref ref="idea_partial_fraction">Key Idea</xref>,
+        Using <xref ref="idea_partial_fraction"/>,
         we can rewrite the new rational function as:
         <me>
           \frac{19x+30}{(x-5)(x+3)} = \frac{A}{x-5} + \frac{B}{x+3}
@@ -488,9 +488,9 @@
 
       <aside>
         <p>
-          The values of <m>A</m> and <m>B</m> can be quickly found using the technique described in <xref ref="ex_pf3">Example</xref>,
+          The values of <m>A</m> and <m>B</m> can be quickly found using the technique described in <xref ref="ex_pf3"/>,
           or they can be found by equating coefficients,
-          as we do in <xref ref="ex_pf4">Example</xref>.
+          as we do in <xref ref="ex_pf4"/>.
         </p>
       </aside>
       <p>
@@ -529,7 +529,7 @@
     <solution>
 
       <p>
-        The degree of the numerator is less than the degree of the denominator so we begin by applying <xref ref="idea_partial_fraction">Key Idea</xref>.
+        The degree of the numerator is less than the degree of the denominator so we begin by applying <xref ref="idea_partial_fraction"/>.
         We have:
       <!--          <md>
           <mrow>\frac{7x^2+31x+54}{(x+1)(x^2+6x+11)} \amp = \frac{A}{x+1} + \frac{Bx+C}{x^2+6x+11}.</mrow>
@@ -592,7 +592,7 @@
       </p>
 
       <p>
-        An antiderivative of the latter term can be found using <xref ref="thm_int_inverse_trig">Theorem</xref> and substitution:
+        An antiderivative of the latter term can be found using <xref ref="thm_int_inverse_trig"/> and substitution:
         <me>
           \int \frac{7}{x^2+6x+11}\, dx = \frac{7}{\sqrt{2}}\tan^{-1}\left(\frac{x+3}{\sqrt{2}}\right)+C
         </me>.
@@ -628,7 +628,7 @@
   </p>
 
   <p>
-    <xref ref="sec_hyperbolic">Section</xref> introduces new functions,
+    <xref ref="sec_hyperbolic"/> introduces new functions,
     called the Hyperbolic Functions.
     They will allow us to make substitutions similar to those found when studying Trigonometric Substitution,
     allowing us to approach even more integration problems.
@@ -669,7 +669,7 @@
         <introduction>
           <p>
             Decompose without solving for the coefficients,
-            as done in <xref ref="ex_pf1">Example</xref>.
+            as done in <xref ref="ex_pf1"/>.
           </p>
         </introduction>
         <!-- Exercise 3 -->

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -7,7 +7,7 @@
       table top or stiff piece of cardboard can be thought of as representing part of a plane.
       Consider a piece of cardboard with a point <m>P</m> marked on it.
       One can take a nail and stick it into the cardboard at <m>P</m> such that the nail is perpendicular to the cardboard;
-      see <xref ref="fig_planes_intro">Figure</xref>.
+      see <xref ref="fig_planes_intro"/>.
     </p>
 
     <figure xml:id="fig_planes_intro">
@@ -193,7 +193,7 @@
           We can use any point we wish in the plane
           (any of <m>P</m>, <m>Q</m> or <m>R</m> will do)
           and we arbitrarily choose <m>P</m>.
-          Following <xref ref="def_planes">Definition</xref>,
+          Following <xref ref="def_planes"/>,
           the equation of the plane in standard form is
           <me>
             2(x-1) + (y-1)+z = 0
@@ -201,11 +201,11 @@
         </p>
 
         <p>
-          The plane is sketched in <xref ref="fig_planes1">Figure</xref>.
+          The plane is sketched in <xref ref="fig_planes1"/>.
         </p>
 
         <figure xml:id="fig_planes1">
-          <caption>Sketching the plane in <xref ref="ex_planes1">Example</xref></caption>
+          <caption>Sketching the plane in <xref ref="ex_planes1"/></caption>
 
           <!-- START figures/figplanes1_3D.asy -->
           <image xml:id="img_planes1" width="47%">
@@ -342,7 +342,7 @@
           We can pick any point in the plane with which to write our equation;
           each line gives us infinite choices of points.
           We choose <m>P</m>, the point of intersection.
-          We follow <xref ref="def_planes">Definition</xref>
+          We follow <xref ref="def_planes"/>
           to write the plane's equation in general form:
           <md>
             <mrow>5(x+1) +4(y-3) -7z \amp = 0</mrow>
@@ -353,11 +353,11 @@
 
         <p>
           The plane's equation in general form is <m>5x+4y-7z=7</m>;
-          it is sketched in <xref ref="fig_planes2">Figure</xref>.
+          it is sketched in <xref ref="fig_planes2"/>.
         </p>
 
         <figure xml:id="fig_planes2">
-          <caption>Sketching the plane in <xref ref="ex_planes2">Example</xref></caption>
+          <caption>Sketching the plane in <xref ref="ex_planes2"/></caption>
 
           <!-- START figures/figplanes2_3D.asy -->
           <image xml:id="img_planes2" width="47%">
@@ -442,11 +442,11 @@
         </p>
 
         <p>
-          The line and plane are sketched in <xref ref="fig_planes3">Figure</xref>.
+          The line and plane are sketched in <xref ref="fig_planes3"/>.
         </p>
 
         <figure xml:id="fig_planes3">
-          <caption>The line and plane in <xref ref="ex_planes3">Example</xref></caption>
+          <caption>The line and plane in <xref ref="ex_planes3"/></caption>
 
           <!-- START figures/figplanes3_3D.asy -->
           <image xml:id="img_planes3" width="47%">
@@ -575,11 +575,11 @@
         </p>
 
         <p>
-          The planes and line are graphed in <xref ref="fig_planes4">Figure</xref>.
+          The planes and line are graphed in <xref ref="fig_planes4"/>.
         </p>
 
         <figure xml:id="fig_planes4">
-          <caption>Graphing the planes and their line of intersection in <xref ref="ex_planes4">Example</xref></caption>
+          <caption>Graphing the planes and their line of intersection in <xref ref="ex_planes4"/></caption>
 
           <!-- START figures/figplanes4_3D.asy -->
           <image xml:id="img_planes4" width="47%">
@@ -695,11 +695,11 @@
           the point on the line satisfies the equation of the plane;
           that point is <m>\ell(2) = \la 1,1,1\ra</m>.
           Thus the point <m>(1,1,1)</m> is the point of intersection between the plane and the line,
-          illustrated in <xref ref="fig_planes5">Figure</xref>.
+          illustrated in <xref ref="fig_planes5"/>.
         </p>
 
         <figure xml:id="fig_planes5">
-          <caption>Illustrating the intersection of a line and a plane in <xref ref="ex_planes5">Example</xref></caption>
+          <caption>Illustrating the intersection of a line and a plane in <xref ref="ex_planes5"/></caption>
 
           <!-- START figures/figplanes5_3D.asy -->
           <image xml:id="img_planes5" width="47%">
@@ -769,7 +769,7 @@
     </figure>
 
     <p>
-      Consider <xref ref="fig_planes_dist">Figure</xref>,
+      Consider <xref ref="fig_planes_dist"/>,
       where a plane with normal vector <m>\vec n</m> is sketched containing a point <m>P</m> and a point <m>Q</m>,
       not on the plane, is given.
       We measure the distance from <m>Q</m> to the plane by measuring the length of the projection of <m>\overrightarrow{PQ}</m> onto <m>\vec n</m>.
@@ -895,7 +895,7 @@
         </p>
 
         <p>
-          The distance <m>h</m> from <m>Q</m> to the plane is given by <xref ref="idea_planes_dist">Key Idea</xref>:
+          The distance <m>h</m> from <m>Q</m> to the plane is given by <xref ref="idea_planes_dist"/>:
           <md>
             <mrow>h \amp = \frac{\abs{\vec n\cdot \overrightarrow{PQ}}}{\vnorm n}</mrow>
             <mrow>\amp = \frac{\abs{\la 2,-5,6\ra \cdot \la 2,1,2.5\ra}}{\norm{\la 2,-5,6\ra}}</mrow>
@@ -907,13 +907,13 @@
     </example>
 
     <p>
-      We can use <xref ref="idea_planes_dist">Key Idea</xref> to find other distances.
+      We can use <xref ref="idea_planes_dist"/> to find other distances.
       Given two parallel planes,
       we can find the distance between these planes by letting <m>P</m> be a point on one plane and <m>Q</m> a point on the other.
       If <m>\ell</m> is a line parallel to a plane,
       we can use the Key Idea to find the distance between them as well:
       again, let <m>P</m> be a point in the plane and let <m>Q</m> be any point on the line.
-      (One can also use <xref ref="idea_line_distance">Key Idea</xref>.)
+      (One can also use <xref ref="idea_line_distance"/>.)
       The Exercise section contains problems of these types.
     </p>
 
@@ -2171,8 +2171,8 @@
             -->
             <statement>
               <p>
-                How is <xref ref="x10_05_ex_30">Exercise</xref>
-                in <xref ref="sec_lines">Section</xref>
+                How is <xref ref="x10_05_ex_30"/>
+                in <xref ref="sec_lines"/>
                 easier to answer once we have an understanding of planes?
               </p>
             </statement>

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -119,7 +119,7 @@
         <mrow number="no">\la x-x_0,y-y_0,z-z_0\ra\cdot \la a,b,c\ra \amp =0</mrow>
         <mrow xml:id="eq-plane-standard-form">a(x-x_0)+b(y-y_0)+c(z-z_0) \amp =0</mrow>
       </mdn>.
-      Equation <xref ref="eq-plane-standard-form"/> defines an <em>implicit</em> function describing the plane. More algebra produces:
+      <xref ref="eq-plane-standard-form">Equation</xref> defines an <em>implicit</em> function describing the plane. More algebra produces:
       <me>
         ax+by+cz = ax_0+by_0+cz_0
       </me>.
@@ -134,7 +134,7 @@
     </p>
 
     <p>
-      Equation <xref ref="eq-plane-graph-form"/> is especially useful as many computer programs can graph functions in this form.
+      <xref ref="eq-plane-graph-form">Equation</xref> is especially useful as many computer programs can graph functions in this form.
       Equations <xref ref="eq-plane-standard-form"/> and <xref ref="eq-plane-general-form"/> have specific names,
       given next.
     </p>
@@ -780,10 +780,10 @@
     </p>
 
     <p>
-      Equation <xref ref="eq_plane_dist"/> is important as it does more than just give the distance between a point and a plane.
+      <xref ref="eq_plane_dist">Equation</xref> is important as it does more than just give the distance between a point and a plane.
       We will see how it allows us to find several other distances as well:
       the distance between parallel planes and the distance from a line and a plane.
-      Because Equation <xref ref="eq_plane_dist"/> is important,
+      Because <xref ref="eq_plane_dist">Equation</xref> is important,
       we restate it as a Key Idea.
     </p>
 

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -42,7 +42,7 @@
       To avoid confusion with rectangular coordinates,
       we will denote polar coordinates with the letter <m>P</m>,
       as in <m>P(r,\theta)</m>.
-      This is illustrated in <xref ref="fig_polar_intro1">Figure</xref>
+      This is illustrated in <xref ref="fig_polar_intro1"/>
           <idx><h>polar coordinates</h></idx>
           <idx><h>polar</h><h>coordinates</h></idx>
           <idx><h>coordinates</h><h>polar</h></idx>
@@ -177,11 +177,11 @@
           To plot <m>D</m>, move along the initial ray <q><m>-1</m></q>
           units <mdash/> in other words,
           <q>back up</q> 1 unit, then rotate counter-clockwise by <m>\pi/4</m>.
-          The results are given in <xref ref="fig_polar1">Figure</xref>.
+          The results are given in <xref ref="fig_polar1"/>.
         </p>
 
         <figure xml:id="fig_polar1">
-          <caption>Plotting polar points in <xref ref="ex_polar1">Example</xref></caption>
+          <caption>Plotting polar points in <xref ref="ex_polar1"/></caption>
           <!-- START figures/fig_polar1.tex -->
           <image xml:id="img_polar1" width="47%">
             <shortdescription>A plot of several points on a polar grid.</shortdescription>
@@ -250,7 +250,7 @@
     <title>Polar to Rectangular Conversion</title>
     <p>
       It is useful to recognize both the rectangular (or, Cartesian) coordinates of a point in the plane and its polar coordinates.
-      <xref ref="fig_polar_intro2">Figure</xref>
+      <xref ref="fig_polar_intro2"/>
       shows a point <m>P</m> in the plane with rectangular coordinates <m>(x,y)</m> and polar coordinates <m>P(r,\theta)</m>.
       Using trigonometry,
       we can make the identities given in the following Key Idea.
@@ -341,7 +341,7 @@
                   <li>
                     <p>
                       We start with <m>P(2,2\pi/3)</m>.
-                      Using <xref ref="idea_polarconvert">Key Idea</xref>, we have
+                      Using <xref ref="idea_polarconvert"/>, we have
                       <me>
                         x= 2\cos(2\pi/3) = -1\qquad y = 2\sin(2\pi/3) = \sqrt{3}
                       </me>.
@@ -362,12 +362,12 @@
               </p>
 
               <p>
-                These points are plotted in <xref ref="fig_polar2a">Figure</xref>.
+                These points are plotted in <xref ref="fig_polar2a"/>.
                 The rectangular coordinate system is drawn lightly under the polar coordinate system so that the relationship between the two can be seen.
               </p>
 
               <figure xml:id="fig_polar2">
-                <caption>Plotting rectangular and polar points in <xref ref="ex_polar2">Example</xref></caption>
+                <caption>Plotting rectangular and polar points in <xref ref="ex_polar2"/></caption>
                 <sidebyside widths="47% 47%" margins="0%">
                   <figure xml:id="fig_polar2a">
                     <caption/>
@@ -518,7 +518,7 @@
               </p>
 
               <p>
-                These points are plotted in <xref ref="fig_polar2b">Figure</xref>.
+                These points are plotted in <xref ref="fig_polar2b"/>.
                 The polar system is drawn lightly under the rectangular grid with rays to demonstrate the angles used.
               </p>
             </li>
@@ -581,7 +581,7 @@
                 We can consider the rectangular equivalent of this equation;
                 using <m>r^2=x^2+y^2</m>, we see that <m>1.5^2=x^2+y^2</m>,
                 which we recognize as the equation of a circle centered at <m>(0,0)</m> with radius 1.5.
-                This is sketched in <xref ref="fig_polar3">Figure</xref>.
+                This is sketched in <xref ref="fig_polar3"/>.
               </p>
             </li>
 
@@ -597,7 +597,7 @@
                 <me>
                   \tan(\pi) /4 = y/x  \Rightarrow x\tan(\pi) /4 = y  \Rightarrow y = x
                 </me>.
-                This graph is also plotted in <xref ref="fig_polar3">Figure</xref>.
+                This graph is also plotted in <xref ref="fig_polar3"/>.
               </p>
 
               <figure xml:id="fig_polar3">
@@ -681,7 +681,7 @@
           then add more if needed.
           When plotting polar equations,
           start with the <q>common</q> angles <mdash/> multiples of <m>\pi/6</m> and <m>\pi/4</m>.
-          <xref ref="fig_polar4">Figure</xref>
+          <xref ref="fig_polar4"/>
           gives a table of just a few values of <m>\theta</m> in <m>[0,\pi]</m>.
         </p>
 
@@ -701,7 +701,7 @@
         </p>
 
         <figure xml:id="fig_polar4">
-          <caption>Graphing a polar function in <xref ref="ex_polar4">Example</xref> by plotting points</caption>
+          <caption>Graphing a polar function in <xref ref="ex_polar4"/> by plotting points</caption>
           <sidebyside widths="47% 47%" margins="0%" valign="bottom">
             <figure xml:id="fig_polar4a"><caption/>
               <tabular halign="center">
@@ -810,8 +810,8 @@
       the more accurate the graph
       (which also increases plotting time).
       Using technology, we graphed the polar function
-      <m>r=1+\cos(\theta)</m> from <xref ref="ex_polar4">Example</xref>
-      in <xref ref="fig_polar4c">Figure</xref>.
+      <m>r=1+\cos(\theta)</m> from <xref ref="ex_polar4"/>
+      in <xref ref="fig_polar4c"/>.
     </p>
 
     <figure xml:id="fig_polar4c">
@@ -871,7 +871,7 @@
           We start by making a table of
           <m>\cos(2\theta)</m> evaluated at common angles <m>\theta</m>,
           as shown in <xref ref="fig_polar5table"/>.
-          These points are then plotted in <xref ref="fig_polar5a">Figure</xref>.
+          These points are then plotted in <xref ref="fig_polar5a"/>.
           This particular graph <q>moves</q>
           around quite a bit and one can easily forget which points should be connected to each other.
           To help us with this,
@@ -905,12 +905,12 @@
         <p>
           Using more points
           (and the aid of technology)
-          a smoother plot can be made as shown in <xref ref="fig_polar5b">Figure</xref>.
+          a smoother plot can be made as shown in <xref ref="fig_polar5b"/>.
           This plot is an example of a <em>rose curve</em>.
         </p>
 
         <figure xml:id="fig_polar5">
-          <caption>Polar plots from <xref ref="ex_polar5">Example</xref></caption>
+          <caption>Polar plots from <xref ref="ex_polar5"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_polar5a">
               <caption/>
@@ -1042,7 +1042,7 @@
       and other times by a rectangular equation.
       Therefore it is necessary to be able to convert between polar and rectangular functions,
       which we practice in the following example.
-      We will make frequent use of the identities found in <xref ref="idea_polarconvert">Key Idea</xref>.
+      We will make frequent use of the identities found in <xref ref="idea_polarconvert"/>.
     </p>
 
     <example xml:id="ex_polar6">
@@ -1118,11 +1118,11 @@
                 This occurs in the first and third quadrants,
                 meaning the domain of this polar function is <m>(0,\pi/2) \cup (\pi,3\pi/2)</m>.
 
-                We can rewrite the original rectangular equation <m>xy=1</m> as <m>y=1/x</m>. This is graphed in <xref ref="fig_polar6">Figure</xref>; note how it only exists in the first and third quadrants.
+                We can rewrite the original rectangular equation <m>xy=1</m> as <m>y=1/x</m>. This is graphed in <xref ref="fig_polar6"/>; note how it only exists in the first and third quadrants.
               </p>
 
               <figure xml:id="fig_polar6">
-                <caption>Graphing <m>xy=1</m> from <xref ref="ex_polar6">Example</xref></caption>
+                <caption>Graphing <m>xy=1</m> from <xref ref="ex_polar6"/></caption>
             <!-- START figures/fig_polar6.tex -->
                 <image xml:id="img_polar6" width="47%">
                   <shortdescription>Graph of the hyperbola y=1/x.</shortdescription>
@@ -1950,13 +1950,13 @@
         <p>
           As technology is generally readily available,
           it is usually a good idea to start with a graph.
-          We have graphed the two functions in <xref ref="fig_polar7a">Figure</xref>;
+          We have graphed the two functions in <xref ref="fig_polar7a"/>;
           to better discern the intersection points,
-          <xref ref="fig_polar7b">Figure</xref> zooms in around the origin.
+          <xref ref="fig_polar7b"/> zooms in around the origin.
         </p>
 
         <figure xml:id="fig_polar7">
-          <caption>Graphs to help determine the points of intersection of the polar functions given in <xref ref="ex_polar7">Example</xref></caption>
+          <caption>Graphs to help determine the points of intersection of the polar functions given in <xref ref="ex_polar7"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_polar7a">
               <caption/>

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -20,7 +20,7 @@
       <m>r=f(\theta)</m> into a set of parametric equations.
       Using the identities <m>x=r\cos(\theta)</m> and <m>y=r\sin(\theta)</m>,
       we can create the parametric equations <m>x=f(\theta)\cos(\theta)</m>,
-      <m>y=f(\theta)\sin(\theta)</m> and apply the concepts of <xref ref="sec_par_calc">Section</xref>.
+      <m>y=f(\theta)\sin(\theta)</m> and apply the concepts of <xref ref="sec_par_calc"/>.
     </p>
   </introduction>
 
@@ -40,7 +40,7 @@
     </p>
 
     <p>
-      Using <xref ref="idea_dydxpar">Key Idea</xref> we have
+      Using <xref ref="idea_dydxpar"/> we have
       <me>
         \frac{dy}{dx} = \frac{dy}{d\theta}\Big/\frac{dx}{d\theta}
       </me>.
@@ -110,7 +110,7 @@
                 <me>
                   y=(-2\sqrt{2}-1)\big(x-(1+\sqrt{2}/2)\big)+1+\sqrt{2}/2 \approx  -3.83 x+8.24
                 </me>.
-                The limaçon and the tangent line are graphed in <xref ref="fig_polcalc1">Figure</xref>.
+                The limaçon and the tangent line are graphed in <xref ref="fig_polcalc1"/>.
 
                 The normal line has the opposite-reciprocal slope as the tangent line, so its equation is
                 <me>
@@ -119,7 +119,7 @@
               </p>
 
               <figure xml:id="fig_polcalc1">
-                <caption>The limaçon in <xref ref="ex_polcalc1">Example</xref> with its tangent line at <m>\theta=\pi/4</m> and points of vertical and horizontal tangency</caption>
+                <caption>The limaçon in <xref ref="ex_polcalc1"/> with its tangent line at <m>\theta=\pi/4</m> and points of vertical and horizontal tangency</caption>
             <!-- START figures/fig_polcalc1.tex -->
                 <image xml:id="img_polcalc1" width="47%">
                   <shortdescription>A limaçon with an inner loops, symmetric about the y axis, and a tangent line.</shortdescription>
@@ -201,7 +201,7 @@
                 one in the third quadrant and one in the fourth.
                 Using reference angles, we have our two solutions as
                 <m>\theta =3.39</m> and <m>6.03</m> radians.
-                The four points we obtained where the limaçon has a horizontal tangent line are given in <xref ref="fig_polcalc1">Figure</xref>
+                The four points we obtained where the limaçon has a horizontal tangent line are given in <xref ref="fig_polcalc1"/>
                 with black-filled dots.
 
                 To find the vertical lines of tangency,
@@ -232,7 +232,7 @@
                 <me>
                   \sin(\theta) = \frac{-1-\sqrt{33}}8  \Rightarrow  \theta = 4.1446,\,5.2802 \text{ radians. }
                 </me>
-                These points are also shown in <xref ref="fig_polcalc1">Figure</xref>
+                These points are also shown in <xref ref="fig_polcalc1"/>
                 with white-filled dots.
               </p>
             </li>
@@ -255,7 +255,7 @@
       This equation makes an interesting point.
       It tells us the slope of the tangent line at the pole is <m>\tan\alpha</m>;
       some of our previous work (see, for instance,
-      <xref ref="ex_polar3">Example</xref>) shows us that the line through the pole with slope
+      <xref ref="ex_polar3"/>) shows us that the line through the pole with slope
       <m>\tan\alpha</m> has polar equation <m>\theta=\alpha</m>.
       Thus when a polar graph touches the pole at <m>\theta=\alpha</m>,
       the equation of the tangent line at the pole is <m>\theta=\alpha</m>.
@@ -288,12 +288,12 @@
           are <m>\theta = 7\pi/6</m> and <m>\theta = 11\pi/6</m>.
           In rectangular form, the tangent lines are
           <m>y=\tan(7\pi/6)x</m> and <m>y=\tan(11\pi/6)x</m>.
-          The full limaçon can be seen in <xref ref="fig_polcalc1">Figure</xref>;
-          we zoom in on the tangent lines in <xref ref="fig_polcalc2">Figure</xref>.
+          The full limaçon can be seen in <xref ref="fig_polcalc1"/>;
+          we zoom in on the tangent lines in <xref ref="fig_polcalc2"/>.
         </p>
 
         <figure xml:id="fig_polcalc2">
-          <caption>Graphing the tangent lines at the pole in <xref ref="ex_polcalc2">Example</xref></caption>
+          <caption>Graphing the tangent lines at the pole in <xref ref="ex_polcalc2"/></caption>
           <!-- START figures/fig_polcalc2.tex -->
           <image xml:id="img_polcalc2" width="47%">
             <shortdescription>A zoomed in view of a limaçon near the origin, and two tangent lines at that point.</shortdescription>
@@ -359,7 +359,7 @@
     </p>
 
     <p>
-      Consider <xref ref="fig_polarea1">Figure</xref>
+      Consider <xref ref="fig_polarea1"/>
       where a region defined by
       <m>r=f(\theta)</m> on <m>[\alpha,\beta]</m> is given.
       (Note how the <q>sides</q> of the region are the lines
@@ -406,7 +406,7 @@
       <m>[\theta_{i-1},\theta_{i}]</m> can be approximated with a sector of a circle with radius <m>f(c_i)</m>,
       for some <m>c_i</m> in <m>[\theta_{i-1},\theta_{i}]</m>.
       The area of this sector is <m>\frac12f(c_i)^2\Delta\theta</m>.
-      This is shown in <xref ref="fig_polarea2">Figure</xref>,
+      This is shown in <xref ref="fig_polarea2"/>,
       where <m>[\alpha,\beta]</m> has been divided into 4 subintervals.
       We approximate the area of the whole region by summing the areas of all sectors:
       <me>
@@ -590,7 +590,7 @@
       </solution>
       <solution>
         <p>
-          This is a direct application of <xref ref="thm_polar_area">Theorem</xref>.
+          This is a direct application of <xref ref="thm_polar_area"/>.
           The circle is traced out on <m>[0,\pi]</m>, leading to the integral
           <md>
             <mrow>\text{ Area }  \amp = \frac12\int_0^\pi \cos^2(\theta)\, d\theta</mrow>
@@ -609,9 +609,9 @@
 
     <aside>
       <p>
-        <xref ref="ex_polcalc3">Example</xref>
+        <xref ref="ex_polcalc3"/>
         requires the use of the integral <m>\ds\int \cos^2(\theta) \,d\theta</m>.
-        This is handled well by using the power reducing formula as found in <xref ref="reference-trig-identities">Section</xref>
+        This is handled well by using the power reducing formula as found in <xref ref="reference-trig-identities"/>
         of the <xref ref="appendix-reference" text="title"/> Appendix.
         Due to the nature of the area formula,
         integrating <m>\cos^2(\theta)</m> and <m>\sin^2(\theta)</m> is required often.
@@ -631,11 +631,11 @@
         <p>
           Find the area of the cardioid <m>r=1+\cos(\theta)</m> bound between
           <m>\theta=\pi/6</m> and <m>\theta=\pi/3</m>,
-          as shown in <xref ref="fig_polcalc4">Figure</xref>.
+          as shown in <xref ref="fig_polcalc4"/>.
         </p>
 
         <figure xml:id="fig_polcalc4">
-          <caption>Finding the area of the shaded region of a cardioid in <xref ref="ex_polcalc4">Example</xref></caption>
+          <caption>Finding the area of the shaded region of a cardioid in <xref ref="ex_polcalc4"/></caption>
           <!-- START figures/fig_polcalc4.tex -->
           <image xml:id="img_polcalc4" width="47%">
             <shortdescription>A cardioid curve, within which is a shaded region bounded by the curve and two rays.</shortdescription>
@@ -684,7 +684,7 @@
       </solution>
       <solution>
         <p>
-          This is again a direct application of <xref ref="thm_polar_area">Theorem</xref>.
+          This is again a direct application of <xref ref="thm_polar_area"/>.
           <md>
             <mrow>\text{ Area }  \amp = \frac12\int_{\pi/6}^{\pi/3} (1+\cos(\theta) )^2\, d\theta</mrow>
             <mrow>\amp = \frac12\int_{\pi/6}^{\pi/3} (1+2\cos(\theta) +\cos^2(\theta) )\, d\theta</mrow>
@@ -705,7 +705,7 @@
       </p>
 
       <p>
-        Consider the shaded region shown in <xref ref="fig_polarea3">Figure</xref>.
+        Consider the shaded region shown in <xref ref="fig_polarea3"/>.
         We can find the area of this region by computing the area bounded by
         <m>r_2=f_2(\theta)</m> and subtracting the area bounded by
         <m>r_1=f_1(\theta)</m> on <m>[\alpha,\beta]</m>.
@@ -800,11 +800,11 @@
           <p>
             Find the area bounded between the curves
             <m>r=1+\cos(\theta)</m> and <m>r=3\cos(\theta)</m>,
-            as shown in <xref ref="fig_polcalc5">Figure</xref>.
+            as shown in <xref ref="fig_polcalc5"/>.
           </p>
 
           <figure xml:id="fig_polcalc5">
-            <caption>Finding the area between polar curves in <xref ref="ex_polcalc5">Example</xref></caption>
+            <caption>Finding the area between polar curves in <xref ref="ex_polcalc5"/></caption>
             <!-- START figures/fig_polcalc5.tex -->
             <image xml:id="img_polcalc5" width="47%">
               <shortdescription>A circle and a cardioid enclose a region that is inside the circle but outside the cardioid.</shortdescription>
@@ -903,10 +903,10 @@
         <statement>
           <p>
             Find the area bounded between the polar curves <m>r=1</m> and <m>r=2\cos(2\theta)</m>,
-            as shown in <xref ref="fig_polcalc6a">Figure</xref>.
+            as shown in <xref ref="fig_polcalc6a"/>.
           </p>
           <figure xml:id="fig_polcalc6a">
-            <caption>The region bounded by the functions in <xref ref="ex_polcalc6">Example</xref></caption>
+            <caption>The region bounded by the functions in <xref ref="ex_polcalc6"/></caption>
             <image xml:id="img_polcalc6" width="47%">
               <shortdescription>A zoomed in view of a region bounded by a circle, a rose curve, and the x axis.</shortdescription>
               <description>
@@ -965,7 +965,7 @@
           </p>
 
           <figure xml:id="fig_polcalc6b">
-            <caption>Breaking the region bounded by the functions in <xref ref="ex_polcalc6">Example</xref> into its component parts</caption>
+            <caption>Breaking the region bounded by the functions in <xref ref="ex_polcalc6"/> into its component parts</caption>
             <image xml:id="img_polcalc6a" width="47%">
               <shortdescription>A zoomed in view of a polar region, showing it divided into two parts.</shortdescription>
               <description>
@@ -1014,7 +1014,7 @@
           </figure>
 
           <p>
-            In <xref ref="fig_polcalc6b">Figure</xref>,
+            In <xref ref="fig_polcalc6b"/>,
             we zoom in on the region and note that it is not really bounded
             <em>between</em> two polar curves,
             but rather <em>by</em> two polar curves,
@@ -1117,7 +1117,7 @@
           With <m>r=1+2\sin(\theta)</m>, we have <m>r\,' = 2\cos(\theta)</m>.
           The limaçon is traced out once on <m>[0,2\pi]</m>,
           giving us our bounds of integration.
-          Applying <xref ref="thm_polar_arclength">Theorem</xref>, we have
+          Applying <xref ref="thm_polar_arclength"/>, we have
           <md>
             <mrow>L   \amp = \int_0^{2\pi} \sqrt{(2\cos\theta)^2+(1+2\sin\theta)^2}\, d\theta</mrow>
             <mrow>\amp =  \int_0^{2\pi} \sqrt{4\cos^2\theta+4\sin^2\theta +4\sin\theta+1}\, d\theta</mrow>
@@ -1127,7 +1127,7 @@
         </p>
 
         <figure xml:id="fig_polcalc7">
-          <caption>The limaçon in <xref ref="ex_polcalc7">Example</xref> whose arc length is measured</caption>
+          <caption>The limaçon in <xref ref="ex_polcalc7"/> whose arc length is measured</caption>
           <!-- START figures/fig_polcalc7.tex -->
           <image xml:id="img_polcalc7" width="47%">
             <shortdescription>A limaçon with an inner loop that is symmetric about the y axis.</shortdescription>
@@ -1180,7 +1180,7 @@
     <title>Surface Area</title>
     <p>
       The formula for arc length leads us to a formula for surface area.
-      The following Theorem is based on <xref ref="thm_surface_area_parametric">Theorem</xref>.
+      The following Theorem is based on <xref ref="thm_surface_area_parametric"/>.
     </p>
 
     <theorem xml:id="thm_surface_area_polar">
@@ -1225,7 +1225,7 @@
         <p>
           Find the surface area formed by revolving one petal of the rose curve
           <m>r=\cos(2\theta)</m> about its central axis,
-          as shown in <xref ref="fig_polcalc8">Figure</xref>.
+          as shown in <xref ref="fig_polcalc8"/>.
         </p>
         <figure xml:id="fig_polcalc8">
           <caption>Finding the surface area of a rose-curve petal that is revolved around its central axis</caption>
@@ -1342,7 +1342,7 @@
           We choose, as implied by the figure,
           to revolve the portion of the curve that lies on
           <m>[0,\pi/4]</m> about the initial ray.
-          Using <xref ref="thm_surface_area_polar">Theorem</xref>
+          Using <xref ref="thm_surface_area_polar"/>
           and the fact that <m>\fp(\theta) = -2\sin(2\theta)</m>, we have
           <md>
             <mrow>\text{ Surface Area }  \amp = 2\pi\int_0^{\pi/4} \cos(2\theta)\sin(\theta)\sqrt{\big(-2\sin(2\theta)\big)^2+\big(\cos(2\theta)\big)^2}\, d\theta</mrow>
@@ -2411,7 +2411,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Use <xref ref="thm_surface_area_polar">Theorem</xref>
+                  Use <xref ref="thm_surface_area_polar"/>
                   to find the surface area of the sphere formed by revolving the circle <m>r=2</m> about the initial ray.
                 </p>
               </statement>
@@ -2429,7 +2429,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  Use <xref ref="thm_surface_area_polar">Theorem</xref>
+                  Use <xref ref="thm_surface_area_polar"/>
                   to find the surface area of the sphere formed by revolving the circle
                   <m>r=2\cos(\theta)</m> about the initial ray.
                 </p>

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -1072,7 +1072,7 @@
       <m>y=f(\theta)\sin(\theta)</m> to create parametric equations based on the polar function.
       We compute <m>x'(\theta)</m> and
       <m>y'(\theta)</m> as done before when computing <m>\frac{dy}{dx}</m>,
-      then apply Equation <xref ref="eq_polar_arclength"/>.
+      then apply <xref ref="eq_polar_arclength">Equation</xref>.
     </p>
 
     <p>

--- a/ptx/sec_power_series.ptx
+++ b/ptx/sec_power_series.ptx
@@ -691,7 +691,7 @@
         We found the derivative of <m>f(x)</m> is <m>f(x)</m>.
         The only functions for which this is true are of the form <m>y=ce^x</m> for some constant <m>c</m>.
         As <m>f(0) = 1</m>
-        (see Equation <xref ref="eq_ps4"/>),
+        (see <xref ref="eq_ps4">Equation</xref>),
         <m>c</m> must be 1.
         Therefore we conclude that
         <me>

--- a/ptx/sec_power_series.ptx
+++ b/ptx/sec_power_series.ptx
@@ -116,7 +116,7 @@
     We introduced power series as a type of function,
     where a value of <m>x</m> is given and the sum of a series is returned.
     Of course, not every series converges.
-    For instance, in part 1 of <xref ref="ex_ps1">Example</xref>,
+    For instance, in part 1 of <xref ref="ex_ps1"/>,
     we recognized the series <m>\ds \infser[0] x^n</m> as a geometric series in <m>x</m>.
     <xref ref="thm_geom_series"/>
     states that this series converges only when <m>\abs{x}\lt 1</m>.
@@ -528,7 +528,7 @@
                 <mrow>\fp(x) \amp = \infser nx^{n-1} = 1+2x+3x^2+4x^3+\cdots</mrow>
                 <mrow>\amp = \infser[0](n+1)x^n</mrow>
               </md>.
-              In <xref ref="ex_ps1">Example</xref>,
+              In <xref ref="ex_ps1"/>,
               we recognized that <m>\ds \infser[0] x^n</m> is a geometric series in <m>x</m>.
               We know that such a geometric series converges when <m>\abs{x}\lt 1</m>;
               that is, the interval of convergence is <m>(-1,1)</m>.
@@ -581,7 +581,7 @@
   </p>
 
   <p>
-    Recall that <m>\ds f(x) = \infser[0] x^n</m> in <xref ref="ex_ps3">Example</xref> is a geometric series.
+    Recall that <m>\ds f(x) = \infser[0] x^n</m> in <xref ref="ex_ps3"/> is a geometric series.
     According to <xref ref="thm_geom_series"/>,
     this series converges to <m>1/(1-x)</m> when <m>\abs{x}\lt 1</m>.
     Thus we can say
@@ -592,7 +592,7 @@
 
   <p>
     Integrating the power series,
-    (as done in <xref ref="ex_ps3">Example</xref>,)
+    (as done in <xref ref="ex_ps3"/>,)
     we find
     <men xml:id="eq_ps3a">
       F(x)  = C_1+\infser[0] \frac{x^{n+1}}{n+1}
@@ -619,7 +619,7 @@
   </p>
 
   <p>
-    We established in <xref ref="ex_ps3">Example</xref>
+    We established in <xref ref="ex_ps3"/>
     that the series on the left converges at <m>x=-1</m>;
     substituting <m>x=-1</m> on both sides of the above equality gives
     <me>
@@ -637,11 +637,11 @@
   </p>
 
   <p>
-    <em>Important:</em> We stated in <xref ref="idea_famous_series">Key Idea</xref>
-    (in <xref ref="sec_series">Section</xref>)
+    <em>Important:</em> We stated in <xref ref="idea_famous_series"/>
+    (in <xref ref="sec_series"/>)
     that the Alternating Harmonic Series converges to <m>\ln(2)</m>,
-    and referred to this fact again in <xref ref="ex_alt1">Example</xref>
-    of <xref ref="sec_alt_series">Section</xref>.
+    and referred to this fact again in <xref ref="ex_alt1"/>
+    of <xref ref="sec_alt_series"/>.
     However, we never gave an argument for why this was the case.
     The work above finally shows how we conclude that the Alternating Harmonic Series converges to <m>\ln(2)</m>.
 
@@ -668,7 +668,7 @@
     <solution>
       <p>
         We start by making two notes:
-        first, in <xref ref="ex_ps2">Example</xref>,
+        first, in <xref ref="ex_ps2"/>,
         we found the interval of convergence of this power series is <m>(-\infty,\infty)</m>.
         Second, we will find it useful later to have a few terms of the series written out:
         <men xml:id="eq_ps4">
@@ -723,8 +723,8 @@
   </example>
 
   <p>
-    <xref ref="ex_ps4">Example</xref>
-    and the work following <xref ref="ex_ps3">Example</xref>
+    <xref ref="ex_ps4"/>
+    and the work following <xref ref="ex_ps3"/>
     established relationships between a power series function and <q>regular</q>
     functions that we have dealt with in the past.
     In general, given a power series function, it is difficult
@@ -803,7 +803,7 @@
       </p>
 
       <p>
-        In <xref ref="sec_taylor_series">Section</xref>,
+        In <xref ref="sec_taylor_series"/>,
         as we study Taylor Series,
         we will learn how to recognize this series as describing <m>y=e^{2x}</m>.
       </p>

--- a/ptx/sec_ratio_root_tests.ptx
+++ b/ptx/sec_ratio_root_tests.ptx
@@ -3,7 +3,7 @@
   <title>Ratio and Root Tests</title>
   <introduction>
     <p>
-      The <m>n</m>th-Term Test of <xref ref="thm_series_nth_term">Theorem</xref>
+      The <m>n</m>th-Term Test of <xref ref="thm_series_nth_term"/>
       states that in order for a series <m>\ds \infser a_n</m> to converge,
       <m>\lim\limits_{n\to\infty}a_n = 0</m>.
       That is, the terms of <m>\{a_n\}</m> must get very small.
@@ -61,7 +61,7 @@
 
     <aside>
       <p>
-        <xref ref="thm_series_behavior">Theorem</xref>
+        <xref ref="thm_series_behavior"/>
         allows us to apply the Ratio Test to series where <m>\{a_n\}</m> is positive for all but a finite number of terms.
       </p>
     </aside>
@@ -139,7 +139,7 @@
                 the term <m>a_{n+1}</m> is roughly <m>3</m> times as large as <m>a_n</m>,
                 so <m>a_n</m> is <em>increasing</em>
                 by roughly a factor of <m>3</m> in the long run.
-                We could also use <xref ref="thm_series_nth_term">Theorem</xref>
+                We could also use <xref ref="thm_series_nth_term"/>
                 to determine that this series diverges.
                 The exponential will dominate the polynomial in the long run,
                 so <m>\inflim 3^n/n^3=\infty</m>.
@@ -362,7 +362,7 @@
               </p>
 
               <p>
-                (Also note: The limit in the denominator is found in a similar fashion as was illustrated in <xref ref="ex_root1_b">Part</xref>.
+                (Also note: The limit in the denominator is found in a similar fashion as was illustrated in <xref ref="ex_root1_b" text="local">Part</xref>.
                 In general <m>\inflim (n)^{b/n}=1</m> for any real number <m>b</m>.)
               </p>
             </li>
@@ -373,14 +373,14 @@
 
     <aside>
       <p>
-        <xref ref="thm_series_behavior">Theorem</xref>
+        <xref ref="thm_series_behavior"/>
         allows us to apply the Root Test to series where <m>\{a_n\}</m> is positive for all but a finite number of terms.
       </p>
     </aside>
     <p>
       Each of the tests we have encountered so far has required that we analyze series from
       <em>positive</em> sequences.
-      <xref ref="sec_alt_series">Section</xref>
+      <xref ref="sec_alt_series"/>
       relaxes this restriction by considering
       <em>alternating series</em>,
       where the underlying sequence has terms that alternate between being positive and negative.

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -41,7 +41,7 @@
   <remark>
     <p>
       This section relies heavily on implicit differentiation,
-      so referring back to <xref ref="sec_imp_deriv">Section</xref> may help.
+      so referring back to <xref ref="sec_imp_deriv"/> may help.
     </p>
   </remark>
 
@@ -115,7 +115,7 @@
     In related rates problems,
     we will be presented with an application problem that involves two or more variables and one or more rate.
     It is the job of the reader to construct the appropriate model that can be used to answer the posed question.
-    <xref ref="idea_relatedrates">Key Idea</xref>
+    <xref ref="idea_relatedrates"/>
     outlines the basic steps for solving a related rates problem.
   </p>
 
@@ -163,7 +163,7 @@
         <li>
           <p>
             Implicitly differentiate both sides of the equation found in
-            <xref ref="li_rrmodel">Step</xref> with respect to <m>t</m>.
+            <xref ref="li_rrmodel" text="local">Step</xref> with respect to <m>t</m>.
           </p>
         </li>
 
@@ -260,7 +260,7 @@
 
             <p>
               Now let's solve the problem using
-              <xref ref="idea_relatedrates">Key Idea</xref>.
+              <xref ref="idea_relatedrates"/>.
               Based on the problem description,
               the quantities that change with time are the volume of water
               (the volume of the puddle),
@@ -294,7 +294,7 @@
           <li>
             <p>
               We already identified the quantities that are changing in
-              <xref ref="ex_rr2a">Part</xref>.
+              <xref ref="ex_rr2a" text="local">Part</xref>.
               The variables of interest in this problem are the radius and the volume.
               We need an equation that relates the volume of the circle to the radius.
               Since the puddle is a right circular cylinder,
@@ -409,7 +409,7 @@
           <mag>30</mag><unit base="mileperhour"/>
         </quantity>
         and sees a car moving due east,
-        as shown in <xref ref="fig_rr3">Figure</xref>.
+        as shown in <xref ref="fig_rr3"/>.
         Using his radar gun, he measures a reading of
         <quantity>
           <mag>20</mag><unit base="mileperhour"/>
@@ -421,7 +421,7 @@
 
       <figure xml:id="fig_rr3">
         <caption>A sketch of a police car (at bottom) attempting to measure the
-          speed of a car (at right) in <xref ref="ex_rr3">Example</xref></caption>
+          speed of a car (at right) in <xref ref="ex_rr3"/></caption>
         <image xml:id="img_rr3" width="47%">
           <shortdescription>
             A passenger car is shown moving east, while a police car is moving north. Their roads are set to intersect.
@@ -479,7 +479,7 @@
       </p>
 
       <p>
-        Using the diagram in <xref ref="fig_rr3">Figure</xref>,
+        Using the diagram in <xref ref="fig_rr3"/>,
         let's label what we know about the situation.
         As both the police officer and other driver are <m>1/2</m> mile from
         the intersection,
@@ -540,7 +540,7 @@
   <aside>
     <title>Practicality</title>
     <p>
-      <xref ref="ex_rr3">Example</xref>
+      <xref ref="ex_rr3"/>
       is both interesting and impractical.
       It highlights the difficulty in using radar in a nonlinear fashion,
       and explains why <q>in real life</q>
@@ -572,7 +572,7 @@
         for a promotional video.
         The video's planners want to know what kind of motor the tripod should
         be equipped with in order to properly track the car as it passes by.
-        <xref ref="fig_rr4">Figure</xref> shows the proposed setup.
+        <xref ref="fig_rr4"/> shows the proposed setup.
       </p>
 
       <figure xml:id="fig_rr4">
@@ -619,7 +619,7 @@
 
       <p>
         The quantities that changing are <m>x</m> and <m>\theta</m> as drawn on
-        <xref ref="fig_rr4">Figure</xref>. (The hypotenuse of the triangle is
+        <xref ref="fig_rr4"/>. (The hypotenuse of the triangle is
         also changing, but this isn't important to the problem).
         We seek information about how fast the camera is to <em>turn</em>;
         therefore, we need an equation that will relate an angle <m>\theta</m>
@@ -627,7 +627,7 @@
       </p>
 
       <p>
-        <xref ref="fig_rr4">Figure</xref>
+        <xref ref="fig_rr4"/>
         suggests we use a trigonometric equation.
         Letting <m>x</m> represent the distance the car is from the point on the
         road directly in front of the camera, we have
@@ -686,7 +686,7 @@
         Common sense tells us this is when the car is directly in front of the
         camera (<ie/>, when <m>\theta = 0</m>).
         Our mathematics bears this out.
-        In <xref ref="eq_rr4b">Equation</xref>
+        In <xref ref="eq_rr4b" text="local">Equation</xref>
         we see this is when <m>\cos^2(\theta)</m> is largest;
         this is when <m>\cos(\theta) = 1</m>,
         or when <m>\theta = 0</m>.
@@ -716,7 +716,7 @@
 
       <p>
         We find that <m>\lz{\theta}{t}</m> is negative;
-        this matches our diagram in <xref ref="fig_rr4">Figure</xref>
+        this matches our diagram in <xref ref="fig_rr4"/>
         for <m>\theta</m> is getting smaller as the car approaches the camera.
       </p>
 
@@ -925,7 +925,7 @@
           </pg-code>
           <statement>
             <p>
-              Consider the traffic situation introduced in <xref ref="ex_rr3">Example</xref>.
+              Consider the traffic situation introduced in <xref ref="ex_rr3"/>.
               How fast is the <q>other car</q> traveling if the officer and the other car are each
               <m><var name="$f"/></m> mile from the intersection, the other car is traveling <em>due west</em>,
               the officer is traveling north at <m><var name="$speed"/>\,\text{mph}</m>,
@@ -959,7 +959,7 @@
           </pg-code>
           <introduction>
             <p>
-              Consider the traffic situation introduced in <xref ref="ex_rr3">Example</xref>.
+              Consider the traffic situation introduced in <xref ref="ex_rr3"/>.
               Calculate how fast the <q>other car</q> is traveling in each of the following situations.
             </p>
           </introduction>
@@ -1124,7 +1124,7 @@
               <var name="$speedU"/>
               with an elevation of <m>100\,\text{ft}</m>
               on a straight-line path that will take it directly over an
-              anti-aircraft gun as in <xref ref="exer_04_02_ex_07">Exercise</xref>
+              anti-aircraft gun as in <xref ref="exer_04_02_ex_07"/>
               (note the lower elevation here).
             </p>
             <p>
@@ -1591,7 +1591,7 @@
           <introduction>
             <p>
               Consider the situation described in
-              <xref ref="exer_04_02_ex_12">Exercise</xref>.
+              <xref ref="exer_04_02_ex_12"/>.
               Suppose the man starts <m><var name="$bU"/></m> from the weight and begins
               to walk away at a rate of <m><var name="$speedU"/></m>.
             </p>

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -637,7 +637,7 @@
       </p>
 
       <p>
-        Now take the derivative of both sides of Equation <xref ref="eq_rr4"/>
+        Now take the derivative of both sides of <xref ref="eq_rr4">Equation</xref>
         using implicit differentiation:
         <md>
           <mrow>\tan(\theta) \amp = \frac{x}{10}</mrow>
@@ -686,7 +686,7 @@
         Common sense tells us this is when the car is directly in front of the
         camera (<ie/>, when <m>\theta = 0</m>).
         Our mathematics bears this out.
-        In <xref ref="eq_rr4b" text="local">Equation</xref>
+        In <xref ref="eq_rr4b" text="global">Equation</xref>
         we see this is when <m>\cos^2(\theta)</m> is largest;
         this is when <m>\cos(\theta) = 1</m>,
         or when <m>\theta = 0</m>.

--- a/ptx/sec_riemann.ptx
+++ b/ptx/sec_riemann.ptx
@@ -23,7 +23,7 @@
     </p>
 
     <p>
-      Consider the region given in <xref ref="fig_rie1a">Figure</xref>,
+      Consider the region given in <xref ref="fig_rie1a"/>,
       which is the area under <m>y=4x-x^2</m> on <m>[0,4]</m>.
       What is the signed area of this region <mdash/> <ie/>, what is <m>\int_0^4(4x-x^2)\, dx</m>?
     </p>
@@ -77,7 +77,7 @@
         <shortdescription>The previously described parabola with a large rectangle containing the shaded area.</shortdescription>
         <description>
           <p>
-            The curve shown in <xref ref="fig_rie1a">Figure</xref>, with a rectangle entirely containing the shaded area.
+            The curve shown in <xref ref="fig_rie1a"/>, with a rectangle entirely containing the shaded area.
             The rectangle has a height and width of 4.
             On the left and right sides of the parabola, area is included in the rectangle which is not shaded.
             The rectangle clearly contains a greater area than is under the parabola.
@@ -128,7 +128,7 @@
       the <em>Right Hand Rule</em>,
       and the <em>Midpoint Rule</em>.
       The <em>Left Hand Rule</em> says to evaluate the function at the left-hand endpoint of the subinterval and make the rectangle that height.
-      In <xref ref="fig_rie1b">Figure</xref>,
+      In <xref ref="fig_rie1b"/>,
       the rectangle drawn on the interval <m>[2,3]</m> has height determined by the Left Hand Rule;
       it has a height of <m>f(2)</m>. (The rectangle is labeled <q>LHR.</q>)
           <idx><h>Left Hand Rule</h></idx>
@@ -143,7 +143,7 @@
         <shortdescription>The area of a downward opening parabola being approximated by 4 rectangles.</shortdescription>
         <description>
           <p>
-            The parabola shown in <xref ref="fig_rie1a">Figure</xref>. The shaded are is being approximated by 4 rectangles of width 1.
+            The parabola shown in <xref ref="fig_rie1a"/>. The shaded are is being approximated by 4 rectangles of width 1.
             The left most rectangle has a height of 3 and is labeled "RHR," for "Right Hand Rule."
             The height of the rectangle is equal to the height of the parabola om the rightmost side, where <m>x = 1</m>.
             The second rectangle has a height of 3.75, and is labeled "MPR," for "Midpoint Rule."
@@ -240,7 +240,7 @@
 
         <p>
           We break the interval <m>[0,4]</m> into four subintervals as before.
-          In <xref ref="fig_rie2a">Figure</xref>
+          In <xref ref="fig_rie2a"/>
           we see 4 rectangles drawn on
           <m>f(x) = 4x-x^2</m> using the Left Hand Rule.
           (The areas of the rectangles are given in each figure.)
@@ -257,14 +257,14 @@
         </p>
 
         <p>
-          <xref ref="fig_rie2b">Figure</xref>
+          <xref ref="fig_rie2b"/>
           shows 4 rectangles drawn under <m>f</m> using the Right Hand Rule;
           note how the <m>[3,4]</m> subinterval has a rectangle of height 0.
         </p>
 
         <p>
           In this example,
-          these rectangles seem to be the mirror image of those found in <xref ref="fig_rie2a">Figure</xref>.
+          these rectangles seem to be the mirror image of those found in <xref ref="fig_rie2a"/>.
           This is because of the symmetry of our shaded region.
           Our approximation gives the same answer as before,
           though calculated a different way:
@@ -275,7 +275,7 @@
         </p>
 
         <p>
-          <xref ref="fig_rie2c">Figure</xref>
+          <xref ref="fig_rie2c"/>
           shows 4 rectangles drawn under <m>f</m> using the Midpoint Rule.
         </p>
 
@@ -291,7 +291,7 @@
           Our three methods provide two approximations of <m>\int_0^4(4x-x^2)\, dx</m>: 10 and 11.
         </p>
         <figure xml:id="fig_rie2">
-          <caption>Approximating <m>\int_0^4(4x-x^2)\, dx</m> in <xref ref="ex_rie2">Example</xref></caption>
+          <caption>Approximating <m>\int_0^4(4x-x^2)\, dx</m> in <xref ref="ex_rie2"/></caption>
           <sidebyside widths="31% 31% 31%" margins="0%">
           <figure xml:id="fig_rie2a">
           <caption>using the Left Hand Rule</caption>
@@ -300,7 +300,7 @@
             <shortdescription>A parabola approximated using the Left Hand Rule.</shortdescription>
             <description>
               <p>
-                The parabola in <xref ref="fig_rie1a">Figure</xref> approximated using 4 strips of width 1.
+                The parabola in <xref ref="fig_rie1a"/> approximated using 4 strips of width 1.
                 The height of each strip is fiven by the left hand rule.
                 The first strip has a height of 0, and an area of 0.
                 The second strip has a height of 3, and an area of 3.
@@ -354,7 +354,7 @@
             <shortdescription>A parabola approximated using the Right Hand Rule.</shortdescription>
             <description>
               <p>
-                The parabola in <xref ref="fig_rie1a">Figure</xref> approximated using 4 strips of width 1.
+                The parabola in <xref ref="fig_rie1a"/> approximated using 4 strips of width 1.
                 The height of each strip is fiven by the right hand rule.
                 The first strip has height of 3, and an area of 3.
                 The second strip has height of 4, and an area of 4.
@@ -408,7 +408,7 @@
             <shortdescription>A parabola approximated using the Midpoint Rule</shortdescription>
             <description>
               <p>
-                The parabola in <xref ref="fig_rie1a">Figure</xref> approximated using 4 strips of width 1.
+                The parabola in <xref ref="fig_rie1a"/> approximated using 4 strips of width 1.
                 The height of each strip is fiven by the Midpoint Rule.
                 The first strip has a height and area of 1.75.
                 The second strip has a height and area of 3.75.
@@ -497,7 +497,7 @@
       To the right of <m>\Sigma</m>,
       the expression <m>a_i</m> is called the summand.
       It tells us what we are summing.
-      This is summarized in <xref ref="eq_sigmanotation">Equation</xref>.
+      This is summarized in <xref ref="eq_sigmanotation" text="local">Equation</xref>.
       <men xml:id="eq_sigmanotation">
         \sum_{\underbrace{i=1}_{i \text{-index of summation}}}^{\overbrace{9}^\text{upper bound}} \underbrace{a_i}_\text{summand}
       </men>
@@ -614,11 +614,11 @@
 
 
     <example xml:id="ex_rie4">
-      <title>Evaluating summations using <xref ref="thm_summation">Theorem</xref></title>
+      <title>Evaluating summations using <xref ref="thm_summation"/></title>
       <statement>
         <p>
-          Revisit <xref ref="ex_rie3">Example</xref> and,
-          using <xref ref="thm_summation">Theorem</xref>, evaluate
+          Revisit <xref ref="ex_rie3"/> and,
+          using <xref ref="thm_summation"/>, evaluate
           <me>
             \sum_{i=1}^6 a_i = \sum_{i=1}^6 (2i-1)
           </me>.
@@ -637,7 +637,7 @@
           We obtained the same answer without writing out all six terms.
           When dealing with small sizes of <m>n</m>,
           it may be faster to write the terms out by hand.
-          However, <xref ref="thm_summation">Theorem</xref>
+          However, <xref ref="thm_summation"/>
           is incredibly important when dealing with large sums as we'll soon see.
         </p>
       </solution>
@@ -648,7 +648,7 @@
     <title>Riemann Sums</title>
     <p>
       Consider again <m>\int_0^4(4x-x^2)\, dx</m>.
-      We will approximate this definite integral using 16 equally spaced subintervals and the Right Hand Rule in <xref ref="ex_rie7">Example</xref>.
+      We will approximate this definite integral using 16 equally spaced subintervals and the Right Hand Rule in <xref ref="ex_rie7"/>.
       Before doing so, it will pay to do some careful preparation.
           <idx><h>Riemann Sum</h></idx>
     </p>
@@ -696,7 +696,7 @@
     </figure>
 
     <p>
-      <xref ref="fig_rie5">Figure</xref>
+      <xref ref="fig_rie5"/>
       shows a number line of <m>[0,4]</m> divided,
       or <em>partitioned</em>, into 16 equally spaced subintervals.
       We denote <m>0</m> as <m>x_0</m>;
@@ -811,7 +811,7 @@
 
     <p>
       We use these formulas in the next two examples.
-      The following example lets us practice using the Right Hand Rule and the summation formulas introduced in <xref ref="thm_summation">Theorem</xref>.
+      The following example lets us practice using the Right Hand Rule and the summation formulas introduced in <xref ref="thm_summation"/>.
     </p>
 
     <example xml:id="ex_rie7">
@@ -860,7 +860,7 @@
 
         <p>
           We were able to sum up the areas of 16 rectangles with very little computation.
-          In <xref ref="fig_rie7">Figure</xref>
+          In <xref ref="fig_rie7"/>
           the function and the 16 rectangles are graphed.
           While some rectangles over-approximate the area,
           other under-approximate the area
@@ -882,7 +882,7 @@
             <shortdescription>A parabola approximated using 16 equal subintervals.</shortdescription>
             <description>
               <p>
-                The parabola in <xref ref="fig_rie1a">Figure</xref> approximated using 16 strips of equal width.
+                The parabola in <xref ref="fig_rie1a"/> approximated using 16 strips of equal width.
                 The height of each strips are given by the Right Hand Rule.
                 On the left side the area of the rectangles is slightly greater than the area of the parabola.
                 On the right side the area of the rectangles is slightly less than the area of the parabola.
@@ -1024,7 +1024,7 @@
         <p>
           Let <m>f</m> be defined on a closed interval <m>[a,b]</m>,
           let <m>\Delta x</m> be a partition of <m>[a,b]</m>
-          as given in <xref ref="def_partition">Definition</xref>,
+          as given in <xref ref="def_partition"/>,
               <idx><h>Riemann Sum</h></idx>
           and let <m>c_i</m> denote any value in the <m>i</m>th subinterval.
         </p>
@@ -1046,7 +1046,7 @@
 
 
     <p>
-      <xref ref="fig_riedef">Figure</xref>
+      <xref ref="fig_riedef"/>
       shows the approximating rectangles of a Riemann sum of <m>\int_0^4(4x-x^2)\, dx</m>.
       While the rectangles in this example do not approximate well the shaded area,
       they demonstrate that the subinterval widths may vary and the heights of the rectangles can be determined without following a particular rule.
@@ -1059,7 +1059,7 @@
         <shortdescription>A parabola approximated by 3 rectangles of different width</shortdescription>
         <description>
           <p>
-            The parabola in <xref ref="fig_rie1a">Figure</xref> approximated using 3 rectangles of different width.
+            The parabola in <xref ref="fig_rie1a"/> approximated using 3 rectangles of different width.
             The height of each rectangle is not given by any particular rule.
             The left most strip has a width of 2, and a height of around 0.95. This height is given by a point at around <m>x=0.3</m>.
             The center strip has a width of 2.5. It has a height of around 2.8, given by a point at around <m>x=3.2</m>.
@@ -1168,7 +1168,7 @@
       <solution>
 
         <p>
-          Following <xref ref="idea_riemann">Key Idea</xref>, we have
+          Following <xref ref="idea_riemann"/>, we have
           <me>
             \Delta x = \frac{3 - (-2)}{10} = 1/2  \text{ and }   x_i = (-2) + (1/2)(i) = i/2-2
           </me>.
@@ -1198,7 +1198,7 @@
         </p>
 
         <figure xml:id="fig_rie8">
-          <caption>Approximating <m>\int_{-2}^3 (5x+2)\, dx</m> using the Midpoint Rule and 10 evenly spaced subintervals in <xref ref="ex_rie8">Example</xref></caption>
+          <caption>Approximating <m>\int_{-2}^3 (5x+2)\, dx</m> using the Midpoint Rule and 10 evenly spaced subintervals in <xref ref="ex_rie8"/></caption>
           <!-- START figures/fig_rie8.tex -->
           <image xml:id="img_rie8" width="47%">
             <shortdescription>The area under a line approximated with 10 even subintervals.</shortdescription>
@@ -1242,7 +1242,7 @@
         </figure>
 
         <p>
-          Note the graph of <m>f(x) = 5x+2</m> in <xref ref="fig_rie8">Figure</xref>.
+          Note the graph of <m>f(x) = 5x+2</m> in <xref ref="fig_rie8"/>.
           The regions whose area is computed by the definite integral are triangles,
           meaning we can find the exact answer without summation techniques.
           We find that the exact answer is indeed 22.5.
@@ -1289,7 +1289,7 @@
       <solution>
 
         <p>
-          Using <xref ref="idea_riemann">Key Idea</xref>,
+          Using <xref ref="idea_riemann"/>,
           we know <m>\Delta x = \frac{4-0}{n} = 4/n</m>.
           We also find <m>x_i = 0 + i\Delta x = 4i/n</m>.
         </p>
@@ -1396,7 +1396,7 @@
       <solution>
 
         <p>
-          Following <xref ref="idea_riemann">Key Idea</xref>,
+          Following <xref ref="idea_riemann"/>,
           we have <m>\Delta x = \frac{5-(-1)}{n} = 6/n</m>.
           We have <m>x_i = (-1) + i\Delta x</m>,
           which is the right endpoint of the <m>i</m>th subinterval.
@@ -1422,7 +1422,7 @@
         <p>
           Once again, we have found a compact formula for approximating the definite integral with <m>n</m> equally spaced subintervals and the Right Hand Rule.
           Using 10 subintervals, we have an approximation of <m>195.96</m>
-          (these rectangles are shown in <xref ref="fig_rie9">Figure</xref>).
+          (these rectangles are shown in <xref ref="fig_rie9"/>).
           Using <m>n=100</m> gives an approximation of <m>159.802</m>.
         </p>
 
@@ -1549,12 +1549,12 @@
       The theorem states that the height of each rectangle doesn't have to be determined following a specific rule,
       but could be <m>f(c_i)</m>,
       where <m>c_i</m> is any point in the <m>i</m>th subinterval,
-      as discussed before Riemann Sums were defined in <xref ref="def_rie_sum">Definition</xref>.
+      as discussed before Riemann Sums were defined in <xref ref="def_rie_sum"/>.
     </p>
 
     <p>
       The theorem goes on to state that the rectangles do not need to be of the same width.
-      Using the notation of <xref ref="def_partition">Definition</xref>,
+      Using the notation of <xref ref="def_partition"/>,
       let <m>\Delta x_i</m> denote the length of the
       <m>i</m>th subinterval in a partition of <m>[a,b]</m> and let
       <m>\norm{\Delta x}</m> represent the length of the largest subinterval in the partition:
@@ -2338,7 +2338,7 @@
       <exercisegroup cols="2" xml:id="exset-riemann-evaluate-sum">
         <introduction>
           <p>
-            Evaluate the summation using <xref ref="thm_summation">Theorem</xref>.
+            Evaluate the summation using <xref ref="thm_summation"/>.
           </p>
         </introduction>
 
@@ -2549,12 +2549,12 @@
       <exercisegroup cols="2" xml:id="exset-riemann-sum-with-properties">
         <introduction>
           <p>
-            <xref ref="thm_summation">Theorem</xref> states
+            <xref ref="thm_summation"/> states
             <m>\sum\limits_{i=1}^na_i = \sum\limits_{i=1}^k a_i + \sum\limits_{i=k+1}^n a_i</m>,
             so
             <m>\sum\limits_{i=k+1}^na_i = \sum\limits_{i=1}^n a_i - \sum\limits_{i=1}^k a_i</m>.
             Use this fact,
-            along with other parts of <xref ref="thm_summation">Theorem</xref>,
+            along with other parts of <xref ref="thm_summation"/>,
             to evaluate the summation.
           </p>
         </introduction>
@@ -2741,8 +2741,8 @@
         <introduction>
           <p>
             A definite integral is given below.
-            As demonstrated in <xref ref="ex_rie9">Examples</xref>
-            and <xref ref="ex_rie10"/>, do the following:
+            As demonstrated in <xref ref="ex_rie9" text="global">Examples</xref>
+            and <xref ref="ex_rie10" text="global"/>, do the following:
             <ol>
               <li>
                 <p>

--- a/ptx/sec_riemann.ptx
+++ b/ptx/sec_riemann.ptx
@@ -497,7 +497,7 @@
       To the right of <m>\Sigma</m>,
       the expression <m>a_i</m> is called the summand.
       It tells us what we are summing.
-      This is summarized in <xref ref="eq_sigmanotation" text="local">Equation</xref>.
+      This is summarized in <xref ref="eq_sigmanotation" text="global">Equation</xref>.
       <men xml:id="eq_sigmanotation">
         \sum_{\underbrace{i=1}_{i \text{-index of summation}}}^{\overbrace{9}^\text{upper bound}} \underbrace{a_i}_\text{summand}
       </men>
@@ -869,7 +869,7 @@
         </p>
 
         <p>
-          Notice Equation <xref ref="eq_rie7"/>;
+          Notice <xref ref="eq_rie7">Equation</xref>;
           by replacing 16 by 1,000
           (and appropriately changing the value of <m>\Delta x</m>),
           we can use that equation to sum up 1000 rectangles!
@@ -920,7 +920,7 @@
 
         <p>
           We do so here,
-          skipping from the original summand to the equivalent of Equation <xref ref="eq_rie7"/> to save space.
+          skipping from the original summand to the equivalent of <xref ref="eq_rie7">Equation</xref> to save space.
           Note that <m>\Delta x = 4/1000 = 0.004</m>.
           <md>
             <mrow>\int_0^4 (4x-x^2)\, dx \amp \approx \sum_{i=1}^{1000} f(x_{i})\Delta x</mrow>

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -10,7 +10,7 @@
   </p>
 
   <figure xml:id="vid-seqseries-sequences-intro" component="video">
-    <caption>Video introduction to <xref ref="sec_sequences">Section</xref></caption>
+    <caption>Video introduction to <xref ref="sec_sequences"/></caption>
     <video youtube="jW6PMyekBtU" label="vid-seqseries-sequences-intro"/>
   </figure>
 
@@ -119,7 +119,7 @@
               We can plot the terms of a sequence with a scatter plot.
               The horizontal axis is used for the values of <m>n</m>,
               and the values of the terms are plotted on the vertical axis.
-              To visualize this sequence, see <xref ref="fig_seq1a">Figure</xref>.
+              To visualize this sequence, see <xref ref="fig_seq1a"/>.
             </p>
             <figure xml:id="fig_seq1a">
               <caption>Plotting the sequence in <xref ref="item_ex_seq1_1"/></caption>
@@ -171,7 +171,7 @@
             <p>
               Note that the range of this sequence is finite,
               consisting of only the values 3 and 5.
-              This sequence is plotted in <xref ref="fig_seq1b">Figure</xref>.
+              This sequence is plotted in <xref ref="fig_seq1b"/>.
             </p>
             <figure xml:id="fig_seq1b">
               <caption>Plotting the sequence in <xref ref="item_ex_seq1_2"/></caption>
@@ -228,7 +228,7 @@
               <m>-</m>, <m>+</m>, <m>+</m>,
               <m>-</m>, <m>-</m>, <m>\ldots</m></q>,
               due to the fact that the exponent of <m>-1</m> is a special quadratic.
-              This sequence is plotted in <xref ref="fig_seq1c">Figure</xref>.
+              This sequence is plotted in <xref ref="fig_seq1c"/>.
             </p>
             <figure xml:id="fig_seq1c">
               <caption>Plotting the sequence in <xref ref="item_ex_seq1_3"/></caption>
@@ -453,7 +453,7 @@
 
   <p>
     This definition is reminiscent of the
-    <m>\varepsilon</m>-<m>\delta</m> proofs of <xref ref="chapter_limits">Chapter</xref>.
+    <m>\varepsilon</m>-<m>\delta</m> proofs of <xref ref="chapter_limits"/>.
     In that chapter we developed other tools to evaluate limits apart from the formal definition;
     we do so here as well.
   </p>
@@ -510,8 +510,8 @@
   </theorem>
 
   <p>
-    <xref ref="thm_seq_limit">Theorem</xref> allows us, in certain cases,
-    to apply the tools developed in <xref ref="chapter_limits">Chapter</xref> to limits of sequences.
+    <xref ref="thm_seq_limit"/> allows us, in certain cases,
+    to apply the tools developed in <xref ref="chapter_limits"/> to limits of sequences.
     Note two things <em>not</em> stated by the theorem:
   </p>
 
@@ -573,11 +573,11 @@
         <ol>
           <li>
             <p>
-              Using <xref ref="thm_lim_rational_fn_at_infty">Theorem</xref>,
+              Using <xref ref="thm_lim_rational_fn_at_infty"/>,
               we can state that <m>\lim\limits_{x\to\infty} \frac{3x^2-2x+1}{x^2-1000} = 3</m>.
               (We could have also directly applied L'Hospital's Rule.)
               Thus the sequence <m>\{a_n\}</m> converges, and its limit is 3.
-              A scatter plot of every 5 values of <m>a_n</m> is given in <xref ref="fig_seq4a">Figure</xref>.
+              A scatter plot of every 5 values of <m>a_n</m> is given in <xref ref="fig_seq4a"/>.
               The values of <m>a_n</m> vary widely near <m>n=30</m>,
               ranging from about <m>-73</m> to <m>125</m>,
               but as <m>n</m> grows, the values approach 3.
@@ -630,12 +630,12 @@
               The limit <m>\lim\limits_{x\to\infty}\cos(x)</m> does not exist,
               as <m>\cos(x)</m> oscillates
               (and takes on every value in <m>[-1,1]</m> infinitely many times).
-              Thus we cannot apply <xref ref="thm_seq_limit">Theorem</xref>.
+              Thus we cannot apply <xref ref="thm_seq_limit"/>.
 
               The fact that the cosine function oscillates strongly hints that <m>\cos(n)</m>,
               when <m>n</m> is restricted to
               <m>\mathbb{N}</m>, will also oscillate.
-              <xref ref="fig_seq4b">Figure</xref>,
+              <xref ref="fig_seq4b"/>,
               where the sequence is plotted, shows that this is true.
               Because only discrete values of cosine are plotted,
               it does not bear strong resemblance to the familiar cosine wave.
@@ -690,13 +690,13 @@
 
           <li>
             <p>
-              We cannot actually apply <xref ref="thm_seq_limit">Theorem</xref> here,
+              We cannot actually apply <xref ref="thm_seq_limit"/> here,
               as the function <m>f(x) = (-1)^x/x</m> is not well defined. (What does <m>(-1)^{\sqrt{2}}</m> mean?
               In actuality, there is an answer,
               but it involves <em>complex analysis</em>,
               beyond the scope of this text.)  Instead,
               we invoke the definition of the limit of a sequence.
-              By looking at the plot in <xref ref="fig_seq4c">Figure</xref>,
+              By looking at the plot in <xref ref="fig_seq4c"/>,
               we would like to conclude that the sequence converges to <m>L=0</m>.
               Let <m>\epsilon\gt 0</m> be given.
               We can find a natural number <m>m</m> such that <m>1/m \lt  \varepsilon</m>.
@@ -763,7 +763,7 @@
   </example>
 
   <p>
-    In the previous example we used the definition of the limit of a sequence to determine the convergence of a sequence as we could not apply <xref ref="thm_seq_limit">Theorem</xref>.
+    In the previous example we used the definition of the limit of a sequence to determine the convergence of a sequence as we could not apply <xref ref="thm_seq_limit"/>.
     In general, we like to avoid invoking the definition of a limit,
     and the following theorem gives us tool that we could use in that example instead.
   </p>
@@ -821,15 +821,15 @@
         <ol>
           <li>
             <p>
-              This appeared in <xref ref="ex_seq4">Example</xref>.
-              We want to apply <xref ref="thm_abs_val_seq">Theorem</xref>,
+              This appeared in <xref ref="ex_seq4"/>.
+              We want to apply <xref ref="thm_abs_val_seq"/>,
               so consider the limit of <m>\{\abs{a_n}\}</m>:
               <md>
                 <mrow>\lim_{n\to\infty} \abs{a_n} \amp = \lim_{n\to\infty} \abs{\frac{(-1)^n}{n}}</mrow>
                 <mrow>\amp = \lim_{n\to\infty} \frac{1}{n}</mrow>
                 <mrow>\amp = 0</mrow>
               </md>.
-              Since this limit is 0, we can apply <xref ref="thm_abs_val_seq">Theorem</xref>
+              Since this limit is 0, we can apply <xref ref="thm_abs_val_seq"/>
               and state that <m>\lim\limits_{n\to\infty} a_n=0</m>.
             </p>
           </li>
@@ -838,7 +838,7 @@
             <p>
               Because of the alternating nature of this sequence (<ie/>, every other term is multiplied by <m>-1</m>),
               we cannot simply look at the limit <m>\lim\limits_{x\to\infty} \frac{(-1)^x(x+1)}{x}</m>.
-              We can try to apply the techniques of <xref ref="thm_abs_val_seq">Theorem</xref>:
+              We can try to apply the techniques of <xref ref="thm_abs_val_seq"/>:
               <md>
                 <mrow>\lim_{n\to\infty} \abs{a_n} \amp = \lim_{n\to\infty} \abs{\frac{(-1)^n(n+1)}{n}}</mrow>
                 <mrow>\amp = \lim_{n\to\infty} \frac{n+1}{n}</mrow>
@@ -846,12 +846,12 @@
               </md>.
               We have concluded that when we ignore the alternating sign,
               the sequence approaches 1.
-              This means we cannot apply <xref ref="thm_abs_val_seq">Theorem</xref>;
+              This means we cannot apply <xref ref="thm_abs_val_seq"/>;
               it states the the limit must be 0 in order to conclude anything.
             </p>
 
             <figure xml:id="fig_seq5">
-              <caption>A plot of a sequence in <xref ref="ex_seq5">Example</xref>, part 2</caption>
+              <caption>A plot of a sequence in <xref ref="ex_seq5"/>, part 2</caption>
           <!-- START figures/fig_seq5.tex -->
               <image xml:id="img_seq5" width="47%">
                 <shortdescription>Scatter plot illustrating the first 20 points in the sequence from the second part of this example.</shortdescription>
@@ -893,7 +893,7 @@
               we know that the limit of <m>\abs{a_n}</m> is 1, we know that as <m>n</m> approaches infinity,
               the terms will alternate between values close to 1 and <m>-1</m>,
               meaning the sequence diverges.
-              A plot of this sequence is given in <xref ref="fig_seq5">Figure</xref>.
+              A plot of this sequence is given in <xref ref="fig_seq5"/>.
             </p>
           </li>
         </ol>
@@ -1004,7 +1004,7 @@
     </solution>
     <solution>
       <p>
-        We will use <xref ref="thm_seq_properties">Theorem</xref> to answer each of these.
+        We will use <xref ref="thm_seq_properties"/> to answer each of these.
       </p>
 
       <p>
@@ -1106,7 +1106,7 @@
               The terms of this sequence are always positive but are decreasing,
               so we have <m>0\lt a_n\lt 2</m> for all <m>n</m>.
               Thus this sequence is bounded.
-              <xref ref="fig_seq3a">Figure</xref> illustrates this.
+              <xref ref="fig_seq3a"/> illustrates this.
             </p>
           </li>
 
@@ -1116,14 +1116,14 @@
               However, it is also true that these terms are all positive,
               meaning <m>0\lt a_n</m>.
               Thus we can say the sequence is unbounded, but also bounded below.
-              <xref ref="fig_seq3b">Figure</xref> illustrates this.
+              <xref ref="fig_seq3b"/> illustrates this.
             </p>
           </li>
         </ol>
       </p>
 
       <figure xml:id="fig_seq3">
-        <caption>A plot of <m>\{a_n\} = \{1/n\}</m> and <m>\{a_n\} = \{2^n\}</m> from <xref ref="ex_seq3">Example</xref></caption>
+        <caption>A plot of <m>\{a_n\} = \{1/n\}</m> and <m>\{a_n\} = \{2^n\}</m> from <xref ref="ex_seq3"/></caption>
         <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
           <figure xml:id="fig_seq3a">
@@ -1219,7 +1219,7 @@
     This implies that the sequence is bounded,
     using the following logic.
     First, <q>most</q> terms are near 0, so we could find some sort of bound on these terms
-    (using <xref ref="def_seq_limit">Definition</xref>,
+    (using <xref ref="def_seq_limit"/>,
     the bound is <m>\varepsilon</m>).
     That leaves a <q>few</q> terms that are not near 0 (<ie/>, a
     <em>finite</em> number of terms).
@@ -1246,7 +1246,7 @@
 
   <aside>
     <p>
-      Keep in mind what <xref ref="thm_converge_bounded">Theorem</xref> does <em>not</em> say.
+      Keep in mind what <xref ref="thm_converge_bounded"/> does <em>not</em> say.
       It does not say that bounded sequences must converge,
       nor does it say that if a sequence does not converge, it is not bounded.
     </p>
@@ -1258,17 +1258,17 @@
   </figure>
 
   <p>
-    In <xref ref="ex_seq6">Example</xref>
+    In <xref ref="ex_seq6"/>
     we saw the sequence <m>\ds \{b_n\} = \left\{\left(1+1/n\right)^{n}\right\}</m>,
     where it was stated that <m>\lim\limits_{n\to\infty} b_n = e</m>.
-    (Note that this is simply restating part of <xref ref="thm_special_limits">Theorem</xref>.
+    (Note that this is simply restating part of <xref ref="thm_special_limits"/>.
     The limit can also be found using logarithms and L'Hospital's rule.)
     Even though it may be difficult to intuitively grasp the behavior of this sequence,
     we know immediately that it is bounded.
   </p>
 
   <p>
-    Another interesting concept to come out of <xref ref="ex_seq3">Example</xref>
+    Another interesting concept to come out of <xref ref="ex_seq3"/>
     again involves the sequence <m>\{1/n\}</m>.
     We stated, without proof, that the terms of the sequence were decreasing.
     That is, that <m>a_{n+1} \lt a_n</m> for all <m>n</m>. (This is easy to show.
@@ -1422,7 +1422,7 @@
 
           <li>
             <p>
-              We can clearly see in <xref ref="fig_seq7c">Figure</xref>,
+              We can clearly see in <xref ref="fig_seq7c"/>,
               where the sequence is plotted, that it is not monotonic.
               However, it does seem that after the first 4 terms it is decreasing.
               To understand why, perform the same analysis as done before:
@@ -1455,7 +1455,7 @@
           <li xml:id="ex_seq7_4">
 
             <p>
-              Again, the plot in <xref ref="fig_seq7d">Figure</xref>
+              Again, the plot in <xref ref="fig_seq7d"/>
               shows that the sequence is not monotonic,
               but it suggests that it is monotonically decreasing after the first term.
               We perform the usual analysis to confirm this.
@@ -1474,7 +1474,7 @@
       </p>
 
       <figure xml:id="fig_seq7">
-        <caption>Plots of sequences in <xref ref="ex_seq7">Example</xref></caption>
+        <caption>Plots of sequences in <xref ref="ex_seq7"/></caption>
         <sbsgroup>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_seq7a">
@@ -1592,7 +1592,7 @@
 
             <figure xml:id="fig_seq7d">
               <caption/>
-              <!-- <caption>A plot of <m>\{a_n\} = \{n^2/n!\}</m> in <xref ref="ex_seq7_4">Example</xref></caption> -->
+              <!-- <caption>A plot of <m>\{a_n\} = \{n^2/n!\}</m> in <xref ref="ex_seq7_4"/></caption> -->
               <!-- Either all get captions, or none. The labels in each image make it clear enough?-->
             <!-- START figures/fig_seq7d.tex -->
               <image xml:id="img_seq7d">
@@ -1678,13 +1678,13 @@
   <p>
     Consider once again the sequence <m>\{a_n\} = \{1/n\}</m>.
     It is easy to show it is monotonically decreasing and that it is always positive (<ie/>, bounded below by 0).
-    Therefore we can conclude by <xref ref="thm_monotonic_converge">Theorem</xref> that the sequence converges.
+    Therefore we can conclude by <xref ref="thm_monotonic_converge"/> that the sequence converges.
     We already knew this by other means,
     but in the following section this theorem will become very useful.
   </p>
 
   <p>
-    We can replace <xref ref="thm_monotonic_converge">Theorem</xref>
+    We can replace <xref ref="thm_monotonic_converge"/>
     with the statement <q>Let <m>\{a_n\}</m> be a bounded,
     monotonic sequence.
     Then <m>\{a_n\}</m> converges;
@@ -1714,7 +1714,7 @@
     <q>Doesn't this just add up to <sq>infinity</sq>?</q> Many times,
     yes, but there are many important cases where the answer is no.
     This is the topic of <em>series</em>,
-    which we begin to investigate in <xref ref="sec_series">Section</xref>.
+    which we begin to investigate in <xref ref="sec_series"/>.
   </p>
 
   <exercises>
@@ -2471,7 +2471,7 @@
               </pg-code>-->
               <statement>
                 <p>
-                  Prove <xref ref="thm_abs_val_seq">Theorem</xref>; that is,
+                  Prove <xref ref="thm_abs_val_seq"/>; that is,
   		            use the definition of the limit of a sequence to show that if <m>\lim\limits_{n\to\infty} \abs{a_n} = 0</m>, then <m>\lim\limits_{n\to\infty} a_n = 0</m>.
                 </p>
               </statement>
@@ -2567,13 +2567,13 @@
                 monotonic sequence.
                 Then <m>\{a_n\}</m> converges;
                 <ie/>, <m>\ds \lim_{n \to\infty}a_n</m> exists.</q>
-                is equivalent to <xref ref="thm_monotonic_converge">Theorem</xref>.
+                is equivalent to <xref ref="thm_monotonic_converge"/>.
                 That is,
 
                 <ol>
                   <li>
                     <p>
-                      Show that if <xref ref="thm_monotonic_converge">Theorem</xref> is true,
+                      Show that if <xref ref="thm_monotonic_converge"/> is true,
                       then above statement is true, and
                     </p>
                   </li>
@@ -2581,7 +2581,7 @@
                   <li>
                     <p>
                       Show that if the above statement is true,
-                      then <xref ref="thm_monotonic_converge">Theorem</xref> is true.
+                      then <xref ref="thm_monotonic_converge"/> is true.
                     </p>
                   </li>
                 </ol>
@@ -2594,12 +2594,12 @@
                 <ol>
                   <li>
                     <p>
-                      Assume that <xref ref="thm_monotonic_converge">Theorem</xref> is true,
+                      Assume that <xref ref="thm_monotonic_converge"/> is true,
                       and let <m>\{a_n\}</m> be bounded and monotonic.
                       Since <m>\{a_n\}</m> is bounded,
                       it is bounded both above and below.
                       If it is increasing,
-                      it is bounded above and we apply <xref ref="thm_monotonic_converge">Theorem</xref>;
+                      it is bounded above and we apply <xref ref="thm_monotonic_converge"/>;
                       if it is decreasing, it is bounded below and we apply the theorem.
                       Either way, <m>\{a_n\}</m> converges and the statement is true.
                     </p>
@@ -2615,7 +2615,7 @@
                       Therefore <m>\{a_n\}</m> is bounded and monotonic;
                       by the statement, <m>\{a_n\}</m> converges.
                       A similar statement can be made for when <m>\{a_n\}</m> is monotonically decreasing and bounded below.
-                      Therefore <xref ref="thm_monotonic_converge">Theorem</xref> is true.
+                      Therefore <xref ref="thm_monotonic_converge"/> is true.
                     </p>
                   </li>
                 </ol>

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -3,7 +3,7 @@
   <title>Infinite Series</title>
   <introduction>
     <figure xml:id="vid-seqseries-series-intro" component="video">
-      <caption>Video introduction to <xref ref="sec_series">Section</xref></caption>
+      <caption>Video introduction to <xref ref="sec_series"/></caption>
       <video youtube="RV9LNPv20TA" label="vid-seqseries-series-intro"/>
     </figure>
     <p>
@@ -164,7 +164,7 @@
                 <md>
                   <mrow>S_n \amp = a_1+a_2+a_3+\cdots+a_n</mrow>
                   <mrow>\amp = 1^2+2^2+3^2\cdots + n^2.</mrow>
-                  <intertext>By <xref ref="thm_summation">Theorem</xref>, this is</intertext>
+                  <intertext>By <xref ref="thm_summation"/>, this is</intertext>
                   <mrow>\amp = \frac{n(n+1)(2n+1)}{6}</mrow>
                 </md>.
                 Since <m>\lim\limits_{n\to\infty}S_n = \infty</m>,
@@ -173,7 +173,7 @@
                 <em>how</em> the series diverges:
                 it grows without bound.
 
-                A scatter plot of the sequences <m>\{a_n\}</m> and <m>\{S_n\}</m> is given in <xref ref="fig_series1a">Figure</xref>.
+                A scatter plot of the sequences <m>\{a_n\}</m> and <m>\{S_n\}</m> is given in <xref ref="fig_series1a"/>.
                 The terms of <m>\{a_n\}</m> are growing,
                 so the terms of the partial sums <m>\{S_n\}</m> are growing even faster,
                 illustrating that the series diverges.
@@ -198,13 +198,13 @@
                 we conclude that <m>\lim\limits_{n\to\infty}S_n</m> does not exist,
                 hence <m>\ds\infser (-1)^{n+1}</m> diverges.
 
-                A scatter plot of the sequence <m>\{b_n\}</m> and the partial sums <m>\{S_n\}</m> is given in <xref ref="fig_series1b">Figure</xref>.
+                A scatter plot of the sequence <m>\{b_n\}</m> and the partial sums <m>\{S_n\}</m> is given in <xref ref="fig_series1b"/>.
                 When <m>n</m> is odd,
                 <m>b_n = S_n</m> so the marks for <m>b_n</m> are drawn oversized to show they coincide.
               </p>
 
               <figure xml:id="fig_series1">
-                <caption>Scatter plots relating to <xref ref="ex_series1">Example</xref></caption>
+                <caption>Scatter plots relating to <xref ref="ex_series1"/></caption>
                 <sidebyside widths="47% 47%" valign="bottom" margins="0%">
                   <figure xml:id="fig_series1a">
                     <caption/>
@@ -396,7 +396,7 @@
             <mrow>S_n(1-r) \amp = 1-r^{n}</mrow>
             <mrow>S_n \amp = \frac{1-r^{n}}{1-r}</mrow>
           </md>.
-          We have shown <xref ref="thm_geom_series_a">Part</xref>
+          We have shown <xref ref="thm_geom_series_a" text="local">Part</xref>
           of <xref ref="thm_geom_series" text="title"/>.
         </p>
 
@@ -460,7 +460,7 @@
       <video youtube="Js5qK6AecSM" label="vid-seqseries-series-geometric"/>
     </figure>
     <p>
-      According to <xref ref="thm_geom_series">Theorem</xref>,
+      According to <xref ref="thm_geom_series"/>,
       the series
       <me>
         \ds\infser[0] \frac{1}{2^n} =\infser[0] \left(\frac 12\right)^2= 1+\frac12+\frac14+\cdots
@@ -511,7 +511,7 @@
             <li>
               <p>
                 Since <m>r=3/4\lt 1</m>, this series converges.
-                By <xref ref="thm_geom_series">Theorem</xref>, we have that
+                By <xref ref="thm_geom_series"/>, we have that
                 <me>
                   \infser[0] \left(\frac34\right)^n = \frac{1}{1-3/4} = 4
                 </me>.
@@ -521,7 +521,7 @@
                 <me>
                   \sum_{n=2}^\infty \left(\frac34\right)^n = 4 - 1 - \frac34 = \frac94
                 </me>.
-                This is illustrated in <xref ref="fig_series2a">Figure</xref>.
+                This is illustrated in <xref ref="fig_series2a"/>.
               </p>
               <figure xml:id="fig_series2a">
                 <caption>Scatter plots for the series in <xref ref="item_ex_ser2_1"/></caption>
@@ -577,11 +577,11 @@
             <li>
               <p>
                 Since <m>\abs{r} = 1/2 \lt  1</m>,
-                this series converges, and by <xref ref="thm_geom_series">Theorem</xref>,
+                this series converges, and by <xref ref="thm_geom_series"/>,
                 <me>
                   \infser[0] \left(\frac{-1}{2}\right)^n = \frac{1}{1-(-1/2)} = \frac23
                 </me>.
-                The partial sums of this series are plotted in <xref ref="fig_series2b">Figure</xref>.
+                The partial sums of this series are plotted in <xref ref="fig_series2b"/>.
                 Note how the partial sums are not purely increasing as some of the terms of the sequence <m>\{(-1/2)^n\}</m> are negative.
               </p>
               <figure xml:id="fig_series2b">
@@ -643,7 +643,7 @@
                   1+3+9+27 + 81+243+\cdots
                 </me>
                 to diverge.)
-                This is illustrated in <xref ref="fig_series2c">Figure</xref>.
+                This is illustrated in <xref ref="fig_series2c"/>.
               </p>
               <figure xml:id="fig_series2c">
                 <caption>Scatter plots for the series in <xref ref="item_ex_ser2_3"/></caption>
@@ -757,8 +757,8 @@
 
     <aside>
       <p>
-        We will be able to prove <xref ref="thm_pseries">Theorem</xref>
-        in <xref ref="sec_int_comp_tests">Section</xref>.
+        We will be able to prove <xref ref="thm_pseries"/>
+        in <xref ref="sec_int_comp_tests"/>.
         This theorem assumes that <m>an+b\gt 0</m> for all <m>n</m>;
         if <m>an+b\lt 0</m>, <m>(an+b)^p</m> won't be defined when <m>p</m> is not an integer,
         and if <m>an+b=0</m> for some <m>n</m>,
@@ -825,7 +825,7 @@
             <li>
               <p>
                 This is a <m>p</m>-series with <m>p=1</m>.
-                By <xref ref="thm_pseries">Theorem</xref>, this series diverges.
+                By <xref ref="thm_pseries"/>, this series diverges.
 
                 This series is a famous series,
                 called the <em>Harmonic Series</em>,
@@ -837,7 +837,7 @@
             <li>
               <p>
                 This is a <m>p</m>-series with <m>p=2</m>.
-                By <xref ref="thm_pseries">Theorem</xref>, it converges.
+                By <xref ref="thm_pseries"/>, it converges.
                 Note that the theorem does not give a formula by which we can determine
                 <em>what</em> the series converges to;
                 we just know it converges.
@@ -856,7 +856,7 @@
               <p>
                 This is not a <m>p</m>-series;
                 the definition does not allow for alternating signs.
-                Therefore we cannot apply <xref ref="thm_pseries">Theorem</xref>.
+                Therefore we cannot apply <xref ref="thm_pseries"/>.
                 (Another famous result states that this series,
                 the <em>Alternating Harmonic Series</em>,
                 converges to <m>\ln(2)</m>.)
@@ -921,11 +921,11 @@
           The sequence <m>\{S_n\}</m> converges,
           as <m>\lim\limits_{n\to\infty}S_n = \lim_{n\to\infty}\left(1-\frac1{n+1}\right) = 1</m>,
           and so we conclude that <m>\ds \infser \left(\frac1n-\frac1{n+1}\right) = 1</m>.
-          Partial sums of the series are plotted in <xref ref="fig_series3">Figure</xref>.
+          Partial sums of the series are plotted in <xref ref="fig_series3"/>.
         </p>
 
         <figure xml:id="fig_series3">
-          <caption>Scatter plots relating to the series of <xref ref="ex_series3">Example</xref></caption>
+          <caption>Scatter plots relating to the series of <xref ref="ex_series3"/></caption>
           <!-- START figures/fig_series3.tex -->
           <image xml:id="img_series3" width="47%">
             <shortdescription>Scatter plots of the sequence, and corresponding partial sums, for this example.</shortdescription>
@@ -979,7 +979,7 @@
     </example>
 
     <p>
-      The series in <xref ref="ex_series3">Example</xref>
+      The series in <xref ref="ex_series3"/>
       is an example of a <em>telescoping series</em>.
       Informally, a telescoping series is one in which most terms cancel with preceding or following terms,
       reducing the number of terms in each partial sum.
@@ -1033,7 +1033,7 @@
                 <me>
                   \frac2{n^2+2n} = \frac1n-\frac1{n+2}
                 </me>.
-                (See <xref ref="sec_partial_fraction">Section</xref>, Partial Fraction Decomposition,
+                (See <xref ref="sec_partial_fraction"/>, Partial Fraction Decomposition,
                 to recall how  this is done, if necessary.)
 
                 <!-- ToDo: Figure out how to format this.
@@ -1059,7 +1059,7 @@
                   \lim_{n\to\infty}S_n = \lim_{n\to\infty} \left(1+\frac12-\frac1{n+1}-\frac1{n+2}\right) = \frac32
                 </me>,
                 so <m> \infser \frac1{n^2+2n} = \frac32</m>.
-                This is illustrated in <xref ref="fig_series4a">Figure</xref>.
+                This is illustrated in <xref ref="fig_series4a"/>.
               </p>
             </li>
 
@@ -1085,7 +1085,7 @@
                 as <m>\lim\limits_{n\to\infty}S_n=\infty</m>.
                 Therefore  <m>\ds\infser  \ln\left(\frac{n+1}{n}\right)=\infty</m>;
                 the series diverges.
-                Note in <xref ref="fig_series4b">Figure</xref> how the sequence of partial sums grows slowly;
+                Note in <xref ref="fig_series4b"/> how the sequence of partial sums grows slowly;
                 after 100 terms, it is not yet over 5.
                 Graphically we may be fooled into thinking the series converges,
                 but our analysis above shows that it does not.
@@ -1095,7 +1095,7 @@
         </p>
 
         <figure xml:id="fig_series4">
-          <caption>Scatter plots relating to the series in <xref ref="ex_series4">Example</xref></caption>
+          <caption>Scatter plots relating to the series in <xref ref="ex_series4"/></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
             <figure xml:id="fig_series4a">
@@ -1334,13 +1334,13 @@
                   <mrow>\amp = \infser\frac{(-1)^{n+1}}{n}-\infser\frac{(-1)^{n+1}}{n^2}</mrow>
                   <mrow>\amp = \ln(2) - \frac{\pi^2}{12}	\approx	-0.1293</mrow>
                 </md>.
-                This is illustrated in <xref ref="fig_series5a">Figure</xref>.
+                This is illustrated in <xref ref="fig_series5a"/>.
               </p>
             </li>
 
             <li>
               <p>
-                This looks very similar to the series that involves <m>e</m> in <xref ref="idea_famous_series">Key Idea</xref>.
+                This looks very similar to the series that involves <m>e</m> in <xref ref="idea_famous_series"/>.
                 Note, however,
                 that the series given in this example starts with <m>n=1</m> and not <m>n=0</m>.
                 The first term of the series in the Key Idea is <m>1/0! = 1</m>,
@@ -1349,12 +1349,12 @@
                   <mrow>\infser \frac{1000}{n!} \amp = 1000\cdot\infser \frac{1}{n!}</mrow>
                   <mrow>\amp = 1000\cdot (e-1) \approx  1718.28</mrow>
                 </md>.
-                This is illustrated in <xref ref="fig_series5b">Figure</xref>.
+                This is illustrated in <xref ref="fig_series5b"/>.
                 The graph shows how this particular series converges very rapidly.
               </p>
 
               <figure xml:id="fig_series5">
-                <caption>Scatter plots relating to the series in <xref ref="ex_series5">Example</xref></caption>
+                <caption>Scatter plots relating to the series in <xref ref="ex_series5"/></caption>
                 <sidebyside widths="47% 47%" valign="bottom" margins="0%">
 
                   <figure xml:id="fig_series5a">
@@ -1462,7 +1462,7 @@
                 we are adding <m>\ds \sum_{n=4}^\infty \frac{1}{n^2}</m>
                 (note  we start with <m>n=4</m>, not <m>n=1</m>).
                 This series will converge.
-                Using the formula from <xref ref="idea_famous_series">Key Idea</xref>,
+                Using the formula from <xref ref="idea_famous_series"/>,
                 we have the following:
                 <md>
                   <mrow>\infser \frac1{n^2} \amp = \sum_{n=1}^3 \frac1{n^2} +\sum_{n=4}^\infty \frac1{n^2}</mrow>
@@ -1562,7 +1562,7 @@
       <em>Important!</em> This theorem <em>does not state</em>
       that if <m>\ds \lim_{n\to\infty} a_n = 0</m> then <m>\ds \sum_{n=1}^\infty a_n</m> converges.
       The standard example of this is the Harmonic Series,
-      as given in <xref ref="idea_famous_series">Key Idea</xref>.
+      as given in <xref ref="idea_famous_series"/>.
       The Harmonic Sequence, <m>\{1/n\}</m>, converges to 0;
       the Harmonic Series, <m>\ds \sum_{n=1}^\infty \frac1n</m>,
       diverges.
@@ -1570,13 +1570,13 @@
 
     <p>
       Looking back,
-      we can apply this theorem to the series in <xref ref="ex_series1">Example</xref>.
+      we can apply this theorem to the series in <xref ref="ex_series1"/>.
       In that example,
       the <m>n</m>th terms of both sequences do not converge to 0, therefore we can quickly conclude that each series diverges.
     </p>
 
     <p>
-      One can rewrite <xref ref="thm_series_nth_term">Theorem</xref>
+      One can rewrite <xref ref="thm_series_nth_term"/>
       to state <q>If a series converges,
       then the underlying sequence converges to 0.</q>
       While it is important to understand the truth of this statement,
@@ -2081,7 +2081,7 @@
         <introduction>
           <p>
             In the following exercises,
-            use <xref ref="thm_series_nth_term">Theorem</xref>
+            use <xref ref="thm_series_nth_term"/>
             to show the given series diverges.
           </p>
         </introduction>
@@ -2098,7 +2098,7 @@
               <solution>
                 <p>
                   <m>\lim\limits_{n\to\infty}a_n = 3</m>;
-                  by <xref ref="thm_series_nth_term">Theorem</xref> the series diverges.
+                  by <xref ref="thm_series_nth_term"/> the series diverges.
                 </p>
               </solution>
           <!--</webwork>-->
@@ -2116,7 +2116,7 @@
               <solution>
                 <p>
                   <m>\lim\limits_{n\to\infty}a_n = \infty</m>;
-                  by <xref ref="thm_series_nth_term">Theorem</xref> the series diverges.
+                  by <xref ref="thm_series_nth_term"/> the series diverges.
                 </p>
               </solution>
           <!--</webwork>-->
@@ -2134,7 +2134,7 @@
               <solution>
                 <p>
                   <m>\lim\limits_{n\to\infty}a_n = \infty</m>;
-                  by <xref ref="thm_series_nth_term">Theorem</xref> the series diverges.
+                  by <xref ref="thm_series_nth_term"/> the series diverges.
                 </p>
               </solution>
           <!--</webwork>-->
@@ -2152,7 +2152,7 @@
               <solution>
                 <p>
                   <m>\lim\limits_{n\to\infty}a_n = 1</m>;
-                  by <xref ref="thm_series_nth_term">Theorem</xref> the series diverges.
+                  by <xref ref="thm_series_nth_term"/> the series diverges.
                 </p>
               </solution>
           <!--</webwork>-->
@@ -2170,7 +2170,7 @@
               <solution>
                 <p>
                   <m>\lim\limits_{n\to\infty}a_n = 1/2</m>;
-                  by <xref ref="thm_series_nth_term">Theorem</xref> the series diverges.
+                  by <xref ref="thm_series_nth_term"/> the series diverges.
                 </p>
               </solution>
           <!--</webwork>-->
@@ -2188,7 +2188,7 @@
               <solution>
                 <p>
                   <m>\lim\limits_{n\to\infty}a_n = e</m>;
-                  by <xref ref="thm_series_nth_term">Theorem</xref> the series diverges.
+                  by <xref ref="thm_series_nth_term"/> the series diverges.
                 </p>
               </solution>
           <!--</webwork>-->
@@ -2300,8 +2300,8 @@
               </statement>
               <solution>
                 <p>
-                  Converges; by <xref ref="idea_famous_series">Key Idea</xref>
-            and <xref ref="thm_series_prop">Theorem</xref>,
+                  Converges; by <xref ref="idea_famous_series"/>
+            and <xref ref="thm_series_prop"/>,
             series converges to <m>10e</m>.
                 </p>
               </solution>
@@ -2353,7 +2353,7 @@
               </statement>
               <solution>
                 <p>
-                  Diverges; by <xref ref="thm_series_prop">Theorem</xref>
+                  Diverges; by <xref ref="thm_series_prop"/>
             this is half the Harmonic Series,
             which diverges by growing without bound.
             <q>Half of growing without bound</q>
@@ -2995,7 +2995,7 @@
               <p>
                 Using partial fractions,
                 we can show that <m>a_n = \frac14\left(\frac1{2n-1}+\frac{1}{2n+1}\right)</m>.
-                The series is effectively twice the sum of the odd terms of the Harmonic Series which was shown to diverge in <xref ref="x08_02_ex_24">Exercise</xref>.
+                The series is effectively twice the sum of the odd terms of the Harmonic Series which was shown to diverge in <xref ref="x08_02_ex_24"/>.
                 Thus this series diverges.
               </p>
             </solution>

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -17,20 +17,20 @@
   </p>
 
   <figure xml:id="vid-intapp-shell-intro" component="video">
-    <caption>Video introduction to <xref ref="sec_shell_method">Section</xref></caption>
+    <caption>Video introduction to <xref ref="sec_shell_method"/></caption>
     <video youtube="YPZjBrm770g" label="vid-intapp-shell-intro"/>
   </figure>
 
   <p>
-    Consider <xref ref="fig_shell_intro">Figure</xref>,
-    where the region shown in <xref ref="fig_shell_intro_b_3D">Figure</xref>
+    Consider <xref ref="fig_shell_intro"/>,
+    where the region shown in <xref ref="fig_shell_intro_b_3D"/>
     is rotated around the <m>y</m>-axis forming the solid shown in
-    <xref ref="fig_shell_intro_a_3D">Figure</xref>.
-    A small slice of the region is drawn in <xref ref="fig_shell_intro_b_3D">Figure</xref>,
+    <xref ref="fig_shell_intro_a_3D"/>.
+    A small slice of the region is drawn in <xref ref="fig_shell_intro_b_3D"/>,
     parallel to the axis of rotation.
     When the region is rotated,
     this thin slice forms a <em>cylindrical shell</em>,
-    as pictured in <xref ref="fig_shell_intro_d_3D">Figure</xref>.
+    as pictured in <xref ref="fig_shell_intro_d_3D"/>.
     The previous section approximated a solid with lots of thin disks (or washers);
     we now approximate a solid with many thin cylindrical shells.
   </p>
@@ -295,7 +295,7 @@
     A simple way of determining this is to cut the label and lay it out flat,
     forming a rectangle with height <m>h</m> and length <m>2\pi r</m>.
     Thus the area is <m>A = 2\pi rh</m>;
-    see <xref ref="fig_soupcana_3D">Figure</xref>.
+    see <xref ref="fig_soupcana_3D"/>.
   </p>
 
   <p>
@@ -304,7 +304,7 @@
     Cutting the shell and laying it flat forms a rectangular solid with length <m>2\pi r</m>,
     height <m>h</m> and depth <m>\dx</m>.
     Thus the volume is <m>V \approx 2\pi rh\dx</m>;
-    see <xref ref="fig_soupcanb_3D">Figure</xref>.
+    see <xref ref="fig_soupcanb_3D"/>.
     (We say <q>approximately</q> since our radius was an approximation.)
   </p>
 
@@ -479,14 +479,14 @@
     </solution>
     <solution>
       <p>
-        This is the region used to introduce the Shell Method in <xref ref="fig_shell_intro">Figure</xref>,
-        but is sketched again in <xref ref="fig_shell1">Figure</xref> for closer reference.
+        This is the region used to introduce the Shell Method in <xref ref="fig_shell_intro"/>,
+        but is sketched again in <xref ref="fig_shell1"/> for closer reference.
         A line is drawn in the region parallel to the axis of rotation representing a shell that will be carved out as the region is rotated about the <m>y</m>-axis.
         (This is the differential element.)
       </p>
 
       <figure xml:id="fig_shell1">
-        <caption>Graphing a region in <xref ref="ex_shell1">Example</xref></caption>
+        <caption>Graphing a region in <xref ref="ex_shell1"/></caption>
         <!-- START figures/fig_shell1.tex -->
         <image xml:id="img_shell1" width="47%">
           <description>
@@ -578,16 +578,16 @@
     </solution>
     <solution>
       <p>
-        The region is sketched in <xref ref="fig_shell2a">Figure</xref> along with the differential element,
+        The region is sketched in <xref ref="fig_shell2a"/> along with the differential element,
         a line within the region parallel to the axis of rotation.
-        In <xref ref="fig_shell2b_3D">Figure</xref>,
+        In <xref ref="fig_shell2b_3D"/>,
         we see the shell traced out by the differential element,
-        and in <xref ref="fig_shell2c_3D">Figure</xref>
+        and in <xref ref="fig_shell2c_3D"/>
         the whole solid is shown.
       </p>
 
       <figure xml:id="fig_shell2">
-        <caption>Graphing a region in <xref ref="ex_shell2">Example</xref></caption>
+        <caption>Graphing a region in <xref ref="ex_shell2"/></caption>
         <sidebyside widths="31% 31% 31%" margins="0%">
           <figure xml:id="fig_shell2a">
             <caption/>
@@ -861,7 +861,7 @@
     <title>Finding volume using the Shell Method</title>
     <statement>
       <p>
-        Find the volume of the solid formed by rotating the region given in <xref ref="ex_shell2">Example</xref> about the <m>x</m>-axis.
+        Find the volume of the solid formed by rotating the region given in <xref ref="ex_shell2"/> about the <m>x</m>-axis.
       </p>
     </statement>
     <solution component="video">
@@ -870,9 +870,9 @@
     </solution>
     <solution>
       <p>
-        The region is sketched in <xref ref="fig_shell3a">Figure</xref> with a sample differential element.
-        In <xref ref="fig_shell3b_3D">Figure</xref> the shell formed by the differential element is drawn,
-        and the solid is sketched in <xref ref="fig_shell3c_3D">Figure</xref>. (Note that the triangular region looks
+        The region is sketched in <xref ref="fig_shell3a"/> with a sample differential element.
+        In <xref ref="fig_shell3b_3D"/> the shell formed by the differential element is drawn,
+        and the solid is sketched in <xref ref="fig_shell3c_3D"/>. (Note that the triangular region looks
         <q>short and wide</q> here,
         whereas in the previous example the same region looked
         <q>tall and narrow.</q>
@@ -890,7 +890,7 @@
       </p>
 
       <figure xml:id="fig_shell3">
-        <caption>Graphing a region in <xref ref="ex_shell3">Example</xref></caption>
+        <caption>Graphing a region in <xref ref="ex_shell3"/></caption>
         <sidebyside widths="31% 31% 31%" margins="0%">
           <figure xml:id="fig_shell3a">
             <caption/>
@@ -1170,11 +1170,11 @@
       <p>
         The region and a differential element,
         the shell formed by this differential element,
-        and the resulting solid are given in <xref ref="fig_shell4">Figure</xref>.
+        and the resulting solid are given in <xref ref="fig_shell4"/>.
       </p>
 
       <figure xml:id="fig_shell4">
-        <caption>Graphing a region in <xref ref="ex_shell4">Example</xref></caption>
+        <caption>Graphing a region in <xref ref="ex_shell4"/></caption>
         <sidebyside widths="31% 31% 31%" margins="0%">
           <figure xml:id="fig_shell4a">
             <caption/>

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -114,7 +114,7 @@
     </figure>
 
     <p>
-      In <xref ref="fig_cartcoord1">Figure</xref>
+      In <xref ref="fig_cartcoord1"/>
       we see the point <m>P=(2,1,3)</m> plotted on a set of axes.
       The basic convention here is that the <m>xy</m>-plane is drawn in its standard way,
       with the <m>z</m>-axis down to the left.
@@ -129,7 +129,7 @@
       One can also consider the <m>xy</m>-plane as being a horizontal plane in, say,
       a room, where the positive <m>z</m>-axis is pointing up.
       When one steps back and looks at this room,
-      one might draw the axes as shown in <xref ref="fig_cartcoord2">Figure</xref>.
+      one might draw the axes as shown in <xref ref="fig_cartcoord2"/>.
       The same point <m>P</m> is drawn, again with dashed lines.
       This point of view is preferred by most mathematicians,
       and is the convention adopted by this text.
@@ -254,19 +254,19 @@
       </solution>
       <solution>
         <p>
-          The points <m>P</m> and <m>Q</m> are plotted in <xref ref="fig_space1">Figure</xref>;
+          The points <m>P</m> and <m>Q</m> are plotted in <xref ref="fig_space1"/>;
           no special consideration need be made to draw the line segment connecting these two points;
           simply connect them with a straight line.
           One <em>cannot</em> actually measure this line on the page and deduce anything meaningful;
           its true length must be measured analytically.
-          Applying <xref ref="def_space_distance">Definition</xref>, we have
+          Applying <xref ref="def_space_distance"/>, we have
           <me>
             \norm{\overline{PQ}} = \sqrt{(2-1)^2+(1-4)^2+(1-(-1))^2} = \sqrt{14}\approx 3.74
           </me>.
         </p>
 
         <figure xml:id="fig_space1">
-          <caption>Plotting points <m>P</m> and <m>Q</m> in <xref ref="ex_space1">Example</xref></caption>
+          <caption>Plotting points <m>P</m> and <m>Q</m> in <xref ref="ex_space1"/></caption>
           <!-- START figures/figspace1_3D.asy -->
           <image xml:id="img_space1" width="47%">
             <shortdescription>
@@ -343,7 +343,7 @@
     <title>Spheres</title>
     <p>
       Just as a circle is the set of all points in the <em>plane</em> equidistant from a given point (its center), a sphere is the set of all points in <em>space</em> that are equidistant from a given point.
-      <xref ref="def_space_distance">Definition</xref>
+      <xref ref="def_space_distance"/>
       allows us to write an equation of the sphere.
       <idx><h>sphere</h></idx>
     </p>
@@ -422,7 +422,7 @@
     <title>Introduction to Planes in Space</title>
     <p>
       The coordinate axes naturally define three planes
-      (shown in <xref ref="fig_coordplanes"></xref>),
+      (shown in <xref ref="fig_coordplanes"/>),
       the <em>coordinate planes</em>:
       the <m>xy</m>-plane,
       the <m>yz</m>-plane and the <m>xz</m>-plane.
@@ -609,7 +609,7 @@
       The equation <m>x=2</m> describes all points in space where the <m>x</m>-value is 2.
       This is a plane,
       parallel to the <m>yz</m>-coordinate plane,
-      shown in <xref ref="fig_space2">Figure</xref>.
+      shown in <xref ref="fig_space2"/>.
     </p>
 
     <figure xml:id="fig_space2">
@@ -680,14 +680,14 @@
       <solution>
         <p>
           The region is all points between the planes <m>y=-1</m> and <m>y=2</m>.
-          These planes are sketched in <xref ref="fig_space3">Figure</xref>,
+          These planes are sketched in <xref ref="fig_space3"/>,
           which are parallel to the <m>xz</m>-plane.
           Thus the region extends infinitely in the <m>x</m> and <m>z</m> directions,
           and is bounded by planes in the <m>y</m> direction.
         </p>
 
         <figure xml:id="fig_space3">
-          <caption>Sketching the boundaries of a region in <xref ref="ex_space3">Example</xref></caption>
+          <caption>Sketching the boundaries of a region in <xref ref="ex_space3"/></caption>
           <!-- START figures/figspace3_3D.asy -->
           <image xml:id="img_space3" width="47%">
             <shortdescription>
@@ -761,13 +761,13 @@
       this equation describes a circle of radius 1, centered at the origin.
       In space, the <m>z</m> coordinate is not specified,
       meaning it can take on any value.
-      In <xref ref="fig_spacecylinder1a_3D">Figure</xref>,
+      In <xref ref="fig_spacecylinder1a_3D"/>,
       we show part of the graph of the equation
       <m>x^2+y^2=1</m> by sketching 3 circles:
       the bottom one has a constant <m>z</m>-value of <m>-1.5</m>,
       the middle one has a <m>z</m>-value of 0 and the top circle has a <m>z</m>-value of 1.
       By plotting <em>all</em> possible <m>z</m>-values,
-      we get the surface shown in <xref ref="fig_spacecylinder1b_3D">Figure</xref>.
+      we get the surface shown in <xref ref="fig_spacecylinder1b_3D"/>.
       This surface looks like a <q>tube,</q> or a <q>cylinder</q>;
       mathematicians call this surface a <em>cylinder</em>
       for an entirely different reason.
@@ -937,10 +937,10 @@
     <p>
       In the example preceding the definition,
       the curve <m>x^2+y^2=1</m> in the <m>xy</m>-plane is the directrix and the rulings are lines parallel to the <m>z</m>-axis.
-      (Any circle shown in <xref ref="fig_spacecylinder1">Figure</xref>
+      (Any circle shown in <xref ref="fig_spacecylinder1"/>
       can be considered a directrix;
       we simply choose the one where <m>z=0</m>.)
-      Sample rulings can also be viewed in <xref ref="fig_spacecylinder1b_3D">Figure</xref>.
+      Sample rulings can also be viewed in <xref ref="fig_spacecylinder1b_3D"/>.
       More examples will help us understand this definition.
     </p>
 
@@ -968,12 +968,12 @@
             <li>
               <p>
                 We can view the equation <m>z=y^2</m> as a parabola in the <m>yz</m>-plane,
-                as illustrated in <xref ref="fig_space4a1_3D">Figure</xref>.
+                as illustrated in <xref ref="fig_space4a1_3D"/>.
                 As <m>x</m> does not appear in the equation,
                 the rulings are lines through this parabola parallel to the <m>x</m>-axis,
-                shown in <xref ref="fig_space4a2_3D">Figure</xref>.
+                shown in <xref ref="fig_space4a2_3D"/>.
                 These rulings give a general idea as to what the surface looks like,
-                drawn in <xref ref="fig_space4a3_3D">Figure</xref>.
+                drawn in <xref ref="fig_space4a3_3D"/>.
               </p>
 
               <figure xml:id="fig_space4a">
@@ -1208,10 +1208,10 @@
 
               <p>
                 We can view the equation <m>x=\sin(z)</m> as a sine curve that exists in the <m>xz</m>-plane,
-                as shown in <xref ref="fig_space4b1_3D">Figure</xref>.
+                as shown in <xref ref="fig_space4b1_3D"/>.
                 The rules are parallel to the <m>y</m> axis as the variable <m>y</m> does not appear in the equation <m>x=\sin(z)</m>;
-                some of these are shown in <xref ref="fig_space4b2_3D">Figure</xref>.
-                The surface is shown in <xref ref="fig_space4b3_3D">Figure</xref>.
+                some of these are shown in <xref ref="fig_space4b2_3D"/>.
+                The surface is shown in <xref ref="fig_space4b3_3D"/>.
               </p>
 
               <figure xml:id="fig_space4b">
@@ -1433,12 +1433,12 @@
       Consider the surface formed by revolving
       <m>y=\sqrt{x}</m> about the <m>x</m>-axis.
       Cross-sections of this surface parallel to the <m>yz</m>-plane are circles,
-      as shown in <xref ref="fig_surf_rev_introa_3D">Figure</xref>.
+      as shown in <xref ref="fig_surf_rev_introa_3D"/>.
       Each circle has equation of the form
       <m>y^2+z^2=r^2</m> for some radius <m>r</m>.
       The radius is a function of <m>x</m>;
       in fact, it is <m>r(x) = \sqrt{x}</m>.
-      Thus the equation of the surface shown in <xref ref="fig_surf_rev_introb_3D">Figure</xref> is <m>y^2+z^2=(\sqrt{x})^2</m>.
+      Thus the equation of the surface shown in <xref ref="fig_surf_rev_introb_3D"/> is <m>y^2+z^2=(\sqrt{x})^2</m>.
     </p>
 
     <figure xml:id="fig_surf_rev_intro">
@@ -1633,19 +1633,19 @@
       </solution>
       <solution>
         <p>
-          Using <xref ref="idea_surf_of_revol">Key Idea</xref>,
+          Using <xref ref="idea_surf_of_revol"/>,
           we find the surface has equation <m>x^2+y^2=\sin^2(z)</m>.
-          The curve is sketched in <xref ref="fig_surfrev1a_3D">Figure</xref> and the surface is drawn in <xref ref="fig_surfrev1b_3D">Figure</xref>.
+          The curve is sketched in <xref ref="fig_surfrev1a_3D"/> and the surface is drawn in <xref ref="fig_surfrev1b_3D"/>.
         </p>
 
         <p>
           Note how the surface
           (and hence the resulting equation)
           is the same if we began with the curve <m>x=\sin(z)</m>,
-          which is also drawn in <xref ref="fig_surfrev1a_3D">Figure</xref>.
+          which is also drawn in <xref ref="fig_surfrev1a_3D"/>.
         </p>
         <figure xml:id="fig_surfrev1">
-          <caption>Revolving <m>y=\sin(z)</m> about the <m>z</m>-axis in <xref ref="ex_surfrev1">Example</xref></caption>
+          <caption>Revolving <m>y=\sin(z)</m> about the <m>z</m>-axis in <xref ref="ex_surfrev1"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_surfrev1a_3D">
               <caption/>
@@ -1772,8 +1772,8 @@
 
     <p>
       This particular method of creating surfaces of revolution is limited.
-      For instance, in <xref ref="ex_shell4">Example</xref>
-      of <xref ref="sec_shell_method">Section</xref>
+      For instance, in <xref ref="ex_shell4"/>
+      of <xref ref="sec_shell_method"/>
       we found the volume of the solid formed by revolving
       <m>y=\sin(x)</m> about the <m>y</m>-axis.
       Our current method of forming surfaces can only rotate
@@ -1819,13 +1819,13 @@
       </statement>
       <solution>
         <p>
-          Using <xref ref="idea_surf_of_revol2">Key Idea</xref>,
+          Using <xref ref="idea_surf_of_revol2"/>,
           the surface has equation <m>z=\sin\big(\sqrt{x^2+y^2}\big)</m>.
-          The curve and surface are graphed in <xref ref="fig_surfrev2">Figure</xref>.
+          The curve and surface are graphed in <xref ref="fig_surfrev2"/>.
         </p>
 
         <figure xml:id="fig_surfrev2">
-          <caption>Revolving <m>z=\sin(x)</m> about the <m>z</m>-axis in <xref ref="ex_surfrev2">Example</xref></caption>
+          <caption>Revolving <m>z=\sin(x)</m> about the <m>z</m>-axis in <xref ref="ex_surfrev2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_surfrev2a_3D">
               <caption/>
@@ -2065,7 +2065,7 @@
       that is, intersections of each surface with a plane parallel to a coordinate plane.
       For instance,
       consider the elliptic paraboloid <m>z= x^2/4+y^2</m>,
-      shown in <xref ref="fig_quadric1">Figure</xref>.
+      shown in <xref ref="fig_quadric1"/>.
       If we intersect this shape with the plane <m>z=d</m><nbsp/> (<ie/>, replace <m>z</m> with <m>d</m>),
       we have the equation:
       <md>
@@ -2712,7 +2712,7 @@
     </sidebyside>
 
     <p>
-      If <m>a=b=c\neq0</m>, the ellipsoid is a sphere with radius <m>a</m>; compare to <xref ref="idea_sphere">Key Idea</xref>.
+      If <m>a=b=c\neq0</m>, the ellipsoid is a sphere with radius <m>a</m>; compare to <xref ref="idea_sphere"/>.
       <idx><h>quadric surface</h><h>ellipsoid</h></idx>
       <idx><h>quadric surface</h><h>sphere</h></idx>
     </p>
@@ -3448,9 +3448,9 @@
               </p>
 
               <p>
-                Graphing each trace in the respective plane creates a sketch as shown in <xref ref="fig_space5a1_3D">Figure</xref>.
+                Graphing each trace in the respective plane creates a sketch as shown in <xref ref="fig_space5a1_3D"/>.
                 This is enough to give an idea of what the paraboloid looks like.
-                The surface is filled in in <xref ref="fig_space5a2_3D">Figure</xref>.
+                The surface is filled in in <xref ref="fig_space5a2_3D"/>.
               </p>
 
               <figure xml:id="fig_space5a">
@@ -3622,7 +3622,7 @@
               </p>
 
               <p>
-                Graphing each trace in the respective plane creates a sketch as shown in <xref ref="fig_space5b1_3D">Figure</xref>. Filling in the surface gives <xref ref="fig_space5b2_3D">Figure</xref>.
+                Graphing each trace in the respective plane creates a sketch as shown in <xref ref="fig_space5b1_3D"/>. Filling in the surface gives <xref ref="fig_space5b2_3D"/>.
               </p>
 
               <figure xml:id="fig_space5b">
@@ -3800,7 +3800,7 @@
               </p>
 
               <p>
-                Sketching these two parabolas gives a sketch like that in <xref ref="fig_space5c1_3D">Figure</xref>, and filling in the surface gives a sketch like <xref ref="fig_space5c2_3D">Figure</xref>.
+                Sketching these two parabolas gives a sketch like that in <xref ref="fig_space5c1_3D"/>, and filling in the surface gives a sketch like <xref ref="fig_space5c2_3D"/>.
               </p>
 
               <figure xml:id="fig_space5c">
@@ -3960,7 +3960,7 @@
       <title>Identifying quadric surfaces</title>
       <statement>
         <p>
-          Consider the quadric surface shown in <xref ref="fig_space6">Figure</xref>.
+          Consider the quadric surface shown in <xref ref="fig_space6"/>.
           Which of the following equations best fits this surface?
         </p>
 
@@ -3974,7 +3974,7 @@
         </p>
 
         <figure xml:id="fig_space6">
-          <caption>A possible equation of this quadric surface is found in <xref ref="ex_space6">Example</xref></caption>
+          <caption>A possible equation of this quadric surface is found in <xref ref="ex_space6"/></caption>
           <!-- START figures/figspace6_3D.asy -->
           <image xml:id="img_space6" width="47%">
             <shortdescription>

--- a/ptx/sec_stokes_divergence.ptx
+++ b/ptx/sec_stokes_divergence.ptx
@@ -4,7 +4,7 @@
   <subsection>
     <title>The Divergence Theorem</title>
     <p>
-      <xref ref="thm_divergence1">Theorem</xref>
+      <xref ref="thm_divergence1"/>
       gives the Divergence Theorem in the plane,
       which states that the flux of a vector field across a closed <em>curve</em>
       equals the sum of the divergences over the region enclosed by the curve.
@@ -45,7 +45,7 @@
     <aside>
       <p>
         <em>Note:</em> the term <q>outer unit normal vector</q>
-        used in <xref ref="thm_divergence2">Theorem</xref>
+        used in <xref ref="thm_divergence2"/>
         means <m>\vec n</m> points to the outside of <m>\surfaceS</m>.
             <idx><h>outer unit normal vector</h></idx>
       </p>
@@ -57,13 +57,13 @@
         <p>
           Let <m>D</m> be the domain in space bounded by the planes <m>z=0</m> and <m>z=2x</m>,
           along with the cylinder <m>x=1-y^2</m>,
-          as graphed in <xref ref="fig_divthm_space2">Figure</xref>,
+          as graphed in <xref ref="fig_divthm_space2"/>,
           let <m>\surfaceS</m> be the boundary of <m>D</m>,
           and let <m>\vec F = \langle x+y,y^2, 2z\rangle</m>.
         </p>
 
         <figure xml:id="fig_divthm_space2">
-          <caption>The surfaces used in  <xref ref="ex_divthm_space2">Example</xref></caption>
+          <caption>The surfaces used in  <xref ref="ex_divthm_space2"/></caption>
           <image xml:id="img_divthm_space2_3D" width="47%">
             <description></description>
             <asymptote>
@@ -229,7 +229,7 @@
         </p>
 
         <p>
-          Following the steps outlined in <xref ref="sec_triple_int">Section</xref>,
+          Following the steps outlined in <xref ref="sec_triple_int"/>,
           we see the bounds of <m>x</m>,
           <m>y</m> and <m>z</m> can be set as (thinking <q>surface to surface,
           curve to curve, point to point</q>):
@@ -250,7 +250,7 @@
     </example>
 
     <p>
-      In <xref ref="ex_divthm_space2">Example</xref>
+      In <xref ref="ex_divthm_space2"/>
       we see that the total outward flux of a vector field across a closed surface can be found two different ways because of the Divergence Theorem.
       One computation took far less work to obtain.
       In that particular case,
@@ -273,13 +273,13 @@
           Let <m>\surfaceS</m> be the surface formed by the paraboloid <m>z=1-x^2-y^2</m>,
           <m>z\geq 0</m>,
           and the unit disk centered at the origin in the <m>xy</m>-plane,
-          graphed in <xref ref="fig_divthm_space1">Figure</xref>,
+          graphed in <xref ref="fig_divthm_space1"/>,
           and let <m>\vec F = \langle 0,0,z\rangle</m>.
-          (This surface and vector field were used in <xref ref="ex_surfflux2">Example</xref>.)
+          (This surface and vector field were used in <xref ref="ex_surfflux2"/>.)
         </p>
 
         <figure xml:id="fig_divthm_space1">
-          <caption>The surfaces used in  <xref ref="ex_divthm_space1">Example</xref></caption>
+          <caption>The surfaces used in  <xref ref="ex_divthm_space1"/></caption>
           <image xml:id="img_divthm_space1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -352,7 +352,7 @@
         </p>
 
         <p>
-          In <xref ref="ex_surfflux2">Example</xref>,
+          In <xref ref="ex_surfflux2"/>,
           we found the flux across <m>\surfaceS_1</m> is 0.
           We also found that the flux across <m>\surfaceS_2</m> is <m>\pi/2</m>.
           (In that example,
@@ -428,12 +428,12 @@
           Consider the cube, centered at the origin,
           with sides of length <m>2a</m> for some <m>a \gt 0</m> (hence corners of the cube lie at <m>(a,a,a)</m>,
           <m>(-a,-a,-a)</m>,
-          etc., as shown in <xref ref="fig_divthm_space3">Figure</xref>).
+          etc., as shown in <xref ref="fig_divthm_space3"/>).
           Find the flux across the six faces of the cube and compare this to <m>\iint_D \divv\vec F\, dV</m>.
         </p>
 
         <figure xml:id="fig_divthm_space3">
-          <caption>The cube used in  <xref ref="ex_divthm_space3">Example</xref></caption>
+          <caption>The cube used in  <xref ref="ex_divthm_space3"/></caption>
           <image xml:id="img_divthm_space3_3D" width="47%">
             <description></description>
             <asymptote>
@@ -709,13 +709,13 @@
           Considering the planar surface <m>f(x,y) = 7-2x-2y</m>,
           let <m>C</m> be the curve in space that lies on this surface above the circle of radius 1 and centered at <m>(1,1)</m> in the <m>xy</m>-plane,
           let <m>\surfaceS</m> be the planar region enclosed by <m>C</m>,
-          as illustrated in <xref ref="fig_stokes1">Figure</xref>,
+          as illustrated in <xref ref="fig_stokes1"/>,
           and let <m>\vec F = \langle x+y,2y, y^2\rangle</m>.
           Verify Stoke's Theorem by showing <m>\oint_C \vec F\cdot \, d\vec r = \iint_\surfaceS (\curl\vec F)\cdot \vec n\, dS</m>.
         </p>
 
         <figure xml:id="fig_stokes1">
-          <caption>As given in <xref ref="ex_stokes1">Example</xref>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve</caption>
+          <caption>As given in <xref ref="ex_stokes1"/>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve</caption>
           <image xml:id="fig_stokes1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -834,7 +834,7 @@
       <title>Stokes' Theorem and surfaces that share a boundary</title>
       <statement>
         <p>
-          Let <m>C</m> be the curve given in <xref ref="ex_stokes1">Example</xref>
+          Let <m>C</m> be the curve given in <xref ref="ex_stokes1"/>
           and note that it lies on the surface <m>z = 6-x^2-y^2</m>.
           Let <m>\surfaceS</m> be the region of this surface bounded by <m>C</m>,
           and let <m>\vec F = \langle x+y,2y,y^2\rangle</m> as in the previous example.
@@ -842,7 +842,7 @@
         </p>
 
         <figure xml:id="fig_stokes2">
-          <caption>As given in <xref ref="ex_stokes2">Example</xref>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve</caption>
+          <caption>As given in <xref ref="ex_stokes2"/>, the surface <m>\surfaceS</m><nbsp/>is the portion of the plane bounded by the curve</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_stokes2a_3D">
               <caption/>
@@ -973,9 +973,9 @@
           We can parametrize the <m>x</m> and <m>y</m> components of <m>C</m> with <m>x=\cos t+1</m>,
           <m>y=\sin t+1</m> as before.
           Lifting these components to the surface <m>z=6-x^2-y^2</m> gives the <m>z</m> component as <m>z = 6-x^2-y^2 = 6-(\cos t+1)^2-(\sin t+1)^2 = 3-2\cos t-2\sin t</m>,
-          which is the same <m>z</m> component as found in <xref ref="ex_stokes1">Example</xref>.
+          which is the same <m>z</m> component as found in <xref ref="ex_stokes1"/>.
           Thus the curve <m>C</m> lies on the surface <m>z=6-x^2-y^2</m>,
-          as illustrated in <xref ref="fig_stokes2">Figure</xref>.
+          as illustrated in <xref ref="fig_stokes2"/>.
         </p>
 
         <p>
@@ -1004,7 +1004,7 @@
         </p>
 
         <p>
-          Even though the surfaces used in this example and in <xref ref="ex_stokes1">Example</xref> are very different,
+          Even though the surfaces used in this example and in <xref ref="ex_stokes1"/> are very different,
           because they share the same boundary, Stokes' Theorem guarantees they have equal <q>sum of curls</q>
           across their respective surfaces.
         </p>
@@ -1030,7 +1030,7 @@
     <p>
       There is yet one more reason of interest in the major theorems of this chapter.
       These important theorems also all share an important principle with the Fundamental Theorem of Calculus,
-      introduced in <xref ref="chapter_integration">Chapter</xref>.
+      introduced in <xref ref="chapter_integration"/>.
     </p>
 
     <p>
@@ -1096,12 +1096,12 @@
       <exercise label="TaC-stokes-divergence-1">
         <statement>
           <p>
-            What are the differences between the Divergence Theorems of <xref ref="sec_greensthm">Section</xref> and this section?
+            What are the differences between the Divergence Theorems of <xref ref="sec_greensthm"/> and this section?
           </p>
         </statement>
         <answer>
           <p>
-            Answers will vary; in <xref ref="sec_greensthm">Section</xref>,
+            Answers will vary; in <xref ref="sec_greensthm"/>,
             the Divergence Theorem connects outward flux over a closed curve in the plane to the divergence of the vector field,
             whereas in this section the Divergence Theorem connects outward flux over a closed surface in space to the divergence of the vector field.
           </p>

--- a/ptx/sec_substitution.ptx
+++ b/ptx/sec_substitution.ptx
@@ -253,7 +253,7 @@
 
     <p>
       Thus <m>\int \sin(7x-4)\, dx = -\frac17\cos(7x-4)+C</m>.
-      Our next example can use <xref ref="idea_linearsub">Key Idea</xref>,
+      Our next example can use <xref ref="idea_linearsub"/>,
       but we will only employ it after going through all of the steps.
     </p>
 
@@ -283,7 +283,7 @@
         </p>
 
         <p>
-          Using <xref ref="idea_linearsub">Key Idea</xref> is faster,
+          Using <xref ref="idea_linearsub"/> is faster,
           recognizing that <m>u</m> is linear and <m>a = -3</m>.
           One may want to continue writing out all the steps until they are comfortable with this particular shortcut.
         </p>
@@ -291,7 +291,7 @@
     </example>
 
     <figure xml:id="vid_int_sub_examples_1" component="video">
-      <caption>Video presentation of <xref first="ex_sub1" last="ex_sub3">Examples</xref></caption>
+      <caption>Video presentation of <xref first="ex_sub1" last="ex_sub3" text="global">Examples</xref></caption>
       <video youtube="-6CFSvtMCDU" label="vid_int_sub_examples_1"/>
     </figure>
 
@@ -407,7 +407,7 @@
       <solution>
         <p>
           This is another example where there does not seem to be an obvious composition of functions.
-          The line of thinking used in <xref ref="ex_sub4">Example</xref> is useful here:
+          The line of thinking used in <xref ref="ex_sub4"/> is useful here:
           choose something for <m>u</m> and consider what this implies <m>du</m> must be.
           If <m>u</m> can be chosen such that <m>du</m> also appears in the integrand,
           then we have chosen well.
@@ -436,7 +436,7 @@
     </example>
 
     <figure xml:id="vid_int_sub_examples_2" component="video">
-      <caption>Video presentation of <xref first="ex_sub4" last="ex_sub5">Examples</xref></caption>
+      <caption>Video presentation of <xref first="ex_sub4" last="ex_sub5" text="global">Examples</xref></caption>
       <video youtube="Qzj4UJX_69c" label="vid_int_sub_examples_2"/>
     </figure>
 
@@ -445,7 +445,7 @@
   <subsection>
     <title>Integrals Involving Trigonometric Functions</title>
     <p>
-      <xref ref="sec_trigint">Section</xref>
+      <xref ref="sec_trigint"/>
       delves deeper into integrals of a variety of trigonometric functions;
       here we use substitution to establish a foundation that we will build upon.
     </p>
@@ -555,8 +555,8 @@
 
 
     <p>
-      We can use similar techniques to those used in <xref ref="ex_sub6">Examples</xref>
-      and <xref ref="ex_sub7"/>
+      We can use similar techniques to those used in <xref ref="ex_sub6" text="global">Examples</xref>
+      and <xref ref="ex_sub7" text="global"/>
       to find antiderivatives of <m>\cot(x)</m> and <m>\csc(x)</m>
       (which the reader can explore in the exercises.)
       We summarize our results here.
@@ -635,7 +635,7 @@
             <mrow>\amp = \frac12x + \frac12\frac{\sin(2x)}{2} + C</mrow>
             <mrow>\amp = \frac12x + \frac{\sin(2x)}4 + C</mrow>
           </md>,
-          where we used <xref ref="idea_linearsub">Key Idea</xref> for the antiderivative of <m>\cos(2x)</m>.
+          where we used <xref ref="idea_linearsub"/> for the antiderivative of <m>\cos(2x)</m>.
         </p>
 
         <p>
@@ -844,7 +844,7 @@
     </example>
 
     <p>
-      <xref ref="ex_subst14">Example</xref>
+      <xref ref="ex_subst14"/>
       demonstrates a general technique that can be applied to other integrands that result in inverse trigonometric functions.
       The results are summarized here.
     </p>
@@ -869,7 +869,7 @@
     </theorem>
 
     <p>
-      Let's practice using <xref ref="thm_int_inverse_trig">Theorem</xref>.
+      Let's practice using <xref ref="thm_int_inverse_trig"/>.
     </p>
 
     <example xml:id="ex_subst15">
@@ -888,7 +888,7 @@
       </statement>
       <solution>
         <p>
-          Each can be answered using a straightforward application of <xref ref="thm_int_inverse_trig">Theorem</xref>.
+          Each can be answered using a straightforward application of <xref ref="thm_int_inverse_trig"/>.
 
           <ol>
             <li>
@@ -917,7 +917,7 @@
     </example>
 
     <p>
-      Most applications of <xref ref="thm_int_inverse_trig">Theorem</xref> are not as straightforward.
+      Most applications of <xref ref="thm_int_inverse_trig"/> are not as straightforward.
       The next examples show some common integrals that can still be approached with this theorem.
     </p>
 
@@ -934,7 +934,7 @@
       </solution>
       <solution>
         <p>
-          Initially, this integral seems to have nothing in common with the integrals in <xref ref="thm_int_inverse_trig">Theorem</xref>.
+          Initially, this integral seems to have nothing in common with the integrals in <xref ref="thm_int_inverse_trig"/>.
           As it lacks a square root,
           it almost certainly is not related to arcsine or arcsecant.
           It is, however, related to the arctangent function.
@@ -970,7 +970,7 @@
         <p>
           We can now integrate this using the arctangent rule.
           Technically, we need to substitute first with <m>u=x-2</m>,
-          but we can employ <xref ref="idea_linearsub">Key Idea</xref> instead.
+          but we can employ <xref ref="idea_linearsub"/> instead.
           Thus we have
           <md>
             <mrow>\int \frac{1}{x^2-4x+13}\, dx \amp = \int \frac{1}{(x-2)^2+9}\, dx</mrow>
@@ -1002,7 +1002,7 @@
 
         <p>
           We handle each separately.
-          The first integral is handled using a straightforward application of <xref ref="thm_int_inverse_trig">Theorem</xref>:
+          The first integral is handled using a straightforward application of <xref ref="thm_int_inverse_trig"/>:
         </p>
 
         <p>
@@ -1080,7 +1080,7 @@
 
     <p>
       At its heart,
-      (using the notation of <xref ref="thm_subst">Theorem</xref>)
+      (using the notation of <xref ref="thm_subst"/>)
       substitution converts integrals of the form
       <m>\int \Fp(g(x))g'(x)\, dx</m> into an integral of the form
       <m>\int \Fp(u)\, du</m> with the substitution of <m>u = g(x)</m>.
@@ -1107,7 +1107,7 @@
     </theorem>
 
     <p>
-      In effect, <xref ref="thm_subst_def_int">Theorem</xref>
+      In effect, <xref ref="thm_subst_def_int"/>
       states that once you convert to integrating with respect to <m>u</m>,
       you do not need to switch back to evaluating with respect to <m>x</m>.
       A few examples will help one understand.
@@ -1117,7 +1117,7 @@
       <title>Definite integrals and substitution: changing the bounds</title>
       <statement>
         <p>
-          Evaluate <m>\ds\int_0^2 \cos(3x-1)\, dx</m> using <xref ref="thm_subst_def_int">Theorem</xref>.
+          Evaluate <m>\ds\int_0^2 \cos(3x-1)\, dx</m> using <xref ref="thm_subst_def_int"/>.
         </p>
       </statement>
       <solution>
@@ -1130,7 +1130,7 @@
 
         <p>
           By setting <m>u = 3x-1</m>, we are implicitly stating that <m>g(x) = 3x-1</m>.
-          <xref ref="thm_subst_def_int">Theorem</xref>
+          <xref ref="thm_subst_def_int"/>
           states that the new lower bound is <m>g(0) = -1</m>;
           the new upper bound is <m>g(2) = 5</m>.
           We now evaluate the definite integral:
@@ -1148,7 +1148,7 @@
         </p>
 
         <figure xml:id="fig_subst12">
-          <caption>Graphing the areas defined by the definite integrals of <xref ref="ex_sub12">Example</xref></caption>
+          <caption>Graphing the areas defined by the definite integrals of <xref ref="ex_sub12"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_subst12a">
               <caption/>
@@ -1233,10 +1233,10 @@
         </figure>
 
         <p>
-          The graphs in <xref ref="fig_subst12">Figure</xref> tell more of the story.
-          In <xref ref="fig_subst12a">Figure</xref>
+          The graphs in <xref ref="fig_subst12"/> tell more of the story.
+          In <xref ref="fig_subst12a"/>
           the area defined by the original integrand is shaded,
-          whereas in <xref ref="fig_subst12b">Figure </xref>
+          whereas in <xref ref="fig_subst12b"/>
           the area defined by the new integrand is shaded.
           In this particular situation,
           the areas look very similar;
@@ -1250,7 +1250,7 @@
       <title>Definite integrals and substitution: changing the bounds</title>
       <statement>
         <p>
-          Evaluate <m>\ds \int_0^{\pi/2} \sin(x) \cos(x) \, dx</m> using <xref ref="thm_subst_def_int">Theorem</xref>.
+          Evaluate <m>\ds \int_0^{\pi/2} \sin(x) \cos(x) \, dx</m> using <xref ref="thm_subst_def_int"/>.
         </p>
       </statement>
       <solution component="video">
@@ -1260,7 +1260,7 @@
       <solution>
 
         <p>
-          We saw the corresponding indefinite integral in <xref ref="ex_sub10">Example</xref>.
+          We saw the corresponding indefinite integral in <xref ref="ex_sub10"/>.
           In that example we set <m>u = \sin(x)</m> but stated that we could have let <m>u = \cos(x)</m>.
           For variety, we do the latter here.
         </p>
@@ -1280,15 +1280,15 @@
         </p>
 
         <p>
-          In <xref ref="fig_subst13">Figure</xref>
+          In <xref ref="fig_subst13"/>
           we have again graphed the two regions defined by our definite integrals.
           Unlike the previous example, they bear no resemblance to each other.
-          However, <xref ref="thm_subst_def_int">Theorem</xref>
+          However, <xref ref="thm_subst_def_int"/>
           guarantees that they have the same area.
         </p>
 
        <figure xml:id="fig_subst13">
-        <caption>Graphing the areas defined by the definite integrals of <xref ref="ex_subst13">Example</xref></caption>
+        <caption>Graphing the areas defined by the definite integrals of <xref ref="ex_subst13"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_subst13a">
               <caption/>
@@ -1881,7 +1881,7 @@
                 <m>\ds \int \cot(x) \, dx</m>
               </p>
               <p>
-                Do not just refer to <xref ref="thm_triganti">Theorem</xref> for the answer;
+                Do not just refer to <xref ref="thm_triganti"/> for the answer;
                 justify it through Substitution.
               </p>
               <p>
@@ -1903,7 +1903,7 @@
                 <m>\ds \int \csc(x) \, dx</m>
               </p>
               <p>
-                Do not just refer to <xref ref="thm_triganti">Theorem</xref> for the answer;
+                Do not just refer to <xref ref="thm_triganti"/> for the answer;
                 justify it through Substitution.
               </p>
               <p>

--- a/ptx/sec_surface_area.ptx
+++ b/ptx/sec_surface_area.ptx
@@ -438,7 +438,7 @@
 
   <aside>
     <p>
-      The inner integral in Equation <xref ref="eq_exsurfacearea2"/> is an improper integral,
+      The inner integral in <xref ref="eq_exsurfacearea2">Equation</xref> is an improper integral,
       as the integrand of <m>\int_0^ar\sqrt{\frac{a^2}{a^2-r^2}}\, dr</m> is not defined at <m>r=a</m>.
       To properly evaluate this integral,
       one must use the techniques of <xref ref="sec_improper_integration"/>.

--- a/ptx/sec_surface_area.ptx
+++ b/ptx/sec_surface_area.ptx
@@ -2,7 +2,7 @@
 <section xml:id="sec_surface_area">
   <title>Surface Area</title>
   <p>
-    In <xref ref="sec_arc_length">Section</xref>
+    In <xref ref="sec_arc_length"/>
     we used definite integrals to compute the arc length of plane curves of the form <m>y=f(x)</m>.
     We later extended these ideas to compute the arc length of plane curves defined by parametric or polar equations.
   </p>
@@ -15,7 +15,7 @@
 
   <p>
     Consider the surface <m>z=f(x,y)</m> over a region <m>R</m> in the <m>xy</m>-plane,
-    shown in <xref ref="fig_sa_intro1_3D">Figure</xref>.
+    shown in <xref ref="fig_sa_intro1_3D"/>.
     Because of the domed shape of the surface,
     the surface area will be greater than that of the area of the region <m>R</m>.
     We can find this area using the same basic technique we have used over and over:
@@ -192,10 +192,10 @@
   </p>
 
   <p>
-    In part <xref ref="fig_sa_intro2_3D">Figure</xref> of the figure, we zoom in on this portion of the surface.
+    In part <xref ref="fig_sa_intro2_3D"/> of the figure, we zoom in on this portion of the surface.
     When <m>\dx_i</m> and <m>\dy_i</m> are small,
     the function is approximated well by the tangent plane at any point <m>(x_i,y_i)</m> in this subregion,
-    which is graphed in part <xref ref="fig_sa_intro2_3D">Figure</xref>.
+    which is graphed in part <xref ref="fig_sa_intro2_3D"/>.
     In fact, the tangent plane approximates the function so well that in this figure,
     it is virtually indistinguishable from the surface itself!
     Therefore we can approximate the surface area <m>S_i</m> of this region of the surface with the area <m>T_i</m> of the corresponding portion of the tangent plane.
@@ -204,7 +204,7 @@
   <p>
     This portion of the tangent plane is a parallelogram,
     defined by sides <m>\vec u</m> and <m>\vec v</m>, as shown.
-    One of the applications of the cross product from <xref ref="sec_cross_product">Section</xref>
+    One of the applications of the cross product from <xref ref="sec_cross_product"/>
     is that the area of this parallelogram is <m>\norm{\vec u\times \vec v}</m>.
     Once we can determine <m>\vec u</m> and <m>\vec v</m>,
     we can determine the area.
@@ -212,7 +212,7 @@
 
   <p>
     The vector <m>\vec u</m> is tangent to the surface in the direction of <m>x</m>,
-    therefore, from <xref ref="sec_multi_tangent">Section</xref>,
+    therefore, from <xref ref="sec_multi_tangent"/>,
     <m>\vec u</m> is parallel to <m>\la 1,0,f_x(x_i,y_i)\ra</m>.
     The <m>x</m>-displacement of <m>\vec u</m> is <m>\dx_i</m>,
     so we know that <m>\vec u = \dx_i\la 1,0,f_x(x_i,y_i)\ra</m>.
@@ -285,12 +285,12 @@
         Let <m>f(x,y) = 4-x-2y</m>,
         and let <m>R</m> be the region in the plane bounded by <m>x=0</m>,
         <m>y=0</m> and <m>y=2-x/2</m>,
-        as shown in <xref ref="fig_surfacearea1">Figure</xref>.
+        as shown in <xref ref="fig_surfacearea1"/>.
         Find the surface area of <m>f</m> over <m>R</m>.
       </p>
 
       <figure xml:id="fig_surfacearea1">
-        <caption>Finding the area of a triangle in space in <xref ref="ex_surfacearea1">Example</xref></caption>
+        <caption>Finding the area of a triangle in space in <xref ref="ex_surfacearea1"/></caption>
 
         <!-- START figures/figsurfacearea1_3D.asy -->
         <image xml:id="img_surfacearea1" width="47%">
@@ -348,7 +348,7 @@
     </statement>
     <solution>
       <p>
-        We follow <xref ref="def_surfacearea">Definition</xref>.
+        We follow <xref ref="def_surfacearea"/>.
         We start by noting that <m>f_x(x,y) = -1</m> and <m>f_y(x,y) = -2</m>.
         To define <m>R</m>, we use bounds
         <m>0\leq y\leq 2-x/2</m> and <m>0\leq x\leq 4</m>.
@@ -441,7 +441,7 @@
       The inner integral in Equation <xref ref="eq_exsurfacearea2"/> is an improper integral,
       as the integrand of <m>\int_0^ar\sqrt{\frac{a^2}{a^2-r^2}}\, dr</m> is not defined at <m>r=a</m>.
       To properly evaluate this integral,
-      one must use the techniques of <xref ref="sec_improper_integration">Section</xref>.
+      one must use the techniques of <xref ref="sec_improper_integration"/>.
     </p>
 
     <p>
@@ -449,7 +449,7 @@
       <me>
         f(x,y) = \sqrt{a^2-x^2-y^2}
       </me>
-      fails the requirements of <xref ref="def_surfacearea">Definition</xref>,
+      fails the requirements of <xref ref="def_surfacearea"/>,
       as <m>f_x</m> and <m>f_y</m> are not continuous on the boundary of the circle <m>x^2+y^2=a^2</m>.
     </p>
 
@@ -471,12 +471,12 @@
         <me>
           \ds f(x,y) = h-\frac{h}a\sqrt{x^2+y^2}
         </me>,
-        shown in <xref ref="fig_surfacearea3">Figure</xref>.
+        shown in <xref ref="fig_surfacearea3"/>.
         Find the surface area of this cone.
       </p>
 
       <figure xml:id="fig_surfacearea3">
-        <caption>Finding the surface area of a cone in <xref ref="ex_surfacearea3">Example</xref></caption>
+        <caption>Finding the surface area of a cone in <xref ref="ex_surfacearea3"/></caption>
 
         <!-- START figures/figsurfacearea3_3D.asy -->
         <image xml:id="img_surfacearea3" width="47%">
@@ -585,11 +585,11 @@
         Find the area of the surface
         <m>f(x,y) = x^2-3y+3</m> over the region <m>R</m> bounded by
         <m>-x\leq y\leq x</m>, <m>0\leq x\leq 4</m>,
-        as pictured in <xref ref="fig_surfacearea4">Figure</xref>.
+        as pictured in <xref ref="fig_surfacearea4"/>.
       </p>
 
       <figure xml:id="fig_surfacearea4">
-        <caption>Graphing the surface in <xref ref="ex_surfacearea4">Example</xref></caption>
+        <caption>Graphing the surface in <xref ref="ex_surfacearea4"/></caption>
 
         <!-- START figures/figsurfacearea4_3D.asy -->
         <image xml:id="img_surfacearea4" width="47%">

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -48,7 +48,7 @@
     </p>
 
     <p>
-      The integral in Equation <xref ref="eq_surface_int"/> is a specific example of a more general construction defined below.
+      The integral in <xref ref="eq_surface_int">Equation</xref> is a specific example of a more general construction defined below.
     </p>
   </introduction>
 

--- a/ptx/sec_surface_integral.ptx
+++ b/ptx/sec_surface_integral.ptx
@@ -89,12 +89,12 @@
         <p>
           Find the mass of a thin sheet modeled by the plane
           <m>2x+y+z=3</m> over the triangular region of the <m>xy</m>-plane bounded by the coordinate axes and the line <m>y=2-2x</m>,
-          as shown in <xref ref="fig_surfint1">Figure</xref>,
+          as shown in <xref ref="fig_surfint1"/>,
           with density function <m>\delta(x,y,z) = x^2+5y+z</m>,
           where all distances are measured in cm and the density is given as gm/cm<m>^2</m>.
         </p>
         <figure xml:id="fig_surfint1">
-          <caption>The surface whose mass is computed in <xref ref="ex_surfint1">Example</xref></caption>
+          <caption>The surface whose mass is computed in <xref ref="ex_surfint1"/></caption>
           <image xml:id="img_surfint1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -315,16 +315,16 @@
       <title>Finding flux across a surface</title>
       <statement>
         <p>
-          Let <m>\surfaceS</m> be the surface given in <xref ref="ex_surfint1">Example</xref>,
+          Let <m>\surfaceS</m> be the surface given in <xref ref="ex_surfint1"/>,
           where <m>\surfaceS</m> is parametrized by
           <m>\vec r(u,v) = \langle u, v(2-2u),3-2u-v(2-2u)\rangle</m> on <m>0\leq u\leq 1</m>,
           <m>0\leq v\leq 1</m>, and let <m>\vec F = \langle 1, x,-y\rangle</m>,
-          as shown in <xref ref="fig_surfflux1">Figure</xref>.
+          as shown in <xref ref="fig_surfflux1"/>.
           Find the flux of <m>\vec F</m> across <m>\surfaceS</m>.
         </p>
 
         <figure xml:id="fig_surfflux1">
-          <caption>The surface and vector field used in  <xref ref="ex_surfflux1">Example</xref></caption>
+          <caption>The surface and vector field used in  <xref ref="ex_surfflux1"/></caption>
           <image xml:id="img_surfflux1_3D" width="47%">
             <description></description>
             <asymptote>
@@ -453,7 +453,7 @@
 
         <p>
           To make full use of this numeric answer,
-          we need to know the direction in which the field is passing across <m>\surfaceS</m>. The graph in <xref ref="fig_surfflux1">Figure</xref> helps,
+          we need to know the direction in which the field is passing across <m>\surfaceS</m>. The graph in <xref ref="fig_surfflux1"/> helps,
           but we need a method that is not dependent on a graph.
         </p>
 
@@ -488,12 +488,12 @@
           Let <m>\surfaceS_1</m> be the unit disk in the <m>xy</m>-plane,
           and let <m>\surfaceS_2</m> be the paraboloid <m>z=1-x^2-y^2</m>,
           for <m>z\geq 0</m>,
-          as graphed in <xref ref="fig_surfflux2">Figure</xref>.
+          as graphed in <xref ref="fig_surfflux2"/>.
           Note how these two surfaces each have the unit circle as a boundary.
         </p>
 
         <figure xml:id="fig_surfflux2">
-          <caption>The surfaces used in  <xref ref="ex_surfflux2">Example</xref></caption>
+          <caption>The surfaces used in  <xref ref="ex_surfflux2"/></caption>
           <image xml:id="img_surfflux2_3D" width="47%">
             <description></description>
             <asymptote>
@@ -704,7 +704,7 @@
       <m>\surfaceS_2</m> form a closed surface that is piecewise smooth.
       That the measurement of flux across each surface was the same for some fields
       (and not for others)
-      is reminiscent of a result from <xref ref="sec_greensthm">Section</xref>,
+      is reminiscent of a result from <xref ref="sec_greensthm"/>,
       where we measured flux across curves.
       The quick answer to why the flux was the same when considering
       <m>\vec F_1</m> is that <m>\divv \vec F_1 = 0</m>.

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -5,7 +5,7 @@
     <title>Unit Tangent Vector</title>
     <p>
       Given a smooth vector-valued function <m>\vrt</m>,
-      we defined in <xref ref="def_vector_tangent">Definition</xref>
+      we defined in <xref ref="def_vector_tangent"/>
       that any vector parallel to <m>\vrp(t_0)</m> is <em>tangent</em>
       to the graph of <m>\vrt</m> at <m>t=t_0</m>.
       It is often useful to consider just the <em>direction</em>
@@ -49,7 +49,7 @@
       </solution>
       <solution>
         <p>
-          We apply <xref ref="def_unit_tangent">Definition</xref> to find <m>\unittangent(t)</m>.
+          We apply <xref ref="def_unit_tangent"/> to find <m>\unittangent(t)</m>.
           <md>
             <mrow>\unittangent(t) \amp = \frac{1}{\norm{\vrp(t)}}\vrp(t)</mrow>
             <mrow>\amp =\frac{1}{\sqrt{\big(-3\sin(t) \big)^2+\big(3\cos(t) \big)^2+ 4^2}}\la -3\sin(t) ,3\cos(t) , 4\ra</mrow>
@@ -65,7 +65,7 @@
         </p>
 
         <p>
-          These are plotted in <xref ref="fig_tannorm1">Figure</xref>
+          These are plotted in <xref ref="fig_tannorm1"/>
           with their initial points at
           <m>\vec r(0)</m> and <m>\vec r(1)</m>, respectively.
           (They look rather <q>short</q>
@@ -73,7 +73,7 @@
         </p>
 
         <figure xml:id="fig_tannorm1">
-          <caption>Plotting unit tangent vectors in <xref ref="ex_tannorm1">Example</xref></caption>
+          <caption>Plotting unit tangent vectors in <xref ref="ex_tannorm1"/></caption>
 
           <!-- START figures/figtannorm1_3D.asy -->
           <image xml:id="img_tannorm1" width="47%">
@@ -177,11 +177,11 @@
           when <m>t=1</m>,
           we have <m>\unittangent(1) = \la 1/\sqrt{10}, 3/\sqrt{10}\ra</m>.
           We leave it to the reader to verify each of these is a unit vector.
-          They are plotted in <xref ref="fig_tannorm2">Figure</xref>
+          They are plotted in <xref ref="fig_tannorm2"/>
         </p>
 
         <figure xml:id="fig_tannorm2">
-          <caption>Plotting unit tangent vectors in <xref ref="ex_tannorm2">Example</xref></caption>
+          <caption>Plotting unit tangent vectors in <xref ref="ex_tannorm2"/></caption>
           <!-- START figures/fig_tannorm2.tex -->
           <image xml:id="img_tannorm2" width="47%">
             <description></description>
@@ -222,7 +222,7 @@
       We can do a similar thing with vector-valued functions.
       Given <m>\vrt</m> in <m>\mathbb{R}^2</m>,
       we have 2 directions perpendicular to the tangent vector,
-      as shown in <xref ref="fig_tannorm_intro1">Figure</xref>.
+      as shown in <xref ref="fig_tannorm_intro1"/>.
       It is good to wonder <q>Is one of these two directions preferable over the other?</q>
     </p>
 
@@ -268,7 +268,7 @@
       The answer in both <m>\mathbb{R}^2</m> and <m>\mathbb{R}^3</m> is <q>Yes,
       there is one vector that is not only preferable,
       it is the <sq>right</sq> one to choose.</q>
-      Recall <xref ref="thm_vects_of_constant_length">Theorem</xref>,
+      Recall <xref ref="thm_vects_of_constant_length"/>,
       which states that if <m>\vrt</m> has constant length,
       then <m>\vrt</m> is orthogonal to <m>\vrp(t)</m> for all <m>t</m>.
       We know <m>\unittangent(t)</m>, the unit tangent vector, has constant length.
@@ -317,7 +317,7 @@
       <title>Computing the unit normal vector</title>
       <statement>
         <p>
-          Let <m>\vrt = \la 3\cos(t) , 3\sin(t) , 4t\ra</m> as in <xref ref="ex_tannorm1">Example</xref>.
+          Let <m>\vrt = \la 3\cos(t) , 3\sin(t) , 4t\ra</m> as in <xref ref="ex_tannorm1"/>.
           Sketch both <m>\unittangent(\pi/2)</m> and
           <m>\unitnormal(\pi/2)</m> with initial points at <m>\vec r(\pi/2)</m>.
         </p>
@@ -328,7 +328,7 @@
       </solution>
       <solution>
         <p>
-          In <xref ref="ex_tannorm1">Example</xref>,
+          In <xref ref="ex_tannorm1"/>,
           we found
           <me>
             \unittangent(t) = \la  (-3/5)\sin(t) ,(3/5)\cos(t) ,4/5\ra
@@ -348,11 +348,11 @@
 
         <p>
           We compute <m>\unittangent(\pi/2) = \la -3/5,0,4/5\ra</m> and <m>\unitnormal(\pi/2) = \la 0,-1,0\ra</m>.
-          These are sketched in <xref ref="fig_tannorm3">Figure</xref>.
+          These are sketched in <xref ref="fig_tannorm3"/>.
         </p>
 
         <figure xml:id="fig_tannorm3">
-          <caption>Plotting unit tangent and normal vectors in <xref ref="fig_tannorm3">Example</xref></caption>
+          <caption>Plotting unit tangent and normal vectors in <xref ref="fig_tannorm3"/></caption>
 
           <!-- START figures/figtannorm3_3D.asy -->
           <image xml:id="img_tannorm3" width="47%">
@@ -431,7 +431,7 @@
       <title>Computing the unit normal vector</title>
       <statement>
         <p>
-          Let <m>\vrt=\la t^2-t,t^2+t\ra</m> as in <xref ref="ex_tannorm2">Example</xref>.
+          Let <m>\vrt=\la t^2-t,t^2+t\ra</m> as in <xref ref="ex_tannorm2"/>.
           Find <m>\unitnormal(t)</m> and sketch <m>\vrt</m> with the unit tangent and normal vectors at <m>t=-1,0</m> and 1.
         </p>
       </statement>
@@ -441,7 +441,7 @@
       </solution>
       <solution>
         <p>
-          In <xref ref="ex_tannorm2">Example</xref>, we found
+          In <xref ref="ex_tannorm2"/>, we found
           <me>
             \unittangent(t) = \la \frac{2t-1}{\sqrt{8t^2+2}},\frac{2t+1}{\sqrt{8t^2+2}}\ra
           </me>.
@@ -478,11 +478,11 @@
 
         <p>
           Using this formula for <m>\unitnormal(t)</m>,
-          we compute the unit tangent and normal vectors for <m>t=-1,0</m> and 1 and sketch them in <xref ref="fig_tannorm4">Figure</xref>.
+          we compute the unit tangent and normal vectors for <m>t=-1,0</m> and 1 and sketch them in <xref ref="fig_tannorm4"/>.
         </p>
 
         <figure xml:id="fig_tannorm4">
-          <caption>Plotting unit tangent and normal vectors in <xref ref="ex_tannorm4">Example</xref></caption>
+          <caption>Plotting unit tangent and normal vectors in <xref ref="ex_tannorm4"/></caption>
           <!-- START figures/fig_tannorm4.tex -->
           <image xml:id="img_tannorm4" width="47%">
             <description></description>
@@ -519,7 +519,7 @@
     </example>
 
     <p>
-      The final result for <m>\unitnormal(t)</m> in <xref ref="ex_tannorm4">Example</xref>
+      The final result for <m>\unitnormal(t)</m> in <xref ref="ex_tannorm4"/>
       is suspiciously similar to <m>\unittangent(t)</m>.
       There is a clear reason for this.
       If <m>\vec u = \la u_1,u_2\ra</m> is a unit vector in <m>\mathbb{R}^2</m>,
@@ -530,7 +530,7 @@
     </p>
 
     <p>
-      Consider again <xref ref="fig_tannorm4">Figure</xref>,
+      Consider again <xref ref="fig_tannorm4"/>,
       where we have plotted some unit tangent and normal vectors.
       Note how <m>\unitnormal(t)</m> always points
       <q>inside</q> the curve,
@@ -563,7 +563,7 @@
     <title>Application to Acceleration</title>
     <p>
       Let <m>\vrt</m> be a position function.
-      It is a fact (stated later in <xref ref="thm_acc_plane">Theorem</xref>)
+      It is a fact (stated later in <xref ref="thm_acc_plane"/>)
       that acceleration, <m>\vat</m>,
       lies in the plane defined by <m>\unittangent</m> and <m>\unitnormal</m>.
       That is, there are scalar functions
@@ -593,8 +593,8 @@
     <p>
       We can find <m>a_\text{T}</m> using the orthogonal projection of
       <m>\vec a(t)</m> onto <m>\unittangent(t)</m>
-      (review <xref ref="def_orthogonal_projection">Definition</xref>
-      in <xref ref="sec_dot_product">Section</xref> if needed).
+      (review <xref ref="def_orthogonal_projection"/>
+      in <xref ref="sec_dot_product"/> if needed).
       Recalling that since <m>\unittangent(t)</m> is a unit vector,
       <m>\unittangent(t)\cdot\unittangent(t)=1</m>, so we have
       <me>
@@ -675,8 +675,8 @@
       <title>Computing <m>a_T</m> and <m>a_N</m></title>
       <statement>
         <p>
-          Let <m>\vrt = \la 3\cos(t) , 3\sin(t) , 4t\ra</m> as in <xref ref="ex_tannorm1">Examples</xref>
-          and <xref ref="ex_tannorm3"/>.
+          Let <m>\vrt = \la 3\cos(t) , 3\sin(t) , 4t\ra</m> as in <xref ref="ex_tannorm1" text="global">Examples</xref>
+          and <xref ref="ex_tannorm3" text="global"/>.
           Find <m>a_\text{T}</m> and <m>a_\text{N}</m>.
         </p>
       </statement>
@@ -718,8 +718,8 @@
       <title>Computing <m>a_T</m> and <m>a_N</m></title>
       <statement>
         <p>
-          Let <m>\vrt=\la t^2-t,t^2+t\ra</m> as in <xref ref="ex_tannorm2">Examples</xref>
-          and <xref ref="ex_tannorm4"/>.
+          Let <m>\vrt=\la t^2-t,t^2+t\ra</m> as in <xref ref="ex_tannorm2" text="global">Examples</xref>
+          and <xref ref="ex_tannorm4" text="global"/>.
           Find <m>a_\text{T}</m> and <m>a_\text{N}</m>.
         </p>
       </statement>
@@ -737,7 +737,7 @@
 
         <p>
           While we can compute <m>a_\text{N}</m> using <m>\unitnormal(t)</m>,
-          we instead demonstrate using another formula from <xref ref="thm_acc_plane">Theorem</xref>.
+          we instead demonstrate using another formula from <xref ref="thm_acc_plane"/>.
           <md>
             <mrow>a_\text{T}  \amp = \vat\cdot\unittangent(t) = \frac{4t-2}{\sqrt{8t^2+2}}+\frac{4t+2}{\sqrt{8t^2+2}} = \frac{8t}{\sqrt{8t^2+2}}.</mrow>
             <mrow>a_\text{N}  \amp = \sqrt{\norm{\vat}^2-a_\text{T} ^2} = \sqrt{8-\left(\frac{8t}{\sqrt{8t^2+2}}\right)^2}=\frac{4}{\sqrt{8t^2+2}}</mrow>
@@ -752,12 +752,12 @@
           not by changing direction.
           As the path near <m>t=2</m> is relatively straight,
           this should make intuitive sense.
-          <xref ref="fig_tannorm6">Figure</xref>
+          <xref ref="fig_tannorm6"/>
           gives a graph of the path for reference.
         </p>
 
         <figure xml:id="fig_tannorm6">
-          <caption>Graphing <m>\vec r(t)</m> in <xref ref="ex_tannorm6">Example</xref></caption>
+          <caption>Graphing <m>\vec r(t)</m> in <xref ref="ex_tannorm6"/></caption>
           <!-- START figures/fig_tannorm6.tex -->
           <image xml:id="img_tannorm6" width="47%">
             <description></description>
@@ -809,13 +809,13 @@
       </statement>
       <solution>
         <p>
-          Using <xref ref="idea_projectile">Key Idea</xref>
-          of <xref ref="sec_vvf_motion">Section</xref>
+          Using <xref ref="idea_projectile"/>
+          of <xref ref="sec_vvf_motion"/>
           we form the position function of the ball:
           <me>
             \vrt = \la \big(64\cos(30^\circ) \big)t, -16t^2+\big(64\sin(30^\circ) \big)t+240\ra
           </me>,
-          which we plot in <xref ref="fig_tannorm7b">Figure</xref>.
+          which we plot in <xref ref="fig_tannorm7b"/>.
         </p>
 
         <figure xml:id="fig_tannorm7b">
@@ -898,7 +898,7 @@
         </p>
 
         <figure xml:id="fig_tannorm7a">
-          <caption>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7">Example</xref></caption>
+          <caption>A table of values of <m>a_T</m> and <m>a_N</m> in <xref ref="ex_tannorm7"/></caption>
           <tabular>
             <row>
               <cell><m>t</m></cell>
@@ -947,7 +947,7 @@
 
     <p>
       Our understanding of the unit tangent and normal vectors is aiding our understanding of motion.
-      The work in <xref ref="ex_tannorm7">Example</xref>
+      The work in <xref ref="ex_tannorm7"/>
       gave quantitative analysis of what we intuitively knew.
     </p>
 
@@ -1152,8 +1152,7 @@
         <introduction>
           <p>
             Find the equation of the line tangent to the curve at the indicated <m>t</m>-value using the unit tangent vector.
-            Note: these are the same problems as in <xref ref="x11_04_ex_05">Exercises</xref>
-            <mdash/> <xref ref="x11_04_ex_08"/>.
+            Note: these are the same problems as in <xref first="x11_04_ex_05" last="x11_04_ex_08" text="local">Exercises</xref>.
           </p>
         </introduction>
 
@@ -1258,8 +1257,8 @@
         <introduction>
           <p>
             In the following exercises,
-            find <m>\unitnormal(t)</m> using <xref ref="def_unit_normal">Definition</xref>.
-            Confirm the result using <xref ref="thm_concave">Theorem</xref>.
+            find <m>\unitnormal(t)</m> using <xref ref="def_unit_normal"/>.
+            Confirm the result using <xref ref="thm_concave"/>.
           </p>
         </introduction>
 
@@ -1356,7 +1355,7 @@
 
               <li>
                 <p>
-                  Using a graph of <m>\vrt</m> and <xref ref="thm_concave">Theorem</xref>,
+                  Using a graph of <m>\vrt</m> and <xref ref="thm_concave"/>,
                   find <m>\unitnormal(a)</m>.
                 </p>
               </li>

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -20,7 +20,7 @@
     </p>
 
     <p>
-      In <xref ref="fig_taypolyintroa_1">Figure</xref>,
+      In <xref ref="fig_taypolyintroa_1"/>,
       we see a function <m>y=f(x)</m> graphed.
       The table in <xref ref="fig_taypolyintroa_2"/>
       shows that <m>f(0)=2</m> and <m>\fp(0) = 1</m>;
@@ -119,7 +119,7 @@
 
     <p component="taypoly-late">
       This is simply an initial-value problem.
-      We can solve this using the techniques first described in <xref ref="sec_antider">Section</xref>.
+      We can solve this using the techniques first described in <xref ref="sec_antider"/>.
       To keep <m>p_2(x)</m> as simple as possible,
       we'll assume that not only <m>p_2''(0)=2</m>,
       but that <m>p_2''(x)=2</m>.
@@ -135,7 +135,7 @@
       Finally, we can compute <m>p_2(x) = x^2+x+C</m>.
       Using our initial values, we know <m>p_2(0) = 2</m> so <m>C=2</m>.
       We conclude that <m>p_2(x) = x^2+x+2</m>.
-      This function is plotted with <m>f</m> in <xref ref="fig_taypolyintrob">Figure</xref>.
+      This function is plotted with <m>f</m> in <xref ref="fig_taypolyintrob"/>.
     </p>
 
     <p component="taypoly-early">
@@ -164,7 +164,7 @@
       higher degree that match more of the derivatives of <m>f</m> at <m>x=0</m>.
       In general, a polynomial of degree <m>n</m> can be created to match the
       first <m>n</m> derivatives of <m>f</m>.
-      <xref ref="fig_taypolyintrob">Figure</xref>
+      <xref ref="fig_taypolyintrob"/>
       shows <m>p_4(x)= -x^4/2-x^3/6+x^2+x+2</m>,
       whose first four derivatives at 0 match those of <m>f</m>. (Using the table in <xref ref="fig_taypolyintroa_2"/>,
       start with <m>p_4^{(4)}(x)=-12</m> and solve the related initial-value problem.)
@@ -175,7 +175,7 @@
       higher degree that match more of the derivatives of <m>f</m> at <m>x=0</m>.
       In general, a polynomial of degree <m>n</m> can be created to match the
       first <m>n</m> derivatives of <m>f</m>.
-      <xref ref="fig_taypolyintrob">Figure</xref>
+      <xref ref="fig_taypolyintrob"/>
       shows <m>p_4(x)= -x^4/2-x^3/6+x^2+x+2</m>,
       whose first four derivatives at 0 match those of <m>f</m>.
     </p>
@@ -272,7 +272,7 @@
       and when we set <m>x=0</m>, all of the terms involving powers of <m>x</m>
       larger than <m>k</m> disappear,
       leaving us with the single constant given in
-      <xref ref="polyderiv">Equation</xref>.
+      <xref ref="polyderiv" text="local">Equation</xref>.
     </p>
 
     <p component="taypoly-early">
@@ -307,7 +307,7 @@
       our polynomial approximation to <m>f</m> gets better and better.
       In this example, the interval on which the approximation is
       <q>good</q> gets bigger and bigger.
-      <xref ref="fig_taypolyintroc">Figure</xref> shows <m>p_{13}(x)</m>;
+      <xref ref="fig_taypolyintroc"/> shows <m>p_{13}(x)</m>;
       we can visually affirm that this polynomial approximates <m>f</m> very
       well on <m>[-2,3]</m>. (The polynomial <m>p_{13}(x)</m> is not
       particularly <q>nice</q>. It is
@@ -528,7 +528,7 @@
                   p_5(1) = 1+1+\frac12+\frac16+\frac1{24}+\frac1{120} = \frac{163}{60} \approx 2.71667
                 </me>.
                 A plot of <m>f(x)=e^x</m> and <m>p_5(x)</m> is given in
-                <xref ref="fig_taypoly1b">Figure</xref>.
+                <xref ref="fig_taypoly1b"/>.
                 To <m>5</m> decimal places, the actual value of <m>e</m> is
                 <m>2.71828</m>. So this approximation agrees to two decimal places.
               <!--previous location of fig_taypoly1b, which isn't allowed, since it's inside the list-->
@@ -671,7 +671,7 @@
 
               <p>
                 Notice that the coefficients alternate in sign starting at <m>n=1</m>.
-                Using <xref ref="def_taypoly">Definition</xref>, we have
+                Using <xref ref="def_taypoly"/>, we have
                 <md>
                   <mrow>p_n(x) \amp = f(c) + \fp(c)(x-c) + \frac{\fpp(c)}{2!}(x-c)^2+\dots</mrow>
                   <mrow>       \amp \dots\frac{\fp''(c)}{3!}(x-c)^3+\cdots+\frac{f\,^{(n)}(c)}{n!}(x-c)^n</mrow>
@@ -702,7 +702,7 @@
                 </md>.
                 This is a good approximation as a calculator shows that
                 <m>\ln(1.5) \approx 0.4055</m>.
-                <xref ref="fig_taypoly2b">Figure</xref> below
+                <xref ref="fig_taypoly2b"/> below
                 plots <m>y=\ln(x)</m> with <m>y=p_6(x)</m>.
                 We can see that <m>\ln(1.5) \approx p_6(1.5)</m>.
                 <!--original location of fig_taypoly2b-->
@@ -722,14 +722,14 @@
                 </md>.
                 This approximation is not terribly impressive:
                 a hand held calculator shows that <m>\ln(2) \approx 0.693147</m>.
-                The graph in <xref ref="fig_taypoly2b">Figure</xref>
+                The graph in <xref ref="fig_taypoly2b"/>
                 shows that <m>p_6(x)</m> provides less accurate approximations
                 of <m>\ln(x)</m> as <m>x</m> gets close to 0 or 2.
 
                 Surprisingly enough,
                 even the <m>20</m>th degree Taylor polynomial fails to
                 approximate <m>\ln(x)</m> for <m>x\gt 2</m> very well,
-                as shown in <xref ref="fig_taypoly2c">Figure</xref>.
+                as shown in <xref ref="fig_taypoly2c"/>.
                 We'll soon discuss why this is.
 
               <!--original location of fig_taypoly2c-->
@@ -867,7 +867,7 @@
 
     <p component="taypoly-late">
       We had the same problem when studying Numerical Integration.
-      <xref ref="thm_numerical_error">Theorem</xref>
+      <xref ref="thm_numerical_error"/>
       provided bounds on the error when using,
       say, Simpson's Rule to approximate a definite integral.
       These bounds allowed us to determine that, for instance,
@@ -967,18 +967,18 @@
 
     <p>
       The following example computes error estimates for the approximations of
-      <m>\ln(1.5)</m> and <m>\ln(2)</m> made in <xref ref="ex_taypoly2">Example</xref>.
+      <m>\ln(1.5)</m> and <m>\ln(2)</m> made in <xref ref="ex_taypoly2"/>.
     </p>
 
     <example xml:id="ex_taypoly3">
       <title>Finding error bounds of a Taylor polynomial</title>
       <statement>
         <p>
-          Use <xref ref="thm_taylorthm">Theorem</xref>
+          Use <xref ref="thm_taylorthm"/>
           to find error bounds when approximating
           <m>\ln(1.5)</m> and <m>\ln(2)</m> with <m>p_6(x)</m>,
           the Taylor polynomial of degree 6 of <m>f(x)=\ln(x)</m> at <m>x=1</m>,
-          as calculated in <xref ref="ex_taypoly2">Example</xref>.
+          as calculated in <xref ref="ex_taypoly2"/>.
         </p>
       </statement>
       <solution component="video">
@@ -1207,7 +1207,7 @@
         </p>
 
         <p>
-          <xref ref="fig_taypoly4b">Figure</xref>
+          <xref ref="fig_taypoly4b"/>
           shows a graph of <m>y=p_8(x)</m> and <m>y=\cos(x)</m>.
           Note how well the two functions agree on about <m>(-\pi,\pi)</m>.
         </p>
@@ -1365,7 +1365,7 @@
                 (It turns out that our approximation is actually accurate to 4
                 places after the decimal.)
                 A graph of <m>f(x)=\sqrt x</m> and <m>p_4(x)</m> is given in
-                <xref ref="fig_taypoly5b">Figure</xref>.
+                <xref ref="fig_taypoly5b"/>.
                 Note how the two functions are nearly indistinguishable on
                 <m>(2,7)</m>.
 
@@ -1523,14 +1523,14 @@
           <m>y'=y^2</m>,
           where <m>y(0)=1</m>, can be solved without too much difficulty:
           <me>y = \frac{1}{1-x}</me>.
-          <xref ref="fig_taypoly6">Figure</xref>
+          <xref ref="fig_taypoly6"/>
           shows this function plotted with <m>p_3(x)</m>.
           Note how similar they are near <m>x=0</m>.
         </p>
 
         <figure xml:id="fig_taypoly6">
           <caption>A graph of <m>y=-1/(x-1)</m> and <m>y=p_3(x)</m> from
-          <xref ref="ex_taypoly6">Example</xref></caption>
+          <xref ref="ex_taypoly6"/></caption>
           <!-- START figures/fig_taypoly6.tex -->
           <image xml:id="img_taypoly6" width="47%">
             <shortdescription>The graph of the exact solution to the differential equation in this example, and a polynomial approximation.</shortdescription>

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -272,7 +272,7 @@
       and when we set <m>x=0</m>, all of the terms involving powers of <m>x</m>
       larger than <m>k</m> disappear,
       leaving us with the single constant given in
-      <xref ref="polyderiv" text="local">Equation</xref>.
+      <xref ref="polyderiv" text="global">Equation</xref>.
     </p>
 
     <p component="taypoly-early">

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -414,7 +414,7 @@
       <p>
         For any <m>x</m>,
         <m>\lim\limits_{n\to\infty} \frac{x^{n+1}}{(n+1)!} = 0</m>.
-        Applying the Squeeze Theorem to Equation <xref ref="eq_coseqtaylor"/>,
+        Applying the Squeeze Theorem to <xref ref="eq_coseqtaylor">Equation</xref>,
         we conclude that <m>\lim\limits_{n\to\infty} R_n(x) = 0</m> for all <m>x</m>,
         and hence
         <me>

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -2,9 +2,9 @@
 <section xml:id="sec_taylor_series">
   <title>Taylor Series</title>
   <p>
-    In <xref ref="sec_power_series">Section</xref>,
+    In <xref ref="sec_power_series"/>,
     we showed how certain functions can be represented by a power series function.
-    In <xref ref="sec_taylor_poly">Section</xref>,
+    In <xref ref="sec_taylor_poly"/>,
     we showed how we can approximate functions with polynomials,
     given that enough derivative information is available.
     In this section we combine these concepts:
@@ -91,7 +91,7 @@
     </solution>
     <solution>
       <p>
-        In <xref ref="ex_taypoly4">Example</xref>
+        In <xref ref="ex_taypoly4"/>
         we found the <m>8</m>th degree Maclaurin polynomial of <m>\cos(x)</m>.
         In doing so,
         we created the table shown in <xref ref="fig_ts1"/>.
@@ -196,10 +196,10 @@
   </example>
 
   <p>
-    <xref ref="ex_ts1">Example</xref>
+    <xref ref="ex_ts1"/>
     found the Taylor Series representation of <m>\cos(x)</m>.
     We can easily find the Taylor Series representation of <m>\sin(x)</m> by recognizing that
-    <m>\int \cos(x)\, dx=\sin(x)</m> and apply <xref ref="thm_calc_power_series">Theorem</xref>.
+    <m>\int \cos(x)\, dx=\sin(x)</m> and apply <xref ref="thm_calc_power_series"/>.
   </p>
 
   <example xml:id="ex_ts2">
@@ -323,7 +323,7 @@
       <aside>
         <p>
           It can be shown that <m>\ln x</m> is equal to this Taylor series on <m>(0,2]</m>.
-          From the work in <xref ref="ex_ts2">Example</xref>,
+          From the work in <xref ref="ex_ts2"/>,
           this justifies our previous declaration that the Alternating Harmonic Series converges to <m>\ln 2</m>.
         </p>
       </aside>
@@ -336,14 +336,14 @@
   </example>
 
   <p>
-    It is important to note that <xref ref="def_taylor_series">Definition</xref>
+    It is important to note that <xref ref="def_taylor_series"/>
     defines a Taylor series given a function <m>f(x)</m> , but makes no claim about their equality.
     We will find that <q>most of the time</q> they are equal,
     but we need to consider the conditions that allow us to conclude this.
   </p>
 
   <p>
-    <xref ref="thm_taylorthm">Theorem</xref>
+    <xref ref="thm_taylorthm"/>
     states that the error between a function <m>f(x)</m> and its
     <m>n</m>th-degree Taylor polynomial <m>p_n(x)</m> is <m>R_n(x)</m>, where
     <me>
@@ -361,7 +361,7 @@
     <statement>
       <p>
         Let <m>f(x)</m> have derivatives of all orders at <m>x=c</m>,
-        let <m>R_n(x)</m> be as stated in <xref ref="thm_taylorthm">Theorem</xref>,
+        let <m>R_n(x)</m> be as stated in <xref ref="thm_taylorthm"/>,
         and let <m>I</m> be an interval on which the Taylor series of <m>f(x)</m> converges.
         If <m>\lim\limits_{n\to\infty} R_n(x) = 0</m> for all <m>x</m> in <m>I</m>, then
         <idx><h>Taylor Series</h><h>equality with generating function</h></idx>
@@ -386,7 +386,7 @@
     <statement>
       <p>
         Show that <m>f(x) = \cos(x)</m> is equal to its Maclaurin series,
-        as found in <xref ref="ex_ts1">Example</xref>, for all <m>x</m>.
+        as found in <xref ref="ex_ts1"/>, for all <m>x</m>.
       </p>
     </statement>
     <solution>
@@ -428,12 +428,12 @@
     It is natural to assume that a function is equal to its Taylor series on the series' interval of convergence,
     but this is not always the case.
     In order to properly establish equality,
-    one must use <xref ref="thm_function_series_equality">Theorem</xref>.
+    one must use <xref ref="thm_function_series_equality"/>.
     This is a bit disappointing,
     as we developed beautiful techniques for determining the interval of convergence of a power series,
     and proving that <m>R_n(x)\to 0</m> can be difficult.
     For instance,
-    it is not a simple task to show that <m>\ln x</m> equals its Taylor series on <m>(0,2]</m> as found in <xref ref="ex_ts2">Example</xref>;
+    it is not a simple task to show that <m>\ln x</m> equals its Taylor series on <m>(0,2]</m> as found in <xref ref="ex_ts2"/>;
     in the Exercises,
     the reader is only asked to show equality on <m>(1,2)</m>,
     which is simpler.
@@ -452,7 +452,7 @@
     exponentials, trigonometric functions,
     etc.) that is not piecewise defined is probably analytic.
     For most functions,
-    we assume the function is equal to its Taylor series on the series' interval of convergence and only use <xref ref="thm_function_series_equality">Theorem</xref>
+    we assume the function is equal to its Taylor series on the series' interval of convergence and only use <xref ref="thm_function_series_equality"/>
     when we suspect something may not work as expected.
   </p>
 
@@ -571,7 +571,7 @@
   </p>
 
   <p>
-    In <xref ref="idea_common_taylor">Key Idea</xref>
+    In <xref ref="idea_common_taylor"/>
     (on the following page)
     we give a table of the Taylor series of a number of common functions.
     We then give a theorem about the
@@ -584,7 +584,7 @@
   <p>
     Before we investigate combining functions,
     consider the Taylor series for the arctangent function
-    (see <xref ref="idea_common_taylor">Key Idea</xref>).
+    (see <xref ref="idea_common_taylor"/>).
     Knowing that <m>\tan^{-1}(1) = \pi/4</m>,
     we can use this series to approximate the value of <m>\pi</m>:
     <md>
@@ -709,7 +709,7 @@
   </aside>
 
   <figure xml:id="vid-seqseries-taylorseries-arctan" component="video">
-    <caption>Deriving the Taylor series for <m>\arctan(x)</m> in <xref ref="idea_common_taylor">Key Idea</xref></caption>
+    <caption>Deriving the Taylor series for <m>\arctan(x)</m> in <xref ref="idea_common_taylor"/></caption>
     <video youtube="v-y5IH796gY" label="vid-seqseries-taylorseries-arctan"/>
   </figure>
 
@@ -718,8 +718,8 @@
     <statement>
       <p>
         Write out the first 3 terms of the Taylor Series for
-        <m>f(x) = e^x\cos(x)</m> using <xref ref="idea_common_taylor">Key Idea</xref>
-        and <xref ref="thm_series_alg">Theorem</xref>.
+        <m>f(x) = e^x\cos(x)</m> using <xref ref="idea_common_taylor"/>
+        and <xref ref="thm_series_alg"/>.
       </p>
     </statement>
     <solution component="video">
@@ -728,14 +728,14 @@
     </solution>
     <solution>
       <p>
-        <xref ref="idea_common_taylor">Key Idea</xref> informs us that
+        <xref ref="idea_common_taylor"/> informs us that
         <me>
           e^x = 1+x+\frac{x^2}{2!}+\frac{x^3}{3!}+\cdots \text{ and }  \cos(x) = 1-\frac{x^2}{2!}+\frac{x^4}{4!}+\cdots
         </me>.
       </p>
 
       <p>
-        Applying <xref ref="thm_series_alg">Theorem</xref>, we find that
+        Applying <xref ref="thm_series_alg"/>, we find that
         <me>
           e^x\cos(x) = \left(1+x+\frac{x^2}{2!}+\frac{x^3}{3!}+\cdots\right)\left(1-\frac{x^2}{2!}+\frac{x^4}{4!}+\cdots\right)
         </me>.
@@ -768,7 +768,7 @@
     <title>Creating new Taylor series</title>
     <statement>
       <p>
-        Use <xref ref="thm_series_alg">Theorem</xref>
+        Use <xref ref="thm_series_alg"/>
         to create series for <m>y=\sin(x^2)</m> and <m>y=x^3/(3+x^4)</m>.
       </p>
     </statement>
@@ -992,7 +992,7 @@
       </p>
 
       <p>
-        We use <xref ref="thm_calc_power_series">Theorem</xref> to integrate:
+        We use <xref ref="thm_calc_power_series"/> to integrate:
         <me>
           \int e^{-x^2}\, dx = C + x - \frac{x^3}{3}+\frac{x^5}{5\cdot2!}-\frac{x^7}{7\cdot3!}+\cdots +(-1)^n\frac{x^{2n+1}}{(2n+1)n!}+\cdots
         </me>
@@ -1014,7 +1014,7 @@
         Summing the 5 terms shown above give the approximation of <m>0.74749</m>.
         Since this is an alternating series,
         we can use the Alternating Series Approximation Theorem,
-        (<xref ref="thm_alt_series_approx">Theorem</xref>),
+        (<xref ref="thm_alt_series_approx"/>),
         to determine how accurate this approximation is.
         The next term of the series is <m>1/(11\cdot5!) \approx 0.00075758</m>.
         Thus we know our approximation is within
@@ -1038,8 +1038,8 @@
     </solution>
     <solution>
       <p>
-        We found the first 5 terms of the power series solution to this differential equation in <xref ref="ex_ps5">Example</xref>
-        in <xref ref="sec_power_series">Section</xref>.
+        We found the first 5 terms of the power series solution to this differential equation in <xref ref="ex_ps5"/>
+        in <xref ref="sec_power_series"/>.
         These are:
         <me>
           a_0=1, a_1 = 2, a_2 = \frac42=2, a_3=\frac{8}{2\cdot3}=\frac43, a_4=\frac{16}{2\cdot3\cdot4} = \frac23
@@ -1048,7 +1048,7 @@
 
       <p>
         We include the <q>unsimplified</q>
-        expressions for the coefficients found in <xref ref="ex_ps5">Example</xref>
+        expressions for the coefficients found in <xref ref="ex_ps5"/>
         as we are looking for a pattern.
         It can be shown that <m>a_n = 2^n/n!</m>.
         Thus the solution, written as a power series, is
@@ -1058,8 +1058,8 @@
       </p>
 
       <p>
-        Using <xref ref="idea_common_taylor">Key Idea</xref>
-        and <xref ref="thm_series_alg">Theorem</xref>,
+        Using <xref ref="idea_common_taylor"/>
+        and <xref ref="thm_series_alg"/>,
         we recognize <m>f(x) = e^{2x}</m>:
         <me>
           e^x = \infser[0] \frac{x^n}{n!} \qquad \Rightarrow \qquad e^{2x} = \infser[0] \frac{(2x)^n}{n!}
@@ -1070,7 +1070,7 @@
 
   <p>
     Finding a pattern in the coefficients that match the series expansion of a known function,
-    such as those shown in <xref ref="idea_common_taylor">Key Idea</xref>,
+    such as those shown in <xref ref="idea_common_taylor"/>,
     can be difficult.
     What if the coefficients in the previous example were given in their reduced form;
     how could we still recover the function <m>y=e^{2x}</m>?
@@ -1084,7 +1084,7 @@
   </p>
 
   <p>
-    <xref ref="def_taylor_series">Definition</xref>
+    <xref ref="def_taylor_series"/>
     states that each term of the Taylor expansion of a function includes an <m>n!</m>.
     This allows us to say that
     <me>
@@ -1108,7 +1108,7 @@
   <p>
     There are simpler,
     more direct ways of solving the differential equation <m>y' = 2y</m>,
-    as discussed in <xref ref="chapter_differential_equations">Chapter</xref>.
+    as discussed in <xref ref="chapter_differential_equations"/>.
     We applied power series techniques to this equation to demonstrate its utility,
     and went on to show how <em>sometimes</em>
     we are able to recover the solution in terms of elementary functions using the theory of Taylor series.
@@ -1169,7 +1169,7 @@
             </statement>
             <solution>
               <p>
-                <xref ref="thm_function_series_equality">Theorem</xref>,
+                <xref ref="thm_function_series_equality"/>,
                 entitled <q>Function and Taylor Series Equality</q>
               </p>
             </solution>
@@ -1181,7 +1181,7 @@
       <exercisegroup cols="2" xml:id="exset-taylor-series-identify-pattern">
         <introduction>
           <p>
-            <xref ref="idea_common_taylor">Key Idea</xref>
+            <xref ref="idea_common_taylor"/>
             gives the <m>n</m>th term of the Taylor series of common functions.
             In the following exercises, verify the formula given in the Key Idea by finding
             the first few terms of the Taylor series of the given function and identifying a pattern.
@@ -1314,7 +1314,7 @@
             find a formula for the <m>n</m>th term of the Taylor series of <m>f(x)</m>,
             centered at <m>c</m>,
             by finding the coefficients of the first few powers of <m>x</m> and looking for a pattern.
-            (The formulas for several of these are found in <xref ref="idea_common_taylor">Key Idea</xref>;
+            (The formulas for several of these are found in <xref ref="idea_common_taylor"/>;
             show work verifying these formula.)
           </p>
         </introduction>
@@ -1461,8 +1461,8 @@
                   The Taylor series starts <m>\frac{\sqrt{2}}2+\frac{\sqrt{2}}2(x-\pi/4) - \frac{\sqrt{2}}2\frac{(x-\pi/4)^2}{2}-\frac{\sqrt{2}}2\frac{(x-\pi/4)^3}{3!}+\frac{\sqrt{2}}2\frac{(x-\pi/4)^4}{4!}+\frac{\sqrt{2}}2\frac{(x-\pi/4)^5}{5!}\cdots</m>.
                   Note how the signs are <q>even,
                   even, odd, odd, even, even, odd,
-                  odd,<m>\ldots</m></q> We saw signs like these in <xref ref="ex_seq1">Example</xref>
-                  of <xref ref="sec_sequences">Section</xref>;
+                  odd,<m>\ldots</m></q> We saw signs like these in <xref ref="ex_seq1"/>
+                  of <xref ref="sec_sequences"/>;
                   one way of producing such signs is to raise <m>(-1)</m> to a special quadratic power.
                   While many possibilities exist,
                   one such quadratic is <m>(n+3)(n+4)/2</m>.
@@ -1482,8 +1482,8 @@
           <p>
             In the following exercises,
             show that the Taylor series for <m>f(x)</m>,
-            as given in <xref ref="idea_common_taylor">Key Idea</xref>,
-            is equal to <m>f(x)</m> by applying <xref ref="thm_function_series_equality">Theorem</xref>;
+            as given in <xref ref="idea_common_taylor"/>,
+            is equal to <m>f(x)</m> by applying <xref ref="thm_function_series_equality"/>;
             that is, show <m>\lim\limits_{n\to\infty}R_n(x) =0</m>.
           </p>
         </introduction>
@@ -1547,7 +1547,7 @@
               <solution>
                 <p>
                   The following argument is essentially the same as that given for
-                  <m>f(x) = \cos(x)</m> in <xref ref="ex_ts3">Example</xref>.
+                  <m>f(x) = \cos(x)</m> in <xref ref="ex_ts3"/>.
                 </p>
 
                 <p>
@@ -1671,7 +1671,7 @@
         <introduction>
           <p>
             In the following exercises,
-            use the Taylor series given in <xref ref="idea_common_taylor">Key Idea</xref> to verify the given identity.
+            use the Taylor series given in <xref ref="idea_common_taylor"/> to verify the given identity.
           </p>
         </introduction>
 
@@ -1855,7 +1855,7 @@
         <introduction>
           <p>
             In the following exercises,
-            use the Taylor series given in <xref ref="idea_common_taylor">Key Idea</xref>
+            use the Taylor series given in <xref ref="idea_common_taylor"/>
             to create the Taylor series of the given functions.
           </p>
         </introduction>

--- a/ptx/sec_total_differential.ptx
+++ b/ptx/sec_total_differential.ptx
@@ -4,8 +4,8 @@
   <introduction>
     <p>
       We studied <em>differentials</em>
-      in <xref ref="sec_differentials">Section</xref>,
-      where <xref ref="def_differential">Definition</xref>
+      in <xref ref="sec_differentials"/>,
+      where <xref ref="def_differential"/>
       states that if <m>y=f(x)</m> and <m>f</m> is differentiable,
       then <m>dy=\fp(x)dx</m>.
       One important use of this differential is in Integration by Substitution.
@@ -59,7 +59,7 @@
 
     <aside>
       <p>
-        From <xref ref="def_total_differential">Definition</xref>,
+        From <xref ref="def_total_differential"/>,
         we can write
         <me>
           dz = \langle\, f_x,f_y\rangle\cdot\langle dx,dy\rangle
@@ -68,7 +68,7 @@
 
       <p>
         While not explored in this section,
-        the vector <m>\langle f_x,f_y\rangle</m> is seen again in the next section and fully defined in <xref ref="sec_directional_derivative">Section</xref>.
+        the vector <m>\langle f_x,f_y\rangle</m> is seen again in the next section and fully defined in <xref ref="sec_directional_derivative"/>.
       </p>
     </aside>
 
@@ -84,7 +84,7 @@
         <p>
           We compute the partial derivatives:
           <m>f_x = 4x^3e^{3y}</m> and <m>f_y = 3x^4e^{3y}</m>.
-          Following <xref ref="def_total_differential">Definition</xref>, we have
+          Following <xref ref="def_total_differential"/>, we have
           <me>
             dz = 4x^3e^{3y}dx+3x^4e^{3y}dy
           </me>.
@@ -166,7 +166,7 @@
       <title>Showing a function is differentiable</title>
       <statement>
         <p>
-          Show <m>f(x,y) = xy+3y^2</m> is differentiable using <xref ref="def_multi_differentiability">Definition</xref>.
+          Show <m>f(x,y) = xy+3y^2</m> is differentiable using <xref ref="def_multi_differentiability"/>.
         </p>
       </statement>
       <solution>
@@ -251,8 +251,8 @@
       The theorems assure us that essentially all functions that we see in the course of our studies here are differentiable
       (and hence continuous)
       on their natural domains.
-      There is a difference between <xref ref="def_multi_differentiability">Definition</xref>
-      and <xref ref="thm_differentiable">Theorem</xref>, though:
+      There is a difference between <xref ref="def_multi_differentiability"/>
+      and <xref ref="thm_differentiable"/>, though:
       it is possible for a function <m>f</m> to be differentiable yet <m>f_x</m> and/or <m>f_y</m> is
       <em>not</em> continuous.
       Such strange behavior of functions is a source of delight for many mathematicians.
@@ -275,7 +275,7 @@
 
     <p>
       We can find <m>f_x(0,0)</m> and
-      <m>f_y(0,0)</m> using <xref ref="def_partial_derivative">Definition</xref>:
+      <m>f_y(0,0)</m> using <xref ref="def_partial_derivative"/>:
       <md>
         <mrow>f_x(0,0) \amp = \lim_{h\to 0} \frac{f(0+h,0) - f(0,0)}{h}</mrow>
         <mrow>\amp = \lim_{h\to 0} \frac{0}{h^2} = 0;</mrow>
@@ -295,15 +295,15 @@
       they give different results.) So even though <m>f_x</m> and <m>f_y</m> <em>exist</em>
       at every point in the <m>xy</m>-plane, they are not continuous.
       Therefore it is possible,
-      by <xref ref="thm_differentiable">Theorem</xref>,
+      by <xref ref="thm_differentiable"/>,
       for <m>f</m> to not be differentiable.
     </p>
 
     <p>
       Indeed, it is not.
       One can show that <m>f</m> is not continuous at <m>(0,0)</m>
-      (see <xref ref="ex_multilimit4">Example</xref>),
-      and by <xref ref="thm_diff_cont_multi">Theorem</xref>,
+      (see <xref ref="ex_multilimit4"/>),
+      and by <xref ref="thm_diff_cont_multi"/>,
       this means <m>f</m> is not differentiable at <m>(0,0)</m>.
     </p>
   </subsection>
@@ -442,20 +442,20 @@
   <subsection xml:id="subsec-tangent-plane-approximation">
     <title>Tangent Plane Approximation</title>
     <p>
-      Recall from <xref ref="chapter_derivatives">Chapter</xref> that in one variable,
+      Recall from <xref ref="chapter_derivatives"/> that in one variable,
       the essence of differentiability is the tangent line approximation.
-      This idea is emphasized in <xref ref="sec_differentials">Section</xref>,
+      This idea is emphasized in <xref ref="sec_differentials"/>,
       where we first introduced the differential.
     </p>
 
     <p>
-      In <xref ref="subsec-tangent-plane">Section</xref> we saw that the partial derivatives of a function <m>f(x,y)</m>
+      In <xref ref="subsec-tangent-plane"/> we saw that the partial derivatives of a function <m>f(x,y)</m>
       can be used to define the tangent <em>plane</em> to a graph <m>z=f(x,y)</m>.
       We will now see that this plane plays the same role for functions of two variables as the tangent line to a graph <m>y=f(x)</m> for a function of one variable.
     </p>
 
     <p>
-      Recall from <xref ref="def-linearization">Definition</xref> that for a function <m>f(x)</m>,
+      Recall from <xref ref="def-linearization"/> that for a function <m>f(x)</m>,
       when <m>x</m> is near <m>c</m> we have the linear approximation <m>f(x)\approx \ell(x)</m>,
       where
       <me>
@@ -653,7 +653,7 @@
     <p>
       Just as before,
       this definition gives a rigorous statement about what it means to be differentiable that is not very intuitive.
-      We follow it with a theorem similar to <xref ref="thm_differentiable">Theorem</xref>.
+      We follow it with a theorem similar to <xref ref="thm_differentiable"/>.
     </p>
 
     <theorem xml:id="thm_differentiable3">

--- a/ptx/sec_total_differential.ptx
+++ b/ptx/sec_total_differential.ptx
@@ -366,7 +366,7 @@
         </p>
 
         <p>
-          Returning to Equation <xref ref="eq_totaldiff2"/>, we have
+          Returning to <xref ref="eq_totaldiff2">Equation</xref>, we have
           <me>
             f(4.1,0.8) \approx 0.039 + 1.414 = 1.4531
           </me>.

--- a/ptx/sec_transformations.ptx
+++ b/ptx/sec_transformations.ptx
@@ -11,7 +11,7 @@
 
 		<aside>
 		  <p>
-		    Recall <xref ref="ex_double_int_polar_gaussian">Exercise</xref> in <xref ref="sec_double_int_polar">Section</xref>:
+		    Recall <xref ref="ex_double_int_polar_gaussian"/> in <xref ref="sec_double_int_polar"/>:
 				the function <m>f(x,y) = e^{-x^2-y^2}</m> is impossible to integrate in rectangular coordinates
 				(at least, by finding antidervatives in terms of elementary functions),
 				but switching to polar coordinates results in an integral that can be evaluated using a simple substitution.
@@ -64,7 +64,7 @@
 		<title>Review of substitution techniques</title>
 		<p>
 			One of the situations that should be covered by our general change of variables formula is that of substitution for a definite integral in one variable,
-			as encountered in <xref ref="sec_substitution">Section</xref>, way back in Calculus I.
+			as encountered in <xref ref="sec_substitution"/>, way back in Calculus I.
 			Of course, for a definite integral in one variable,
 			there is only one type of region of integration: a closed interval <m>[a,b]</m>.
 			For single integrals, our only consideration when making a change of variables is the function being integrated.
@@ -99,7 +99,7 @@
 		  <p>
 		    For double and triple integrals, it will be important to understand how both the function <em>and</em>
 				the region of integration are transformed. For single integrals,
-				the Fundamental Theorem of Calculus (<xref ref="thm_FTC2">Theorem</xref>)
+				the Fundamental Theorem of Calculus (<xref ref="thm_FTC2"/>)
 				lets us gloss over some of the details we'll now need to consider.
 				In particular, we don't really need to pay any attention to the interval over which we integrate in a single integral,
 				as long as we can come up with an antiderivative.
@@ -131,10 +131,10 @@
 			</md>,
 			where <m>D</m> is some subset of <m>\mathbb{R}^2</m> (with coordinates labelled by <m>r</m> and <m>\theta</m>),
 			and the codomain is <m>\mathbb{R}^2</m> with usual <m>(x,y)</m> coordinates.
-			As we know from <xref ref="sec_double_int_polar">Section</xref>,
+			As we know from <xref ref="sec_double_int_polar"/>,
 			the polar coordinate transformation <m>T</m> given above transforms a rectangle such as
 			<m>D=[0,3]\times [0,2\pi]</m> into a disk <mdash/> in this case,
-			the set of points <m>(x,y)</m> with <m>x^2+y^2\leq 9</m>, as shown in <xref ref="fig_polar_trans1">Figure</xref> below.
+			the set of points <m>(x,y)</m> with <m>x^2+y^2\leq 9</m>, as shown in <xref ref="fig_polar_trans1"/> below.
 		</p>
 
 		<aside>
@@ -145,7 +145,7 @@
 				However, the polar coordinate transformation is a bit unusual,
 				in that it violates some of the principles we will require below for a general transformation.
 				For example, the transformation is not one-to-one, and since we often allow <m>r\lt 0</m>
-				(recall <xref ref="sec_polar">Section</xref>),
+				(recall <xref ref="sec_polar"/>),
 				the inverse transformation (from polar to rectangular) technically isn't even a function!
 				However, we're willing to overlook these defects due to the ubiquity and usefulness of the polar coordinate system.
 		  </p>
@@ -230,7 +230,7 @@
 		<p>
 		  It is perhaps easier to picture the transformation for a domain of the form <m>[a,b]\times [\alpha,\beta]</m>,
 			with <m>0\lt a\lt b</m> and <m>0\leq \alpha\lt \beta\lt 2\pi</m>.
-			The case <m>r\in [1,2]</m>, <m>\theta\in [\pi/6, \pi/3]</m> is pictured in <xref ref="fig_polar_trans2">Figure</xref> below.
+			The case <m>r\in [1,2]</m>, <m>\theta\in [\pi/6, \pi/3]</m> is pictured in <xref ref="fig_polar_trans2"/> below.
 		</p>
 
 		<figure xml:id="fig_polar_trans2">
@@ -310,7 +310,7 @@
 		</p>
 
 		<p>
-			<xref ref="def_transformation">Definition</xref>
+			<xref ref="def_transformation"/>
 			below specifies the properties we require for a function <m>T:D\subseteq \mathbb{R}^n\to\mathbb{R}^n</m>
 			to be used to define a change of variables. To explain some of those properties, we will need the following definitions.
 		</p>
@@ -327,7 +327,7 @@
 			<p>
 			  Note however that the choice of domain is part of the definition of a function,
 				and it can significantly affect important properties of that function,
-				such as being one-to-one: recall the definition of the inverse trigonometric functions in <xref ref="sec_deriv_inverse_function">Section</xref>.
+				such as being one-to-one: recall the definition of the inverse trigonometric functions in <xref ref="sec_deriv_inverse_function"/>.
 			</p>
 		</aside>
 
@@ -399,9 +399,9 @@
 			A function used for a change of variables is called a <em>transformation</em>.
 			Such functions need to be one-to-one, except possibly on the boundary of their domain,
 			and they need to be continuously differentiable.
-			(See <xref ref="def_transformation">Definition</xref> below.)
+			(See <xref ref="def_transformation"/> below.)
 			One of the important properties of a transformation, which we will justify later in this section
-			(see <xref ref="thm_boundary_transform">Theorem</xref>),
+			(see <xref ref="thm_boundary_transform"/>),
 			is that the boundary of a closed, bounded domain is mapped to the boundary of the range.
 			This observation is key to visualizing the effect of a transformation.
 		</p>
@@ -429,7 +429,7 @@
 				    While it is important to know that our function is one-to-one,
 						we will usually not ask you to check this fact.
 						However, you should make sure you're aware of what can go wrong if this property is not satisfied:
-						see the discussion following <xref ref="def_transformation">Definition</xref>.
+						see the discussion following <xref ref="def_transformation"/>.
 				  </p>
 				</aside>
 
@@ -483,7 +483,7 @@
 				</p>
 
 				<p>
-					The resulting region is plotted in <xref ref="fig_trans_map1">Figure</xref>.
+					The resulting region is plotted in <xref ref="fig_trans_map1"/>.
 					Interestingly, two of the four sides of the rectangle bounding <m>D</m> were mapped to (different portions of) the same curve.
 				</p>
 
@@ -537,7 +537,7 @@
 			One other observation is worthy of note:
 			we mentioned above that we will be primarily concerned with finding transformations that can be used to simplify a double integral.
 			Suppose we were given a double integral over <m>R=T(D)</m>,
-			as pictured in <xref ref="fig_trans_map1">Figure</xref>.
+			as pictured in <xref ref="fig_trans_map1"/>.
 			We probably wouldn't even consider a change of variables in this case,
 			unless one was needed for the function being integrated:
 			the region can be described by the inequalities
@@ -565,7 +565,7 @@
 
 		<p>
 			The transformation affects the size of the subintervals in the partition:
-			from <xref ref="sec_differentials">Section</xref>, we know that <m>\Delta x_i \approx T\primeskip' (u_i)\Delta x_i</m>.
+			from <xref ref="sec_differentials"/>, we know that <m>\Delta x_i \approx T\primeskip' (u_i)\Delta x_i</m>.
 			Thus, the derivative tells us how the size of each subinterval changes under the transformation.
 		</p>
 
@@ -629,7 +629,7 @@
 		</p>
 
 		<p>
-			If you read <xref ref="sec_deriv_matrix">Section</xref>
+			If you read <xref ref="sec_deriv_matrix"/>
 			on the definition of the derivative as a matrix of partial derivatives,
 			you probably recognize the matrix whose determinant gives us the Jacobian:
 			it's the derivative matrix! One therefore could write
@@ -672,7 +672,7 @@
 			</statement>
 			<solution>
 			  <p>
-					We apply <xref ref="def_jacobian">Definition</xref> directly:
+					We apply <xref ref="def_jacobian"/> directly:
 					<md>
 					  <mrow>J_T(u,v) \amp = \det\begin{bmatrix}x_u(u,v)\amp x_v(u,v)\\y_u(u,v)\amp y_v(u,v)\end{bmatrix}</mrow>
 						<mrow>\amp = \det\begin{bmatrix}7\amp -3\\-4\amp 2\end{bmatrix}</mrow>
@@ -818,7 +818,7 @@
 		</aside>
 
 		<p>
-			When <m>D</m> is a closed, bounded subset, note that we do not require <xref ref="def_transformation">Definition</xref> to hold on the boundary.
+			When <m>D</m> is a closed, bounded subset, note that we do not require <xref ref="def_transformation"/> to hold on the boundary.
 			Each of the three conditions above must hold on the interior of <m>D</m>,
 			but are allowed to fail on all or part of the boundary.
 			In particular, this is the case for cylindrical, and spherical coordinates:
@@ -835,7 +835,7 @@
 
 					<p>
 					  Of course, we often use a domain such as <m>r\in [0,R]</m>, <m>\theta = [0,2\pi]</m> to describe a disk centred at the origin.
-						The conditions of <xref ref="def_transformation">Definition</xref> fail at <m>r=0</m>,
+						The conditions of <xref ref="def_transformation"/> fail at <m>r=0</m>,
 						and because points with <m>\theta=0</m> get mapped to the same place as points with <m>\theta = 2\pi</m>.
 						But these coordinates describe 3 of the 4 sides of the boundary rectangle for our domain,
 						and the conditions are not required to hold on the boundadry.
@@ -866,7 +866,7 @@
 		</p>
 
 		<p>
-		  We saw in <xref ref="ex_jacobian1">Example</xref> that when <m>x</m> and <m>y</m> are linear functions of <m>u</m> and <m>v</m>,
+		  We saw in <xref ref="ex_jacobian1"/> that when <m>x</m> and <m>y</m> are linear functions of <m>u</m> and <m>v</m>,
 			the Jacobian of the transformation is a constant.
 			What does that constant tell us about the transformation?
 			Here is an example taken from the book Matrix Algebra, by Greg Hartman (who is also the main author of this text).
@@ -909,7 +909,7 @@
 			  </p>
 
 				<p>
-				  The unit square and its transformation are graphed in <xref ref="fig_mv_3">Figure</xref>,
+				  The unit square and its transformation are graphed in <xref ref="fig_mv_3"/>,
 					where the shaped vertices correspond to each other across the two graphs.
 					Note how the square got turned into some sort of quadrilateral (it's actually a parallelogram).
 					A really interesting thing is how the triangular and square vertices seem to have changed places <mdash/> it is as though the square,
@@ -917,7 +917,7 @@
 				</p>
 
 				<figure xml:id="fig_mv_3">
-					<caption>Transforming the unit square by matrix multiplication in <xref ref="ex_mv_3">Example</xref></caption>
+					<caption>Transforming the unit square by matrix multiplication in <xref ref="ex_mv_3"/></caption>
 					<sidebyside widths="47% 47%" margins="0%">
 						<image xml:id="img_ex_mv_3a">
 						  <description></description>
@@ -994,7 +994,7 @@
 		</p>
 
 		<p>
-			Let us make a note of a few key points about <xref ref="ex_mv_3">Example</xref>.
+			Let us make a note of a few key points about <xref ref="ex_mv_3"/>.
 			First, note that in this case, the derivative matrix, (and as a result, the Jacobian) is constant.
 			(This of course is generally true of the derivative for linear functions.)
 		</p>
@@ -1036,7 +1036,7 @@
 		</aside>
 
 		<p>
-			Let us make a couple more remarks about the <xref ref="ex_mv_3">Example</xref>.
+			Let us make a couple more remarks about the <xref ref="ex_mv_3"/>.
 			First, note the need for an absolute value around the determinant,
 			to ensure the area computed is positive. This absolute value will be needed in our change of variables formula as well.
 		</p>
@@ -1054,7 +1054,7 @@
 				<m>\displaystyle \int_a^bf(x)\,dx = -\int_b^af(x)\,dx</m>.
 				The definite integral is sensitive to the <em>orientation</em> of the interval over which the integration is performed.
 				(Left to right or right to left.) Double and triple integrals do not have this sensitivity.
-				We'll see in <xref ref="sec_parametric_surfaces">Section</xref> how information about orientation is reintroduced in the context of vector calculus.
+				We'll see in <xref ref="sec_parametric_surfaces"/> how information about orientation is reintroduced in the context of vector calculus.
 		  </p>
 		</aside>
 
@@ -1148,7 +1148,7 @@
 		<p>
 			We computed the above <m>3\times 3</m> determinant using a cofactor expansion along the second column.
 			This is once again exactly the correction factor for the volume element in spherical coordinates,
-			as given in <xref ref="thm_triple_int_spherical">Theorem</xref> in <xref ref="sec_cylindrical_spherical">Section</xref>.
+			as given in <xref ref="thm_triple_int_spherical"/> in <xref ref="sec_cylindrical_spherical"/>.
 		</p>
 
 		<figure xml:id="vid-transformation-spherical" component="video">
@@ -1212,7 +1212,7 @@
 
 						<li>
 						  <p>
-						    Use the transformation <m>T</m> and <xref ref="thm_change_of_variables">Theorem</xref>
+						    Use the transformation <m>T</m> and <xref ref="thm_change_of_variables"/>
 								to determine the area of <m>R</m>.
 						  </p>
 						</li>
@@ -1224,7 +1224,7 @@
 			    <ol>
 			      <li>
 			        <p>
-			          For inspiration, we look to <xref ref="ex_mv_3">Example</xref>.
+			          For inspiration, we look to <xref ref="ex_mv_3"/>.
 								Notice how the transformation defined by the matrix
 								<m>A=\begin{bmatrix}1\amp 4\\2\amp 3\end{bmatrix}</m> preserves the origin,
 								and sends the points <m>(1,0)</m> and <m>(0,1)</m> to <m>(1,2)</m> and <m>(4,3)</m>, respectively.
@@ -1259,7 +1259,7 @@
 
 						<li>
 						  <p>
-								To use <xref ref="thm_change_of_variables">Theorem</xref>,
+								To use <xref ref="thm_change_of_variables"/>,
 								we need to compute the Jacobian of our transformation. We have
 								<me>
 								  J_T(u,v) = \det\begin{bmatrix}3\amp1\\1\amp4\end{bmatrix} = 11
@@ -1300,11 +1300,11 @@
 			</statement>
 			<solution>
 			  <p>
-			    The region of integration is shown in <xref ref="fig_trans_int_reg0">Figure</xref>.
+			    The region of integration is shown in <xref ref="fig_trans_int_reg0"/>.
 				</p>
 
 				<figure xml:id="fig_trans_int_reg0">
-					<caption>The region of integration <m>R</m> in <xref ref="ex_int_trans0">Example</xref></caption>
+					<caption>The region of integration <m>R</m> in <xref ref="ex_int_trans0"/></caption>
 					<image xml:id="img_trans_int_reg0" width="47%">
 					  <description></description>
 						<latex-image>
@@ -1344,7 +1344,7 @@
 				</p>
 
 				<p>
-					Now, we apply <xref ref="thm_change_of_variables">Theorem</xref>. Recall the formula:
+					Now, we apply <xref ref="thm_change_of_variables"/>. Recall the formula:
 					<me>
 					  \iint_D f(T(u,v))\lvert J_T(u,v)\rvert\,du\,dv = \iint_{T(D)} f(x,y)\,dx\,dy
 					</me>.
@@ -1419,7 +1419,7 @@
 					The region <m>R</m> is therefore the image under the transformation
 					<m>T(u,v)=(u/v,v)</m> of the region <m>D</m> bounded by the curves
 					<m>u=v^2</m> and <m>u=\frac14 v^2</m>, and the lines <m>u=1, u=4</m>;
-					see <xref ref="fig_int_trans00b">Figure</xref>.
+					see <xref ref="fig_int_trans00b"/>.
 				</p>
 
 				<aside>
@@ -1488,8 +1488,8 @@
 
 				<p>
 					This is perhaps not the best possible change of variables: the domain <m>D</m> is not a rectangle.
-					(See <xref ref="ex_int_trans2">Example</xref> below for a change of variables that is more effective for this type of region.)
-					However, it is a region of the type we considered in <xref ref="sec_double_int_volume">Section</xref>,
+					(See <xref ref="ex_int_trans2"/> below for a change of variables that is more effective for this type of region.)
+					However, it is a region of the type we considered in <xref ref="sec_double_int_volume"/>,
 					so we're better off than we were with the original region.
 					We have <m>1\leq u\leq 4</m>, and the equations <m>u=v^2</m>,
 					<m>u=\frac14 v^2</m> can be re-written (noting that <m>v>0</m>) as <m>v=\sqrt{u}</m> and <m>v=2\sqrt{u}</m>.
@@ -1520,9 +1520,9 @@
 		</p>
 
 		<p>
-			Recall from <xref ref="def_transformation">Definition</xref>
+			Recall from <xref ref="def_transformation"/>
 			that we require transformations to be one-to-one and onto
-			(see <xref ref="def_one_to_one_onto">Definition</xref>),
+			(see <xref ref="def_one_to_one_onto"/>),
 			except possibly on the boundary of their domain.
 		</p>
 
@@ -1586,7 +1586,7 @@
 
 		<aside>
 		  <p>
-				Recall that in <xref ref="sec_deriv_matrix">Section</xref>
+				Recall that in <xref ref="sec_deriv_matrix"/>
 				we gave the following alternative definition of differentiability:
 				<m>f:D\subset \mathbb{R}^n\to\mathbb{R}^m</m> is <em>differentiable</em> if the limit of
 				<me>
@@ -1603,7 +1603,7 @@
 			If a function <m>T:D\subset\mathbb{R}^n\to E\subset \mathbb{R}^n</m> is <m>C^1</m>,
 			then as with real-valued functions,
 			being continuously differentiable implies that <m>T</m> is differentiable
-			(in the sense of the definition from <xref ref="sec_deriv_matrix">Section</xref>),
+			(in the sense of the definition from <xref ref="sec_deriv_matrix"/>),
 			and therefore continuous.
 			The derivative of <m>T</m> is then an <m>n\times n</m> matrix.
 			For example, when <m>n=2</m>, if <m>T(u,v) = (x(u,v), y(u,v))</m>, we get
@@ -1623,10 +1623,10 @@
 		<p>
 			Given our function <m>T:D\subset \mathbb{R}^n\to E\subset \mathbb{R}^n</m>,
 			let us denote by <m>DT</m> the matrix of partial derivatives,
-			as in <xref ref="sec_deriv_matrix">Section</xref>.
+			as in <xref ref="sec_deriv_matrix"/>.
 			Since the dimension of the domain and range are the same,
 			<m>DT</m> is a square (<m>n\times n</m>) matrix, so we can compute its determinant,
-			and this, of course, is the Jacobian, as defined in <xref ref="def_jacobian">Definition</xref>.
+			and this, of course, is the Jacobian, as defined in <xref ref="def_jacobian"/>.
 		</p>
 
 		<p>
@@ -1667,7 +1667,7 @@
 		  <p>
 		    The <m>-1</m> on the right-hand side of Equation <xref ref="eqn_gen_inverse"/> denotes a matrix inverse.
 				A basic result from linear algebra tells us that a matrix is invertible if and only if its determinant is non-zero,
-				which is one reason why we require a nonzero Jacobian in <xref ref="def_transformation">Definition</xref>.
+				which is one reason why we require a nonzero Jacobian in <xref ref="def_transformation"/>.
 				(Compare this to the result <m>(f^{-1})'(x) = \dfrac{1}{f'(f^{-1}(x))}</m> in one variable.)
 		  </p>
 		</aside>
@@ -1746,7 +1746,7 @@
 
 		<aside>
 		  <p>
-		    A result such as <xref ref="thm_open_transform">Theorem</xref>
+		    A result such as <xref ref="thm_open_transform"/>
 				that is used as a step towards proving a more substantial result is often referred to as a <em>lemma</em>.
 		  </p>
 		</aside>
@@ -1789,7 +1789,7 @@
 		</p>
 
 		<proof>
-			<title>Proof of <xref ref="thm_boundary_transform">Theorem</xref></title>
+			<title>Proof of <xref ref="thm_boundary_transform"/></title>
 
 			<p>
 				Let <m>T:D\to E</m> be the given transformation,
@@ -1814,7 +1814,7 @@
 			</p>
 
 			<p>
-				However, since <m>T</m> satisfies the conditions of <xref ref="thm_open_transform">Theorem</xref>,
+				However, since <m>T</m> satisfies the conditions of <xref ref="thm_open_transform"/>,
 				we know that <m>T</m> must map open sets to open sets.
 				In particular, since <m>N_\delta(\mathbf{u})</m> is an open subset of <m>D</m>,
 				<m>T(N_\delta(\mathbf{u}))</m> must be an open subset of <m>E</m>.
@@ -1845,7 +1845,7 @@
 			</statement>
 			<solution>
 			  <p>
-					The region <m>E</m> is pictured in <xref ref="fig_int_trans1">Figure</xref> below.
+					The region <m>E</m> is pictured in <xref ref="fig_int_trans1"/> below.
 					We need to find a region <m>D\subset \mathbb{R}^2</m> and a transformation <m>T:D\to \mathbb{R}^2</m> whose image is <m>E</m>.
 					We use the fact that <m>T</m> must map the boundary of <m>D</m> to the boundary of <m>E</m> as a guideline.
 					In particular, note that since <m>T</m> is <m>C^1</m>, it must map smooth curves to smooth curves by the chain rule.
@@ -1855,7 +1855,7 @@
 				</p>
 
 				<figure xml:id="fig_int_trans1">
-					<caption>The region of integration for <xref ref="ex_int_trans1">Example</xref></caption>
+					<caption>The region of integration for <xref ref="ex_int_trans1"/></caption>
 					<image xml:id="img_int_trans1" width="47%">
 					  <description></description>
 						<latex-image>
@@ -1969,7 +1969,7 @@
 			<solution>
 			  <p>
 					We need to find a region <m>D\subset \mathbb{R}^2</m> and a transformation <m>T:D\to \mathbb{R}^2</m> whose image is <m>E</m>.
-					This problem is almost identical to the one we solved in <xref ref="ex_int_trans00">Example</xref>,
+					This problem is almost identical to the one we solved in <xref ref="ex_int_trans00"/>,
 					where we were given a change of variables whose domain was still somewhat complicated.
 					This time, we look for a transformation with a rectangular domain.
 				</p>
@@ -1982,7 +1982,7 @@
 				</p>
 
 				<figure xml:id="fig_int_trans2">
-					<caption>The region of integration in <xref ref="ex_int_trans2">Example</xref></caption>
+					<caption>The region of integration in <xref ref="ex_int_trans2"/></caption>
 					<image xml:id="img_int_trans2" width="47%">
 					  <description></description>
 						<latex-image>
@@ -2037,7 +2037,7 @@
 		</example>
 
 		<figure xml:id="vid-multint-transformations-example" component="video">
-		  <caption>A video presentation of <xref ref="ex_int_trans2">Example</xref>, with slightly different numbers</caption>
+		  <caption>A video presentation of <xref ref="ex_int_trans2"/>, with slightly different numbers</caption>
 		  <video youtube="hSDH3FnD97w" label="vid-multint-transformations-example"/>
 		</figure>
 	</subsection>
@@ -2115,7 +2115,7 @@
 			with grid lines given by <m>u=\text{constant}</m> or <m>v=\text{constant}</m>
 			is transformed into a <q>grid of curves</q> in the <m>x,y</m> plane.
 			This is the case, for example, with the polar coordinate transformation,
-			as seen in <xref ref="fig_polar_trans3">Figure</xref> below.
+			as seen in <xref ref="fig_polar_trans3"/> below.
 		</p>
 
 		<figure xml:id="fig_polar_trans3">
@@ -2194,7 +2194,7 @@
 		<p>
 			A grid in the <m>u,v</m> plane is transformed to two families of curves:
 			lines <m>u=m</m>, <m>v=n</m>, where <m>m,n</m> are constants become the curves <m>y=\frac{m}{x}</m> and <m>y=nx^2</m>, respectively.
-			The transformation is pictured in <xref ref="fig_gen_trans_eg">Figure</xref> below.
+			The transformation is pictured in <xref ref="fig_gen_trans_eg"/> below.
 		</p>
 
 		<figure xml:id="fig_gen_trans_eg">
@@ -2285,14 +2285,14 @@
 		</figure>
 
 		<p>
-			In <xref ref="fig_gen_trans_eg">Figure</xref> we've highlighted one of the rectangles in our grid to see how it's transformed.
+			In <xref ref="fig_gen_trans_eg"/> we've highlighted one of the rectangles in our grid to see how it's transformed.
 			Imagine now that our grid lines are much finer, coming not from the integer values of <m>u</m> and <m>v</m>,
 			but from a partition of a rectangle <m>D</m> in the <m>u,v</m> plane.
 			Zooming in, we'd see that each rectangle in the partition is transformed much like the one above.
 		</p>
 
 		<p>
-			Indeed, recall the following philosophy from <xref ref="sec_deriv_matrix">Section</xref>:
+			Indeed, recall the following philosophy from <xref ref="sec_deriv_matrix"/>:
 			the transformation <m>T</m> maps points in the <m>u,v</m> plane to points in the <m>x,y</m> plane.
 			The derivative matrix <m>DT(u,v)</m> of <m>T</m> at a point <m>(u,v)</m>,
 			when viewed as the matrix of a linear transformation, maps (tangent) vectors at the point <m>(u,v)</m> to (tangent) vectors at the point <m>(x,y)=T(u,v)</m>.
@@ -2334,7 +2334,7 @@
 
 		<p>
 			Now, let's consider the corresponding region in the <m>x,y</m> plane.
-			The curves in <xref ref="fig_gen_trans_eg">Figure</xref> above can also be realized as parametric curves.
+			The curves in <xref ref="fig_gen_trans_eg"/> above can also be realized as parametric curves.
 			In fact, they are precisely the composition of the curves above with our transformation,
 			if we view <m>T</m> as a vector-valued function. We have curves
 			<md>
@@ -2349,7 +2349,7 @@
 			not lines, and the image of our rectangle is no longer rectangular.
 			But for <m>\Delta u,\Delta v</m> small enough, our curves are <em>approximately</em> linear,
 			and the image of our rectangle is <em>approximately</em> a parallelogram.
-			See <xref ref="fig_pargrm_approx">Figure</xref>.
+			See <xref ref="fig_pargrm_approx"/>.
 		</p>
 
 		<p>
@@ -2441,7 +2441,7 @@
 			</me>.
 			This equation should be viewed somewhat skeptically.
 			The area element on the left is that of a rectangle, not the parallelogram we ended up with above.
-			The argument given here is far from a complete proof of <xref ref="thm_change_of_variables">Theorem</xref>,
+			The argument given here is far from a complete proof of <xref ref="thm_change_of_variables"/>,
 			but the result is true nonetheless. The interested reader is directed to search online,
 			or seek out the advanced calculus section of their library, should they wish to see a proof.
 		</p>

--- a/ptx/sec_transformations.ptx
+++ b/ptx/sec_transformations.ptx
@@ -91,7 +91,7 @@
 			and not the function being integrated. (In one variable, one closed interval is transformed into another,
 			and we apply the Fundamental Theorem of Calculus.
 			 What we will find is that in most cases,
-			 we start on the <em>right</em> hand side of our analogue of Equation <xref ref="eqn_single_sub"/>,
+			 we start on the <em>right</em> hand side of our analogue of <xref ref="eqn_single_sub">Equation</xref>,
 			 and move to the left.
 		</p>
 
@@ -753,7 +753,7 @@
 
 		<p>
 			As hinted at earlier, the Jacobian is important because it appears in the change of variables formula to come.
-			Its role is analogous to that of the derivative <m>g'(u)</m> in Equation <xref ref="eqn_single_sub"/>.
+			Its role is analogous to that of the derivative <m>g'(u)</m> in <xref ref="eqn_single_sub">Equation</xref>.
 			We also need the Jacobian to precisely define the type of function that can be used for a change of variables.
 		</p>
 
@@ -1162,7 +1162,7 @@
 		<title>The Change of Variables Formula</title>
 		<p>
 			It seems that we're onto something. It is time that we stated the general change of variables formula for multiple integrals.
-			Notice how, as with the derivative <m>g'(u)</m> in Equation <xref ref="eqn_single_sub"/>,
+			Notice how, as with the derivative <m>g'(u)</m> in <xref ref="eqn_single_sub">Equation</xref>,
 			the Jacobian gives us a measure of how subregions in the domain are stretched or shrunk.
 			It shouldn't be too surprising, then, that the Jacobian plays the same role in multiple integrals that the derivative does in a single integral.
 		</p>
@@ -1665,7 +1665,7 @@
 
 		<aside>
 		  <p>
-		    The <m>-1</m> on the right-hand side of Equation <xref ref="eqn_gen_inverse"/> denotes a matrix inverse.
+		    The <m>-1</m> on the right-hand side of <xref ref="eqn_gen_inverse">Equation</xref> denotes a matrix inverse.
 				A basic result from linear algebra tells us that a matrix is invertible if and only if its determinant is non-zero,
 				which is one reason why we require a nonzero Jacobian in <xref ref="def_transformation"/>.
 				(Compare this to the result <m>(f^{-1})'(x) = \dfrac{1}{f'(f^{-1}(x))}</m> in one variable.)
@@ -1673,7 +1673,7 @@
 		</aside>
 
 		<p>
-			A useful consequence of Equation <xref ref="eqn_gen_inverse"/>
+			A useful consequence of <xref ref="eqn_gen_inverse">Equation</xref>
 			is obtained by taking the determinant of both sides of the above equation
 			(recall that <m>\det(A^{-1}) = 1/\det(A)</m> for any invertible matrix <m>A</m>).
 		</p>

--- a/ptx/sec_transformations_old.ptx
+++ b/ptx/sec_transformations_old.ptx
@@ -91,7 +91,7 @@
 			and not the function being integrated. (In one variable, one closed interval is transformed into another,
 			and we apply the Fundamental Theorem of Calculus.
 			 What we will find is that in most cases,
-			 we start on the <em>right</em> hand side of our analogue of Equation <xref ref="eqn_single_sub"/>,
+			 we start on the <em>right</em> hand side of our analogue of <xref ref="eqn_single_sub">Equation</xref>,
 			 and move to the left.
 		</p>
 
@@ -751,7 +751,7 @@
 
 		<p>
 			As hinted at earlier, the Jacobian is important because it appears in the change of variables formula to come.
-			Its role is analogous to that of the derivative <m>g'(u)</m> in Equation <xref ref="eqn_single_sub"/>.
+			Its role is analogous to that of the derivative <m>g'(u)</m> in <xref ref="eqn_single_sub">Equation</xref>.
 			We also need the Jacobian to precisely define the type of function that can be used for a change of variables.
 		</p>
 
@@ -1166,7 +1166,7 @@
 		<title>The Change of Variables Formula</title>
 		<p>
 			It seems that we're onto something. It is time that we stated the general change of variables formula for multiple integrals.
-			Notice how, as with the derivative <m>g'(u)</m> in Equation <xref ref="eqn_single_sub"/>,
+			Notice how, as with the derivative <m>g'(u)</m> in <xref ref="eqn_single_sub">Equation</xref>,
 			the Jacobian gives us a measure of how subregions in the domain are stretched or shrunk.
 			It shouldn't be too surprising, then, that the Jacobian plays the same role in multiple integrals that the derivative does in a single integral.
 		</p>
@@ -1669,7 +1669,7 @@
 
 		<aside>
 		  <p>
-		    The <m>-1</m> on the right-hand side of Equation <xref ref="eqn_gen_inverse"/> denotes a matrix inverse.
+		    The <m>-1</m> on the right-hand side of <xref ref="eqn_gen_inverse">Equation</xref> denotes a matrix inverse.
 				A basic result from linear algebra tells us that a matrix is invertible if and only if its determinant is non-zero,
 				which is one reason why we require a nonzero Jacobian in <xref ref="def_transformation"/>.
 				(Compare this to the result <m>(f^{-1})'(x) = \dfrac{1}{f'(f^{-1}(x))}</m> in one variable.)
@@ -1677,7 +1677,7 @@
 		</aside>
 
 		<p>
-			A useful consequence of Equation <xref ref="eqn_gen_inverse"/>
+			A useful consequence of <xref ref="eqn_gen_inverse">Equation</xref>
 			is obtained by taking the determinant of both sides of the above equation
 			(recall that <m>\det(A^{-1}) = 1/\det(A)</m> for any invertible matrix <m>A</m>).
 		</p>

--- a/ptx/sec_transformations_old.ptx
+++ b/ptx/sec_transformations_old.ptx
@@ -11,7 +11,7 @@
 
 		<aside>
 		  <p>
-		    Recall <xref ref="ex_double_int_polar_gaussian">Exercise</xref> in <xref ref="sec_double_int_polar">Section</xref>:
+		    Recall <xref ref="ex_double_int_polar_gaussian"/> in <xref ref="sec_double_int_polar"/>:
 				the function <m>f(x,y) = e^{-x^2-y^2}</m> is impossible to integrate in rectangular coordinates
 				(at least, by finding antidervatives in terms of elementary functions),
 				but switching to polar coordinates results in an integral that can be evaluated using a simple substitution.
@@ -64,7 +64,7 @@
 		<title>Review of substitution techniques</title>
 		<p>
 			One of the situations that should be covered by our general change of variables formula is that of substitution for a definite integral in one variable,
-			as encountered in <xref ref="sec_substitution">Section</xref>, way back in Calculus I.
+			as encountered in <xref ref="sec_substitution"/>, way back in Calculus I.
 			Of course, for a definite integral in one variable,
 			there is only one type of region of integration: a closed interval <m>[a,b]</m>.
 			For single integrals, our only consideration when making a change of variables is the function being integrated.
@@ -99,7 +99,7 @@
 		  <p>
 		    For double and triple integrals, it will be important to understand how both the function <em>and</em>
 				the region of integration are transformed. For single integrals,
-				the Fundamental Theorem of Calculus (<xref ref="thm_FTC2">Theorem</xref>)
+				the Fundamental Theorem of Calculus (<xref ref="thm_FTC2"/>)
 				lets us gloss over some of the details we'll now need to consider.
 				In particular, we don't really need to pay any attention to the interval over which we integrate in a single integral,
 				as long as we can come up with an antiderivative.
@@ -131,10 +131,10 @@
 			</md>,
 			where <m>D</m> is some subset of <m>\mathbb{R}^2</m> (with coordinates labelled by <m>r</m> and <m>\theta</m>),
 			and the codomain is <m>\mathbb{R}^2</m> with usual <m>(x,y)</m> coordinates.
-			As we know from <xref ref="sec_double_int_polar">Section</xref>,
+			As we know from <xref ref="sec_double_int_polar"/>,
 			the polar coordinate transformation <m>T</m> given above transforms a rectangle such as
 			<m>D=[0,3]\times [0,2\pi]</m> into a disk <mdash/> in this case,
-			the set of points <m>(x,y)</m> with <m>x^2+y^2\leq 9</m>, as shown in <xref ref="fig_polar_trans1">Figure</xref> below.
+			the set of points <m>(x,y)</m> with <m>x^2+y^2\leq 9</m>, as shown in <xref ref="fig_polar_trans1"/> below.
 		</p>
 
 		<aside>
@@ -145,7 +145,7 @@
 				However, the polar coordinate transformation is a bit unusual,
 				in that it violates some of the principles we will require below for a general transformation.
 				For example, the transformation is not one-to-one, and since we often allow <m>r\lt 0</m>
-				(recall <xref ref="sec_polar">Section</xref>),
+				(recall <xref ref="sec_polar"/>),
 				the inverse transformation (from polar to rectangular) technically isn't even a function!
 				However, we're willing to overlook these defects due to the ubiquity and usefulness of the polar coordinate system.
 		  </p>
@@ -230,7 +230,7 @@
 		<p>
 		  It is perhaps easier to picture the transformation for a domain of the form <m>[a,b]\times [\alpha,\beta]</m>,
 			with <m>0\lt a\lt b</m> and <m>0\leq \alpha\lt \beta\lt 2\pi</m>.
-			The case <m>r\in [1,2]</m>, <m>\theta\in [\pi/6, \pi/3]</m> is pictured in <xref ref="fig_polar_trans2">Figure</xref> below.
+			The case <m>r\in [1,2]</m>, <m>\theta\in [\pi/6, \pi/3]</m> is pictured in <xref ref="fig_polar_trans2"/> below.
 		</p>
 
 		<figure xml:id="fig_polar_trans2">
@@ -310,7 +310,7 @@
 		</p>
 
 		<p>
-			<xref ref="def_transformation">Definition</xref>
+			<xref ref="def_transformation"/>
 			below specifies the properties we require for a function <m>T:D\subseteq \mathbb{R}^n\to\mathbb{R}^n</m>
 			to be used to define a change of variables. To explain some of those properties, we will need the following definitions.
 		</p>
@@ -327,7 +327,7 @@
 			<p>
 			  Note however that the choice of domain is part of the definition of a function,
 				and it can significantly affect important properties of that function,
-				such as being one-to-one: recall the definition of the inverse trigonometric functions in <xref ref="sec_deriv_inverse_function">Section</xref>.
+				such as being one-to-one: recall the definition of the inverse trigonometric functions in <xref ref="sec_deriv_inverse_function"/>.
 			</p>
 		</aside>
 
@@ -399,9 +399,9 @@
 			A function used for a change of variables is called a <em>transformation</em>.
 			Such functions need to be one-to-one, except possibly on the boundary of their domain,
 			and they need to be continuously differentiable.
-			(See <xref ref="def_transformation">Definition</xref> below.)
+			(See <xref ref="def_transformation"/> below.)
 			One of the important properties of a transformation, which we will justify later in this section
-			(see <xref ref="thm_boundary_transform">Theorem</xref>),
+			(see <xref ref="thm_boundary_transform"/>),
 			is that the boundary of a closed, bounded domain is mapped to the boundary of the range.
 			This observation is key to visualizing the effect of a transformation.
 		</p>
@@ -429,7 +429,7 @@
 				    While it is important to know that our function is one-to-one,
 						we will usually not ask you to check this fact.
 						However, you should make sure you're aware of what can go wrong if this property is not satisfied:
-						see the discussion following <xref ref="def_transformation">Definition</xref>.
+						see the discussion following <xref ref="def_transformation"/>.
 				  </p>
 				</aside>
 
@@ -483,7 +483,7 @@
 				</p>
 
 				<p>
-					The resulting region is plotted in <xref ref="fig_trans_map1">Figure</xref>.
+					The resulting region is plotted in <xref ref="fig_trans_map1"/>.
 					Interestingly, two of the four sides of the rectangle bounding <m>D</m> were mapped to (different portions of) the same curve.
 				</p>
 
@@ -537,7 +537,7 @@
 			One other observation is worthy of note:
 			we mentioned above that we will be primarily concerned with finding transformations that can be used to simplify a double integral.
 			Suppose we were given a double integral over <m>R=T(D)</m>,
-			as pictured in <xref ref="fig_trans_map1">Figure</xref>.
+			as pictured in <xref ref="fig_trans_map1"/>.
 			We probably wouldn't even consider a change of variables in this case,
 			unless one was needed for the function being integrated:
 			the region can be described by the inequalities
@@ -565,7 +565,7 @@
 
 		<p>
 			The transformation affects the size of the subintervals in the partition:
-			from <xref ref="sec_differentials">Section</xref>, we know that <m>\Delta x_i \approx T\primeskip' (u_i)\Delta x_i</m>.
+			from <xref ref="sec_differentials"/>, we know that <m>\Delta x_i \approx T\primeskip' (u_i)\Delta x_i</m>.
 			Thus, the derivative tells us how the size of each subinterval changes under the transformation.
 		</p>
 
@@ -629,7 +629,7 @@
 		</p>
 
 		<p>
-			If you read <xref ref="sec_deriv_matrix">Section</xref>
+			If you read <xref ref="sec_deriv_matrix"/>
 			on the definition of the derivative as a matrix of partial derivatives,
 			you probably recognize the matrix whose determinant gives us the Jacobian:
 			it's the derivative matrix! One therefore could write
@@ -672,7 +672,7 @@
 			</statement>
 			<solution>
 			  <p>
-					We apply <xref ref="def_jacobian">Definition</xref> directly:
+					We apply <xref ref="def_jacobian"/> directly:
 					<me>
 					  J_T(u,v) = \det\begin{bmatrix}x_u(u,v)\amp x_v(u,v)\\y_u(u,v)\amp y_v(u,v)\end{bmatrix} = \det\begin{bmatrix}7\amp -3\\-4\amp 2\end{bmatrix} = 7(2)-(-3)(-4)=2
 					</me>.
@@ -816,7 +816,7 @@
 		</aside>
 
 		<p>
-			When <m>D</m> is a closed, bounded subset, note that we do not require <xref ref="def_transformation">Definition</xref> to hold on the boundary.
+			When <m>D</m> is a closed, bounded subset, note that we do not require <xref ref="def_transformation"/> to hold on the boundary.
 			Each of the three conditions above must hold on the interior of <m>D</m>,
 			but are allowed to fail on all or part of the boundary.
 			In particular, this is the case for cylindrical, and spherical coordinates:
@@ -833,7 +833,7 @@
 
 					<p>
 					  Of course, we often use a domain such as <m>r\in [0,R]</m>, <m>\theta = [0,2\pi]</m> to describe a disk centred at the origin.
-						The conditions of <xref ref="def_transformation">Definition</xref> fail at <m>r=0</m>,
+						The conditions of <xref ref="def_transformation"/> fail at <m>r=0</m>,
 						and because points with <m>\theta=0</m> get mapped to the same place as points with <m>\theta = 2\pi</m>.
 						But these coordinates describe 3 of the 4 sides of the boundary rectangle for our domain,
 						and the conditions are not required to hold on the boundadry.
@@ -864,7 +864,7 @@
 		</p>
 
 		<p>
-		  We saw in <xref ref="ex_jacobian1">Example</xref> that when <m>x</m> and <m>y</m> are linear functions of <m>u</m> and <m>v</m>,
+		  We saw in <xref ref="ex_jacobian1"/> that when <m>x</m> and <m>y</m> are linear functions of <m>u</m> and <m>v</m>,
 			the Jacobian of the transformation is a constant.
 			What does that constant tell us about the transformation?
 			Here is an example taken from the book Matrix Algebra, by Greg Hartman (who is also the main author of this text).
@@ -907,7 +907,7 @@
 			  </p>
 
 				<p>
-				  The unit square and its transformation are graphed in <xref ref="fig_mv_3">Figure</xref>,
+				  The unit square and its transformation are graphed in <xref ref="fig_mv_3"/>,
 					where the shaped vertices correspond to each other across the two graphs.
 					Note how the square got turned into some sort of quadrilateral (it's actually a parallelogram).
 					A really interesting thing is how the triangular and square vertices seem to have changed places <mdash/> it is as though the square,
@@ -915,7 +915,7 @@
 				</p>
 
 				<figure xml:id="fig_mv_3">
-					<caption>Transforming the unit square by matrix multiplication in <xref ref="ex_mv_3">Example</xref></caption>
+					<caption>Transforming the unit square by matrix multiplication in <xref ref="ex_mv_3"/></caption>
 					<sidebyside widths="47% 47%" margins="0%">
 						<image xml:id="img_ex_mv_3a">
 						  <description></description>
@@ -992,7 +992,7 @@
 		</p>
 
 		<p>
-			Let us make a note of a few key points about <xref ref="ex_mv_3">Example</xref>.
+			Let us make a note of a few key points about <xref ref="ex_mv_3"/>.
 			First, note that in this case, the derivative matrix, (and as a result, the Jacobian) is constant.
 			(This of course is generally true of the derivative for linear functions.)
 		</p>
@@ -1034,7 +1034,7 @@
 		</aside>
 
 		<p>
-			Let us make a couple more remarks about the <xref ref="ex_mv_3">Example</xref>.
+			Let us make a couple more remarks about the <xref ref="ex_mv_3"/>.
 			First, note the need for an absolute value around the determinant,
 			to ensure the area computed is positive. This absolute value will be needed in our change of variables formula as well.
 		</p>
@@ -1052,7 +1052,7 @@
 				<m>\displaystyle \int_a^bf(x)\,dx = -\int_b^af(x)\,dx</m>.
 				The definite integral is sensitive to the <em>orientation</em> of the interval over which the integration is performed.
 				(Left to right or right to left.) Double and triple integrals do not have this sensitivity.
-				We'll see in <xref ref="sec_parametric_surfaces">Section</xref> how information about orientation is reintroduced in the context of vector calculus.
+				We'll see in <xref ref="sec_parametric_surfaces"/> how information about orientation is reintroduced in the context of vector calculus.
 		  </p>
 		</aside>
 
@@ -1146,9 +1146,9 @@
 		<p>
 			We computed the above <m>3\times 3</m> determinant using a cofactor expansion along the second column.
 			Except for the minus sign this is once again exactly the correction factor for the volume element in spherical coordinates,
-			as given in <xref ref="thm_triple_int_spherical">Theorem</xref> in <xref ref="sec_cylindrical_spherical">Section</xref>.
+			as given in <xref ref="thm_triple_int_spherical"/> in <xref ref="sec_cylindrical_spherical"/>.
 			In fact, we can account for the minus sign as simply an artifact of how the coordinates <m>(\rho,\theta,\varphi)</m>
-			are ordered in <xref ref="sec_cylindrical_spherical">Section</xref>.
+			are ordered in <xref ref="sec_cylindrical_spherical"/>.
 			Had we chosen the order <m>(\rho,\varphi,\theta)</m>,
 			the second and third columns in the determinant above would be switched,
 			and the minus sign disappears.
@@ -1216,7 +1216,7 @@
 
 						<li>
 						  <p>
-						    Use the transformation <m>T</m> and <xref ref="thm_change_of_variables">Theorem</xref>
+						    Use the transformation <m>T</m> and <xref ref="thm_change_of_variables"/>
 								to determine the area of <m>R</m>.
 						  </p>
 						</li>
@@ -1228,7 +1228,7 @@
 			    <ol>
 			      <li>
 			        <p>
-			          For inspiration, we look to <xref ref="ex_mv_3">Example</xref>.
+			          For inspiration, we look to <xref ref="ex_mv_3"/>.
 								Notice how the transformation defined by the matrix
 								<m>A=\begin{bmatrix}1\amp 4\\2\amp 3\end{bmatrix}</m> preserves the origin,
 								and sends the points <m>(1,0)</m> and <m>(0,1)</m> to <m>(1,2)</m> and <m>(4,3)</m>, respectively.
@@ -1263,7 +1263,7 @@
 
 						<li>
 						  <p>
-								To use <xref ref="thm_change_of_variables">Theorem</xref>,
+								To use <xref ref="thm_change_of_variables"/>,
 								we need to compute the Jacobian of our transformation. We have
 								<me>
 								  J_T(u,v) = \det\begin{bmatrix}3\amp1\\1\amp4\end{bmatrix} = 11
@@ -1304,11 +1304,11 @@
 			</statement>
 			<solution>
 			  <p>
-			    The region of integration is shown in <xref ref="fig_trans_int_reg0">Figure</xref>.
+			    The region of integration is shown in <xref ref="fig_trans_int_reg0"/>.
 				</p>
 
 				<figure xml:id="fig_trans_int_reg0">
-					<caption>The region of integration <m>R</m> in <xref ref="ex_int_trans0">Example</xref></caption>
+					<caption>The region of integration <m>R</m> in <xref ref="ex_int_trans0"/></caption>
 					<image xml:id="img_trans_int_reg0" width="47%">
 					  <description></description>
 						<latex-image>
@@ -1348,7 +1348,7 @@
 				</p>
 
 				<p>
-					Now, we apply <xref ref="thm_change_of_variables">Theorem</xref>. Recall the formula:
+					Now, we apply <xref ref="thm_change_of_variables"/>. Recall the formula:
 					<me>
 					  \iint_D f(T(u,v))\lvert J_T(u,v)\rvert\,du\,dv = \iint_{T(D)} f(x,y)\,dx\,dy
 					</me>.
@@ -1423,7 +1423,7 @@
 					The region <m>R</m> is therefore the image under the transformation
 					<m>T(u,v)=(u/v,v)</m> of the region <m>D</m> bounded by the curves
 					<m>u=v^2</m> and <m>u=\frac14 v^2</m>, and the lines <m>u=1, u=4</m>;
-					see <xref ref="fig_int_trans00b">Figure</xref>.
+					see <xref ref="fig_int_trans00b"/>.
 				</p>
 
 				<aside>
@@ -1492,8 +1492,8 @@
 
 				<p>
 					This is perhaps not the best possible change of variables: the domain <m>D</m> is not a rectangle.
-					(See <xref ref="ex_int_trans2">Example</xref> below for a change of variables that is more effective for this type of region.)
-					However, it is a region of the type we considered in <xref ref="sec_double_int_volume">Section</xref>,
+					(See <xref ref="ex_int_trans2"/> below for a change of variables that is more effective for this type of region.)
+					However, it is a region of the type we considered in <xref ref="sec_double_int_volume"/>,
 					so we're better off than we were with the original region.
 					We have <m>1\leq u\leq 4</m>, and the equations <m>u=v^2</m>,
 					<m>u=\frac14 v^2</m> can be re-written (noting that <m>v>0</m>) as <m>v=\sqrt{u}</m> and <m>v=2\sqrt{u}</m>.
@@ -1524,9 +1524,9 @@
 		</p>
 
 		<p>
-			Recall from <xref ref="def_transformation">Definition</xref>
+			Recall from <xref ref="def_transformation"/>
 			that we require transformations to be one-to-one and onto
-			(see <xref ref="def_one_to_one_onto">Definition</xref>),
+			(see <xref ref="def_one_to_one_onto"/>),
 			except possibly on the boundary of their domain.
 		</p>
 
@@ -1590,7 +1590,7 @@
 
 		<aside>
 		  <p>
-				Recall that in <xref ref="sec_deriv_matrix">Section</xref>
+				Recall that in <xref ref="sec_deriv_matrix"/>
 				we gave the following alternative definition of differentiability:
 				<m>f:D\subset \mathbb{R}^n\to\mathbb{R}^m</m> is <em>differentiable</em> if the limit of
 				<me>
@@ -1607,7 +1607,7 @@
 			If a function <m>T:D\subset\mathbb{R}^n\to E\subset \mathbb{R}^n</m> is <m>C^1</m>,
 			then as with real-valued functions,
 			being continuously differentiable implies that <m>T</m> is differentiable
-			(in the sense of the definition from <xref ref="sec_deriv_matrix">Section</xref>),
+			(in the sense of the definition from <xref ref="sec_deriv_matrix"/>),
 			and therefore continuous.
 			The derivative of <m>T</m> is then an <m>n\times n</m> matrix.
 			For example, when <m>n=2</m>, if <m>T(u,v) = (x(u,v), y(u,v))</m>, we get
@@ -1627,10 +1627,10 @@
 		<p>
 			Given our function <m>T:D\subset \mathbb{R}^n\to E\subset \mathbb{R}^n</m>,
 			let us denote by <m>DT</m> the matrix of partial derivatives,
-			as in <xref ref="sec_deriv_matrix">Section</xref>.
+			as in <xref ref="sec_deriv_matrix"/>.
 			Since the dimension of the domain and range are the same,
 			<m>DT</m> is a square (<m>n\times n</m>) matrix, so we can compute its determinant,
-			and this, of course, is the Jacobian, as defined in <xref ref="def_jacobian">Definition</xref>.
+			and this, of course, is the Jacobian, as defined in <xref ref="def_jacobian"/>.
 		</p>
 
 		<p>
@@ -1671,7 +1671,7 @@
 		  <p>
 		    The <m>-1</m> on the right-hand side of Equation <xref ref="eqn_gen_inverse"/> denotes a matrix inverse.
 				A basic result from linear algebra tells us that a matrix is invertible if and only if its determinant is non-zero,
-				which is one reason why we require a nonzero Jacobian in <xref ref="def_transformation">Definition</xref>.
+				which is one reason why we require a nonzero Jacobian in <xref ref="def_transformation"/>.
 				(Compare this to the result <m>(f^{-1})'(x) = \dfrac{1}{f'(f^{-1}(x))}</m> in one variable.)
 		  </p>
 		</aside>
@@ -1750,7 +1750,7 @@
 
 		<aside>
 		  <p>
-		    A result such as <xref ref="thm_open_transform">Theorem</xref>
+		    A result such as <xref ref="thm_open_transform"/>
 				that is used as a step towards proving a more substantial result is often referred to as a <em>lemma</em>.
 		  </p>
 		</aside>
@@ -1793,7 +1793,7 @@
 		</p>
 
 		<proof>
-			<title>Proof of <xref ref="thm_boundary_transform">Theorem</xref></title>
+			<title>Proof of <xref ref="thm_boundary_transform"/></title>
 
 			<p>
 				Let <m>T:D\to E</m> be the given transformation,
@@ -1818,7 +1818,7 @@
 			</p>
 
 			<p>
-				However, since <m>T</m> satisfies the conditions of <xref ref="thm_open_transform">Theorem</xref>,
+				However, since <m>T</m> satisfies the conditions of <xref ref="thm_open_transform"/>,
 				we know that <m>T</m> must map open sets to open sets.
 				In particular, since <m>N_\delta(\mathbf{u})</m> is an open subset of <m>D</m>,
 				<m>T(N_\delta(\mathbf{u}))</m> must be an open subset of <m>E</m>.
@@ -1849,7 +1849,7 @@
 			</statement>
 			<solution>
 			  <p>
-					The region <m>E</m> is pictured in <xref ref="fig_int_trans1">Figure</xref> below.
+					The region <m>E</m> is pictured in <xref ref="fig_int_trans1"/> below.
 					We need to find a region <m>D\subset \mathbb{R}^2</m> and a transformation <m>T:D\to \mathbb{R}^2</m> whose image is <m>E</m>.
 					We use the fact that <m>T</m> must map the boundary of <m>D</m> to the boundary of <m>E</m> as a guideline.
 					In particular, note that since <m>T</m> is <m>C^1</m>, it must map smooth curves to smooth curves by the chain rule.
@@ -1859,7 +1859,7 @@
 				</p>
 
 				<figure xml:id="fig_int_trans1">
-					<caption>The region of integration for <xref ref="ex_int_trans1">Example</xref></caption>
+					<caption>The region of integration for <xref ref="ex_int_trans1"/></caption>
 					<image xml:id="img_int_trans1" width="47%">
 					  <description></description>
 						<latex-image>
@@ -1973,7 +1973,7 @@
 			<solution>
 			  <p>
 					We need to find a region <m>D\subset \mathbb{R}^2</m> and a transformation <m>T:D\to \mathbb{R}^2</m> whose image is <m>E</m>.
-					This problem is almost identical to the one we solved in <xref ref="ex_int_trans00">Example</xref>,
+					This problem is almost identical to the one we solved in <xref ref="ex_int_trans00"/>,
 					where we were given a change of variables whose domain was still somewhat complicated.
 					This time, we look for a transformation with a rectangular domain.
 				</p>
@@ -1986,7 +1986,7 @@
 				</p>
 
 				<figure xml:id="fig_int_trans2">
-					<caption>The region of integration in <xref ref="ex_int_trans2">Example</xref></caption>
+					<caption>The region of integration in <xref ref="ex_int_trans2"/></caption>
 					<image xml:id="img_int_trans2" width="47%">
 					  <description></description>
 						<latex-image>
@@ -2041,7 +2041,7 @@
 		</example>
 
 		<figure xml:id="vid-multint-transformations-example" component="video">
-		  <caption>A video presentation of <xref ref="ex_int_trans2">Example</xref>, with slightly different numbers</caption>
+		  <caption>A video presentation of <xref ref="ex_int_trans2"/>, with slightly different numbers</caption>
 		  <video youtube="hSDH3FnD97w" label="vid-multint-transformations-example"/>
 		</figure>
 	</subsection>
@@ -2119,7 +2119,7 @@
 			with grid lines given by <m>u=\text{constant}</m> or <m>v=\text{constant}</m>
 			is transformed into a <q>grid of curves</q> in the <m>x,y</m> plane.
 			This is the case, for example, with the polar coordinate transformation,
-			as seen in <xref ref="fig_polar_trans3">Figure</xref> below.
+			as seen in <xref ref="fig_polar_trans3"/> below.
 		</p>
 
 		<figure xml:id="fig_polar_trans3">
@@ -2198,7 +2198,7 @@
 		<p>
 			A grid in the <m>u,v</m> plane is transformed to two families of curves:
 			lines <m>u=m</m>, <m>v=n</m>, where <m>m,n</m> are constants become the curves <m>y=\frac{m}{x}</m> and <m>y=nx^2</m>, respectively.
-			The transformation is pictured in <xref ref="fig_gen_trans_eg">Figure</xref> below.
+			The transformation is pictured in <xref ref="fig_gen_trans_eg"/> below.
 		</p>
 
 		<figure xml:id="fig_gen_trans_eg">
@@ -2289,14 +2289,14 @@
 		</figure>
 
 		<p>
-			In <xref ref="fig_gen_trans_eg">Figure</xref> we've highlighted one of the rectangles in our grid to see how it's transformed.
+			In <xref ref="fig_gen_trans_eg"/> we've highlighted one of the rectangles in our grid to see how it's transformed.
 			Imagine now that our grid lines are much finer, coming not from the integer values of <m>u</m> and <m>v</m>,
 			but from a partition of a rectangle <m>D</m> in the <m>u,v</m> plane.
 			Zooming in, we'd see that each rectangle in the partition is transformed much like the one above.
 		</p>
 
 		<p>
-			Indeed, recall the following philosophy from <xref ref="sec_deriv_matrix">Section</xref>:
+			Indeed, recall the following philosophy from <xref ref="sec_deriv_matrix"/>:
 			the transformation <m>T</m> maps points in the <m>u,v</m> plane to points in the <m>x,y</m> plane.
 			The derivative matrix <m>DT(u,v)</m> of <m>T</m> at a point <m>(u,v)</m>,
 			when viewed as the matrix of a linear transformation, maps (tangent) vectors at the point <m>(u,v)</m> to (tangent) vectors at the point <m>(x,y)=T(u,v)</m>.
@@ -2338,7 +2338,7 @@
 
 		<p>
 			Now, let's consider the corresponding region in the <m>x,y</m> plane.
-			The curves in <xref ref="fig_gen_trans_eg">Figure</xref> above can also be realized as parametric curves.
+			The curves in <xref ref="fig_gen_trans_eg"/> above can also be realized as parametric curves.
 			In fact, they are precisely the composition of the curves above with our transformation,
 			if we view <m>T</m> as a vector-valued function. We have curves
 			<md>
@@ -2353,7 +2353,7 @@
 			not lines, and the image of our rectangle is no longer rectangular.
 			But for <m>\Delta u,\Delta v</m> small enough, our curves are <em>approximately</em> linear,
 			and the image of our rectangle is <em>approximately</em> a parallelogram.
-			See <xref ref="fig_pargrm_approx">Figure</xref>.
+			See <xref ref="fig_pargrm_approx"/>.
 		</p>
 
 		<p>
@@ -2445,7 +2445,7 @@
 			</me>.
 			This equation should be viewed somewhat skeptically.
 			The area element on the left is that of a rectangle, not the parallelogram we ended up with above.
-			The argument given here is far from a complete proof of <xref ref="thm_change_of_variables">Theorem</xref>,
+			The argument given here is far from a complete proof of <xref ref="thm_change_of_variables"/>,
 			but the result is true nonetheless. The interested reader is directed to search online,
 			or seek out the advanced calculus section of their library, should they wish to see a proof.
 		</p>

--- a/ptx/sec_trig_sub.ptx
+++ b/ptx/sec_trig_sub.ptx
@@ -36,7 +36,7 @@
   </figure>
 
   <p>
-    We start by demonstrating this method in evaluating the integral in <xref ref="eq_trigsub1"/>.
+    We start by demonstrating this method in evaluating the integral in <xref ref="eq_trigsub1">Equation</xref>.
     After the example,
     we will generalize the method and give more examples.
   </p>
@@ -106,7 +106,7 @@
         <li xml:id="idea_trigsuba">
           <title>Integrands containing <m>\sqrt{a^2-x^2}</m></title>
 
-          <sidebyside widths="57% 37%" margins="0%">
+          <sidebyside widths="55% 40%" margins="0%">
             <p>
               <idx><h>integration</h><h>trig. subst.</h></idx>
 
@@ -151,7 +151,7 @@
         <li xml:id="idea_trigsubb">
           <title>Integrands containing <m>\sqrt{x^2+a^2}</m></title>
 
-          <sidebyside widths="57% 37%" margins="0%">
+          <sidebyside widths="55% 40%" margins="0%">
             <p>
               Let <m>x=a\tan(\theta)</m>, <m>dx = a\sec^2(\theta) \, d\theta</m>.
               Thus <m>\theta = \tan^{-1}(x/a)</m>,
@@ -163,7 +163,7 @@
             <figure xml:id="fig_trigsub_intro3">
               <caption/>
               <!-- START figures/fig_trigsub_intro3.tex -->
-              <image xml:id="img_trigsub_intro3" width="47%">
+              <image xml:id="img_trigsub_intro3">
                 <shortdescription>
                   Diagram showing trigonometric substitution with integrands containing square root of x^2+a^2.
                 </shortdescription>
@@ -194,7 +194,7 @@
         <li xml:id="idea_trigsubc">
           <title>Integrands containing <m>\sqrt{x^2-a^2}</m></title>
 
-          <sidebyside widths="50% 44%" margins="0%">
+          <sidebyside widths="55% 40%" margins="0%">
             <p>
               Let <m>x=a\sec(\theta)</m>,
               <m>dx = a\sec(\theta) \tan(\theta) \, d\theta</m>.
@@ -210,7 +210,7 @@
             <figure xml:id="fig_trigsub_intro2">
               <caption/>
               <!-- START figures/fig_trigsub_intro2.tex -->
-              <image xml:id="img_trigsub_intro2" width="47%">
+              <image xml:id="img_trigsub_intro2">
                 <shortdescription>
                   Diagram showing trigonometric substitution with integrands containing square root of x^2-a^2.
                 </shortdescription>
@@ -225,7 +225,7 @@
 
                   \begin{tikzpicture}
 
-                  \draw [very thick] (0,0) -- node [below,pos=.5] { $a$} (3,0) -- node [right,pos=.5] { $\sqrt{x^2-a^2}$} (3,2) -- node [pos=.5,above] { $x$} (0,0);
+                  \draw [very thick] (0,0) -- node [below,pos=.5] { $a$} (3,0) -- node [right,xshift=3mm,pos=.9,rotate=-90] { $\sqrt{x^2-a^2}$} (3,2) -- node [pos=.5,above] { $x$} (0,0);
                   \draw [thick] (2.7,0) -- (2.7,.3) -- (3,.3);
                   \draw (.75,.25) node {$\theta$};
 
@@ -551,7 +551,7 @@
 
       <p>
         Finally, we return to <m>x</m> with the substitution <m>u=x+3</m>.
-        We start with the expression in Equation <xref ref="eq_extrigsub7"/>:
+        We start with the expression in <xref ref="eq_extrigsub7">Equation</xref>:
         <md>
           <mrow>\frac12\theta + \frac14\sin(2\theta) + C \amp = \frac12\tan^{-1}(u) + \frac12\frac{u}{u^2+1}+C</mrow>
           <mrow>\amp = \frac12\tan^{-1}(x+3) + \frac{x+3}{2(x^2+6x+10)}+C</mrow>

--- a/ptx/sec_trig_sub.ptx
+++ b/ptx/sec_trig_sub.ptx
@@ -2,7 +2,7 @@
 <section xml:id="sec_trig_sub">
   <title>Trigonometric Substitution</title>
   <p>
-    In <xref ref="sec_def_int">Section</xref>
+    In <xref ref="sec_def_int"/>
     we defined the definite integral as the
     <q>signed area under the curve.</q>
     In that section we had not yet learned the Fundamental Theorem of Calculus,
@@ -21,9 +21,9 @@
     yet we are still unable to evaluate the above integral without resorting to a geometric interpretation.
     This section introduces Trigonometric Substitution,
     a method of integration that fills this gap in our integration skill.
-    This technique works on the same principle as Substitution as found in <xref ref="sec_substitution">Section</xref>,
+    This technique works on the same principle as Substitution as found in <xref ref="sec_substitution"/>,
     though it can feel <q>backward.</q>
-    In <xref ref="sec_substitution">Section</xref>, we set <m>u=f(x)</m>,
+    In <xref ref="sec_substitution"/>, we set <m>u=f(x)</m>,
     for some function <m>f</m>, and replaced <m>f(x)</m> with <m>u</m>.
     In this section, we will set <m>x=f(\theta)</m>,
     where <m>f</m> is a trigonometric function,
@@ -106,7 +106,7 @@
         <li xml:id="idea_trigsuba">
           <title>Integrands containing <m>\sqrt{a^2-x^2}</m></title>
 
-          <sidebyside widths="47% 47%" margins="0%">
+          <sidebyside widths="57% 37%" margins="0%">
             <p>
               <idx><h>integration</h><h>trig. subst.</h></idx>
 
@@ -151,7 +151,7 @@
         <li xml:id="idea_trigsubb">
           <title>Integrands containing <m>\sqrt{x^2+a^2}</m></title>
 
-          <sidebyside widths="47% 47%" margins="0%">
+          <sidebyside widths="57% 37%" margins="0%">
             <p>
               Let <m>x=a\tan(\theta)</m>, <m>dx = a\sec^2(\theta) \, d\theta</m>.
               Thus <m>\theta = \tan^{-1}(x/a)</m>,
@@ -194,7 +194,7 @@
         <li xml:id="idea_trigsubc">
           <title>Integrands containing <m>\sqrt{x^2-a^2}</m></title>
 
-          <sidebyside widths="47% 47%" margins="0%">
+          <sidebyside widths="50% 44%" margins="0%">
             <p>
               Let <m>x=a\sec(\theta)</m>,
               <m>dx = a\sec(\theta) \tan(\theta) \, d\theta</m>.
@@ -242,9 +242,9 @@
   </insight>
 
   <!--<p>
-    We will now apply <xref ref="idea_trigsubc">Key Idea</xref>
-    to a type of problem that we were able to solve using algebra and substitution in <xref ref="sec_substitution">Section</xref>.
-    <xref ref="ex_trigsub1b">Example</xref>
+    We will now apply <xref ref="idea_trigsubc"/>
+    to a type of problem that we were able to solve using algebra and substitution in <xref ref="sec_substitution"/>.
+    <xref ref="ex_trigsub1b"/>
     shows an alternate way to approach these problems.
   </p>
 
@@ -257,9 +257,9 @@
     </statement>
     <solution>
       <p>
-        Using <xref ref="idea_trigsubc">Item</xref>
-        from <xref ref="idea_trigsub">Key Idea</xref>,
-        we recognize <m>a=2</m> and set
+        Using <xref ref="idea_trigsubc"/>
+        from <xref ref="idea_trigsub"/>,
+        we recognize <m>a=2</m> and sethttps://opentext.uleth.ca/apex-standard/sec_antider.html
         <m>x= 2\sec(\theta)</m> for <m>0 \leq \theta \lt \pi/2</m>.
         This makes <m>dx = 2\sec(\theta)\tan(\theta) \, d\theta</m>.
         We will use the Pythagorean identity
@@ -291,7 +291,7 @@
     </solution>
     <solution>
       <p>
-        Using <xref ref="idea_trigsubb">Item</xref><xref ref="idea_trigsub">Key Idea</xref>,
+        Using <xref ref="idea_trigsubb" text="local">Item</xref> in <xref ref="idea_trigsub"/>,
         we recognize <m>a=\sqrt{5}</m> and set <m>x= \sqrt{5}\tan(\theta)</m>.
         This makes <m>dx = \sqrt{5}\sec^2(\theta) \, d\theta</m>.
         We will use the fact that <m>\sqrt{5+x^2} = \sqrt{5+5\tan^2(\theta) } = \sqrt{5\sec^2(\theta) } = \sqrt{5}\sec(\theta)</m>.
@@ -312,7 +312,7 @@
       </p>
 
       <p>
-        The reference triangle given in <xref ref="idea_trigsub">Key Idea</xref>(b) helps.
+        The reference triangle given in <xref ref="fig_trigsub_intro3"/> helps.
         With <m>x=\sqrt{5}\tan(\theta)</m>, we have
         <me>
           \tan(\theta) = \frac x{\sqrt{5}} \text{ and }  \sec(\theta) = \frac{\sqrt{x^2+5}}{\sqrt{5}}
@@ -337,7 +337,7 @@
           <mrow>\amp =	\ln\abs{\sqrt{x^2+5}+ x}+C</mrow>
         </md>,
         where the <m>\ln\big(1/\sqrt{5}\big)</m> term is absorbed into the constant <m>C</m>.
-        (In <xref ref="sec_hyperbolic">Section</xref>
+        (In <xref ref="sec_hyperbolic"/>
         we will learn another way of approaching this problem.)
       </p>
     </solution>
@@ -366,7 +366,7 @@
 
       <p>
         So we have <m>a=1/2</m>,
-        and following <xref ref="idea_trigsub">Key Idea</xref>(c),
+        and following <xref ref="idea_trigsubc" text="local">Part</xref> of <xref ref="idea_trigsub"/>,
         we set <m>x= \frac12\sec(\theta)</m>,
         and hence <m>dx = \frac12\sec(\theta) \tan(\theta) \, d\theta</m>.
         We now rewrite the integral with these substitutions:
@@ -382,7 +382,7 @@
       </p>
 
       <p>
-        We integrated <m>\sec^3(\theta)</m> in <xref ref="ex_trigint6">Example</xref>,
+        We integrated <m>\sec^3(\theta)</m> in <xref ref="ex_trigint6"/>,
         finding its antiderivatives to be
         <me>
           \int \sec^3(\theta) \, d\theta = \frac12\Big(\sec(\theta) \tan(\theta) + \ln\abs{\sec(\theta) +\tan(\theta) }\Big)+C
@@ -405,7 +405,7 @@
         is in terms of <m>\theta</m>.
         We need to rewrite our answer in terms of <m>x</m>.
         With <m>a=1/2</m>, and <m>x=\frac12\sec(\theta)</m>,
-        the reference triangle in <xref ref="idea_trigsub">Key Idea</xref>(c) shows that
+        the reference triangle in <xref ref="fig_trigsub_intro2"/> shows that
         <me>
           \tan(\theta) = \sqrt{x^2-1/4}\Big/(1/2) = 2\sqrt{x^2-1/4} \text{ and }  \sec(\theta) = 2x
         </me>.
@@ -442,7 +442,7 @@
     </solution>
     <solution>
       <p>
-        We use <xref ref="idea_trigsub">Key Idea</xref>(a) with <m>a=2</m>,
+        We use <xref ref="idea_trigsuba" text="local">Part</xref> of <xref ref="idea_trigsub"/> with <m>a=2</m>,
         <m>x=2\sin(\theta)</m>,
         <m>dx = 2\cos(\theta)</m> and hence <m>\sqrt{4-x^2} = 2\cos(\theta)</m>.
         This gives
@@ -456,7 +456,7 @@
 
       <p>
         We need to rewrite our answer in terms of <m>x</m>.
-        Using the reference triangle found in <xref ref="idea_trigsub">Key Idea</xref>(a),
+        Using the reference triangle found in <xref ref="fig_trigsub_intro1"/>,
         we have <m>\cot(\theta) = \sqrt{4-x^2}/x</m> and <m>\theta = \sin^{-1}(x/2)</m>.
         Thus
         <me>
@@ -488,7 +488,7 @@
       </p>
 
       <p>
-        Using <xref ref="idea_trigsub">Key Idea</xref>(b),
+        Using <xref ref="idea_trigsubb" text="local">Part</xref> of <xref ref="idea_trigsub"/>,
         let <m>x=\tan(\theta)</m>,
         <m>dx=\sec^2(\theta) \, d\theta</m> and note that <m>x^2+1 = \tan^2(\theta) +1 = \sec^2(\theta)</m>.
         Thus
@@ -542,7 +542,8 @@
       <p>
         We need to return to the variable <m>x</m>.
         As <m>u=\tan(\theta)</m>, <m>\theta = \tan^{-1}(u)</m>.
-        Using the identity <m>\sin(2\theta) = 2\sin(\theta) \cos(\theta)</m> and using the reference triangle found in <xref ref="idea_trigsub">Key Idea</xref>(b), we have
+        Using the identity <m>\sin(2\theta) = 2\sin(\theta) \cos(\theta)</m> and using the reference triangle found in
+        <xref ref="fig_trigsub_intro3"/>, we have
         <me>
           \frac14\sin(2\theta) = \frac12\frac u{\sqrt{u^2+1}}\cdot\frac 1{\sqrt{u^2+1}} = \frac12\frac u{u^2+1}
         </me>.
@@ -591,7 +592,7 @@
     </solution>
     <solution>
       <p>
-        Using <xref ref="idea_trigsub">Key Idea</xref>(b),
+        Using <xref ref="idea_trigsubb" text="local">Part</xref> of <xref ref="idea_trigsub"/>,
         we set <m>x=5\tan(\theta)</m>,
         <m>dx = 5\sec^2(\theta) \, d\theta</m>,
         and note that <m>\sqrt{x^2+25} = 5\sec(\theta)</m>.
@@ -616,7 +617,7 @@
       </p>
 
       <p>
-        We encountered this indefinite integral in <xref ref="ex_trigsub2">Example</xref> where we found
+        We encountered this indefinite integral in <xref ref="ex_trigsub2"/> where we found
         <me>
           \int \tan^2(\theta) \sec(\theta) \, d\theta = \frac12\big(\sec(\theta) \tan(\theta) -\ln\abs{\sec(\theta) +\tan(\theta) }\big)
         </me>.
@@ -762,7 +763,8 @@
         <webwork xml:id="webwork-TaC-trig-substitution-4">
           <statement>
             <p>
-              Why does <xref ref="idea_trigsub">Key Idea</xref>(a) state that <m>\sqrt{a^2-x^2} = a\cos(\theta)</m>,
+              Why does <xref ref="idea_trigsuba" text="local">Part</xref> of <xref ref="idea_trigsub"/>
+              state that <m>\sqrt{a^2-x^2} = a\cos(\theta)</m>,
               and not <m>\abs{a\cos(\theta) }</m>?
             </p>
             <p>

--- a/ptx/sec_trigint.ptx
+++ b/ptx/sec_trigint.ptx
@@ -12,7 +12,7 @@
     <title>Integrals of the form <m>\int \sin^m(x) \cos^n(x) \, dx</m></title>
     <p>
       In learning the technique of Substitution,
-      we saw the integral <m>\int \sin(x) \cos(x) \, dx</m> in <xref ref="ex_sub10">Example</xref>.
+      we saw the integral <m>\int \sin(x) \cos(x) \, dx</m> in <xref ref="ex_sub10"/>.
       The integration was not difficult,
       and one could easily evaluate the indefinite integral by letting
       <m>u=\sin(x)</m> or by letting <m>u = \cos(x)</m>.
@@ -43,7 +43,7 @@
       <solution>
         <p>
           We have used substitution on problems similar to this problem in
-          <xref ref="sec_substitution">Section</xref> .
+          <xref ref="sec_substitution"/> .
           If we let <m>u=\sin(x)</m>,
           then <m>du=\cos(x)\,dx</m>, and
           <me>
@@ -149,7 +149,7 @@
     </insight>
 
     <p>
-      We practice applying <xref ref="idea_trig_int_1">Key Idea</xref> in the next examples.
+      We practice applying <xref ref="idea_trig_int_1"/> in the next examples.
     </p>
 
     <example xml:id="ex_trigint1">
@@ -206,7 +206,7 @@
         <p>
           The powers of both the sine and cosine terms are odd,
           therefore we can apply the techniques of
-          <xref ref="idea_trig_int_1">Key Idea</xref> to either power.
+          <xref ref="idea_trig_int_1"/> to either power.
           We choose to work with the power of the cosine term since the previous example used the sine term's power.
         </p>
 
@@ -258,14 +258,14 @@
         x)}{24576}-\frac{\cos(14 x)}{114688}
       </me>,
       which clearly has a different form than our answer in
-      <xref ref="ex_trigint2">Example</xref>, which is
+      <xref ref="ex_trigint2"/>, which is
       <me>
         g(x)=\frac16\sin^6(x) -\frac12\sin^8(x) +\frac35\sin^{10}(x) -\frac13\sin^{12}(x) +\frac{1}{14}\sin^{14}(x)
       </me>.
     </p>
 
     <p>
-      <xref ref="fig_trigint2">Figure</xref>
+      <xref ref="fig_trigint2"/>
       shows a graph of <m>f</m> and <m>g</m>;
       they are clearly not equal, but they differ
       <em>only by a constant</em>.
@@ -275,7 +275,7 @@
     </p>
 
     <figure xml:id="fig_trigint2">
-      <caption>A plot of <m>f(x)</m> and <m>g(x)</m> from <xref ref="ex_trigint2">Example</xref> and the Technology Note</caption>
+      <caption>A plot of <m>f(x)</m> and <m>g(x)</m> from <xref ref="ex_trigint2"/> and the Technology Note</caption>
       <!-- START figures/fig_trigint2.tex -->
       <image xml:id="img_trigint2" width="47%">
         <shortdescription>
@@ -354,7 +354,7 @@
         <p>
           The first integral labeled <m>a</m> is easy to integrate.
           The <m>\cos(2x)</m> term is also easy to integrate,
-          especially with <xref ref="idea_linearsub">Key Idea</xref>.
+          especially with <xref ref="idea_linearsub"/>.
           The <m>\cos^2(2x)</m> term is another trigonometric integral with an even power,
           requiring the power-reducing formula again.
           The <m>\cos^3(2x)</m> term is a cosine function with an odd power,
@@ -565,12 +565,12 @@
     </insight>
 
     <p>
-      The techniques described in <xref ref="idea_trig_int_2a"> Item</xref>
-      and <xref ref="idea_trig_int_2b"> Item</xref>
-      of <xref ref="idea_trig_int_2">Key Idea</xref>
+      The techniques described in <xref ref="idea_trig_int_2a" text="local"> Item</xref>
+      and <xref ref="idea_trig_int_2b" text="local"> Item</xref>
+      of <xref ref="idea_trig_int_2"/>
       are relatively straightforward,
-      but the techniques in <xref ref="idea_trig_int_2c"> Item</xref>
-      and <xref ref="idea_trig_int_2d"> Item</xref> can be rather tedious.
+      but the techniques in <xref ref="idea_trig_int_2c" text="local"> Item</xref>
+      and <xref ref="idea_trig_int_2d" text="local"> Item</xref> can be rather tedious.
       A few examples will help with these methods.
     </p>
 
@@ -588,7 +588,7 @@
       <solution>
         <p>
           Since the power of secant is even,
-          we use <xref ref="idea_trig_int_2a"> Rule</xref>from <xref ref="idea_trig_int_2">Key Idea</xref>
+          we use <xref ref="idea_trig_int_2a" text="local"> Rule</xref>from <xref ref="idea_trig_int_2"/>
           and pull out a <m>\sec^2(x)</m> in the integrand.
           We convert the remaining powers of secant into powers of tangent.
           <md>
@@ -627,8 +627,8 @@
       </solution>
       <solution>
         <p>
-          We apply <xref ref="idea_trig_int_2c"> Rule</xref>
-          from <xref ref="idea_trig_int_2">Key Idea</xref>
+          We apply <xref ref="idea_trig_int_2c" text="local"> Rule</xref>
+          from <xref ref="idea_trig_int_2"/>
           as the power of secant is odd and the power of tangent is even (<m>0</m> is an even number).
           We use Integration by Parts;
           the rule suggests letting <m>dv = \sec^2(x) \, dx</m>,
@@ -664,7 +664,8 @@
           <md>
             <mrow>\int \sec^3(x) \, dx  	\amp =	\int \underbrace{\sec(x) }_u\cdot\underbrace{\sec^2(x) \, dx}_{dv}</mrow>
             <mrow>\amp =	\sec(x) \tan(x) - \int \sec(x) \tan^2(x) \, dx.</mrow>
-            <intertext>This new integral also requires applying <xref ref="idea_trig_int_2c"> Rule</xref> of <xref ref="idea_trig_int_2">Key Idea</xref>:</intertext>
+            <intertext>This new integral also requires applying <xref ref="idea_trig_int_2c" text="local"> Rule</xref>
+              of <xref ref="idea_trig_int_2"/>:</intertext>
             <mrow>\int \sec^3(x)\, dx\amp = \sec(x) \tan(x) - \int \sec(x) \big(\sec^2(x) -1\big)\, dx</mrow>
             <mrow>\amp =	\sec(x) \tan(x) - \int \sec^3(x) \, dx + \int \sec(x) \, dx</mrow>
             <mrow>\amp = \sec(x) \tan(x) -\int \sec^3(x) \, dx + \ln\abs{\sec(x) +\tan(x) }</mrow>
@@ -710,17 +711,19 @@
       </solution>
       <solution>
         <p>
-          We employ <xref ref="idea_trig_int_2c"> Rule</xref> of
-          <xref ref="idea_trig_int_2">Key Idea</xref>.
+          We employ <xref ref="idea_trig_int_2c" text="local"> Rule</xref> of
+          <xref ref="idea_trig_int_2"/>.
           <md>
             <mrow>\int \tan^6(x) \, dx \amp = \int \tan^4(x) \tan^2(x) \, dx</mrow>
             <mrow>\amp = \int\tan^4(x) \big(\sec^2(x) -1\big)\, dx</mrow>
             <mrow>\amp = \int\tan^4(x) \sec^2(x) \, dx - \int\tan^4(x) \, dx</mrow>
-            <intertext>Integrate the first integral with substitution, <m>u=\tan(x)</m>; integrate the second by employing rule <xref ref="idea_trig_int_2d"> Rule</xref> again.</intertext>
+            <intertext>Integrate the first integral with substitution, <m>u=\tan(x)</m>; integrate the second by employing rule
+              <xref ref="idea_trig_int_2d" text="local"> Rule</xref> again.</intertext>
             <mrow>\amp =	\frac15\tan^5(x) -\int\tan^2(x) \tan^2(x) \, dx</mrow>
             <mrow>\amp =	\frac15\tan^5(x) -\int\tan^2(x) \big(\sec^2(x) -1\big)\, dx</mrow>
             <mrow>\amp = \frac15\tan^5(x) -\underbrace{\int\tan^2(x) \sec^2(x) \, dx}_{a} + \underbrace{\int\tan^2(x) \, dx}_b</mrow>
-            <intertext>Again, use substitution (<m>u=\tan(x)</m>) for the first integral (a) and <xref ref="idea_trig_int_2d"> Rule</xref> for the second (b).</intertext>
+            <intertext>Again, use substitution (<m>u=\tan(x)</m>) for the first integral (a) and 
+              <xref ref="idea_trig_int_2d" text="local"> Rule</xref> for the second (b).</intertext>
             <mrow>\amp = \frac15\tan^5(x) -\frac13\tan^3(x) +\int\big(\sec^2(x) -1\big)\, dx</mrow>
             <mrow>\int \tan^6(x)\, dx\amp =	 \frac15\tan^5(x) -\frac13\tan^3(x) +\tan(x) - x+C</mrow>
           </md>.
@@ -737,7 +740,7 @@
     </p>
 
     <p>
-      <xref ref="sec_trig_sub">Section</xref>
+      <xref ref="sec_trig_sub"/>
       introduces an integration technique known as Trigonometric Substitution,
       a clever combination of Substitution and the Pythagorean Theorem.
     </p>
@@ -824,7 +827,7 @@
         </introduction>
         <!-- Exercise 5 -->
         <!-- Not randomized since it is resused in the next block -->
-        <exercise label="ex-indefinite-trig-integral-1">
+        <exercise xml:id="ex-indefinite-trig-integral-1" label="ex-indefinite-trig-integral-1">
           <webwork xml:id="webwork-ex-indefinite-trig-integral-1">
             <pg-code>
               $F = FormulaUpToConstant("-1/5*cos(x)^5");
@@ -1269,7 +1272,7 @@
         </exercise>
         <!-- Exercise 27 -->
         <!-- Not randomized because of the special nature of tan^2 sec^3 -->
-        <exercise label="ex-indefinite-trig-integral-23">
+        <exercise xml:id="ex-indefinite-trig-integral-23" label="ex-indefinite-trig-integral-23">
           <webwork xml:id="webwork-ex-indefinite-trig-integral-23">
             <pg-code>
               $F = FormulaUpToConstant("1/4*tan(x)*sec(x)^3-1/8*(sec(x)*tan(x)+ln(abs(sec(x)+tan(x))))");
@@ -1291,7 +1294,7 @@
           <p>
             Evaluate the definite integral.
             Note: the corresponding indefinite integrals appear in
-            <xref ref="exercisegroup-indefinite-trig-integrals" text="custom">Exercises</xref>.
+            <xref first="ex-indefinite-trig-integral-1" last="ex-indefinite-trig-integral-23" text="local">Exercises</xref>.
           </p>
         </introduction>
         <!-- Exercise 28 -->

--- a/ptx/sec_triple_int.ptx
+++ b/ptx/sec_triple_int.ptx
@@ -4,7 +4,7 @@
   <subsection>
     <title>Volume between surfaces</title>
     <p>
-      We learned in <xref ref="sec_double_int_volume">Section</xref>
+      We learned in <xref ref="sec_double_int_volume"/>
       how to compute the signed volume <m>V</m> under a surface
       <m>z=f(x,y)</m> over a region <m>R</m>:
       <m>V = \iint_R f(x,y)\, dA</m>.
@@ -38,12 +38,12 @@
           Find the volume of the space region bounded by the planes <m>z=3x+y-4</m>,
           <m>z=8-3x-2y</m>, <m>x=0</m> and <m>y=0</m>.
 
-          In <xref ref="fig_trip1a_3D">Figure</xref> the planes are drawn;
-          in <xref ref="fig_trip1b_3D">Figure</xref>, only the defined region is given.
+          In <xref ref="fig_trip1a_3D"/> the planes are drawn;
+          in <xref ref="fig_trip1b_3D"/>, only the defined region is given.
         </p>
 
         <figure xml:id="fig_trip1">
-          <caption>Finding the volume between the planes given in <xref ref="ex_trip1">Example</xref></caption>
+          <caption>Finding the volume between the planes given in <xref ref="ex_trip1"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip1a_3D">
               <caption/>
@@ -224,7 +224,7 @@
 
     <p>
       Note how we can rewrite the integrand as an integral,
-      much as we did in <xref ref="sec_iterated_integrals">Section</xref>:
+      much as we did in <xref ref="sec_iterated_integrals"/>:
       <me>
         8-3x-2y-(3x+y-4) = \int_{3x+y-4}^{8-3x-2y}\, dz
       </me>.
@@ -365,11 +365,11 @@
     <p>
       To formally find the volume of a closed,
       bounded region <m>D</m> in space,
-      such as the one shown in <xref ref="fig_tripintroa_3D">Figure</xref>,
+      such as the one shown in <xref ref="fig_tripintroa_3D"/>,
       we start with an approximation.
       Break <m>D</m> into <m>n</m> rectangular solids;
       the solids near the boundary of <m>D</m> may possibly not include portions of <m>D</m> and/or include extra space.
-      In <xref ref="fig_tripintrob_3D">Figure</xref>,
+      In <xref ref="fig_tripintrob_3D"/>,
       we zoom in on a portion of the boundary of <m>D</m> to show a rectangular solid that contains space not in <m>D</m>;
       as this is an approximation of the volume,
       this is acceptable and this error will be reduced as we shrink the size of our solids.
@@ -510,7 +510,7 @@
     <p>
       We evaluated the area of a plane region <m>R</m> by iterated integration,
       where the bounds were <q>from curve to curve,
-      then from point to point.</q> <xref ref="thm_triple_integration">Theorem</xref>
+      then from point to point.</q> <xref ref="thm_triple_integration"/>
       allows us to find the volume of a space region with an iterated integral with bounds
       <q>from surface to surface, then from curve to curve,
       then from point to point.</q> In the iterated integral
@@ -526,7 +526,7 @@
     </p>
     <aside>
       <p>
-        <xref ref="ex_trip2">Example</xref>
+        <xref ref="ex_trip2"/>
         uses the term <q>first octant.</q>
         Recall how the <m>x</m>-, <m>y</m>- and <m>z</m>-axes divide space into eight <em>octants</em>;
         the octant in which <m>x</m>,
@@ -548,12 +548,12 @@
       <statement>
         <p>
           Find the volume of the space region in the first octant bounded by the plane <m>z=2-y/3-2x/3</m>,
-          shown in <xref ref="fig_trip2a1_3D">Figure</xref>,
+          shown in <xref ref="fig_trip2a1_3D"/>,
           using the order of integration <m>dz\, dy\, dx</m>.
           Set up the triple integrals that give the volume in the other 5 orders of integration.
         </p>
         <figure xml:id="fig_trip2a1_3D">
-          <caption>The region <m>D</m> used in <xref ref="ex_trip2">Example</xref></caption>
+          <caption>The region <m>D</m> used in <xref ref="ex_trip2"/></caption>
 
           <!-- START figures/figtrip2_3D.asy -->
           <image xml:id="img_trip2a1_3D" width="47%">
@@ -613,7 +613,7 @@
         <p>
           To find the bounds on <m>y</m> and <m>x</m>,
           we <q>collapse</q> the region onto the <m>xy</m>-plane,
-          giving the triangle shown in <xref ref="fig_trip2a2_3D">Figure</xref>. (We know the equation of the line <m>y=6-2x</m> in two ways.
+          giving the triangle shown in <xref ref="fig_trip2a2_3D"/>. (We know the equation of the line <m>y=6-2x</m> in two ways.
           First, by setting <m>z=0</m>,
           we have <m>0 = 2-y/3-2x/3 \Rightarrow y=6-2x</m>.
           Secondly, we know this is going to be a straight line between the points <m>(3,0)</m> and <m>(0,6)</m> in the <m>xy</m>-plane.)
@@ -691,7 +691,7 @@
           Now consider the volume using the order of integration <m>dz\, dx\, dy</m>.
           The bounds on <m>z</m> are the same as before,
           <m>0\leq z\leq 2-y/3-2x/3</m>.
-          Collapsing the space region on the <m>xy</m>-plane as shown in <xref ref="fig_trip2a2_3D">Figure</xref>,
+          Collapsing the space region on the <m>xy</m>-plane as shown in <xref ref="fig_trip2a2_3D"/>,
           we now describe this triangle with the order of integration <m>dx\, dy</m>.
           This gives bounds <m>0\leq x\leq 3-y/2</m> and <m>0\leq y\leq 6</m>.
           Thus the volume is given by the triple integral
@@ -720,7 +720,7 @@
 
         <p>
           Now collapse the space region onto the <m>yz</m>-plane,
-          as shown in <xref ref="fig_trip2b1_3D">Figure</xref>. (Again,
+          as shown in <xref ref="fig_trip2b1_3D"/>. (Again,
           we find the equation of the line <m>z=2-y/3</m> by setting <m>x=0</m> in the equation
           <m>x=3-y/2-3z/2</m>.) We need to find bounds on this region with the order <m>dy\, dz</m>.
           The <em>curves</em> that bound <m>y</m> are <m>y=0</m> and <m>y=6-3z</m>;
@@ -753,7 +753,7 @@
         </p>
 
         <figure xml:id="fig_trip2b">
-          <caption>The region <m>D</m> in <xref ref="ex_trip2">Example</xref> is collapsed onto the <m>yz</m>-plane in (a); in (b), the region is collapsed onto the <m>xz</m>-plane</caption>
+          <caption>The region <m>D</m> in <xref ref="ex_trip2"/> is collapsed onto the <m>yz</m>-plane in (a); in (b), the region is collapsed onto the <m>xz</m>-plane</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip2b1_3D">
               <caption/>
@@ -858,7 +858,7 @@
 
         <p>
           The <m>x</m>-bounds are the same as the order above.
-          We now consider the triangle in <xref ref="fig_trip2b1_3D">Figure</xref> and describe it with the order <m>dz\, dy</m>:
+          We now consider the triangle in <xref ref="fig_trip2b1_3D"/> and describe it with the order <m>dz\, dy</m>:
           <m>0\leq z\leq 2-y/3</m> and <m>0\leq y\leq 6</m>.
           Thus the volume is given by:
         </p>
@@ -899,7 +899,7 @@
 
         <p>
           Now collapse the region onto the <m>xz</m>-plane,
-          as shown in <xref ref="fig_trip2b2_3D">Figure</xref>.
+          as shown in <xref ref="fig_trip2b2_3D"/>.
           The curves bounding this triangle are <m>z=0</m> and <m>z=2-2x/3</m>;
           <m>x</m> is bounded by the points <m>x=0</m> to <m>x=3</m>.
           Thus the triple integral giving volume is:
@@ -931,7 +931,7 @@
 
         <p>
           The <m>y</m>-bounds are the same as in the order above.
-          We now determine the bounds of the triangle in <xref ref="fig_trip2b2_3D">Figure</xref> using the order <m>dy\, dx\, dz</m>.
+          We now determine the bounds of the triangle in <xref ref="fig_trip2b2_3D"/> using the order <m>dy\, dx\, dz</m>.
           <m>x</m> is bounded by <m>x=0</m> and <m>x=3-3z/2</m>;
           <m>z</m> is bounded between <m>z=0</m> and <m>z=2</m>.
           This leads to the triple integral:
@@ -985,14 +985,14 @@
       <statement>
         <p>
           Consider the surfaces <m>z=3-x^2-y^2</m> and <m>z=2y</m>,
-          as shown in <xref ref="fig_trip2bb1_3D">Figure</xref>.
+          as shown in <xref ref="fig_trip2bb1_3D"/>.
           The curve of their intersection is shown,
           along with the projection of this curve into the coordinate planes,
           shown dashed.
           Find the equations of the projections into the coordinate planes.
         </p>
         <figure xml:id="fig_trip2bb">
-          <caption>Finding the projections of the curve of intersection in <xref ref="ex_trip2b">Example</xref></caption>
+          <caption>Finding the projections of the curve of intersection in <xref ref="ex_trip2b"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip2bb1_3D">
               <caption/>
@@ -1183,7 +1183,7 @@
         </p>
 
         <p>
-          All three projections are shown in <xref ref="fig_trip2bb2_3D">Figure</xref>.
+          All three projections are shown in <xref ref="fig_trip2bb2_3D"/>.
         </p>
       </solution>
     </example>
@@ -1199,13 +1199,13 @@
         <p>
           Set up the triple integrals that find the volume of the space region <m>D</m> bounded by the surfaces <m>x^2+y^2=1</m>,
           <m>z=0</m> and <m>z=-y</m>,
-          as shown in <xref ref="fig_trip3a1_3D">Figure</xref>,
+          as shown in <xref ref="fig_trip3a1_3D"/>,
           with the orders of integration <m>dz\, dy\, dx</m>,
           <m>dy\, dx\, dz</m> and <m>dx\, dz\, dy</m>.
         </p>
 
         <figure xml:id="fig_trip3a">
-          <caption>The region <m>D</m> in <xref ref="ex_trip3">Example</xref> is shown in (a); in (b), it is collapsed onto the <m>xy</m>-plane</caption>
+          <caption>The region <m>D</m> in <xref ref="ex_trip3"/> is shown in (a); in (b), it is collapsed onto the <m>xy</m>-plane</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip3a1_3D">
               <caption/>
@@ -1347,7 +1347,7 @@
         <p>
           Collapsing the region into the <m>xy</m>-plane,
           we get part of the circle with equation
-          <m>x^2+y^2=1</m> as shown in <xref ref="fig_trip3a2_3D">Figure</xref>.
+          <m>x^2+y^2=1</m> as shown in <xref ref="fig_trip3a2_3D"/>.
           As a function of <m>x</m>,
           this half circle has equation <m>y=-\sqrt{1-x^2}</m>.
           Thus <m>y</m> is bounded below by
@@ -1401,7 +1401,7 @@
         </p>
 
         <p>
-          Collapsing the region onto the <m>xz</m>-plane gives the region shown in <xref ref="fig_trip3b1_3D">Figure</xref>;
+          Collapsing the region onto the <m>xz</m>-plane gives the region shown in <xref ref="fig_trip3b1_3D"/>;
           this half disk is bounded by <m>z=0</m> and <m>x^2+z^2=1</m>.
           (We find this curve by solving each surface for <m>y^2</m>,
           then setting them equal to each other.
@@ -1433,7 +1433,7 @@
         </sidebyside>
 
         <figure xml:id="fig_trip3b">
-          <caption>The region <m>D</m> in <xref ref="ex_trip3">Example</xref> is shown collapsed onto the <m>xz</m>-plane in (a); in (b), it is collapsed onto the <m>yz</m>-plane</caption>
+          <caption>The region <m>D</m> in <xref ref="ex_trip3"/> is shown collapsed onto the <m>xz</m>-plane in (a); in (b), it is collapsed onto the <m>yz</m>-plane</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip3b1_3D">
               <caption/>
@@ -1551,7 +1551,7 @@
         <p>
           <m>D</m> is bounded below by the surface
           <m>x=-\sqrt{1-y^2}</m> and above by <m>\sqrt{1-y^2}</m>.
-          We then collapse the region onto the <m>yz</m>-plane and get the triangle shown in <xref ref="fig_trip3b2_3D">Figure</xref>. (The hypotenuse is the line <m>z=-y</m>,
+          We then collapse the region onto the <m>yz</m>-plane and get the triangle shown in <xref ref="fig_trip3b2_3D"/>. (The hypotenuse is the line <m>z=-y</m>,
           just as the plane.) Thus <m>z</m> is bounded by
           <m>0\leq z\leq -y</m> and <m>y</m> is bounded by <m>-1\leq y\leq 0</m>.
           This gives:
@@ -1629,12 +1629,12 @@
         <p>
           Find the volume of the space region <m>D</m> bounded by the coordinate planes,
           <m>z=1-x/2</m> and <m>z=1-y/4</m>,
-          as shown in <xref ref="fig_trip4a1_3D">Figure</xref>.
+          as shown in <xref ref="fig_trip4a1_3D"/>.
           Set up the triple integrals that find the volume of <m>D</m> in all 6 orders of integration.
         </p>
 
         <figure xml:id="fig_trip4a">
-          <caption>The region <m>D</m> in <xref ref="ex_trip4">Example</xref> is shown in (a); in (b), it is collapsed onto the <m>xy</m>-plane</caption>
+          <caption>The region <m>D</m> in <xref ref="ex_trip4"/> is shown in (a); in (b), it is collapsed onto the <m>xy</m>-plane</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip4a1_3D">
               <caption/>
@@ -1771,10 +1771,10 @@
 
         <p>
           We now collapse the region <m>D</m> onto the <m>xy</m>-axis,
-          as shown in <xref ref="fig_trip4a2_3D">Figure</xref>.
+          as shown in <xref ref="fig_trip4a2_3D"/>.
           The boundary of <m>D</m>,
           the line from <m>(0,0,1)</m> to <m>(2,4,0)</m>,
-          is shown in <xref ref="fig_trip4a2_3D">Figure</xref> as a dashed line;
+          is shown in <xref ref="fig_trip4a2_3D"/> as a dashed line;
           it has equation <m>y=2x</m>. (We can recognize this in two ways:
           one, in collapsing the line from <m>(0,0,1)</m> to <m>(2,4,0)</m> onto the <m>xy</m>-plane,
           we simply ignore the <m>z</m>-values,
@@ -1784,7 +1784,7 @@
         </p>
 
         <p>
-          We use the second property of <xref ref="thm_triple_int_prop">Theorem</xref> to state that
+          We use the second property of <xref ref="thm_triple_int_prop"/> to state that
           <me>
             \iiint_D \, dV = \iiint_{D_1}\, dV + \iiint_{D_2}\, dV
           </me>,
@@ -1833,14 +1833,14 @@
 
         <p>
           The remaining four orders of integration do not require a sum of triple integrals.
-          In <xref ref="fig_trip4b">Figure</xref>
+          In <xref ref="fig_trip4b"/>
           we show <m>D</m> collapsed onto the other two coordinate planes.
           Using these graphs, we give the final orders of integration here,
           again leaving it to the reader to confirm these results.
         </p>
 
         <figure xml:id="fig_trip4b">
-          <caption>The region <m>D</m> in <xref ref="ex_trip4">Example</xref> is shown collapsed onto the <m>xz</m>-plane in (a); in (b), it is collapsed onto the <m>yz</m>-plane</caption>
+          <caption>The region <m>D</m> in <xref ref="ex_trip4"/> is shown collapsed onto the <m>xz</m>-plane in (a); in (b), it is collapsed onto the <m>yz</m>-plane</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip4b1_3D">
               <caption/>
@@ -2049,9 +2049,9 @@
         <p>
           Set up a triple integral that gives the volume of the space region <m>D</m> bounded by
           <m>z= 2x^2+2</m> and <m>z=6-2x^2-y^2</m>.
-          These surfaces are plotted in <xref ref="fig_trip5a1_3D">Figure</xref> and <xref ref="fig_trip5a2_3D">Figure</xref>,
+          These surfaces are plotted in <xref ref="fig_trip5a1_3D"/> and <xref ref="fig_trip5a2_3D"/>,
           respectively;
-          the region <m>D</m> is shown in <xref ref="fig_trip5a3_3D">Figure</xref>.
+          the region <m>D</m> is shown in <xref ref="fig_trip5a3_3D"/>.
         </p>
 
         <figure xml:id="fig_trip5">
@@ -2249,7 +2249,7 @@
 
         <p>
           The bounds on <m>z</m> are clearly <m>2x^2+2\leq z\leq 6-2x^2-y^2</m>.
-          Collapsing <m>D</m> onto the <m>xy</m>-plane gives the ellipse shown in <xref ref="fig_trip5a3_3D">Figure</xref>.
+          Collapsing <m>D</m> onto the <m>xy</m>-plane gives the ellipse shown in <xref ref="fig_trip5a3_3D"/>.
           The equation of this ellipse is found by setting the two surfaces equal to each other:
           <me>
             2x^2+2 = 6-2x^2-y^2 \Rightarrow 4x^2+y^2=4 \Rightarrow x^2+\frac{y^2}4=1
@@ -2303,7 +2303,7 @@
         </p>
 
         <p>
-          Collapsing <m>D</m> onto the <m>xz</m>-plane gives the region shown in <xref ref="fig_trip5b1_3D">Figure</xref>;
+          Collapsing <m>D</m> onto the <m>xz</m>-plane gives the region shown in <xref ref="fig_trip5b1_3D"/>;
           the lower curve is from the cylinder,
           with equation <m>z=2x^2+2</m>.
           The upper curve is from the paraboloid;
@@ -2334,7 +2334,7 @@
         </sidebyside>
 
         <figure xml:id="fig_trip5b">
-          <caption>The region <m>D</m> in <xref ref="ex_trip5">Example</xref> is collapsed onto the <m>xz</m>-plane in (a); in (b), it is collapsed onto the <m>yz</m>-plane</caption>
+          <caption>The region <m>D</m> in <xref ref="ex_trip5"/> is collapsed onto the <m>xz</m>-plane in (a); in (b), it is collapsed onto the <m>yz</m>-plane</caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_trip5b1_3D">
               <caption/>
@@ -2481,9 +2481,9 @@
         </p>
 
         <p>
-          Collapsing <m>D</m> onto the <m>yz</m>-axes gives the regions shown in <xref ref="fig_trip5b2_3D">Figure</xref>.
+          Collapsing <m>D</m> onto the <m>yz</m>-axes gives the regions shown in <xref ref="fig_trip5b2_3D"/>.
           We find the equation of the curve
-          <m>z=4-y^2/2</m> by noting that the equation of the ellipse seen in <xref ref="fig_trip5a3_3D">Figure</xref> has equation
+          <m>z=4-y^2/2</m> by noting that the equation of the ellipse seen in <xref ref="fig_trip5a3_3D"/> has equation
           <me>
             x^2+y^2/4=1  \Rightarrow  x = \sqrt{1-y^2/4}
           </me>.
@@ -2519,7 +2519,7 @@
     </example>
 
     <p>
-      If all one wanted to do in <xref ref="ex_trip5">Example</xref>
+      If all one wanted to do in <xref ref="ex_trip5"/>
       was find the volume of the region <m>D</m>,
       one would have likely stopped at the first integration setup
       (with order <m>dz\, dy\, dx</m>)
@@ -2575,7 +2575,7 @@
       </statement>
       <solution>
         <p>
-          We evaluate this integral according to <xref ref="def_triple_integral_2">Definition</xref>.
+          We evaluate this integral according to <xref ref="def_triple_integral_2"/>.
         </p>
 
         <p>
@@ -2700,7 +2700,7 @@
 
     <!-- TODO: a knowl containing an aside does not look good. Is there a better way to reference this? -->
     <p>
-      <em>Note:</em> In an <!--<xref ref="note_doubleint" text="custom">-->aside<!--</xref>--> in <xref ref="sec_double_int_volume">Section</xref>,
+      <em>Note:</em> In an <!--<xref ref="note_doubleint" text="custom">-->aside<!--</xref>--> in <xref ref="sec_double_int_volume"/>,
       we showed how the summation of rectangles over a region <m>R</m> in the plane could be viewed as a double sum,
       leading to the double integral.
       Likewise, we can view the sum
@@ -2728,7 +2728,7 @@
     <p>
       This triple summation understanding leads to the
       <m>\iiint_D</m> notation of the triple integral,
-      as well as the method of evaluation shown in <xref ref="thm_triple_integration2">Theorem</xref>.
+      as well as the method of evaluation shown in <xref ref="thm_triple_integration2"/>.
     </p>
 
     <p>
@@ -2739,7 +2739,7 @@
   <subsection>
     <title>Mass and Center of Mass</title>
     <p>
-      One may wish to review <xref ref="sec_center_of_mass">Section</xref>
+      One may wish to review <xref ref="sec_center_of_mass"/>
       for a reminder of the relevant terms and concepts.
     </p>
 
@@ -2801,13 +2801,13 @@
       <statement>
         <p>
           Find the mass and center of mass of the solid represented by the space region bounded by the coordinate planes and <m>z=2-y/3-2x/3</m>,
-          shown in <xref ref="fig_trip7_3D">Figure</xref>,
+          shown in <xref ref="fig_trip7_3D"/>,
           with constant density <m>\delta(x,y,z)=3\,\text{g/cm}^3</m>.
-          (Note: this space region was used in <xref ref="ex_trip2">Example</xref>.)
+          (Note: this space region was used in <xref ref="ex_trip2"/>.)
         </p>
 
         <figure xml:id="fig_trip7_3D">
-          <caption>Finding the center of mass of this solid in <xref ref="ex_trip7">Example</xref></caption>
+          <caption>Finding the center of mass of this solid in <xref ref="ex_trip7"/></caption>
 
           <!-- START figures/figtrip2_3D.asy -->
           <image xml:id="img_trip7_3D" width="47%">
@@ -2856,8 +2856,8 @@
       </statement>
       <solution>
         <p>
-          We apply <xref ref="def_mass_3d">Definition</xref>.
-          In <xref ref="ex_trip2">Example</xref>,
+          We apply <xref ref="def_mass_3d"/>.
+          In <xref ref="ex_trip2"/>,
           we found bounds for the order of integration
           <m>dz\, dy\, dx</m> to be <m>0\leq z\leq 2-y/3-2x/3</m>,
           <m>0\leq y\leq 6-2x</m> and <m>0\leq x\leq 3</m>.
@@ -2871,7 +2871,7 @@
         </p>
 
         <p>
-          The evaluation of the triple integral is done in <xref ref="ex_trip2">Example</xref>,
+          The evaluation of the triple integral is done in <xref ref="ex_trip2"/>,
           so we skipped those steps above.
           Note how the mass of an object with constant density is simply
           <q>density<times/>volume.</q>
@@ -2912,13 +2912,13 @@
       <statement>
         <p>
           Find the center of mass of the solid represented by the region bounded by the planes <m>z=0</m> and <m>z=-y</m> and the cylinder <m>x^2+y^2=1</m>,
-          shown in <xref ref="fig_trip8_3D">Figure</xref>,
+          shown in <xref ref="fig_trip8_3D"/>,
           with density function <m>\delta(x,y,z) = 10+x^2+5y-5z</m>.
-          (Note: this space region was used in <xref ref="ex_trip3">Example</xref>.)
+          (Note: this space region was used in <xref ref="ex_trip3"/>.)
         </p>
 
         <figure xml:id="fig_trip8_3D">
-          <caption>Finding the center of mass of this solid in <xref ref="ex_trip8">Example</xref></caption>
+          <caption>Finding the center of mass of this solid in <xref ref="ex_trip8"/></caption>
 
           <!-- START figures/figtrip3_3D.asy -->
           <image xml:id="img_trip8_3D" width="47%">
@@ -3003,7 +3003,7 @@
           in complex situations we can appeal to technology for a good approximation,
           if not the exact answer.
           We use the order of integration <m>dz\, dy\, dx</m>,
-          using the bounds found in <xref ref="ex_trip3">Example</xref>.
+          using the bounds found in <xref ref="ex_trip3"/>.
           (As these are the same for all four triple integrals,
           we explicitly show the bounds only for <m>M</m>.)
           <md>
@@ -3048,7 +3048,7 @@
     </p>
 
     <p>
-      In <xref ref="sec_cylindrical_spherical">Section</xref>, we learn about two new coordinate systems
+      In <xref ref="sec_cylindrical_spherical"/>, we learn about two new coordinate systems
       (each related to polar coordinates)
       that allow us to integrate over closed regions in space more easily than when using rectangular coordinates.
     </p>
@@ -4240,7 +4240,7 @@
                 </p>
 
                 <p>
-                  (Note: this is the same region as used in <xref ref="x13_06_ex_07">Exercise</xref>.)
+                  (Note: this is the same region as used in <xref ref="x13_06_ex_07"/>.)
                 </p>
               </statement>
               <solution>
@@ -4271,7 +4271,7 @@
                 </p>
 
                 <p>
-                  (Note: this is the same region as used in <xref ref="x13_06_ex_08">Exercise</xref>.)
+                  (Note: this is the same region as used in <xref ref="x13_06_ex_08"/>.)
                 </p>
               </statement>
               <solution>
@@ -4302,7 +4302,7 @@
                 </p>
 
                 <p>
-                  (Note: this is the same region as used in <xref ref="x13_06_ex_11">Exercise</xref>.)
+                  (Note: this is the same region as used in <xref ref="x13_06_ex_11"/>.)
                 </p>
               </statement>
               <solution>
@@ -4332,7 +4332,7 @@
                 </p>
 
                 <p>
-                  (Note: this is the same region as used in <xref ref="x13_06_ex_12">Exercise</xref>.)
+                  (Note: this is the same region as used in <xref ref="x13_06_ex_12"/>.)
                 </p>
               </statement>
               <solution>

--- a/ptx/sec_vector_fields.ptx
+++ b/ptx/sec_vector_fields.ptx
@@ -214,7 +214,7 @@
     </p>
 
     <p>
-      In <xref ref="fig_vectorfieldintro1a">Figure</xref>,
+      In <xref ref="fig_vectorfieldintro1a"/>,
       one can see that the vector <m>\langle 2,0\rangle</m> is drawn
       <em>starting from</em> the point <m>(1,1)</m>.
       A total of 8 vectors are drawn,
@@ -224,7 +224,7 @@
     </p>
 
     <p>
-      In <xref ref="fig_vectorfieldintro1b">Figure</xref>,
+      In <xref ref="fig_vectorfieldintro1b"/>,
       the same field is redrawn with each vector <m>\vec F(x,y)</m> drawn
       <em>centered on</em> the point <m>(x,y)</m>.
       This makes for a better looking image,
@@ -236,7 +236,7 @@
     <p>
       A common way to address this problem is limit the length of each arrow,
       and represent long vectors with thick arrows,
-      as done in <xref ref="fig_vectorfieldintro2a">Figure</xref>.
+      as done in <xref ref="fig_vectorfieldintro2a"/>.
       Usually we do not use a graph of a vector field to determine exactly the magnitude of a particular vector.
       Rather, we are more concerned with the relative magnitudes of vectors:
       which are bigger than others?
@@ -364,7 +364,7 @@
       search the documentation of your favorite graphing program for terms like <q>vector fields</q>
       or <q>slope fields</q> to learn how.
       Technology obviously allows us to plot many vectors in a vector field nicely;
-      in <xref ref="fig_vectorfieldintro2b">Figure</xref>,
+      in <xref ref="fig_vectorfieldintro2b"/>,
       we see the same vector field drawn with many vectors,
       and finally get a clear picture of how this vector field behaves.
       (If this vector field represented the velocity of air moving across a flat surface,
@@ -374,11 +374,11 @@
 
     <p>
       We can similarly plot vector fields in space,
-      as shown in <xref ref="fig_vectorfieldintro3">Figure</xref>,
+      as shown in <xref ref="fig_vectorfieldintro3"/>,
       though it is not often done.
       The plots get very busy very quickly,
       as there are lots of arrows drawn in a small amount of space.
-      In <xref ref="fig_vectorfieldintro3">Figure</xref>
+      In <xref ref="fig_vectorfieldintro3"/>
       the field <m>\vec F = \langle -y,x,z\rangle</m> is graphed.
       If one could view the graph from above,
       one could see the arrows point in a circle about the <m>z</m>-axis.
@@ -496,7 +496,7 @@
   <subsection>
     <title>Vector Field Notation and Del Operator</title>
     <p>
-      <xref ref="def_vector_field">Definition</xref>
+      <xref ref="def_vector_field"/>
       defines a vector field <m>\vec F</m> using the notation
       <me>
         \vec F(x,y) = \langle M(x,y), N(x,y)\rangle \text{ and }  \vec F(x,y,z) = \langle M(x,y,z), N(x,y,z),P(x,y,z)\rangle
@@ -518,7 +518,7 @@
       Another item of notation will become useful:
       the <q>del operator.</q>
           <idx><h>del operator</h></idx>
-      Recall in <xref ref="sec_directional_derivative">Section</xref>
+      Recall in <xref ref="sec_directional_derivative"/>
       how we used the symbol <m>\nabla</m>
       (pronounced <q>del</q>)
       to represent the gradient of a function of two variables.
@@ -739,25 +739,25 @@
           <ol>
             <li>
               <p>
-                <m>\vec F = \langle y,0\rangle</m> (see <xref ref="fig_vectorfield1a_a">Figure</xref>)
+                <m>\vec F = \langle y,0\rangle</m> (see <xref ref="fig_vectorfield1a_a"/>)
               </p>
             </li>
 
             <li>
               <p>
-                <m>\vec F = \langle -y,x\rangle</m> (see <xref ref="fig_vectorfield1a_b">Figure</xref>)
+                <m>\vec F = \langle -y,x\rangle</m> (see <xref ref="fig_vectorfield1a_b"/>)
               </p>
             </li>
 
             <li>
               <p>
-                <m>\vec F = \langle x,y\rangle</m> (see <xref ref="fig_vectorfield1b_a">Figure</xref>)
+                <m>\vec F = \langle x,y\rangle</m> (see <xref ref="fig_vectorfield1b_a"/>)
               </p>
             </li>
 
             <li>
               <p>
-                <m>\vec F = \langle \cos y, \sin x\rangle</m> (see <xref ref="fig_vectorfield1b_b">Figure</xref>)
+                <m>\vec F = \langle \cos y, \sin x\rangle</m> (see <xref ref="fig_vectorfield1b_b"/>)
               </p>
             </li>
           </ol>
@@ -778,7 +778,7 @@
               </p>
 
               <figure xml:id="fig_vectorfield1a">
-                <caption>The vector fields in parts 1 and 2 in <xref ref="ex_vectorfield1">Example</xref></caption>
+                <caption>The vector fields in parts 1 and 2 in <xref ref="ex_vectorfield1"/></caption>
                 <sidebyside widths="47% 47%" margins="0%">
                   <figure xml:id="fig_vectorfield1a_a">
                     <caption/>
@@ -972,7 +972,7 @@
               </p>
 
               <figure xml:id="fig_vectorfield1b">
-                <caption>The vector fields in parts 3 and 4 in <xref ref="ex_vectorfield1">Example</xref></caption>
+                <caption>The vector fields in parts 3 and 4 in <xref ref="ex_vectorfield1"/></caption>
                 <sidebyside widths="47% 47%" margins="0%">
                   <figure xml:id="fig_vectorfield1b_a">
                     <caption/>
@@ -1218,7 +1218,7 @@
         </p>
 
         <p>
-          The analogous planar vector field is given in <xref ref="fig_vectorfield3">Figure</xref>.
+          The analogous planar vector field is given in <xref ref="fig_vectorfield3"/>.
           Note how all arrows point to the origin,
           and the magnitude gets very small when
           <q>far</q> from the origin.
@@ -1298,7 +1298,7 @@
     <p>
       A function <m>f(x,y)</m> naturally induces a vector field,
       <m>\vec F = \nabla f = \langle f_x,f_y\rangle</m>.
-      Given what we learned of the gradient in <xref ref="sec_directional_derivative">Section</xref>,
+      Given what we learned of the gradient in <xref ref="sec_directional_derivative"/>,
       we know that the vectors of <m>\vec F</m> point in the direction of greatest increase of <m>f</m>.
       Because of this, <m>f</m> is said to be the
       <em>potential function</em>
@@ -1320,8 +1320,8 @@
         <p>
           Given <m>f</m>,
           we find <m>\vec F = \nabla f = \langle -2x,-4y\rangle</m>.
-          A graph of <m>\vec F</m> is given in <xref ref="fig_vectorfield4a">Figure</xref>.
-          In <xref ref="fig_vectorfield4b_3D">Figure</xref>,
+          A graph of <m>\vec F</m> is given in <xref ref="fig_vectorfield4a"/>.
+          In <xref ref="fig_vectorfield4b_3D"/>,
           the vector field is given along with a graph of the surface itself;
           one can see how each vector is pointing in the direction of
           <q>steepest uphill</q>,
@@ -1330,7 +1330,7 @@
         </p>
 
         <figure xml:id="fig_vectorfield4">
-          <caption>A graph of a function <m>f(x,y)</m> and the vector field <m>\vec F = \nabla f</m> in <xref ref="ex_vectorfield4">Example</xref></caption>
+          <caption>A graph of a function <m>f(x,y)</m> and the vector field <m>\vec F = \nabla f</m> in <xref ref="ex_vectorfield4"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_vectorfield4a">
               <caption/>

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1627,7 +1627,7 @@
       </p>
 
       <p>
-        We can then use either equality from Equation <xref ref="eq_vect8"/> to solve for <m>\varphi</m>.
+        We can then use either equality from <xref ref="eq_vect8">Equation</xref> to solve for <m>\varphi</m>.
         We choose the first equality as using arccosine will return an angle in the <m>2</m>nd quadrant:
         <me>
           5 + 5\sqrt{26}\cos(\varphi) = 0  \Rightarrow  \varphi = \cos^{-1}\left(\frac{-5}{5\sqrt{26}}\right) \approx 1.7682\approx 101.31^\circ

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -70,7 +70,7 @@
   </definition>
 
   <p>
-    <xref ref="fig_vectintro1">Figure</xref>
+    <xref ref="fig_vectintro1"/>
     shows multiple instances of the same vector.
     Each directed line segment has the same direction and length (magnitude),
     hence each is the same vector.
@@ -164,7 +164,7 @@
   </figure>
 
   <p>
-    Consider the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{RS}</m> as shown in <xref ref="fig_vectintro2">Figure</xref>.
+    Consider the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{RS}</m> as shown in <xref ref="fig_vectintro2"/>.
     The vectors look to be equal;
     that is, they seem to have the same length and direction.
     Indeed, they are.
@@ -180,7 +180,7 @@
     This demonstrates that inherently all we care about is <em>displacement</em>;
     that is, how far in the <m>x</m>,
     <m>y</m> and possibly <m>z</m> directions the terminal point is from the initial point.
-    Both the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{RS}</m> in <xref ref="fig_vectintro2">Figure</xref>
+    Both the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{RS}</m> in <xref ref="fig_vectintro2"/>
     have an <m>x</m>-displacement of 2 and a <m>y</m>-displacement of 1.
     This suggests a standard way of describing vectors in the plane.
     A vector whose <m>x</m>-displacement is <m>a</m> and whose <m>y</m>-displacement is <m>b</m> will have terminal point <m>(a,b)</m> when the initial point is the origin,
@@ -275,7 +275,7 @@
             <p>
               Using <m>P</m> as the initial point,
               we move 2 units in the positive <m>x</m>-direction and <m>-1</m> units in the positive <m>y</m>-direction to arrive at the terminal point <m>P\,'=(5,1)</m>,
-              as drawn in <xref ref="fig_vect1a">Figure</xref>.
+              as drawn in <xref ref="fig_vect1a"/>.
 
               The magnitude of <m>\vec v</m> is determined directly from the component form:
               <me>
@@ -283,7 +283,7 @@
               </me>.
             </p>
             <figure xml:id="fig_vect1">
-              <caption>Graphing vectors in <xref ref="ex_vect1">Example</xref></caption>
+              <caption>Graphing vectors in <xref ref="ex_vect1"/></caption>
               <sidebyside widths="47% 47%" margins="0%">
                 <figure xml:id="fig_vect1a">
                   <caption/>
@@ -399,11 +399,11 @@
 
           <li>
             <p>
-              Using the note following <xref ref="def_vector_component">Definition</xref>, we have
+              Using the note following <xref ref="def_vector_component"/>, we have
               <me>
                 \overrightarrow{RS} = \la -1-(-3), 2-(-2)\ra = \la 2,4\ra
               </me>.
-              One can readily see from <xref ref="fig_vect1a">Figure</xref> that the <m>x</m>- and <m>y</m>-displacement of <m>\overrightarrow{RS}</m> is 2 and 4, respectively,
+              One can readily see from <xref ref="fig_vect1a"/> that the <m>x</m>- and <m>y</m>-displacement of <m>\overrightarrow{RS}</m> is 2 and 4, respectively,
               as the component form suggests.
             </p>
           </li>
@@ -414,7 +414,7 @@
               we move 2 units in the positive <m>x</m>-direction,
               <m>-1</m> unit in the positive <m>y</m>-direction,
               and 3 units in the positive <m>z</m>-direction to arrive at the terminal point <m>Q' = (3,0,4)</m>,
-              illustrated in <xref ref="fig_vect1b_3D">Figure</xref>.
+              illustrated in <xref ref="fig_vect1b_3D"/>.
 
               The magnitude of <m>\vec u</m> is:
               <me>
@@ -539,7 +539,7 @@
       </p>
 
       <figure xml:id="fig_vect2">
-        <caption>Graphing the sum of vectors in <xref ref="ex_vect2">Example</xref></caption>
+        <caption>Graphing the sum of vectors in <xref ref="ex_vect2"/></caption>
         <!-- START figures/fig_vect2.tex -->
         <image xml:id="img_vect2" width="47%">
           <shortdescription>
@@ -579,7 +579,7 @@
       </figure>
 
       <p>
-        These are all sketched in <xref ref="fig_vect2">Figure</xref>.
+        These are all sketched in <xref ref="fig_vect2"/>.
       </p>
     </solution>
   </example>
@@ -597,7 +597,7 @@
   </blockquote>
 
   <p>
-    This idea is sketched in <xref ref="fig_vect2b">Figure</xref>,
+    This idea is sketched in <xref ref="fig_vect2b"/>,
     where the initial point of <m>\vec v</m> is the terminal point of <m>\vec u</m>.
     This is known as the <q>Head to Tail Rule</q> of adding vectors.
     Vector addition is very important.
@@ -668,7 +668,7 @@
   <p>
     Analytically,
     it is easy to see that <m>\vec u+\vec v = \vec v+\vec u</m>.
-    <xref ref="fig_vect2b">Figure</xref>
+    <xref ref="fig_vect2b"/>
     also gives a graphical representation of this, using gray vectors.
     Note that the vectors <m>\vec u</m> and <m>\vec v</m>,
     when arranged as in the figure, form a parallelogram.
@@ -685,7 +685,7 @@
   </p>
 
   <p>
-    It follows from the properties of the real numbers and <xref ref="def_vector_algebra">Definition</xref> that
+    It follows from the properties of the real numbers and <xref ref="def_vector_algebra"/> that
     <me>
       \vec u-\vec v = \vec u + (-1)\vec v
     </me>.
@@ -767,7 +767,7 @@
       </figure>
 
       <p>
-        <xref ref="fig_vect4">Figure</xref> illustrates,
+        <xref ref="fig_vect4"/> illustrates,
         using the Head to Tail Rule,
         how the subtraction can be viewed as the sum <m>\vec u + (-\vec v)</m>.
         The figure also illustrates how
@@ -813,7 +813,7 @@
             </p>
 
             <figure xml:id="fig_vect3">
-              <caption>Graphing vectors <m>\vec v</m> and <m>2\vec v</m> in <xref ref="ex_vect3">Example</xref></caption>
+              <caption>Graphing vectors <m>\vec v</m> and <m>2\vec v</m> in <xref ref="ex_vect3"/></caption>
             <!-- START figures/fig_vect3.tex -->
               <image xml:id="img_vect3" width="47%">
                 <shortdescription>
@@ -851,7 +851,7 @@
             </figure>
 
             <p>
-              Both <m>\vec v</m> and <m>2\vec v</m> are sketched in <xref ref="fig_vect3">Figure</xref>.
+              Both <m>\vec v</m> and <m>2\vec v</m> are sketched in <xref ref="fig_vect3"/>.
               Make note that <m>2\vec v</m> does not start at the terminal point of <m>\vec v</m>;
               rather, its initial point is also the origin.
             </p>
@@ -967,7 +967,7 @@
   </theorem>
 
   <figure xml:id="vid-vectors-intro-normprop" component="video">
-    <caption>Video presentation of <xref ref="thm_zero_norm" text="custom">Part</xref> of <xref ref="thm_vector_properties"/></caption>
+    <caption>Video presentation of <xref ref="thm_zero_norm" text="local">Part</xref> of <xref ref="thm_vector_properties"/></caption>
     <video youtube="oixzQ2EGYPM" label="vid-vectors-intro-normprop"/>
   </figure>
 
@@ -1009,8 +1009,8 @@
   </p>
 
   <p>
-    <xref ref="thm_norm_prop">Property</xref>
-    of <xref ref="thm_vector_properties">Theorem</xref> holds the key.
+    <xref ref="thm_norm_prop" text="local">Property</xref>
+    of <xref ref="thm_vector_properties"/> holds the key.
     If we divide <m>\vec v</m> by its magnitude,
     it becomes a vector of length 1.
     Consider:
@@ -1086,11 +1086,11 @@
               To create a vector with magnitude 5 in the direction of <m>\vec v</m>,
               we multiply the unit vector <m>\vec u</m> by 5.
               Thus <m>5\vec u = \la 15/\sqrt{10},5/\sqrt{10}\ra</m> is the vector we seek.
-              This is sketched in <xref ref="fig_vect5">Figure</xref>.
+              This is sketched in <xref ref="fig_vect5"/>.
             </p>
 
             <figure xml:id="fig_vect5">
-              <caption>Graphing vectors in <xref ref="ex_vect5">Example</xref>. All vectors shown have their initial point at the origin</caption>
+              <caption>Graphing vectors in <xref ref="ex_vect5"/>. All vectors shown have their initial point at the origin</caption>
             <!-- START figures/fig_vect5.tex -->
               <image xml:id="img_vect5" width="47%">
                 <shortdescription>
@@ -1210,7 +1210,7 @@
     </p>
 
     <p>
-      We define what it means for two vectors to be perpendicular in <xref ref="def_orthogonal">Definition</xref>,
+      We define what it means for two vectors to be perpendicular in <xref ref="def_orthogonal"/>,
       which is written to exclude <m>\vec 0</m>.
       It could be written to include <m>\vec 0</m>;
       by such a definition, <m>\vec 0</m> is perpendicular to all vectors.
@@ -1221,7 +1221,7 @@
     <p>
       We prefer the given definition of parallel as it is grounded in the fact that unit vectors provide direction information.
       One may adopt the convention that <m>\vec 0</m> is parallel to all vectors if they desire.
-      (See also the <xref ref="aside-cross-orthogonal" text="custom">aside</xref> in <xref ref="sec_cross_product">Section</xref>.)
+      (See also the <xref ref="aside-cross-orthogonal" text="custom">aside</xref> in <xref ref="sec_cross_product"/>.)
     </p>
   </aside>
   <p>
@@ -1284,14 +1284,14 @@
     <statement>
       <p>
         Consider a weight of 50lb hanging from two chains,
-        as shown in <xref ref="fig_vect6">Figure</xref>.
+        as shown in <xref ref="fig_vect6"/>.
         One chain makes an angle of <m>30^\circ</m> with the vertical,
         and the other an angle of <m>45^\circ</m>.
         Find the force applied to each chain.
       </p>
 
       <figure xml:id="fig_vect6">
-        <caption>A diagram of a weight hanging from 2 chains in <xref ref="ex_vect6">Example</xref></caption>
+        <caption>A diagram of a weight hanging from 2 chains in <xref ref="ex_vect6"/></caption>
         <!-- START figures/fig_vect6.tex -->
         <image xml:id="img_vect6" width="40%">
           <shortdescription>
@@ -1349,8 +1349,8 @@
         Let <m>\vec F_1</m> represent the force from the chain making an angle of <m>30^\circ</m> with the vertical,
         and let <m>\vec F_2</m> represent the force form the other chain.
         Convert all angles to be measured from the horizontal
-        (as shown in <xref ref="fig_vect6b">Figure</xref>),
-        and apply <xref ref="idea_unit_vectors">Key Idea</xref>.
+        (as shown in <xref ref="fig_vect6b"/>),
+        and apply <xref ref="idea_unit_vectors"/>.
         As we do not yet know the magnitudes of these vectors,
         (that is the problem at hand),
         we use <m>m_1</m> and <m>m_2</m> to represent them.
@@ -1372,7 +1372,7 @@
       </p>
 
       <figure xml:id="fig_vect6b">
-        <caption>A diagram of the force vectors from <xref ref="ex_vect6">Example</xref></caption>
+        <caption>A diagram of the force vectors from <xref ref="ex_vect6"/></caption>
         <!-- START figures/fig_vect6b.tex -->
         <image xml:id="img_vect6b" width="47%">
           <shortdescription>
@@ -1535,13 +1535,13 @@
     <title>Finding Component Force</title>
     <statement>
       <p>
-        A weight of 25lb is suspended from a chain of length 2ft while a wind pushes the weight to the right with constant force of 5lb as shown in <xref ref="fig_vect8">Figure</xref>.
+        A weight of 25lb is suspended from a chain of length 2ft while a wind pushes the weight to the right with constant force of 5lb as shown in <xref ref="fig_vect8"/>.
         What angle will the chain make with the vertical as a result of the wind's pushing?
         How much higher will the weight be?
       </p>
 
       <figure xml:id="fig_vect8">
-        <caption>A figure of a weight being pushed by the wind in <xref ref="ex_vect8">Example</xref></caption>
+        <caption>A figure of a weight being pushed by the wind in <xref ref="ex_vect8"/></caption>
         <!-- START figures/fig_vect8.tex -->
         <image xml:id="img_vect8" width="40%">
           <shortdescription>
@@ -2758,7 +2758,7 @@
              -->
             <statement>
               <p>
-                Verify, from <xref ref="idea_unit_vectors">Key Idea</xref>,
+                Verify, from <xref ref="idea_unit_vectors"/>,
                 that
                 <me>
                   \vec u=\la \sin(\theta) \cos(\varphi) ,\sin(\theta) \sin(\varphi) ,\cos(\theta) \ra

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -44,12 +44,12 @@
       For instance, if <m>\vec r(t) = \la t^2,t^2+t-1\ra</m>,
       then <m>\vec r(-2) = \la 4,1\ra</m>.
       We can sketch this vector,
-      as is done in <xref ref="fig_vvfintro1a">Figure</xref>.
+      as is done in <xref ref="fig_vvfintro1a"/>.
       Plotting lots of vectors is cumbersome, though,
       so generally we do not sketch the whole vector but just the terminal point.
       The <em>graph</em> of a vector-valued function is the set of all terminal points of <m>\vec r(t)</m>,
       where the initial point of each vector is always the origin.
-      In <xref ref="fig_vvfintro1b">Figure</xref> we sketch the graph of <m>\vec r</m> ; we can indicate individual points on the graph with their respective vector,
+      In <xref ref="fig_vvfintro1b"/> we sketch the graph of <m>\vec r</m> ; we can indicate individual points on the graph with their respective vector,
       as shown.
           <idx><h>vector-valued function</h><h>graphing</h></idx>
     </p>
@@ -162,7 +162,7 @@
         </p>
 
         <figure xml:id="fig_vvf1">
-          <caption>Sketching the vector-valued function of <xref ref="ex_vvf1">Example</xref></caption>
+          <caption>Sketching the vector-valued function of <xref ref="ex_vvf1"/></caption>
           <sidebyside widths="47% 47%" valign="bottom" margins="0%">
             <figure xml:id="fig_vvf1a">
               <caption/>
@@ -273,12 +273,12 @@
           we see that as the graph winds around the <m>z</m>-axis,
           it is also increasing at a constant rate in the positive <m>z</m> direction,
           forming a spiral.
-          This is graphed in <xref ref="fig_vvf2">Figure</xref>.
+          This is graphed in <xref ref="fig_vvf2"/>.
           In the graph <m>\vec r(7\pi/4)\approx (0.707,-0.707,5.498)</m> is highlighted to help us understand the graph.
         </p>
 
         <figure xml:id="fig_vvf2">
-          <caption>The graph of <m>\vec r(t)</m> in <xref ref="ex_vvf2">Example</xref></caption>
+          <caption>The graph of <m>\vec r(t)</m> in <xref ref="ex_vvf2"/></caption>
 
           <!-- START figures/figvvf2_3D.asy -->
           <image xml:id="img_vvf2" width="47%">
@@ -414,14 +414,14 @@
         <p>
           We are familiar with <m>\vec r_2(t) = \la\, \cos(t) ,\sin(t) \,\ra</m>;
           it traces out a circle, centered at the origin, of radius 1.
-          <xref ref="fig_vvf3a">Figure</xref> graphs
+          <xref ref="fig_vvf3a"/> graphs
           <m>\vec r_1(t)</m> and <m>\vec r_2(t)</m>.
         </p>
 
         <p>
           Adding <m>\vec r_1(t)</m> to
           <m>\vec r_2(t)</m> produces <m>\vec r(t) = \la\,\cos(t) + 0.2t,\sin(t) +0.3t\,\ra</m>,
-          graphed in <xref ref="fig_vvf3b">Figure</xref>.
+          graphed in <xref ref="fig_vvf3b"/>.
           The linear movement of the line combines with the circle to create loops that move in the direction of
           <m>\la 0.2,0.3\ra</m>. (We encourage the reader to experiment by changing
           <m>\vec r_1(t)</m> to <m>\la 2t,3t\ra</m>,
@@ -429,7 +429,7 @@
         </p>
 
         <figure xml:id="fig_vvf3">
-          <caption>Graphing the functions in <xref ref="ex_vvf3">Example</xref></caption>
+          <caption>Graphing the functions in <xref ref="ex_vvf3"/></caption>
           <sidebyside widths="31% 31% 31%" margins="0%">
             <figure xml:id="fig_vvf3a">
               <caption/>
@@ -539,10 +539,11 @@
 
         <p>
           Multiplying <m>\vec r(t)</m> by 5 scales the function by 5, producing <m>5\vec r(t) = \langle 5\cos(t) +t,5\sin(t) +1.5t\rangle</m>,
-          which is graphed in <xref ref="fig_vvf3c">Figure</xref> along with <m>\vec r(t)</m>.
+          which is graphed in <xref ref="fig_vvf3c"/> along with <m>\vec r(t)</m>.
           The new function is <q>5 times bigger</q> than <m>\vec r(t)</m>.
-          Note how the graph of <m>5\vec r(t)</m> in <xref ref="fig_vvf3c">Figure</xref> looks identical to the graph of <m>\vec r(t)</m> in <xref ref="fig_vvf3b">Figure</xref>.
-          This is due to the fact that the <m>x</m> and <m>y</m> bounds of the plot in <xref ref="fig_vvf3c">Figure</xref> are exactly 5 times larger than the bounds in <xref ref="fig_vvf3b">Figure</xref>.
+          Note how the graph of <m>5\vec r(t)</m> in <xref ref="fig_vvf3c"/> looks identical to the graph of <m>\vec r(t)</m> in <xref ref="fig_vvf3b"/>.
+          This is due to the fact that the <m>x</m> and <m>y</m> bounds of the plot in 
+          <xref ref="fig_vvf3c"/> are exactly 5 times larger than the bounds in <xref ref="fig_vvf3b"/>.
         </p>
       </solution>
     </example>
@@ -552,7 +553,7 @@
       <statement>
         <p>
           A <em>cycloid</em> is a graph traced by a point <m>p</m> on a rolling circle,
-          as shown in <xref ref="fig_vvf4a">Figure</xref>.
+          as shown in <xref ref="fig_vvf4a"/>.
           Find an equation describing the cycloid,
           where the circle has radius 1.
               <idx><h>cycloid</h></idx>
@@ -633,10 +634,10 @@
         <p>
           We now combine <m>\vec p</m> and <m>\vec c</m> together to form the equation of the cycloid:
           <m>\vec r(t) = \vec p(t) + \vec c(t) = \la \cos(t) + t,-\sin(t) +1\ra</m>,
-          which is graphed in <xref ref="fig_vvf4b">Figure</xref>.
+          which is graphed in <xref ref="fig_vvf4b"/>.
         </p>
         <figure xml:id="fig_vvf4b">
-          <caption>The cycloid in <xref ref="ex_vvf4">Example</xref></caption>
+          <caption>The cycloid in <xref ref="ex_vvf4"/></caption>
           <!-- START figures/fig_vvf4a.tex -->
           <image xml:id="img_vvf4b" width="47%">
             <description>
@@ -736,7 +737,7 @@
         </p>
 
         <figure xml:id="fig_vvf5">
-          <caption>Graphing the displacement of a position function in <xref ref="ex_vvf5">Example</xref></caption>
+          <caption>Graphing the displacement of a position function in <xref ref="ex_vvf5"/></caption>
           <!-- START figures/fig_vvf5.tex -->
           <image xml:id="img_vvf5" width="47%">
             <description>
@@ -769,7 +770,7 @@
         </figure>
 
         <p>
-          A graph of <m>\vec r(t)</m> on <m>[-1,1]</m> is given in <xref ref="fig_vvf5">Figure</xref>,
+          A graph of <m>\vec r(t)</m> on <m>[-1,1]</m> is given in <xref ref="fig_vvf5"/>,
           along with the displacement vector <m>\vec d</m> on this interval.
         </p>
       </solution>
@@ -778,7 +779,7 @@
     <p>
       Measuring displacement makes us contemplate related,
       yet very different, concepts.
-      Considering the semi-circular path the object in <xref ref="ex_vvf5">Example</xref> took,
+      Considering the semi-circular path the object in <xref ref="ex_vvf5"/> took,
       we can quickly verify that the object ended up a distance of 2 units from its initial location.
       That is, we can compute <m>\vnorm{d} = 2</m>.
       However, measuring <em>distance from the starting point</em>
@@ -811,7 +812,7 @@
       <title>Average rate of change</title>
       <statement>
         <p>
-          Let <m>\vec r(t) = \la \cos(\frac{\pi}2t),\sin(\frac{\pi}2t)\ra</m> as in <xref ref="ex_vvf5">Example</xref>.
+          Let <m>\vec r(t) = \la \cos(\frac{\pi}2t),\sin(\frac{\pi}2t)\ra</m> as in <xref ref="ex_vvf5"/>.
           Find the average rate of change of
           <m>\vec r(t)</m> on <m>[-1,1]</m> and on <m>[-1,5]</m>.
         </p>
@@ -822,7 +823,7 @@
       </solution>
       <solution>
         <p>
-          We computed in <xref ref="ex_vvf5">Example</xref>
+          We computed in <xref ref="ex_vvf5"/>
           that the displacement of <m>\vec r(t)</m> on <m>[-1,1]</m> was <m>\vec d = \la 0,2\ra</m>.
           Thus the average rate of change of <m>\vec r(t)</m> on <m>[-1,1]</m> is:
           <me>
@@ -857,8 +858,8 @@
     </example>
 
     <p>
-      We considered average rates of change in <xref ref="sec_limit_intro">Sections</xref>
-      and <xref ref="sec_derivative"/>
+      We considered average rates of change in <xref ref="sec_limit_intro" text="global">Sections</xref>
+      and <xref ref="sec_derivative" text="global"/>
       as we studied limits and derivatives.
       The same is true here;
       in the following section we apply calculus concepts to vector-valued functions as we find limits,

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -15,13 +15,13 @@
     <title>Limits of Vector-Valued Functions</title>
     <p>
       The initial definition of the limit of a vector-valued function is a bit intimidating,
-      as was the definition of the limit in <xref ref="def_limit">Definition</xref>.
+      as was the definition of the limit in <xref ref="def_limit"/>.
       The theorem following the definition shows that in practice,
       taking limits of vector-valued functions is no more difficult than taking limits of real-valued functions.
     </p>
     <aside>
       <p>
-        We can define one-sided limits in a manner very similar to <xref ref="def_vvf_limit">Definition</xref>.
+        We can define one-sided limits in a manner very similar to <xref ref="def_vvf_limit"/>.
       </p>
     </aside>
 
@@ -56,7 +56,7 @@
     </p>
 
     <p>
-      <xref ref="thm_vvf_limit">Theorem</xref>
+      <xref ref="thm_vvf_limit"/>
       states that we can compute limits of vector-valued functions component-wise.
     </p>
 
@@ -213,9 +213,9 @@
     <p>
       Consider a vector-valued function <m>\vec r</m> defined on an open interval <m>I</m> containing <m>t_0</m> and <m>t_1</m>.
       We can compute the displacement of <m>\vec r</m> on <m>[t_0,t_1]</m>,
-      as shown in <xref ref="fig_vvfderiv_introa">Figure</xref>.
+      as shown in <xref ref="fig_vvfderiv_introa"/>.
       Recall that dividing the displacement vector by <m>t_1-t_0</m> gives the average rate of change on <m>[t_0,t_1]</m>,
-      as shown in <xref ref="fig_vvfderiv_introb">Figure</xref>.
+      as shown in <xref ref="fig_vvfderiv_introb"/>.
     </p>
 
     <figure xml:id="fig_vvfderiv_intro">
@@ -431,12 +431,12 @@
           <ol>
             <li>
               <p>
-                <xref ref="thm_vvf_deriv">Theorem</xref>
+                <xref ref="thm_vvf_deriv"/>
                 allows us to compute derivatives component-wise, so
                 <me>
                   \vrp(t) = \la 2t, 1\ra
                 </me>.
-                <m>\vec r(t)</m> and <m>\vrp(t)</m> are graphed together in <xref ref="fig_vvflimit3a">Figure</xref>.
+                <m>\vec r(t)</m> and <m>\vrp(t)</m> are graphed together in <xref ref="fig_vvflimit3a"/>.
                 Note how plotting the two of these together,
                 in this way, is not very illuminating.
                 When dealing with real-valued functions,
@@ -449,14 +449,14 @@
             <li>
               <p>
                 We easily compute <m>\vrp(1) = \la 2,1\ra</m>,
-                which is drawn in <xref ref="fig_vvflimit3">Figure</xref>
+                which is drawn in <xref ref="fig_vvflimit3"/>
                 with its initial point at the origin,
                 as well as at <m>\vec r(1) = \la 1,1\ra</m>.
-                These are sketched in <xref ref="fig_vvflimit3b">Figure</xref>.
+                These are sketched in <xref ref="fig_vvflimit3b"/>.
               </p>
 
               <figure xml:id="fig_vvflimit3">
-                <caption>Graphing the derivative of a vector-valued function in <xref ref="ex_vvflimit3">Example</xref></caption>
+                <caption>Graphing the derivative of a vector-valued function in <xref ref="ex_vvflimit3"/></caption>
                 <sidebyside widths="47% 47%" margins="0%">
                   <figure xml:id="fig_vvflimit3a">
                     <caption/>
@@ -553,7 +553,7 @@
         <p>
           We compute <m>\vrp</m> as <m>\vrp(t) = \la -\sin(t) , \cos(t) , 1\ra</m>.
           At <m>t= \pi/2</m>, we have <m>\vrp(\pi/2) = \la -1,0,1\ra</m>.
-          <xref ref="fig_vvflimit4">Figure</xref>
+          <xref ref="fig_vvflimit4"/>
           shows a graph of <m>\vec r(t)</m>,
           with <m>\vrp(\pi/2)</m> plotted with its initial point at the origin and at <m>\vec r(\pi/2)</m>.
         </p>
@@ -621,8 +621,8 @@
     </example>
 
     <p>
-      In <xref ref="ex_vvflimit3">Examples</xref>
-      and <xref ref="ex_vvflimit4"/>,
+      In <xref ref="ex_vvflimit3" text="global">Examples</xref>
+      and <xref ref="ex_vvflimit4" text="global"/>,
       sketching a particular derivative with its initial point at the origin did not seem to reveal anything significant.
       However, when we sketched the vector with its initial point on the corresponding point on the graph,
       we did see something significant:
@@ -759,7 +759,7 @@
 
         <p>
           The vector equation of the line is <m>\ell(t) = \la -1,1,-1\ra + t\la 1,-2,3\ra</m>.
-          This line and <m>\vec r(t)</m> are sketched in <xref ref="fig_vvfderiv1">Figure</xref>.
+          This line and <m>\vec r(t)</m> are sketched in <xref ref="fig_vvfderiv1"/>.
         </p>
       </solution>
     </example>
@@ -790,11 +790,11 @@
         </p>
 
         <p>
-          This line is graphed with <m>\vec r(t)</m> in <xref ref="fig_vvfderiv3">Figure</xref>.
+          This line is graphed with <m>\vec r(t)</m> in <xref ref="fig_vvfderiv3"/>.
         </p>
 
         <figure xml:id="fig_vvfderiv3">
-          <caption>Graphing <m>\vec r(t)</m> and its tangent line in <xref ref="ex_vvfderiv3">Example</xref></caption>
+          <caption>Graphing <m>\vec r(t)</m> and its tangent line in <xref ref="ex_vvfderiv3"/></caption>
           <!-- START figures/fig_vvfderiv3.tex -->
           <image xml:id="img_vvfderiv3" width="47%">
             <description>
@@ -836,7 +836,7 @@
           At <m>t=0</m>, we have <m>\vrp(0) = \la 0,0\ra=\vec 0</m>!
           This implies that the tangent line
           <q>has no direction.</q>
-          We cannot apply <xref ref="def_vector_tangent">Definition</xref>,
+          We cannot apply <xref ref="def_vector_tangent"/>,
           hence cannot find the equation of the tangent line.
         </p>
       </solution>
@@ -845,11 +845,11 @@
     <p>
       We were unable to compute the equation of the tangent line to
       <m>\vec r(t)= \la t^3,t^2\ra</m> at <m>t=0</m> because <m>\vrp(0) = \vec 0</m>.
-      The graph in <xref ref="fig_vvfderiv3">Figure</xref>
+      The graph in <xref ref="fig_vvfderiv3"/>
       shows that there is a cusp at this point.
       This leads us to another definition of <em>smooth</em>,
-      previously defined by <xref ref="def_smooth">Definition</xref>
-      in <xref ref="sec_param_eqs">Section</xref>.
+      previously defined by <xref ref="def_smooth"/>
+      in <xref ref="sec_param_eqs"/>.
     </p>
 
     <definition xml:id="def_vector_smooth">
@@ -977,14 +977,14 @@
                 <me>
                   \norm{\vec r(t)} = \sqrt{t^2+(t^2-1)^2}  \Rightarrow  \vec u(t) = \frac{1}{\sqrt{t^2+(t^2-1)^2}}\la t,t^2-1\ra
                 </me>.
-                <m>\vec r(t)</m> and <m>\vec u(t)</m> are graphed in <xref ref="fig_vvfderiv2a">Figure</xref>.
+                <m>\vec r(t)</m> and <m>\vec u(t)</m> are graphed in <xref ref="fig_vvfderiv2a"/>.
                 Note how the graph of <m>\vec u(t)</m> forms part of a circle;
                 this must be the case, as the length of
                 <m>\vec u(t)</m> is 1 for all <m>t</m>.
               </p>
 
               <figure xml:id="fig_vvfderiv2a">
-                <caption>Graphing <m>\vec r(t)</m> and <m>\vec u(t)</m> in <xref ref="ex_vvfderiv2">Example</xref></caption>
+                <caption>Graphing <m>\vec r(t)</m> and <m>\vec u(t)</m> in <xref ref="ex_vvfderiv2"/></caption>
               <!-- START figures/fig_vvfderiv2a.tex -->
                 <image xml:id="img_vvfderiv2a" width="47%">
                   <description>
@@ -1028,7 +1028,7 @@
             <li>
               <p>
                 To compute <m>\vec u\,'(t)</m>,
-                we use <xref ref="thm_vvf_deriv_prop">Theorem</xref>, writing
+                we use <xref ref="thm_vvf_deriv_prop"/>, writing
                 <me>
                   \vec u(t) = f(t)\vec r(t),  \text{ where }  f(t) = \frac{1}{\sqrt{t^2+(t^2-1)^2}}=\big(t^2+(t^2-1)^2\big)^{-1/2}
                 </me>.
@@ -1043,7 +1043,7 @@
                   <mrow>\fp(t) \amp = -\frac12\big(t^2+(t^2-1)^2\big)^{-3/2}\big(2t+2(t^2-1)(2t)\big)</mrow>
                   <mrow>\amp = -\frac{2t(2t^2-1)}{2\big(\sqrt{t^2+(t^2-1)^2}\,\big)^3}</mrow>
                 </md>
-                We now find <m>\vec u\,'(t)</m> using part 3 of <xref ref="thm_vvf_deriv_prop">Theorem</xref>:
+                We now find <m>\vec u\,'(t)</m> using part 3 of <xref ref="thm_vvf_deriv_prop"/>:
                 <md>
                   <mrow>\vec u\,'(t) \amp =  \fp(t)\vec u(t) + f(t)\vec u\,'(t)</mrow>
                   <mrow>\amp =  -\frac{2t(2t^2-1)}{2\big(\sqrt{t^2+(t^2-1)^2}\,\big)^3}\la t,t^2-1\ra + \frac{1}{\sqrt{t^2+(t^2-1)^2}}\la 1,2t\ra</mrow>
@@ -1060,7 +1060,7 @@
               </p>
 
               <figure xml:id="fig_vvfderiv2b">
-                <caption>Graphing some of the derivatives of <m>\vec u(t)</m> in <xref ref="ex_vvfderiv2">Example</xref></caption>
+                <caption>Graphing some of the derivatives of <m>\vec u(t)</m> in <xref ref="ex_vvfderiv2"/></caption>
               <!-- START figures/fig_vvfderiv2b.tex -->
                 <image xml:id="img_vvfderiv2b" width="47%">
                   <description>
@@ -1102,7 +1102,7 @@
               </figure>
 
               <p>
-                Each of these is sketched in <xref ref="fig_vvfderiv2b">Figure</xref>.
+                Each of these is sketched in <xref ref="fig_vvfderiv2b"/>.
                 Note how the length of the vector gives an indication of how quickly the circle is being traced at that point.
                 When <m>t=-2</m>, the circle is being drawn relatively slow;
                 when <m>t=-1</m>, the circle is being traced much more quickly.
@@ -1115,7 +1115,7 @@
 
     <p>
       It is a basic geometric fact that a line tangent to a circle at a point <m>P</m> is perpendicular to the line passing through the center of the circle and <m>P</m>.
-      This is illustrated in <xref ref="fig_vvfderiv2b">Figure</xref>;
+      This is illustrated in <xref ref="fig_vvfderiv2b"/>;
       each tangent vector is perpendicular to the line that passes through its initial point and the center of the circle.
       Since the center of the circle is the origin,
       we can state this another way:
@@ -1170,11 +1170,11 @@
     </p>
 
     <p>
-      We can define antiderivatives and the indefinite integral of vector-valued functions in the same manner we defined indefinite integrals in <xref ref="def_antider">Definition</xref>.
-      However, we cannot define the definite integral of a vector-valued function as we did in <xref ref="def_def_int">Definition</xref>.
+      We can define antiderivatives and the indefinite integral of vector-valued functions in the same manner we defined indefinite integrals in <xref ref="def_antider"/>.
+      However, we cannot define the definite integral of a vector-valued function as we did in <xref ref="def_def_int"/>.
       That definition was based on the signed area between a function <m>y=f(x)</m> and the <m>x</m>-axis.
       An area-based definition will not be useful in the context of vector-valued functions.
-      Instead, we define the definite integral of a vector-valued function in a manner similar to that of <xref ref="thm_riemann_sum">Theorem</xref>,
+      Instead, we define the definite integral of a vector-valued function in a manner similar to that of <xref ref="thm_riemann_sum"/>,
       utilizing Riemann sums.
     </p>
 
@@ -1275,7 +1275,7 @@
       </solution>
       <solution>
         <p>
-          We follow <xref ref="thm_vvf_integration">Theorem</xref>.
+          We follow <xref ref="thm_vvf_integration"/>.
           <md>
             <mrow>\int_0^1 \vec r(t) \,dt \amp = \int_0^1 \la e^{2t},\sin(t) \ra \,dt</mrow>
             <mrow>\amp = \la \int_0^1 e^{2t}\,dt\,, \int_0^1 \sin(t) \,dt \ra</mrow>
@@ -1395,8 +1395,8 @@
       <me>
         \text{ Arc Length }  = \int_a^b\sqrt{\fp(t)^2+g'(t)^2}\, dt
       </me>,
-      as stated in <xref ref="thm_arc_length_parametric">Theorem</xref>
-      in <xref ref="sec_par_calc">Section</xref>.
+      as stated in <xref ref="thm_arc_length_parametric"/>
+      in <xref ref="sec_par_calc"/>.
       If <m>\vrt = \la f(t), g(t)\ra</m>,
       note that <m>\sqrt{\fp(t)^2+g'(t)^2} = \norm{\vrp(t)}</m>.
       Therefore we can express the arc length of the graph of a vector-valued function as an integral of the magnitude of its derivative.
@@ -1487,7 +1487,7 @@
       <exercise label="TaC-vector-functions-caluclus-4">
         <statement>
           <p>
-            <xref ref="thm_vvf_deriv_prop">Theorem</xref> contains three product rules.
+            <xref ref="thm_vvf_deriv_prop"/> contains three product rules.
             What are the three different types of products used in these rules?
           </p>
         </statement>
@@ -2152,7 +2152,7 @@
 
         <introduction>
           <p>
-            The following exercises ask you to verify parts of <xref ref="thm_vvf_deriv_prop">Theorem</xref>.
+            The following exercises ask you to verify parts of <xref ref="thm_vvf_deriv_prop"/>.
             In each let <m>f(t) = t^3</m>,
             <m>\vec r(t) =\la t^2,t-1,1\ra</m> and <m>\vec s(t) = \la \sin(t) , e^t,t\ra</m>.
             Compute the various derivatives as indicated.
@@ -2487,7 +2487,7 @@
             </pg-code> -->
             <statement>
               <p>
-                Prove <xref ref="thm_vects_of_constant_length">Theorem</xref>;
+                Prove <xref ref="thm_vects_of_constant_length"/>;
                 that is, show if <m>\vec r(t)</m> has constant length and is differentiable,
                 then <m>\vec r(t)\cdot \vrp(t)=0</m>. (Hint:
                 use the Product Rule to compute <m>\frac{d}{dt}\big(\vec r(t)\cdot\vec r(t)\big)</m>.)

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -111,7 +111,7 @@
                 <m>\vec a(-1) = \la 2,2\ra</m>;
                 <m>\vec v(1) = \la 1,3\ra</m>,
                 <m>\vec a(1) = \la 2,2\ra</m>.
-                These are plotted with <m>\vrt</m> in <xref ref="fig_motion1a">Figure</xref>.
+                These are plotted with <m>\vrt</m> in <xref ref="fig_motion1a"/>.
 
                 We can think of acceleration as <q>pulling</q>
                 the velocity vector in a certain direction.
@@ -119,12 +119,12 @@
                 at <m>t=1</m>,
                 the velocity vector has been pulled in the <m>\la 2,2\ra</m>
                 direction and is now pointing up and to the right.
-                In <xref ref="fig_motion1b">Figure</xref> we plot more velocity/acceleration vectors,
+                In <xref ref="fig_motion1b"/> we plot more velocity/acceleration vectors,
                 making more clear the effect acceleration has on velocity.
               </p>
 
               <figure xml:id="fig_motion1">
-                <caption>Graphing the position, velocity and acceleration of an object in <xref ref="ex_motion1">Example</xref></caption>
+                <caption>Graphing the position, velocity and acceleration of an object in <xref ref="ex_motion1"/></caption>
                 <sidebyside widths="47% 47%" margins="0%">
                   <figure xml:id="fig_motion1a">
                     <caption/>
@@ -231,7 +231,7 @@
                 Thus the speed is minimized at <m>t=0</m>,
                 with a speed of <m>\sqrt{2}</m> <quantity><unit base="foot"/><per base="second"/></quantity>.
 
-                The graph in <xref ref="fig_motion1b">Figure</xref> also implies speed is minimized here.
+                The graph in <xref ref="fig_motion1b"/> also implies speed is minimized here.
                 The filled dots on the graph are located at integer values of <m>t</m> between <m>-3</m> and 3.
                 Dots that are far apart imply the object traveled a far distance in 1 second, indicating high speed;
                 dots that are close together imply the object did not travel far in 1 second,
@@ -277,7 +277,7 @@
         </p>
 
         <figure xml:id="fig_motion2a">
-          <caption>Plotting velocity and acceleration vectors for Object 1 in <xref ref="ex_motion2">Example</xref></caption>
+          <caption>Plotting velocity and acceleration vectors for Object 1 in <xref ref="ex_motion2"/></caption>
         <!-- START figures/fig_motion2a.tex -->
           <image xml:id="img_motion2a" width="47%">
             <description></description>
@@ -328,7 +328,7 @@
         </p>
 
         <p>
-          In <xref ref="fig_motion2a">Figure</xref>,
+          In <xref ref="fig_motion2a"/>,
           we see the velocity and acceleration vectors for Object 1 plotted for <m>t=-1, -1/2, 0, 1/2</m> and <m>t=1</m>.
           Note again how the constant acceleration vector seems to <q>pull</q>
           the velocity vector from pointing down, right to up, right.
@@ -337,7 +337,7 @@
 
         <p>
           Instead, we simply plot the locations of Object 1 and 2 on intervals of <m>1/10^{\text{ th } }</m> of a second,
-          shown in <xref ref="fig_motion2b1">Figure</xref> and <xref ref="fig_motion2b2">Figure</xref> .
+          shown in <xref ref="fig_motion2b1"/> and <xref ref="fig_motion2b2"/>.
           Note how the <m>x</m>-values of Object 1 increase at a steady rate.
           This is because the <m>x</m>-component of <m>\vec a(t)</m> is 0;
           there is no acceleration in the <m>x</m>-component.
@@ -346,7 +346,7 @@
         </p>
 
         <figure xml:id="fig_motion2b">
-          <caption>Comparing the positions of Objects 1 and 2 in <xref ref="ex_motion2">Example</xref></caption>
+          <caption>Comparing the positions of Objects 1 and 2 in <xref ref="ex_motion2"/></caption>
           <sidebyside widths="47% 47%" margins="0%">
             <figure xml:id="fig_motion2b1">
               <caption/>
@@ -432,7 +432,7 @@
         </figure>
 
         <p>
-          In <xref ref="fig_motion2b2">Figure</xref>, we see the points plotted for Object 2.
+          In <xref ref="fig_motion2b2"/>, we see the points plotted for Object 2.
           Note the large change in position from <m>t=-1</m> to <m>t=-0.8</m>;
           the object starts moving very quickly.
           However, it slows considerably at it approaches the origin,
@@ -569,7 +569,7 @@
               </p>
 
               <figure xml:id="fig_motion3">
-                <caption>Modeling the flight of a ball in <xref ref="ex_motion3">Example</xref></caption>
+                <caption>Modeling the flight of a ball in <xref ref="ex_motion3"/></caption>
               <!-- START figures/fig_motion3.tex -->
                 <image xml:id="img_motion3" width="47%">
                   <description></description>
@@ -628,7 +628,7 @@
               <p>
                 There are many ways to find this time value.
                 We choose one that is relatively simple computationally.
-                As shown in <xref ref="fig_motion3">Figure</xref>,
+                As shown in <xref ref="fig_motion3"/>,
                 the vector from the release point to the tree is <m>\la 0,10\ra - \vec r(t_0)</m>.
                 This line segment is tangent to the circle,
                 which means it is also perpendicular to <m>\vec r(t_0)</m> itself,
@@ -684,10 +684,10 @@
     </example>
 
     <p>
-      The objects in <xref ref="ex_motion3">Examples</xref>
-      and <xref ref="ex_motion4"/> traveled at a constant speed.
+      The objects in <xref ref="ex_motion3" text="global">Examples</xref>
+      and <xref ref="ex_motion4" text="global"/> traveled at a constant speed.
       That is, <m>\norm{\vvt} = c</m> for some constant <m>c</m>.
-      Recall <xref ref="thm_vects_of_constant_length">Theorem</xref>,
+      Recall <xref ref="thm_vects_of_constant_length"/>,
       which states that if a vector-valued function <m>\vrt</m> has constant length,
       then <m>\vrt</m> is perpendicular to its derivative:
       <m>\vrt\cdot\vrp(t) = 0</m>.
@@ -840,7 +840,7 @@
       </solution>
       <solution>
         <p>
-          A direct application of <xref ref="idea_projectile">Key Idea</xref> gives
+          A direct application of <xref ref="idea_projectile"/> gives
           <md>
             <mrow>\vrt \amp = \la (350\cos(5^\circ) )t, -16t^2 + (350\sin(5^\circ) )t + 4\ra</mrow>
             <mrow>\amp \approx \la 346.67t, -16t^2+30.50t+4\ra</mrow>
@@ -1001,7 +1001,7 @@
     </theorem>
 
     <p>
-      Note that this is just a restatement of <xref ref="thm_vvf_arc_length">Theorem</xref>:
+      Note that this is just a restatement of <xref ref="thm_vvf_arc_length"/>:
       arc length is the same as distance traveled,
       just viewed in a different context.
     </p>
@@ -1051,7 +1051,7 @@
           <ol>
             <li>
               <p>
-                We use <xref ref="thm_distance_traveled">Theorem</xref> to establish the integral:
+                We use <xref ref="thm_distance_traveled"/> to establish the integral:
                 <md>
                   <mrow>\text{ distance traveled }  \amp = \int_{-2}^2 \norm{\vvt}\, dt</mrow>
                   <mrow>\amp = \int_{-2}^2 \sqrt{1+(2t)^2+ \pi^2\cos^2(\pi t)}\, dt</mrow>
@@ -1068,7 +1068,7 @@
                   \vec r(2)-\vec r(-2) = \la 2,4,0\ra - \la -2,4,0\ra = \la 4,0,0\ra
                 </me>.
                 That is, the particle ends with an <m>x</m>-value increased by 4 and with <m>y</m>- and <m>z</m>-values the same
-                (see <xref ref="fig_motion6">Figure</xref>).
+                (see <xref ref="fig_motion6"/>).
               </p>
             </li>
 
@@ -1079,7 +1079,7 @@
               </p>
 
               <figure xml:id="fig_motion6">
-                <caption>The path of the particle in <xref ref="ex_motion6">Example</xref></caption>
+                <caption>The path of the particle in <xref ref="ex_motion6"/></caption>
 
               <!-- START figures/figmotion6_3D.asy -->
                 <image xml:id="img_motion6" width="47%">
@@ -1126,8 +1126,8 @@
               </figure>
 
               <p>
-                We should also consider <xref ref="def_av_val">Definition</xref>
-                of <xref ref="sec_FTC">Section</xref>,
+                We should also consider <xref ref="def_av_val"/>
+                of <xref ref="sec_FTC"/>,
                 which says that the average value of a function <m>f</m> on <m>[a,b]</m> is <m>\frac{1}{b-a}\int_a^b f(x)\, dx</m>.
                 In our context, the average value of the speed is
                 <me>
@@ -1142,8 +1142,8 @@
     </example>
 
     <p>
-      In <xref ref="def_av_val">Definition</xref>
-      of <xref ref="chapter_integration">Chapter</xref>
+      In <xref ref="def_av_val"/>
+      of <xref ref="chapter_integration"/>
       we defined the average value of a function <m>f(x)</m> on <m>[a,b]</m> to be
       <me>
         \frac{1}{b-a}\int_a^bf(x)\, dx
@@ -1151,7 +1151,7 @@
     </p>
 
     <p>
-      Note how in <xref ref="ex_motion6">Example</xref>
+      Note how in <xref ref="ex_motion6"/>
       we computed the average speed as
       <me>
         \frac{\text{ distance traveled } }{\text{ travel time } } = \frac1{2-(-2)}\int_{-2}^2\norm{\vvt}\, dt

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -150,7 +150,7 @@
       </statement>
       <solution>
         <p>
-          From <xref ref="ex_work1">Example</xref>
+          From <xref ref="ex_work1"/>
           we know the total work performed is <m>1,164.24</m> J.
           We want to find a height <m>h</m> such that the work in pulling the rope from a height of <m>x=0</m>
           to a height of <m>x=h</m> is <m>582.12</m>, or half the total work.
@@ -179,7 +179,7 @@
         </p>
         <aside>
           <p>
-            In <xref ref="ex_work1_5">Example</xref>,
+            In <xref ref="ex_work1_5"/>,
             we find that half of the work performed in pulling up a <quantity><mag>60</mag><unit base="meter"/></quantity>
             rope is done in the last <quantity><mag>42.43</mag><unit base="meter"/></quantity>.
             Why is it not coincidental that <m>60/\sqrt{2}=42.43</m>?
@@ -327,14 +327,14 @@
           but rather that a force of
           <quantity><mag>20</mag><unit base="pound"/></quantity>
           stretches the spring by <m>5</m> inches.
-          This is illustrated in <xref ref="fig_spring1">Figure</xref>;
+          This is illustrated in <xref ref="fig_spring1"/>;
           we only measure the change in the spring's length,
           not the overall length of the spring.
         </p>
 
         <!-- START figures/fig_work_spring1.tex -->
         <figure xml:id="fig_spring1">
-          <caption>Illustrating the important aspects of stretching a spring in computing work in <xref ref="ex_spring1">Example</xref></caption>
+          <caption>Illustrating the important aspects of stretching a spring in computing work in <xref ref="ex_spring1"/></caption>
           <image xml:id="img_spring1" width="47%">
             <description>
               Image of a spring showing the spring both before and after streching.
@@ -522,12 +522,12 @@
       </statement>
       <solution>
         <p>
-          We will refer often to <xref ref="fig_pump1a">Figure</xref>
+          We will refer often to <xref ref="fig_pump1a"/>
           which illustrates the salient aspects of this problem.
         </p>
 
         <figure xml:id="fig_pump1a">
-          <caption>Illustrating a water tank in order to compute the work required to empty it in <xref ref="ex_pump1">Example</xref></caption>
+          <caption>Illustrating a water tank in order to compute the work required to empty it in <xref ref="ex_pump1"/></caption>
           <!-- START figures/fig_work_pump1.tex -->
           <image xml:id="img_pump1a" width="47%">
             <description>
@@ -590,7 +590,7 @@
 
         <p>
           Consider the work <m>W_i</m> of pumping only the water residing in the <m>i</m>th subinterval,
-          illustrated in <xref ref="fig_pump1a">Figure</xref>.
+          illustrated in <xref ref="fig_pump1a"/>.
           The force required to move this water is equal to its weight which we calculate as volume <times /> density.
           The volume of water in this subinterval is <m>V_i = 10^2\pi \Delta y_i</m>;
           its density is <quantity><mag>62.4</mag><unit base="pound"/><per base="foot" exp="3"/></quantity>.
@@ -637,8 +637,8 @@
 
     <p>
       We can <q>streamline</q> the above process a bit as we may now recognize what the important features of the problem are.
-      <xref ref="fig_pump1b">Figure</xref>
-      shows the tank from <xref ref="ex_pump1">Example</xref>
+      <xref ref="fig_pump1b"/>
+      shows the tank from <xref ref="ex_pump1"/>
       without the <m>i</m>th subinterval identified.
     </p>
 
@@ -709,7 +709,7 @@
       </statement>
       <solution>
         <p>
-          The conical tank is sketched in <xref ref="fig_pump2">Figure</xref>.
+          The conical tank is sketched in <xref ref="fig_pump2"/>.
           We can orient the tank in a variety of ways;
           we could let <m>y=0</m> represent the base of the tank and <m>y=10</m> represent the top of the tank,
           but we choose to keep the convention of the wording given in the problem and let <m>y=0</m> represent ground level and hence <m>y=-10</m> represents the bottom of the tank.
@@ -718,7 +718,7 @@
         </p>
 
         <figure xml:id="fig_pump2">
-          <caption>A graph of the conical water tank in <xref ref="ex_pump2">Example</xref></caption>
+          <caption>A graph of the conical water tank in <xref ref="ex_pump2"/></caption>
           <!-- START figures/fig_work_pump3.tex -->
           <image xml:id="img_pump2" width="47%">
             <description>
@@ -795,12 +795,12 @@
           A rectangular swimming pool is <quantity><mag>20</mag><unit base="foot"/></quantity> wide and has a <quantity><mag>3</mag><unit base="foot"/></quantity>
           <q>shallow end</q> and a <quantity><mag>6</mag><unit base="foot"/></quantity> <q>deep end.</q>
           It is to have its water pumped out to a point <quantity><mag>2</mag><unit base="foot"/></quantity> above the current top of the water.
-          The cross-sectional dimensions of the water in the pool are given in <xref ref="fig_pump3">Figure</xref>;
+          The cross-sectional dimensions of the water in the pool are given in <xref ref="fig_pump3"/>;
           note that the dimensions are for the water, not the pool itself.
           Compute the amount of work performed in draining the pool.
         </p>
         <figure xml:id="fig_pump3">
-          <caption>The cross-section of a swimming pool filled with water in <xref ref="ex_pump3">Example</xref></caption>
+          <caption>The cross-section of a swimming pool filled with water in <xref ref="ex_pump3"/></caption>
           <!-- START figures/fig_pump4.tex -->
           <image xml:id="img_pump3" width="47%">
             <description>
@@ -838,7 +838,7 @@
         </p>
 
         <figure xml:id="fig_pump_3a">
-          <caption>Orienting the pool and showing differential elements for <xref ref="ex_pump3">Example</xref></caption>
+          <caption>Orienting the pool and showing differential elements for <xref ref="ex_pump3"/></caption>
           <!-- START figures/fig_pump4b.tex -->
           <image xml:id="img_pump3a" width="47%">
             <description>
@@ -888,7 +888,7 @@
         </figure>
 
         <p>
-          <xref ref="fig_pump_3a">Figure</xref>
+          <xref ref="fig_pump_3a"/>
           shows the pool oriented with this <m>y</m>-axis,
           along with 2 differential elements as the pool must be split into two different regions.
         </p>
@@ -1505,7 +1505,7 @@
         <introduction>
           <p>
             A conical water tank is <quantity><mag>5</mag><unit base="meter"/></quantity> deep with a top radius of <quantity><mag>3</mag><unit base="meter"/></quantity>.
-            (This is similar to <xref ref="ex_pump2">Example</xref>.)
+            (This is similar to <xref ref="ex_pump2"/>.)
             The tank is filled with pure water,
             with a mass density of <quantity><mag>1000</mag><unit prefix="kilo" base="gram"/><per base="meter" exp="3"/></quantity>.
           </p>


### PR DESCRIPTION
We've had a hodgepodge of syntax usage for cross references for quite awhile.

The original conversion used syntax like `<xref ref="eg_foo">Example</xref>` for pretty much all cross-references; I think this was the standard at the time.

I've updated most of these to use the syntax `<xref ref="eg_foo"/>`. I think this is more future-proof, and also has the advantage that the link text is inherited automatically. (For example, if a figure becomes a table, or vice-versa, the link text changes accordingly, with no action required on our part.)

Exercise labelling was a mixed bag. There were a lot of things like "In Exercises `<xref ref="ex_first"></xref> <ndash/> <xref ref="ex_last"></xref>`" that I've updated as "In `<xref first="ex_first" last="ex_last" text="local">Exercises</xref>`"

This should now be consistent across the book, although it's possible I missed one or two. The link text now looks like "Exercises 13 -- 18". (The `text="local"` means we use the exercise number, rather than "Exercises 4.5.13 -- 4.5.18". I think the former makes more sense, since these exercise references are internal to a section.

For "Part", "Item", "Step", "Rule" I kept the supplied text, with local numbering. I used global numbering (including chapter and section number) when referring to definitions, theorems, etc.

One note: for equations I went with the syntax `<xref ref="eq_foo" text="global">Equation</xref>`. This makes "Equation" part of the cross-reference link. We were about 50/50 between doing this and writing "Equation `<xref ref="eq_foo"/>`", which leaves "Equation" out of the link text. And there were a few instances of just `<xref ref="eq_foo"/>`, which refers to the equation by number only, without "Equation".

If a different style is preferred for equations, it shouldn't be hard to adjust.