### PR TITLE
Move video solutions to second spot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ vshifts.ods
 # CLI bloat
 codechat_config.yaml
 .devcontainer.json
+.github/workflows

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -275,10 +275,6 @@
         <!-- figures/fig_abc1.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="qbhOWW70UyM" xml:id="vid-intapp-area-example1" label="vid-intapp-area-example1" component="video"/>
-    </solution>
     <solution>
       <p>
         The graph verifies that the upper boundary of the region is given by <m>f</m> and the lower bound is given by <m>g</m>.
@@ -289,6 +285,10 @@
           <mrow>\amp =	12\pi \approx 37.7\,\text{units}^2</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="qbhOWW70UyM" xml:id="vid-intapp-area-example1" label="vid-intapp-area-example1" component="video"/>
     </solution>
   </example>
 
@@ -348,10 +348,6 @@
         <!-- figures/fig_abc2.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="4wap7fFasZk" xml:id="vid-intapp-area-example2" label="vid-intapp-area-example2" component="video"/>
-    </solution>
     <solution>
       <p>
         A quick calculation shows that <m>f=g</m> at <m>x=1, 2</m> and 4.
@@ -369,8 +365,12 @@
         </md>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="4wap7fFasZk" xml:id="vid-intapp-area-example2" label="vid-intapp-area-example2" component="video"/>
+    </solution>
   </example>
-
+  
   <p>
     The previous example makes note that we are expecting area to be <em>positive</em>.
     When first learning about the definite integral,
@@ -437,10 +437,6 @@
         <!-- figures/fig_abc3.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="GhdqEHPbPm0" xml:id="vid-intapp-area-example3" label="vid-intapp-area-example3" component="video"/>
-    </solution>
     <solution>
       <p>
         We give two approaches to this problem.
@@ -449,7 +445,7 @@
         On <m>[0,1]</m>, the top function is <m>y=\sqrt{x}+2</m>;
         on <m>[1,2]</m>, the top function is <m>y=-(x-1)^2+3</m>.
       </p>
-
+      
       <p>
         Thus we compute the area as the sum of two integrals:
         <md>
@@ -458,7 +454,7 @@
           <mrow>\amp =4/3</mrow>
         </md>.
       </p>
-
+      
       <p>
         The second approach is clever and very useful in certain situations.
         We are used to viewing curves as functions of <m>x</m>;
@@ -473,7 +469,7 @@
           y=-(x-1)^2+3  \Rightarrow  x=\sqrt{3-y}+1
         </me>.
       </p>
-
+      
       <figure xml:id="fig_abc3b">
         <caption>The region used in <xref ref="ex_abc3"/> with boundaries relabeled as functions of <m>y</m></caption>
         <!-- START figures/fig_abc3b.tex -->
@@ -484,18 +480,18 @@
           </description>
           <shortdescription>Graph of the shaded region with boundaries relabeled as functions of y.</shortdescription>
           <latex-image>
-
-          \begin{tikzpicture}
-
-          \begin{axis}[
-          axis on top,
-          xtick={1,2},
-          ymin=-.1,ymax=3.5,
-          xmin=-.1,xmax=2.5
-          ]
-
-          \addplot [firstcurvestyle,areastyle] coordinates {(0,2.)(0.02,2.141)(0.04,2.2)(0.06,2.245)(0.08,2.283)(0.1,2.316)(0.12,2.346)(0.14,2.374)(0.16,2.4)(0.18,2.424)(0.2,2.447)(0.22,2.469)(0.24,2.49)(0.26,2.51)(0.28,2.529)(0.3,2.548)(0.32,2.566)(0.34,2.583)(0.36,2.6)(0.38,2.616)(0.4,2.632)(0.42,2.648)(0.44,2.663)(0.46,2.678)(0.48,2.693)(0.5,2.707)(0.52,2.721)(0.54,2.735)(0.56,2.748)(0.58,2.762)(0.6,2.775)(0.62,2.787)(0.64,2.8)(0.66,2.812)(0.68,2.825)(0.7,2.837)(0.72,2.849)(0.74,2.86)(0.76,2.872)(0.78,2.883)(0.8,2.894)(0.82,2.906)(0.84,2.917)(0.86,2.927)(0.88,2.938)(0.9,2.949)(0.92,2.959)(0.94,2.97)(0.96,2.98)(0.98,2.99)(1.,3.)(1.04,2.998)(1.08,2.994)(1.12,2.986)(1.16,2.974)(1.2,2.96)(1.24,2.942)(1.28,2.922)(1.32,2.898)(1.36,2.87)(1.4,2.84)(1.44,2.806)(1.48,2.77)(1.52,2.73)(1.56,2.686)(1.6,2.64)(1.64,2.59)(1.68,2.538)(1.72,2.482)(1.76,2.422)(1.8,2.36)(1.84,2.294)(1.88,2.226)(1.92,2.154)(1.96,2.078)(2.,2.)(0,2)};
-
+            
+            \begin{tikzpicture}
+            
+            \begin{axis}[
+            axis on top,
+            xtick={1,2},
+            ymin=-.1,ymax=3.5,
+            xmin=-.1,xmax=2.5
+            ]
+            
+            \addplot [firstcurvestyle,areastyle] coordinates {(0,2.)(0.02,2.141)(0.04,2.2)(0.06,2.245)(0.08,2.283)(0.1,2.316)(0.12,2.346)(0.14,2.374)(0.16,2.4)(0.18,2.424)(0.2,2.447)(0.22,2.469)(0.24,2.49)(0.26,2.51)(0.28,2.529)(0.3,2.548)(0.32,2.566)(0.34,2.583)(0.36,2.6)(0.38,2.616)(0.4,2.632)(0.42,2.648)(0.44,2.663)(0.46,2.678)(0.48,2.693)(0.5,2.707)(0.52,2.721)(0.54,2.735)(0.56,2.748)(0.58,2.762)(0.6,2.775)(0.62,2.787)(0.64,2.8)(0.66,2.812)(0.68,2.825)(0.7,2.837)(0.72,2.849)(0.74,2.86)(0.76,2.872)(0.78,2.883)(0.8,2.894)(0.82,2.906)(0.84,2.917)(0.86,2.927)(0.88,2.938)(0.9,2.949)(0.92,2.959)(0.94,2.97)(0.96,2.98)(0.98,2.99)(1.,3.)(1.04,2.998)(1.08,2.994)(1.12,2.986)(1.16,2.974)(1.2,2.96)(1.24,2.942)(1.28,2.922)(1.32,2.898)(1.36,2.87)(1.4,2.84)(1.44,2.806)(1.48,2.77)(1.52,2.73)(1.56,2.686)(1.6,2.64)(1.64,2.59)(1.68,2.538)(1.72,2.482)(1.76,2.422)(1.8,2.36)(1.84,2.294)(1.88,2.226)(1.92,2.154)(1.96,2.078)(2.,2.)(0,2)};
+            
           \addplot [firstcurvestyle,-,domain=0:.1] {sqrt(x) + 2};
           \addplot [firstcurvestyle,-,domain=.1:1] {sqrt(x) + 2};
           \addplot [firstcurvestyle,-,domain=1:2] {-(x-1)^2+3};
@@ -504,16 +500,16 @@
           \addplot [secondcurvestyle,-,solid,fill] coordinates {(0.0625,2.2)(0.0625,2.3)(1.867,2.3)(1.867,2.2)(0.0625,2.2)};
 
           \draw (axis cs:.5,3.1) node { $x=(y-2)^2$} (axis cs:1.8,3.2) node { $x=\sqrt{3-y}+1$};
-
+          
           \end{axis}
 
           \end{tikzpicture}
 
-          </latex-image>
+        </latex-image>
         </image>
         <!-- figures/fig_abc3b.tex END -->
       </figure>
-
+      
       <p>
         <xref ref="fig_abc3b"/>
         shows the region with the boundaries relabeled.
@@ -528,7 +524,7 @@
           \big(\sqrt{3-y}+1\big) - (y-2)^2
         </me>.
       </p>
-
+      
       <p>
         The area is found by integrating the above function with respect to <m>y</m> with the appropriate bounds.
         We determine these by considering the <m>y</m>-values the region occupies.
@@ -543,6 +539,10 @@
           <mrow>\amp = 4/3</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="GhdqEHPbPm0" xml:id="vid-intapp-area-example3" label="vid-intapp-area-example3" component="video"/>
     </solution>
   </example>
 
@@ -608,10 +608,6 @@
         <!-- figures/fig_abc4.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="tdFHE8cjDAY" xml:id="vid-intapp-area-example4" label="vid-intapp-area-example4" component="video"/>
-    </solution>
     <solution>
       <p>
         Recognize that there are two <q>top</q>
@@ -648,6 +644,10 @@
         (It is interesting to note that the area of all 4 subregions used is 3/4.
         This is coincidental.)
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="tdFHE8cjDAY" xml:id="vid-intapp-area-example4" label="vid-intapp-area-example4" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_ABC.ptx
+++ b/ptx/sec_ABC.ptx
@@ -65,10 +65,10 @@
         <image xml:id="img_abcintroa">
           <description>
             <p>
-              Graph of two functions <m> f(x) </m> and <m> g(x) </m> lying on the <m>xy</m> plane. 
-              The x-axis contains two marked points, a and b, which are both plotted on the positive x-axis. 
-              The functions <m> f(x) </m> and <m> g(x) </m> cross at the y-axis before diverging. 
-              The function <m> f(x) </m> lies above the function <m> g(x) </m> and resembles a sine wave. 
+              Graph of two functions <m> f(x) </m> and <m> g(x) </m> lying on the <m>xy</m> plane.
+              The x-axis contains two marked points, a and b, which are both plotted on the positive x-axis.
+              The functions <m> f(x) </m> and <m> g(x) </m> cross at the y-axis before diverging.
+              The function <m> f(x) </m> lies above the function <m> g(x) </m> and resembles a sine wave.
               The function <m> g(x) </m> is a quadratic function which lies below <m> f(x) </m> on the interval <m>(a,b)</m>.
               The area lying between the marked points a and b and below <m> f(x) </m> and above <m> g(x) </m> is shaded, which gives the exact area of this region.
             </p>
@@ -146,11 +146,11 @@
         <caption/>
       <!-- START figures/fig_abcintroc.tex -->
         <image xml:id="img_abcintroc">
-          <description>            
+          <description>
             <p>
-              Graph of the same two functions <m> f(x) </m> and <m> g(x) </m> as in the previous two images. 
+              Graph of the same two functions <m> f(x) </m> and <m> g(x) </m> as in the previous two images.
               Now, the area lying between the marked points <m>a</m> and <m>b</m> and below <m> f(x) </m> and above <m> g(x) </m> is subdivided into 10 approximate vertical slices.
-              These slices showcase the slight inaccuracy of approximation using Riemann sums for small <m> n </m>, while the first image shows us that taking the limit as <m>n\to \infty</m> gives the exact area of this region between the two functions. 
+              These slices showcase the slight inaccuracy of approximation using Riemann sums for small <m> n </m>, while the first image shows us that taking the limit as <m>n\to \infty</m> gives the exact area of this region between the two functions.
             </p>
           </description>
           <shortdescription>Graph of the shaded region between the two curves is approximated using 10 rectangles.</shortdescription>
@@ -241,7 +241,7 @@
         <image xml:id="img_abc1" width="47%">
           <description>
             <p>
-              Graph showing the area of the region bounded by <m>f(x) = \sin(x) +2</m>, <m>g(x) = \frac12\cos(2x)-1</m>, <m>x=0</m> and <m>x=4\pi</m>. 
+              Graph showing the area of the region bounded by <m>f(x) = \sin(x) +2</m>, <m>g(x) = \frac12\cos(2x)-1</m>, <m>x=0</m> and <m>x=4\pi</m>.
               The function <m> f(x) </m> is drawn starting from the y-axis and ends at the point <m> x=4 \pi </m>.
               The function <m> g(x) </m> is also drawn starting from the y-axis and ending at the point <m> x=4 \pi </m>.
               For the duration of the region between <m> x=0 </m> and <m> x=4 \pi </m>, the curve <m>f(x) = \sin(x) +2</m> lies above the curve <m>g(x) = \frac12\cos(2x)-1</m>.
@@ -306,18 +306,18 @@
         <image xml:id="img_abc2" width="47%">
           <description>
             <p>
-              Graph showing the area of the region bounded by <m>f(x) = -2x+5</m>, <m>g(x) = x^3 -7x^2 +12x -3</m>. 
+              Graph showing the area of the region bounded by <m>f(x) = -2x+5</m>, <m>g(x) = x^3 -7x^2 +12x -3</m>.
               The line given by <m> f(x) </m> is drawn starting approximately at <m> x=1 </m> and ending at the point <m> x=5 </m>.
               The cubic function given by <m> g(x) </m> is drawn starting from the y-axis as it comes up, before intersecting and going above the line <m> f(x) </m> at the point <m> (1,3) </m>.
               The function <m> g(x) </m> then meets <m> f(x) </m> at the point <m> (2,1) </m> and continues below <m> f(x) </m> until once again intercepting at the point <m> (4,-3) </m>.
-              After this point, the function <m> g(x) </m> continues above the x-axis while the line <m> f(x) </m> slopes downwards never to meet again. 
+              After this point, the function <m> g(x) </m> continues above the x-axis while the line <m> f(x) </m> slopes downwards never to meet again.
             </p>
             <p>
               The area encosed by the curves <m>f(x)</m> and <m>g(x)</m> contains two parts.
               The first part begins when <m> g(x) </m> rises above <m> f(x) </m> at <m> x=1 </m> and ends at <m> x=2 </m>, where <m> g(x) </m> falls below <m> f(x) </m>.
               The second part begins at the point <m> x=2 </m> where <m> g(x) </m> is below <m> f(x) </m> and ends at <m> x=4 </m>, where <m> g(x) </m> rises above <m> f(x) </m>.
               The first region is bounded below by <m> f(x) </m>, above by <m> g(x) </m>, <m> x=1 </m> and <m> x=2 </m>.
-              The second region is bounded above by <m> f(x) </m>, below by <m> g(x) </m>, <m> x=2 </m> and <m> x=4 </m>. 
+              The second region is bounded above by <m> f(x) </m>, below by <m> g(x) </m>, <m> x=2 </m> and <m> x=4 </m>.
               The two regions are shaded to showcase the total area enclosed by the two functions.
             </p>
           </description>
@@ -370,7 +370,7 @@
       <video width="98%" youtube="4wap7fFasZk" xml:id="vid-intapp-area-example2" label="vid-intapp-area-example2" component="video"/>
     </solution>
   </example>
-  
+
   <p>
     The previous example makes note that we are expecting area to be <em>positive</em>.
     When first learning about the definite integral,
@@ -399,11 +399,11 @@
         <image xml:id="img_abc3" width="47%">
           <description>
             <p>
-              Graph showing the area of the region bounded by <m>y=\sqrt{x}+2</m>, <m>y=-(x-1)^2+3</m> and <m>y=2</m>. 
+              Graph showing the area of the region bounded by <m>y=\sqrt{x}+2</m>, <m>y=-(x-1)^2+3</m> and <m>y=2</m>.
               The curve given by <m> y=\sqrt{x}+2 </m> is drawn starting at the y-axis and ending at the point <m> (1,3) </m>.
               The curve given by <m>y=-(x-1)^2+3</m> is drawn starting from the end of the previous curve, at the point <m> (1,3) </m>.
               This curve then slopes downwards before intersecting the horizontal line <m>y=2</m> at the point <m> (2,2) </m>.
-              Both curves lie entirely above the line <m>y=2</m>. 
+              Both curves lie entirely above the line <m>y=2</m>.
               Additionally, the curve <m> y=\sqrt{x}+2 </m> lies to the left of <m>y=-(x-1)^2+3</m> for the entirety of the enclosed region.
             </p>
           </description>
@@ -445,7 +445,7 @@
         On <m>[0,1]</m>, the top function is <m>y=\sqrt{x}+2</m>;
         on <m>[1,2]</m>, the top function is <m>y=-(x-1)^2+3</m>.
       </p>
-      
+
       <p>
         Thus we compute the area as the sum of two integrals:
         <md>
@@ -454,7 +454,7 @@
           <mrow>\amp =4/3</mrow>
         </md>.
       </p>
-      
+
       <p>
         The second approach is clever and very useful in certain situations.
         We are used to viewing curves as functions of <m>x</m>;
@@ -469,7 +469,7 @@
           y=-(x-1)^2+3  \Rightarrow  x=\sqrt{3-y}+1
         </me>.
       </p>
-      
+
       <figure xml:id="fig_abc3b">
         <caption>The region used in <xref ref="ex_abc3"/> with boundaries relabeled as functions of <m>y</m></caption>
         <!-- START figures/fig_abc3b.tex -->
@@ -480,18 +480,18 @@
           </description>
           <shortdescription>Graph of the shaded region with boundaries relabeled as functions of y.</shortdescription>
           <latex-image>
-            
+
             \begin{tikzpicture}
-            
+
             \begin{axis}[
             axis on top,
             xtick={1,2},
             ymin=-.1,ymax=3.5,
             xmin=-.1,xmax=2.5
             ]
-            
+
             \addplot [firstcurvestyle,areastyle] coordinates {(0,2.)(0.02,2.141)(0.04,2.2)(0.06,2.245)(0.08,2.283)(0.1,2.316)(0.12,2.346)(0.14,2.374)(0.16,2.4)(0.18,2.424)(0.2,2.447)(0.22,2.469)(0.24,2.49)(0.26,2.51)(0.28,2.529)(0.3,2.548)(0.32,2.566)(0.34,2.583)(0.36,2.6)(0.38,2.616)(0.4,2.632)(0.42,2.648)(0.44,2.663)(0.46,2.678)(0.48,2.693)(0.5,2.707)(0.52,2.721)(0.54,2.735)(0.56,2.748)(0.58,2.762)(0.6,2.775)(0.62,2.787)(0.64,2.8)(0.66,2.812)(0.68,2.825)(0.7,2.837)(0.72,2.849)(0.74,2.86)(0.76,2.872)(0.78,2.883)(0.8,2.894)(0.82,2.906)(0.84,2.917)(0.86,2.927)(0.88,2.938)(0.9,2.949)(0.92,2.959)(0.94,2.97)(0.96,2.98)(0.98,2.99)(1.,3.)(1.04,2.998)(1.08,2.994)(1.12,2.986)(1.16,2.974)(1.2,2.96)(1.24,2.942)(1.28,2.922)(1.32,2.898)(1.36,2.87)(1.4,2.84)(1.44,2.806)(1.48,2.77)(1.52,2.73)(1.56,2.686)(1.6,2.64)(1.64,2.59)(1.68,2.538)(1.72,2.482)(1.76,2.422)(1.8,2.36)(1.84,2.294)(1.88,2.226)(1.92,2.154)(1.96,2.078)(2.,2.)(0,2)};
-            
+
           \addplot [firstcurvestyle,-,domain=0:.1] {sqrt(x) + 2};
           \addplot [firstcurvestyle,-,domain=.1:1] {sqrt(x) + 2};
           \addplot [firstcurvestyle,-,domain=1:2] {-(x-1)^2+3};
@@ -500,7 +500,7 @@
           \addplot [secondcurvestyle,-,solid,fill] coordinates {(0.0625,2.2)(0.0625,2.3)(1.867,2.3)(1.867,2.2)(0.0625,2.2)};
 
           \draw (axis cs:.5,3.1) node { $x=(y-2)^2$} (axis cs:1.8,3.2) node { $x=\sqrt{3-y}+1$};
-          
+
           \end{axis}
 
           \end{tikzpicture}
@@ -509,7 +509,7 @@
         </image>
         <!-- figures/fig_abc3b.tex END -->
       </figure>
-      
+
       <p>
         <xref ref="fig_abc3b"/>
         shows the region with the boundaries relabeled.
@@ -524,7 +524,7 @@
           \big(\sqrt{3-y}+1\big) - (y-2)^2
         </me>.
       </p>
-      
+
       <p>
         The area is found by integrating the above function with respect to <m>y</m> with the appropriate bounds.
         We determine these by considering the <m>y</m>-values the region occupies.
@@ -573,7 +573,7 @@
         <image xml:id="img_abc4" width="47%">
           <description>
             <p>
-              Graph showing the enclosed area of the triangular region bounded by <m>y=x+1</m>, <m>y=-2x+7</m> and <m>y=-\frac12x+\frac52</m>. 
+              Graph showing the enclosed area of the triangular region bounded by <m>y=x+1</m>, <m>y=-2x+7</m> and <m>y=-\frac12x+\frac52</m>.
               The corners of the triangle are the points <m> (1,2) </m>, <m> (2,3) </m> and <m> (3,1) </m>.
               The line <m>y=x+1</m> lies above the line <m>y=-\frac12x+\frac52</m> between <m>x=1</m> and <m>x=2</m>.
               The line <m>y=-2x+7</m> also lies above the line <m>y=-\frac12x+\frac52</m> between <m>x=2</m> and <m>x=3</m>.
@@ -1150,7 +1150,7 @@
                 $D = Formula("$F-$G");
                 $area = $D->eval(x=>$x1) - $D->eval(x=>$x0);
               </pg-code>
-              
+
               <statement>
                 <p>
                   Between <m>y=\sin(4x)</m> and <m>y=\sec^2(x)</m>,
@@ -2246,7 +2246,7 @@
                 <image xml:id="img_07_01_ex_30" width="47%">
                   <description>
                     <p>
-                      A sketch of a lake with five vertically strenching length measurements with lengths in hundreds of feet. 
+                      A sketch of a lake with five vertically strenching length measurements with lengths in hundreds of feet.
                       Each length measurement is given in 200-foot increments from the previous measurement, starting 200 feet from the leftmost point of the lake.
                       The first vertical length measurement is 4.25.
                       The second is 6.6.

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -33,15 +33,15 @@
         </shortdescription>
         <description>
           <p>
-            The <m>t</m> and the <m>y</m> axes are uncalibrated. 
-            There are three distinct positions on the <m>t</m> axis, 
-            <m>a</m>, <m>x</m> and <m>b</m> in the order from left to right. 
+            The <m>t</m> and the <m>y</m> axes are uncalibrated.
+            There are three distinct positions on the <m>t</m> axis,
+            <m>a</m>, <m>x</m> and <m>b</m> in the order from left to right.
             The function <m>f(t)</m> is a curve facing downward,
-            the areas under the curve between <m>a</m> and <m>x</m> 
-            are shaded. <m>b</m> lies to the right of <m>x</m> 
+            the areas under the curve between <m>a</m> and <m>x</m>
+            are shaded. <m>b</m> lies to the right of <m>x</m>
             outside of the shaded portion.
           </p>
-        </description>          
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -86,11 +86,11 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-2</m> to <m>8</m> while the 
-                <m>t</m> axis is drawn without calibration but it has 
-                two distinct points <m>1</m> and <m>x</m>. 
-                The graph is a straight line passing through the origin and 
-                has a positive slope. The shaded portion is drawn under the 
+                The <m>y</m> axis is drawn from <m>-2</m> to <m>8</m> while the
+                <m>t</m> axis is drawn without calibration but it has
+                two distinct points <m>1</m> and <m>x</m>.
+                The graph is a straight line passing through the origin and
+                has a positive slope. The shaded portion is drawn under the
                 graph between <m>1</m> and <m>x</m>.
               </p>
             </description>
@@ -120,7 +120,7 @@
           </image>
         </figure>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -143,20 +143,20 @@
                 Graph of function same as the one used for the previous example.
               </p>
               <p>
-                The <m>y</m> axis is drawn from <m>-2</m> to <m>8</m> while the 
+                The <m>y</m> axis is drawn from <m>-2</m> to <m>8</m> while the
                 <m>t</m> axis is drawn without calibration but it has two
-                distinct positions <m>1</m> and <m>x</m>. The graph is a straight 
+                distinct positions <m>1</m> and <m>x</m>. The graph is a straight
                 line passing through the origin and has a positive slope.
                 The shaded portion is drawn under the graph between <m>1</m> and <m>x</m>.
               </p>
               <p>
-                The distance from the origin to point <m>x</m> on the <m>t</m> 
-                axis is marked <m>x</m>. The distance from origin to <m>1</m> 
-                is labeled <m>1</m>. The left boundary of the shaded region the 
-                <m>y</m> value is labeled <m>2</m> and on the right boundaries 
+                The distance from the origin to point <m>x</m> on the <m>t</m>
+                axis is marked <m>x</m>. The distance from origin to <m>1</m>
+                is labeled <m>1</m>. The left boundary of the shaded region the
+                <m>y</m> value is labeled <m>2</m> and on the right boundaries
                 the <m>y</m> value is labeled <m>2x</m>.
               </p>
-            </description>              
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -219,23 +219,23 @@
             <description>
               <p>
                 The <m>y</m> axis is drawn from <m>-2</m> to <m>8</m> and
-                the <m>x</m> axis is drawn from <m>-1</m> to <m>3</m>. 
-                The graphs of two functions are shown. 
+                the <m>x</m> axis is drawn from <m>-1</m> to <m>3</m>.
+                The graphs of two functions are shown.
                 The first is a line through the origin with slope 2,
-                and the second is a parabola that opens upward, with its vertex at <m>(0,-1)</m>. 
-                Both functions intersect at approximately <m>x=-0.4</m> 
-                and <m>x=2.4</m>, it is also between these points that 
-                the line is above the curve beyond which the curve is 
+                and the second is a parabola that opens upward, with its vertex at <m>(0,-1)</m>.
+                Both functions intersect at approximately <m>x=-0.4</m>
+                and <m>x=2.4</m>, it is also between these points that
+                the line is above the curve beyond which the curve is
                 above the line.
               </p>
               <p>
                 The straight line that passes through the origin and has
-                a positive slope. It lies in the first and the third 
+                a positive slope. It lies in the first and the third
                 quadrant.
               </p>
               <p>
-                The curve appears to start from <m>x</m> intercept 
-                <m>1</m>. It has a <m>y</m> intercept at <m>-1</m> and 
+                The curve appears to start from <m>x</m> intercept
+                <m>1</m>. It has a <m>y</m> intercept at <m>-1</m> and
                 the second <m>x</m> intercept at <m>1</m>.
               </p>
             </description>
@@ -319,7 +319,7 @@
           What is <m>\Fp(x)</m>?
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -488,7 +488,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -659,20 +659,20 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>y</m> axis is drawn from <m>-10</m> to <m>20</m> 
+                  The <m>y</m> axis is drawn from <m>-10</m> to <m>20</m>
                   and the <m>t</m> axis is drawn from <m>0</m> to <m>1</m>.
                   The function is a straight line with a negative slope.
-                  The function has an <m>y</m> intercept of <m>20</m> and 
-                  an <m>t</m> intercept of <m>5/8</m>. 
+                  The function has an <m>y</m> intercept of <m>20</m> and
+                  an <m>t</m> intercept of <m>5/8</m>.
                 </p>
                 <p>
-                  The line forms two shaded regions with the <m>t</m> axis. 
+                  The line forms two shaded regions with the <m>t</m> axis.
                   Between <m>0</m> to <m>5/8</m> on the <m>t</m> axis the region
                   under the graph is shaded and labeled <m>A1</m>.
-                  The second area is between <m>5/8</m> and <m>1</m> that lies 
+                  The second area is between <m>5/8</m> and <m>1</m> that lies
                   in the fourth quadrant and the area is labeled <m>A2</m>.
                 </p>
-              </description>                
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -712,17 +712,17 @@
                   The <m>y</m> axis is drawn from <m>-10</m> to <m>20</m> and the
                   <m>t</m> axis is drawn from <m>0</m> to <m>1</m>.
                   The function is a straight line with a negative slope.
-                  The function has an <m>y</m> intercept of <m>20 </m>and an 
-                  <m>t</m> intercept of <m>5/8</m>. 
+                  The function has an <m>y</m> intercept of <m>20 </m>and an
+                  <m>t</m> intercept of <m>5/8</m>.
                 </p>
                 <p>
-                  The  line forms two shaded regions with the <m>t</m> axis. 
-                  Between <m>0</m> to <m>5/8</m> on the <m>t</m> axis the region 
+                  The  line forms two shaded regions with the <m>t</m> axis.
+                  Between <m>0</m> to <m>5/8</m> on the <m>t</m> axis the region
                   under the graph is shaded and labeled <m>A1</m>.
-                  Between <m>5/8</m> and <m>1</m> lies the second shaded region 
+                  Between <m>5/8</m> and <m>1</m> lies the second shaded region
                   labeled <m>A3</m>.
                 </p>
-              </description>  
+              </description>
               <latex-image>
 
               \begin{tikzpicture}
@@ -870,7 +870,7 @@
           Find the derivative of <m>\ds F(x) = \int_{\cos(x) }^5 t^3\, dt</m>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -915,16 +915,16 @@
             </shortdescription>
             <description>
               <p>
-                The <m>x</m> and the <m>y</m> axes are uncalibrated but there 
+                The <m>x</m> and the <m>y</m> axes are uncalibrated but there
                 are two positions <m>a</m> and <m>b</m> marked on the <m>x</m> axis.
                 There are two functions <m>f(x)</m> and <m>g(x)</m> graphed.
-                The graph shows the area that <m>f(x)</m> forms on <m>g(x)</m> 
-                between positions <m>a</m> and <m>b</m>. 
+                The graph shows the area that <m>f(x)</m> forms on <m>g(x)</m>
+                between positions <m>a</m> and <m>b</m>.
                 The two functions intersect at one point.
               </p>
               <p>
-                The function <m>f(x)</m> is above <m>g(x)</m>, 
-                it first curves up and reaches a maxima after which it dips 
+                The function <m>f(x)</m> is above <m>g(x)</m>,
+                it first curves up and reaches a maxima after which it dips
                 down for a minima and then continues to increase.
                 The function <m>g(x)</m> has a dip between <m>a</m> and
                 <m>b</m> then it increases.
@@ -969,14 +969,14 @@
                 The <m>x</m> and the <m>y</m> axes are uncalibrated but there
                 are two positions <m>a</m> and <m>b</m> marked on the <m>x</m> axis.
                 There are two functions <m>f(x)</m> and <m>g(x)</m> graphed.
-                The graph shows the area that <m>f(x)</m> forms on <m>g(x)</m> 
-                between positions <m>a</m> and <m>b</m>. 
+                The graph shows the area that <m>f(x)</m> forms on <m>g(x)</m>
+                between positions <m>a</m> and <m>b</m>.
                 The two functions intersect at one point.
               </p>
               <p>
-                The function <m>f(x)</m> is above <m>g(x)</m>, it first curves 
-                up and reaches a maxima after which it dips down for a minima 
-                and then continues to increase.The function <m>g(x)</m> has a 
+                The function <m>f(x)</m> is above <m>g(x)</m>, it first curves
+                up and reaches a maxima after which it dips down for a minima
+                and then continues to increase.The function <m>g(x)</m> has a
                 dip between <m>a</m> and <m>b</m> then it increases.
                 The graph shows areas under both curves as different shaded regions.
               </p>
@@ -1049,7 +1049,7 @@
           Find the area of the region enclosed by <m>y=x^2+x-5</m> and <m>y=3x-2</m>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1065,12 +1065,12 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-5</m> to <m>15</m> and 
-                the <m>x</m> axis is drawn from <m>-2</m> to <m>4</m>. 
-                The first function <m>x^2 +x-5</m>is a curve that has a 
-                <m>y</m> intercept at <m>-5</m> and the <m>x</m> intercept 
-                near <m>1.8</m>. The second function <m>3*x-2</m> is a 
-                straight line. The two lines intersect at points <m>(-1,-5)</m> 
+                The <m>y</m> axis is drawn from <m>-5</m> to <m>15</m> and
+                the <m>x</m> axis is drawn from <m>-2</m> to <m>4</m>.
+                The first function <m>x^2 +x-5</m>is a curve that has a
+                <m>y</m> intercept at <m>-5</m> and the <m>x</m> intercept
+                near <m>1.8</m>. The second function <m>3*x-2</m> is a
+                straight line. The two lines intersect at points <m>(-1,-5)</m>
                 and <m>(3,7)</m>. The area bounded by the two functions is shaded.
               </p>
             </description>
@@ -1151,9 +1151,9 @@
         </shortdescription>
         <description>
           <p>
-            The <m>y</m> axis is uncalibrated and the <m>x</m> axis is 
-            drawn from <m>0</m> to <m>4</m>. 
-            The curve first decreases from <m>0</m> to <m>3</m> then 
+            The <m>y</m> axis is uncalibrated and the <m>x</m> axis is
+            drawn from <m>0</m> to <m>4</m>.
+            The curve first decreases from <m>0</m> to <m>3</m> then
             it increases until <m>x=4</m>.
           </p>
         </description>
@@ -1218,11 +1218,11 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is uncalibrated and the <m>x</m> axis is drawn 
-                from <m>0</m> to <m>4</m>. The curve first decreases from <m>0</m> 
+                The <m>y</m> axis is uncalibrated and the <m>x</m> axis is drawn
+                from <m>0</m> to <m>4</m>. The curve first decreases from <m>0</m>
                 to <m>3</m> then it increases until <m>x=4</m>.
                 The area under the curve between <m>x=1</m> to <m>x=4</m> is shaded.
-                A rectangular boundary is drawn on the <m>x</m> axis with height 
+                A rectangular boundary is drawn on the <m>x</m> axis with height
                 above the curve.
               </p>
             </description>
@@ -1259,11 +1259,11 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is uncalibrated and the <m>x</m> axis is drawn 
-                from <m>0</m> to <m>4</m>. The curve first decreases from <m>0</m> 
+                The <m>y</m> axis is uncalibrated and the <m>x</m> axis is drawn
+                from <m>0</m> to <m>4</m>. The curve first decreases from <m>0</m>
                 to <m>3</m> then it increases until <m>x=4</m>.
                 The area under the curve between <m>x=1</m> to <m>x=4</m> is shaded.
-                A rectangular boundary is drawn on the <m>x</m> axis with height 
+                A rectangular boundary is drawn on the <m>x</m> axis with height
                 a little below the curve.
               </p>
             </description>
@@ -1300,12 +1300,12 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is uncalibrated and the <m>x</m> axis is drawn from 
-                <m>0</m> to <m>4</m>. The curve first decreases from <m>0</m> to <m>3</m> 
+                The <m>y</m> axis is uncalibrated and the <m>x</m> axis is drawn from
+                <m>0</m> to <m>4</m>. The curve first decreases from <m>0</m> to <m>3</m>
                 then it increases until <m>x=4</m>.
                 The area under the curve between <m>x=1</m> to <m>x=4</m> is shaded.
-                A rectangular boundary is drawn on the <m>x</m> axis such that from 
-                <m>1</m> to <m>2</m> the curve is above the rectangle and from <m>2</m> 
+                A rectangular boundary is drawn on the <m>x</m> axis such that from
+                <m>1</m> to <m>2</m> the curve is above the rectangle and from <m>2</m>
                 to <m>4</m> the curve is below the rectangle.
               </p>
             </description>
@@ -1414,10 +1414,10 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis has two positions marked <m>sin(0.69)</m> and 
-                <m>1</m>, the <m>x</m> axis has <m>c</m>, <m>1</m>, <m>2</m> and 
-                <m>\pi</m> marked in order. The function is an inverted parabola 
-                of height <m>1</m> and has <m>x</m> intercepts at <m>x=0</m> and 
+                The <m>y</m> axis has two positions marked <m>sin(0.69)</m> and
+                <m>1</m>, the <m>x</m> axis has <m>c</m>, <m>1</m>, <m>2</m> and
+                <m>\pi</m> marked in order. The function is an inverted parabola
+                of height <m>1</m> and has <m>x</m> intercepts at <m>x=0</m> and
                 <m>x=\pi</m>. The area under the parabola until the <m>x</m> axis
                 is shaded.
                 A rectangular boundary is  drawn with height <m>sin(0.69)</m> and
@@ -1487,23 +1487,23 @@
       <sidebyside widths="47% 47%" margins="0%">
         <image xml:id="img_ftc9a">
           <shortdescription>
-            A graph of y = f(x) and the rectangle guaranteed by the Mean Value Theorem. 
+            A graph of y = f(x) and the rectangle guaranteed by the Mean Value Theorem.
           </shortdescription>
           <description>
             <p>
-              The <m>x</m> and the <m>y</m> axes are uncalibrated. 
-              The <m>y</m> axis is labeled as <m>f(x)</m>. 
-              The <m>x</m> axis has three distinct positions marked <m>a</m>, 
+              The <m>x</m> and the <m>y</m> axes are uncalibrated.
+              The <m>y</m> axis is labeled as <m>f(x)</m>.
+              The <m>x</m> axis has three distinct positions marked <m>a</m>,
               <m>c</m> and <m>b</m> in the order.
             </p>
             <p>
-              The function represents a parabola and the graph shows 
-              the area under the parabola. <m>a</m> and <m>b</m> are the 
-              two ends for the area. <m>c</m> is to the left of the vertex 
-              of the parabola almost at half the distance from <m>a</m>. 
+              The function represents a parabola and the graph shows
+              the area under the parabola. <m>a</m> and <m>b</m> are the
+              two ends for the area. <m>c</m> is to the left of the vertex
+              of the parabola almost at half the distance from <m>a</m>.
             </p>
             <p>
-              The rectangle guaranteed by the Mean Value Theorem lies above 
+              The rectangle guaranteed by the Mean Value Theorem lies above
               the vertex of the parabola.
             </p>
           </description>
@@ -1541,25 +1541,25 @@
           </shortdescription>
           <description>
             <p>
-              The <m>x</m> and the <m>y</m> axes are uncalibrated. 
-              The <m>y</m> axis is labeled as <m>f(x)</m>. 
-              The <m>x</m> axis has three distinct positions marked 
+              The <m>x</m> and the <m>y</m> axes are uncalibrated.
+              The <m>y</m> axis is labeled as <m>f(x)</m>.
+              The <m>x</m> axis has three distinct positions marked
               <m>a</m>, <m>c</m> and <m>b</m> in the order.
             </p>
             <p>
-              The function represents a parabola and the graph shows 
-              the area under the parabola. <m>a</m> and <m>b</m> are the 
-              two ends for the area. <m>c</m> is to the left of the 
-              vertex of the parabola almost at half the distance from 
-              <m>a</m>. 
+              The function represents a parabola and the graph shows
+              the area under the parabola. <m>a</m> and <m>b</m> are the
+              two ends for the area. <m>c</m> is to the left of the
+              vertex of the parabola almost at half the distance from
+              <m>a</m>.
             </p>
             <p>
               Sine the function is shifted by <m>f(c)</m>, there are three
-              parts to the area, two are positive and are above the 
-              <m>x</m> axis, from <m>a</m> to <m>c</m> and from a little 
-              before <m>b</m> to <m>b</m>. From a little before <m>b</m> 
-              to <m>b</m> the area is drawn in the fourth quadrant from 
-              above the parabola on the <m>x</m> axis. 
+              parts to the area, two are positive and are above the
+              <m>x</m> axis, from <m>a</m> to <m>c</m> and from a little
+              before <m>b</m> to <m>b</m>. From a little before <m>b</m>
+              to <m>b</m> the area is drawn in the fourth quadrant from
+              above the parabola on the <m>x</m> axis.
             </p>
           </description>
           <latex-image>
@@ -2371,7 +2371,7 @@
                 <var form="essay"/>
               </p>
             </statement>
-          </task>            
+          </task>
         </webwork>
       </exercise>
       <!-- Exercise 30 -->

--- a/ptx/sec_FTC.ptx
+++ b/ptx/sec_FTC.ptx
@@ -120,10 +120,7 @@
           </image>
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="zVyMghQRLcI" xml:id="vid_int_FTC_ex_1" label="vid_int_FTC_ex_1" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -262,6 +259,10 @@
           </image>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="zVyMghQRLcI" xml:id="vid_int_FTC_ex_1" label="vid_int_FTC_ex_1" component="video"/>
+      </solution>
     </example>
   </introduction>
 
@@ -318,10 +319,7 @@
           What is <m>\Fp(x)</m>?
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="7tHmgPcUZG4" xml:id="vid_int_FTC_ex_2" label="vid_int_FTC_ex_2" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -339,6 +337,10 @@
           We know that <m>F(-5)=0</m>, which allows us to compute <m>C</m>.
           In this case, <m>C=\cos(-5)+\frac{125}3</m>.)
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="7tHmgPcUZG4" xml:id="vid_int_FTC_ex_2" label="vid_int_FTC_ex_2" component="video"/>
       </solution>
     </example>
 
@@ -486,10 +488,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="YxQyFln5UIQ" xml:id="vid_int_FTC_ex_3" label="vid_int_FTC_ex_3" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -555,6 +554,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="YxQyFln5UIQ" xml:id="vid_int_FTC_ex_3" label="vid_int_FTC_ex_3" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -867,10 +870,7 @@
           Find the derivative of <m>\ds F(x) = \int_{\cos(x) }^5 t^3\, dt</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="nGS4ENM8arI" xml:id="vid_int_FTC_examples_2" label="vid_int_FTC_examples_2" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -881,6 +881,10 @@
             <mrow>\amp= \cos^3(x)\sin(x)</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="nGS4ENM8arI" xml:id="vid_int_FTC_examples_2" label="vid_int_FTC_examples_2" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -1045,10 +1049,7 @@
           Find the area of the region enclosed by <m>y=x^2+x-5</m> and <m>y=3x-2</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="su2CXdpYPdo" xml:id="vid_int_FTC_ex_4" label="vid_int_FTC_ex_4" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1120,6 +1121,10 @@
             <mrow>\amp = 10\frac23 = 10.\overline{6}</mrow>
           </md>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="su2CXdpYPdo" xml:id="vid_int_FTC_ex_4" label="vid_int_FTC_ex_4" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -136,10 +136,7 @@
           Solve the differential equation <m>\yp = 2y</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="PAn_TrwF27M" xml:id="vid-diffeq-basic-example1" label="vid-diffeq-basic-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The solution is a function <m>y</m> such that differentiation yields twice the original function.
@@ -235,6 +232,10 @@
           </image>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="PAn_TrwF27M" xml:id="vid-diffeq-basic-example1" label="vid-diffeq-basic-example1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_simple_de2">
@@ -244,10 +245,7 @@
           Solve the differential equation <m>\yp' + 9y = 0</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="ByArQF0qdH0" xml:id="vid-diffeq-basic-example2" label="vid-diffeq-basic-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We seek a function whose second derivative is negative 9 multiplied by the original function.
@@ -262,6 +260,10 @@
           For example, the initial conditions <m>y(0)=1</m> and
           <m>\yp(0)=3</m> yield <m>C_1 = C_2 = 1</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="ByArQF0qdH0" xml:id="vid-diffeq-basic-example2" label="vid-diffeq-basic-example2" component="video"/>
       </solution>
     </example>
 
@@ -290,10 +292,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="bf_WyPauK0Y" xml:id="vid-diffeq-basic-verify" label="vid-diffeq-basic-verify" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Verifying a solution to a differential equation is simply an exercise in differentiation and simplification.
@@ -361,6 +360,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="bf_WyPauK0Y" xml:id="vid-diffeq-basic-verify" label="vid-diffeq-basic-verify" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_verify_solutions2">
@@ -370,10 +373,7 @@
           Verify that <m>x^2+y^2 = Cy</m> is a solution to <m>\displaystyle \yp = \frac{2xy}{x^2-y^2}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="B0gxkvJf9oY" xml:id="vid-diffeq-basic-verify-implicit" label="vid-diffeq-basic-verify-implicit" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The solution in this example is called an
@@ -407,6 +407,10 @@
         <p>
           We have verified that <m>x^2+y^2 = Cy</m> is a solution to <m>\displaystyle \yp = \frac{2xy}{x^2-y^2}</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="B0gxkvJf9oY" xml:id="vid-diffeq-basic-verify-implicit" label="vid-diffeq-basic-verify-implicit" component="video"/>
       </solution>
     </example>
   </subsection>

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -136,7 +136,7 @@
           Solve the differential equation <m>\yp = 2y</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The solution is a function <m>y</m> such that differentiation yields twice the original function.
@@ -198,17 +198,17 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the <m>x</m> axis is drawn from <m>-2</m> 
-                to <m>2</m>. A group of dashed lines  emerge very close to the <m>x</m> axis on either side of it. 
-                From left to right, these lines diverge with increasing values of <m>x</m>. At about <m>x =1</m> the 
-                lines diverge greatly, forming a trumpet shape. 
+                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the <m>x</m> axis is drawn from <m>-2</m>
+                to <m>2</m>. A group of dashed lines  emerge very close to the <m>x</m> axis on either side of it.
+                From left to right, these lines diverge with increasing values of <m>x</m>. At about <m>x =1</m> the
+                lines diverge greatly, forming a trumpet shape.
               </p>
               <p>
-                The particular solution to the initial value problem with <m>y(0) = 3/2</m> from the example is shown 
-                as a curve in the second and the third quadrant that runs along one of the groups of dashed lines that 
+                The particular solution to the initial value problem with <m>y(0) = 3/2</m> from the example is shown
+                as a curve in the second and the third quadrant that runs along one of the groups of dashed lines that
                 crosses the <m>y</m> axis at <m>3/2</m>.
               </p>
-            </description>    
+            </description>
             <latex-image>
               \begin{tikzpicture}
 
@@ -245,7 +245,7 @@
           Solve the differential equation <m>\yp' + 9y = 0</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We seek a function whose second derivative is negative 9 multiplied by the original function.
@@ -292,7 +292,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Verifying a solution to a differential equation is simply an exercise in differentiation and simplification.
@@ -373,7 +373,7 @@
           Verify that <m>x^2+y^2 = Cy</m> is a solution to <m>\displaystyle \yp = \frac{2xy}{x^2-y^2}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The solution in this example is called an
@@ -441,11 +441,11 @@
         </shortdescription>
         <description>
           <p>
-            The <m>y</m> and the <m>x</m> axes are drawn from <m>0</m> to <m>1</m>. There is a curve and a 
-            dashed line shown in the graph. The dashed straight line is drawn from the origin and has a 
+            The <m>y</m> and the <m>x</m> axes are drawn from <m>0</m> to <m>1</m>. There is a curve and a
+            dashed line shown in the graph. The dashed straight line is drawn from the origin and has a
             positive slope. The curve starts at point <m>(0, 1)</m> and curves down to about point <m>(1, 0.5)</m>.
           </p>
-        </description>          
+        </description>
         <latex-image>
           \begin{tikzpicture}
 
@@ -564,14 +564,14 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axis are shown, the graph shows the slope field as a group of 
-                dashed lines. In the first quadrant, from left to right the slope fields are shown moving 
-                from north-east to north. In the second quadrant the lines are south facing on the bottom 
-                left and curving towards north-east to the top right. In the third quadrant all lines are 
-                facing south-east. In the fourth quadrant the lines are facing south-east on the bottom left 
+                The <m>y</m> and the <m>x</m> axis are shown, the graph shows the slope field as a group of
+                dashed lines. In the first quadrant, from left to right the slope fields are shown moving
+                from north-east to north. In the second quadrant the lines are south facing on the bottom
+                left and curving towards north-east to the top right. In the third quadrant all lines are
+                facing south-east. In the fourth quadrant the lines are facing south-east on the bottom left
                 and curving towards north-east to the top right, in the transition the lines are facing east.
               </p>
-            </description>              
+            </description>
             <latex-image>
               \def\length{sqrt(1+(x+y)^2)}
               \begin{tikzpicture}
@@ -640,20 +640,20 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axis are shown, the graph shows the slope field as a group 
-                of dashed lines. In the first quadrant, from left to right the slope fields are shown 
-                moving from north-east to north. In the second quadrant the lines are south facing on the 
-                bottom left and curving towards north-east to the top right. In the third quadrant all 
-                lines are facing south-east. In the fourth quadrant the lines are facing south-east on 
-                the bottom left and curving towards north-east to the top right, in the transition the 
+                The <m>y</m> and the <m>x</m> axis are shown, the graph shows the slope field as a group
+                of dashed lines. In the first quadrant, from left to right the slope fields are shown
+                moving from north-east to north. In the second quadrant the lines are south facing on the
+                bottom left and curving towards north-east to the top right. In the third quadrant all
+                lines are facing south-east. In the fourth quadrant the lines are facing south-east on
+                the bottom left and curving towards north-east to the top right, in the transition the
                 lines are facing east.
               </p>
               <p>
-                The initial value at <m>y(1) = -1</m> is a curve that moves down starting in the second 
-                quadrant then crossing the third quadrant, in the fourth quadrant it curves up after passing 
+                The initial value at <m>y(1) = -1</m> is a curve that moves down starting in the second
+                quadrant then crossing the third quadrant, in the fourth quadrant it curves up after passing
                 the point <m>(1,-1)</m> and moves up to touch the <m>x</m> axis.
               </p>
-            </description>  
+            </description>
             <latex-image>
               \def\length{sqrt(1+(x+y)^2)}
               \begin{tikzpicture}
@@ -699,14 +699,14 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>t</m> axis are drawn. There are two positions where the slope field 
-                runs parallel to the <m>t</m> axis, once along the <m>t</m> axis itself and again at some 
-                positive value of <m>y</m>.  The two horizontal lines appear to divide the slope files into 
-                three distinct parts. Over the horizontal line about some <m>y</m> value, the field lines are 
-                directed south-east. Between the line and the <m>t</m> axis the field lines are directed south-west. 
+                The <m>y</m> and the <m>t</m> axis are drawn. There are two positions where the slope field
+                runs parallel to the <m>t</m> axis, once along the <m>t</m> axis itself and again at some
+                positive value of <m>y</m>.  The two horizontal lines appear to divide the slope files into
+                three distinct parts. Over the horizontal line about some <m>y</m> value, the field lines are
+                directed south-east. Between the line and the <m>t</m> axis the field lines are directed south-west.
                 Below the <m>t</m> axis the field lines are again directed south-east.
               </p>
-            </description>              
+            </description>
             <latex-image>
               \def\length{sqrt(1+(y*(1-y))^2)}
               \begin{tikzpicture}
@@ -787,26 +787,26 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>t</m> axis are drawn. There are two positions where the slope field runs 
-                parallel to the <m>t</m> axis, once along the <m>t</m> axis itself and again at some positive 
-                value of <m>y</m>. The two horizontal lines appear to divide the slope files into three distinct parts. 
+                The <m>y</m> and the <m>t</m> axis are drawn. There are two positions where the slope field runs
+                parallel to the <m>t</m> axis, once along the <m>t</m> axis itself and again at some positive
+                value of <m>y</m>. The two horizontal lines appear to divide the slope files into three distinct parts.
               </p>
               <p>
-                Over the horizontal line, about some <m>y</m> value, the field lines are directed south-east. 
-                A curve that starts a little before the <m>y</m> axis in the second quadrant, enters the first 
-                quadrant with a negative slope it bends and moves along the horizontal line. 
+                Over the horizontal line, about some <m>y</m> value, the field lines are directed south-east.
+                A curve that starts a little before the <m>y</m> axis in the second quadrant, enters the first
+                quadrant with a negative slope it bends and moves along the horizontal line.
               </p>
               <p>
-                Between the horizontal line and the <m>t</m> axis the field lines are directed south-west. 
-                From left to right, a curve is drawn that moves with a positive slope from the second quadrant 
-                to the first, then becomes parallel to the horizontal line. 
+                Between the horizontal line and the <m>t</m> axis the field lines are directed south-west.
+                From left to right, a curve is drawn that moves with a positive slope from the second quadrant
+                to the first, then becomes parallel to the horizontal line.
               </p>
               <p>
-                Below the <m>t</m> axis the field lines are again directed south-east. From left to right, the 
-                third curve starts in the third quadrant and moves parallel to the t axis then it moves away 
+                Below the <m>t</m> axis the field lines are again directed south-east. From left to right, the
+                third curve starts in the third quadrant and moves parallel to the t axis then it moves away
                 from the t axis with a negative slope.
               </p>
-            </description>              
+            </description>
             <latex-image>
               \def\length{sqrt(1+(y*(1-y))^2)}
               \begin{tikzpicture}
@@ -999,17 +999,17 @@
           along with the analytical solution to the initial value problem</caption>
           <image xml:id="img-euler1" width="47%">
             <shortdescription>
-                Euler&#39;s Method approximation to y&#39;=x+y with y(1)=-1, with the analytical solution. 
+                Euler&#39;s Method approximation to y&#39;=x+y with y(1)=-1, with the analytical solution.
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-1</m> to <m>0</m> and the <m>x</m> axis is drawn from <m>0</m> 
-                to <m>2</m>. The function <m>y&#39;=x+y</m> with <m>y(1)=-1</m> is drawn in the fourth quadrant. From left to right from point <m>(1, -1)</m> 
-                the function curves up till point <m>(2, -0.25)</m>. There is a plot of three points which are joined 
-                by straight lines; this plot starts at the same point <m>(1,-1)</m> as the curve. The second point is 
+                The <m>y</m> axis is drawn from <m>-1</m> to <m>0</m> and the <m>x</m> axis is drawn from <m>0</m>
+                to <m>2</m>. The function <m>y&#39;=x+y</m> with <m>y(1)=-1</m> is drawn in the fourth quadrant. From left to right from point <m>(1, -1)</m>
+                the function curves up till point <m>(2, -0.25)</m>. There is a plot of three points which are joined
+                by straight lines; this plot starts at the same point <m>(1,-1)</m> as the curve. The second point is
                 a <m>(1.5, -1)</m> and the third point is at  <m>(2, -0.75)</m>.
               </p>
-            </description>              
+            </description>
             <latex-image>
               \begin{tikzpicture}
 
@@ -1087,19 +1087,19 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-1</m> to <m>0</m> and the <m>x</m> axis is drawn from <m>0</m> 
-                to <m>2</m>. The function is drawn in the fourth quadrant. From left to right from point <m>(1, -1)</m> 
-                the function curves up till point <m>(2, -0.25)</m>. 
+                The <m>y</m> axis is drawn from <m>-1</m> to <m>0</m> and the <m>x</m> axis is drawn from <m>0</m>
+                to <m>2</m>. The function is drawn in the fourth quadrant. From left to right from point <m>(1, -1)</m>
+                the function curves up till point <m>(2, -0.25)</m>.
               </p>
               <p>
-                There is a plot of three points which are joined by straight lines; this plot starts at the same point 
-                <m>(1,-1)</m> as the curve. The second point is a <m>(1.5, -1)</m> and the third point is at 
+                There is a plot of three points which are joined by straight lines; this plot starts at the same point
+                <m>(1,-1)</m> as the curve. The second point is a <m>(1.5, -1)</m> and the third point is at
                 <m>(2, -0.75)</m>, this plot is marked as <m>h=0.5</m>.
               </p>
               <p>
-                A second plot is drawn with five points every <m>0.25</m> interval of the <m>x</m> value. It coincides 
-                with the first plot from <m>x=1</m> to <m>x=1.25</m>, after which the third, the fourth and the fifth 
-                points of the second plot are all above the first plot at <m>x=1.5</m>, <m>x= 1.75</m> and <m>x=2</m>. 
+                A second plot is drawn with five points every <m>0.25</m> interval of the <m>x</m> value. It coincides
+                with the first plot from <m>x=1</m> to <m>x=1.25</m>, after which the third, the fourth and the fifth
+                points of the second plot are all above the first plot at <m>x=1.5</m>, <m>x= 1.75</m> and <m>x=2</m>.
               </p>
             </description>
             <latex-image>
@@ -1231,14 +1231,14 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is drawn from <m>0</m> 
-                to <m>4</m>. There is a curve and a plot of <m>11</m> points, the curve and the plot overlap indicating 
+                The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is drawn from <m>0</m>
+                to <m>4</m>. There is a curve and a plot of <m>11</m> points, the curve and the plot overlap indicating
                 the appropriateness of the approximation.
-                The curve starts at y intercept <m>0.25</m> and rises with a positive slope and ends in the graph at 
-                point <m>(4,1)</m>, the plot has the points distributed evenly along the curve, with few points slightly 
-                away from the curve. 
+                The curve starts at y intercept <m>0.25</m> and rises with a positive slope and ends in the graph at
+                point <m>(4,1)</m>, the plot has the points distributed evenly along the curve, with few points slightly
+                away from the curve.
               </p>
-            </description>              
+            </description>
             <latex-image>
               \begin{tikzpicture}
 
@@ -1485,11 +1485,11 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated.In the first quadrant in the top left, 
-                  the field lines are north-east facing and in the bottom right they are southeast facing. 
-                  In the second quadrant the field lines are all north-east facing. In the third quadrant 
-                  like in the first quadrant in the top left the field lines are northeast facing and in 
-                  the bottom right they are southeast facing. In the fourth quadrant all lines are 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated.In the first quadrant in the top left,
+                  the field lines are north-east facing and in the bottom right they are southeast facing.
+                  In the second quadrant the field lines are all north-east facing. In the third quadrant
+                  like in the first quadrant in the top left the field lines are northeast facing and in
+                  the bottom right they are southeast facing. In the fourth quadrant all lines are
                   southeast facing.
                 </p>
               </description>
@@ -1527,11 +1527,11 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated. The field lines form concentric 
-                  ovals facing away from the origin on both positive and negative <m>x</m> and 
-                  <m>y</m> axes. The concentric shorter arcs are on either end of the <m>x</m> axis. 
-                  On the two ends of the <m>y</m> axis concentric wider arcs are drawn. 
-                  The field lines intermix to form an 'X' with centre at the origin. 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated. The field lines form concentric
+                  ovals facing away from the origin on both positive and negative <m>x</m> and
+                  <m>y</m> axes. The concentric shorter arcs are on either end of the <m>x</m> axis.
+                  On the two ends of the <m>y</m> axis concentric wider arcs are drawn.
+                  The field lines intermix to form an 'X' with centre at the origin.
                 </p>
               </description>
               <latex-image>
@@ -1567,18 +1567,18 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated. There are five instances where 
-                  the field lines run parallel to the <m>x</m> axis. One of them is on the <m>x</m> 
-                  axis itself, other two pairs of such field lines are above and below the <m>x</m> 
-                  axis. In between the <m>x</m> axis and the first horizontal field line for some 
-                  positive <m>y</m> value, the field lines are all northeast facing. Above the 
-                  horizontal field line for some <m>y</m> value until another with a higher <m>y</m> 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated. There are five instances where
+                  the field lines run parallel to the <m>x</m> axis. One of them is on the <m>x</m>
+                  axis itself, other two pairs of such field lines are above and below the <m>x</m>
+                  axis. In between the <m>x</m> axis and the first horizontal field line for some
+                  positive <m>y</m> value, the field lines are all northeast facing. Above the
+                  horizontal field line for some <m>y</m> value until another with a higher <m>y</m>
                   value, the field lines in between are southeast facing.
                 </p>
                 <p>
-                  Similarly below the <m>x</m> axis till the first horizontal line with some negative 
-                  <m>y</m> value, the field lines in between are southeast facing. In between this 
-                  horizontal line and another horizontal line with a higher negative <m>y</m> value, 
+                  Similarly below the <m>x</m> axis till the first horizontal line with some negative
+                  <m>y</m> value, the field lines in between are southeast facing. In between this
+                  horizontal line and another horizontal line with a higher negative <m>y</m> value,
                   the field lines are northeast facing.
                 </p>
               </description>
@@ -1617,9 +1617,9 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated. The field lines run 
-                  almost parallel to the <m>x</m> axis. Above the axis the field lines 
-                  are slightly facing north east. Below the <m>x</m> axis the lines are 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated. The field lines run
+                  almost parallel to the <m>x</m> axis. Above the axis the field lines
+                  are slightly facing north east. Below the <m>x</m> axis the lines are
                   directed facing southeast.
                 </p>
               </description>
@@ -1654,17 +1654,17 @@
             <sidebyside widths="40% 40%">
               <image xml:id="img_slopefield_exercise_a">
                 <shortdescription>
-                  Graph of slope field used in the exercise. 
+                  Graph of slope field used in the exercise.
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>y</m> and the <m>x</m> axis are shown both uncalibrated. In the second and the third 
-                    quadrants the field lines towards larger negative values are south facing. The field lines 
-                    closer to the <m>y</m> axis are south-east facing. Around the <m>y</m> axis the field lines 
-                    are almost horizontal. In the first and the fourth quadrants the field lines closer to the 
+                    The <m>y</m> and the <m>x</m> axis are shown both uncalibrated. In the second and the third
+                    quadrants the field lines towards larger negative values are south facing. The field lines
+                    closer to the <m>y</m> axis are south-east facing. Around the <m>y</m> axis the field lines
+                    are almost horizontal. In the first and the fourth quadrants the field lines closer to the
                     <m>y</m> axis are east facing but for greater values of <m>x</m> they are south-east facing.
                   </p>
-                </description>                  
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
 
@@ -1687,18 +1687,18 @@
               </image>
               <image xml:id="img_slopefield_exercise_b">
                 <shortdescription>
-                  Graph of slope field used in the exercise. 
+                  Graph of slope field used in the exercise.
                 </shortdescription>
                 <description>
                   <p>
-                    The field lines are concentric facing upwards in the second and the first quadrant along the 
-                    positive <m>y</m> axis. The lines furthest away from the origin are more circular and the lines 
-                    closest to the <m>x</m> axis are almost parallel to the <m>x</m> axis. Similarly in the third 
-                    and the fourth quadrant the field lines are concentric along the negative <m>y</m> axis and the 
-                    ones away from origin are more circular and the ones closest to the <m>x</m> axis are almost 
+                    The field lines are concentric facing upwards in the second and the first quadrant along the
+                    positive <m>y</m> axis. The lines furthest away from the origin are more circular and the lines
+                    closest to the <m>x</m> axis are almost parallel to the <m>x</m> axis. Similarly in the third
+                    and the fourth quadrant the field lines are concentric along the negative <m>y</m> axis and the
+                    ones away from origin are more circular and the ones closest to the <m>x</m> axis are almost
                     parallel to the <m>x</m> axis.
                   </p>
-                </description>                  
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
 
@@ -1731,16 +1731,16 @@
             <sidebyside widths="40% 40%">
               <image xml:id="img_slopefield_exercise_c">
                 <shortdescription>
-                  Graph of slope field used in the exercise. 
+                  Graph of slope field used in the exercise.
                 </shortdescription>
                 <description>
                   <p>
-                    The field lines in the second and the first quadrant are south-east facing and appear to be east 
-                    facing when they come very close to the <m>x</m> axis. Similarly the field lines in the third 
-                    and the fourth quadrants are north-east facing and become east facing when they come very close 
+                    The field lines in the second and the first quadrant are south-east facing and appear to be east
+                    facing when they come very close to the <m>x</m> axis. Similarly the field lines in the third
+                    and the fourth quadrants are north-east facing and become east facing when they come very close
                     to the <m>x</m> axis.
                   </p>
-                </description>                  
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
 
@@ -1763,14 +1763,14 @@
               </image>
               <image xml:id="img_slopefield_exercise_d">
                 <shortdescription>
-                  Graph of slope field used in the exercise. 
+                  Graph of slope field used in the exercise.
                 </shortdescription>
                 <description>
                   <p>
-                    The field lines appear to be concentric dome shaped lines with peaks along the positive <m>y</m> 
+                    The field lines appear to be concentric dome shaped lines with peaks along the positive <m>y</m>
                     axis.
                   </p>
-                </description>                  
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
 
@@ -1874,15 +1874,15 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first quadrant 
-                  are shown. The field lines very close to the <m>y</m> axis are almost north facing for 
-                  higher values of <m>y</m> and almost east facing for lower values of <m>y</m>.  With 
-                  smaller values of <m>x</m>, the field lines, from left to right the lines first face 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first quadrant
+                  are shown. The field lines very close to the <m>y</m> axis are almost north facing for
+                  higher values of <m>y</m> and almost east facing for lower values of <m>y</m>.  With
+                  smaller values of <m>x</m>, the field lines, from left to right the lines first face
                   northeast then east and southeast after for greater values of <m>x</m>.
                 </p>
                 <p>
-                  A curve is drawn that starts at a point for some small value of <m>x</m> and a high 
-                  value of <m>y</m>. The curve has a positive slope at first after reaching a peak it 
+                  A curve is drawn that starts at a point for some small value of <m>x</m> and a high
+                  value of <m>y</m>. The curve has a positive slope at first after reaching a peak it
                   declines almost close to the <m>x</m> axis.
                 </p>
               </description>
@@ -1927,18 +1927,18 @@
               </shortdescription>
               <description>
                 <p>
-                The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first 
-                quadrant are shown. 
-                Front left to right, a little away from the x axis the field lines are northeast 
-                facing that transition to north facing. Moving further right then again become 
-                northeast facing then transition to southeast facing, further right they become 
-                south facing then east facing. The pattern then repeats. Very close to the <m>x</m> 
-                axis the field lines are almost parallel to it. 
+                The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first
+                quadrant are shown.
+                Front left to right, a little away from the x axis the field lines are northeast
+                facing that transition to north facing. Moving further right then again become
+                northeast facing then transition to southeast facing, further right they become
+                south facing then east facing. The pattern then repeats. Very close to the <m>x</m>
+                axis the field lines are almost parallel to it.
                 </p>
                 <p>
-                  A wave is drawn that starts at some y intercept above the origin. It has a high 
-                  positive slope, it reaches peak when the field lines change from northeast facing 
-                  to southeast facing, then it declines until the point the field lines are parallel 
+                  A wave is drawn that starts at some y intercept above the origin. It has a high
+                  positive slope, it reaches peak when the field lines change from northeast facing
+                  to southeast facing, then it declines until the point the field lines are parallel
                   to the <m>x</m> axis. The curve continues to form a second wave.
                 </p>
               </description>
@@ -1982,12 +1982,12 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first 
-                  quadrant are shown. There are two instances where the field lines are parallel 
-                  to the <m>x</m> axis. From under the <m>x</m> axis to the first such line the 
-                  field lines transition from almost north facing to  northeast facing. Between 
-                  the horizontal field line for a small <m>y</m> value and a greater <m>y</m> value 
-                  the field lines are facing southeast. Above the line with a higher <m>y</m> value 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first
+                  quadrant are shown. There are two instances where the field lines are parallel
+                  to the <m>x</m> axis. From under the <m>x</m> axis to the first such line the
+                  field lines transition from almost north facing to  northeast facing. Between
+                  the horizontal field line for a small <m>y</m> value and a greater <m>y</m> value
+                  the field lines are facing southeast. Above the line with a higher <m>y</m> value
                   the field lines transition from northeast facing to north facing.
                 </p>
               </description>
@@ -2030,10 +2030,10 @@
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first quadrant are shown. 
-                  In the  top right and the centre the field lines are southeast facing, very close to the <m>x</m> 
+                  The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in the first quadrant are shown.
+                  In the  top right and the centre the field lines are southeast facing, very close to the <m>x</m>
                   and <m>y</m> axis the field lines are almost parallel to the <m>x</m> axis.
-                  A curve is drawn that starts from a <m>y</m> intercept and  decreases along the slope lines coming 
+                  A curve is drawn that starts from a <m>y</m> intercept and  decreases along the slope lines coming
                   close to the <m>x</m> axis.
                 </p>
               </description>

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -104,7 +104,7 @@
         Evaluate <m>\ds\int x\cos(x) \, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The key to Integration by Parts is to identify part of the integrand as
@@ -305,7 +305,7 @@
         Evaluate <m>\displaystyle \int x^2\cos(x) \,dx</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -406,7 +406,7 @@
         Evaluate <m>\displaystyle \int e^x\cos(x) \,dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         This is a classic problem.
@@ -527,7 +527,7 @@
         Evaluate <m>\int \ln(x)\,dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         One may have noticed that we have rules for integrating the familiar trigonometric functions and <m>e^x</m>,
@@ -593,7 +593,7 @@
         Evaluate <m>\displaystyle \int \arctan x \,dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The same sneaky trick we used above works here.
@@ -647,7 +647,7 @@
           Evaluate <m>\ds \int \cos(\ln(x))\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The integrand contains a composition of functions,
@@ -712,7 +712,7 @@
           Evaluate <m>\displaystyle \int_1^2 x^2 \ln(x) \,dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Our mnemonic suggests letting <m>u=\ln(x)</m>, hence <m>dv =x^2\,dx</m>.

--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -104,10 +104,7 @@
         Evaluate <m>\ds\int x\cos(x) \, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="gKtzlaH2EPo" xml:id="vid-int-parts-ex-onestep" label="vid-int-parts-ex-onestep" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The key to Integration by Parts is to identify part of the integrand as
@@ -178,6 +175,10 @@
           <mrow>\amp = x\cos(x)</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="gKtzlaH2EPo" xml:id="vid-int-parts-ex-onestep" label="vid-int-parts-ex-onestep" component="video"/>
     </solution>
   </example>
 
@@ -304,10 +305,7 @@
         Evaluate <m>\displaystyle \int x^2\cos(x) \,dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="j9pCcQMSjbg" xml:id="vid-int-parts-ex-twostep" label="vid-int-parts-ex-twostep" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -395,6 +393,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="j9pCcQMSjbg" xml:id="vid-int-parts-ex-twostep" label="vid-int-parts-ex-twostep" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_ibp4">
@@ -404,10 +406,7 @@
         Evaluate <m>\displaystyle \int e^x\cos(x) \,dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="z0A1v2Zkfns" xml:id="vid-int-parts-ex-exp-times-cos" label="vid-int-parts-ex-exp-times-cos" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         This is a classic problem.
@@ -515,6 +514,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="z0A1v2Zkfns" xml:id="vid-int-parts-ex-exp-times-cos" label="vid-int-parts-ex-exp-times-cos" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_ibp5">
@@ -524,10 +527,7 @@
         Evaluate <m>\int \ln(x)\,dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="NGkLj7djFSw" xml:id="vid-int-parts-ex-log" label="vid-int-parts-ex-log" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         One may have noticed that we have rules for integrating the familiar trigonometric functions and <m>e^x</m>,
@@ -580,6 +580,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="NGkLj7djFSw" xml:id="vid-int-parts-ex-log" label="vid-int-parts-ex-log" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_ibp6">
@@ -589,10 +593,7 @@
         Evaluate <m>\displaystyle \int \arctan x \,dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="md3-8bv5E5M" xml:id="vid-int-parts-ex-arctan" label="vid-int-parts-ex-arctan" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The same sneaky trick we used above works here.
@@ -623,6 +624,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="md3-8bv5E5M" xml:id="vid-int-parts-ex-arctan" label="vid-int-parts-ex-arctan" component="video"/>
+    </solution>
   </example>
 
   <paragraphs>
@@ -642,10 +647,7 @@
           Evaluate <m>\ds \int \cos(\ln(x))\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="0j0vM0nosYs" xml:id="vid-int-parts-ex-sub-first" label="vid-int-parts-ex-sub-first" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The integrand contains a composition of functions,
@@ -687,6 +689,10 @@
           </md>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="0j0vM0nosYs" xml:id="vid-int-parts-ex-sub-first" label="vid-int-parts-ex-sub-first" component="video"/>
+      </solution>
     </example>
   </paragraphs>
 
@@ -706,10 +712,7 @@
           Evaluate <m>\displaystyle \int_1^2 x^2 \ln(x) \,dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="O9_0B2gatMo" xml:id="vid-int-parts-ex-definite" label="vid-int-parts-ex-definite" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Our mnemonic suggests letting <m>u=\ln(x)</m>, hence <m>dv =x^2\,dx</m>.
@@ -751,6 +754,10 @@
             <mrow>\amp \approx 1.07</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="O9_0B2gatMo" xml:id="vid-int-parts-ex-definite" label="vid-int-parts-ex-definite" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -329,10 +329,7 @@
           Find the general solution to <m>\yp = xy</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="fgeo61eY3qo" xml:id="vid-diffeq-linear-example1" label="vid-diffeq-linear-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We solve by following the steps in <xref ref="idea_solving_linear"/>.
@@ -387,6 +384,10 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="fgeo61eY3qo" xml:id="vid-diffeq-linear-example1" label="vid-diffeq-linear-example1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_linear2">
@@ -396,10 +397,7 @@
           Find the general solution to <m>\yp -(\cos(x))y = \cos(x)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="qB_aSFCQfcE" xml:id="vid-diffeq-linear-example2" label="vid-diffeq-linear-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The differential equation is already in the correct form.
@@ -428,6 +426,10 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="qB_aSFCQfcE" xml:id="vid-diffeq-linear-example2" label="vid-diffeq-linear-example2" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -442,10 +444,7 @@
           with <m>y(1)=0</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="XsFRAzdk7WI" xml:id="vid-diffeq-linear-example3" label="vid-diffeq-linear-example3" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We first divide by <m>x</m> to get
@@ -488,6 +487,10 @@
             y = \frac{1}{2}x^3\ln(x) - \frac{1}{4}x^3 + \frac{1}{4}x
           </me>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="XsFRAzdk7WI" xml:id="vid-diffeq-linear-example3" label="vid-diffeq-linear-example3" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -329,7 +329,7 @@
           Find the general solution to <m>\yp = xy</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We solve by following the steps in <xref ref="idea_solving_linear"/>.
@@ -397,7 +397,7 @@
           Find the general solution to <m>\yp -(\cos(x))y = \cos(x)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The differential equation is already in the correct form.
@@ -444,7 +444,7 @@
           with <m>y(1)=0</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We first divide by <m>x</m> to get
@@ -644,15 +644,15 @@
         </shortdescription>
         <description>
           <p>
-            The horizontal axis represents time and the vertical axis represents the velocity, 
-            both axes are drawn from <m>0</m> to <m>10</m>. The graph has assumptions that 
-            <m>v(0)=0 </m>, <m>g =9.8</m>, <m>m=1</m> and <m>k=1</m>. The velocity of a falling 
-            object without air resistance is a straight line that is very close to the vertical 
-            axis. The velocity function of a falling object with air resistance is along the 
-            previous velocity till <m>v=3</m> after which it diverges away, gets a bend at 
+            The horizontal axis represents time and the vertical axis represents the velocity,
+            both axes are drawn from <m>0</m> to <m>10</m>. The graph has assumptions that
+            <m>v(0)=0 </m>, <m>g =9.8</m>, <m>m=1</m> and <m>k=1</m>. The velocity of a falling
+            object without air resistance is a straight line that is very close to the vertical
+            axis. The velocity function of a falling object with air resistance is along the
+            previous velocity till <m>v=3</m> after which it diverges away, gets a bend at
             <m>y=10</m> and then runs parallel to the <m>x</m> axis after <m>x=4</m>.
           </p>
-        </description>          
+        </description>
         <latex-image>
           \begin{tikzpicture}
 
@@ -985,12 +985,12 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines 
-                    in the first quadrant are shown. 
-                    On the bottom right the field lines are facing northeast. On the 
-                    top left the field lines transition from southeast facing to east 
+                    The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines
+                    in the first quadrant are shown.
+                    On the bottom right the field lines are facing northeast. On the
+                    top left the field lines transition from southeast facing to east
                     facing moving downwards.
-                    A curve is shown that almost represents a straight line with a 
+                    A curve is shown that almost represents a straight line with a
                     positive slope.
                   </p>
                 </description>
@@ -1032,9 +1032,9 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in 
-                    the first quadrant are shown. The lines in the top are southeast facing, 
-                    for lower values of <m>y</m> from left to right the field lines are 
+                    The <m>x</m> and <m>y</m> axes are uncalibrated, the field lines in
+                    the first quadrant are shown. The lines in the top are southeast facing,
+                    for lower values of <m>y</m> from left to right the field lines are
                     northeast facing then they transition to east facing.
                     A downward sloping curve is shown on the field lines.
                   </p>

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -91,10 +91,7 @@
           <idx><h>bacterial growth</h></idx>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="EC18tbH7SQw" xml:id="vid-diffeq-model-bacterial-growth" label="vid-diffeq-model-bacterial-growth" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We already know that the population at time <m>t</m> is given by
@@ -122,7 +119,12 @@
           The population is predicted to reach 10,000 bacteria in slightly more than five and a half hours.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="EC18tbH7SQw" xml:id="vid-diffeq-model-bacterial-growth" label="vid-diffeq-model-bacterial-growth" component="video"/>
+      </solution>
     </example>
+    
     <p>
       Another example of porportional change is
       <em>Newton's Law of Cooling.</em>
@@ -184,10 +186,7 @@
           how long will the impatient coffee drinker have to wait until the coffee has cooled to 165<m>^\circ</m>?
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="tEMLcz1yvFI" xml:id="vid-diffeq-model-newton-cooling" label="vid-diffeq-model-newton-cooling" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Since we have already solved the differential equation for Newton's Law of Cooling,
@@ -226,6 +225,10 @@
         <p>
           The coffee drinker must wait <m>\displaystyle t = \frac{3 \ln \left(\frac{93}{128}\right)}{\ln \left(\frac{59}{64}\right)} \approx 11.78</m> minutes.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="tEMLcz1yvFI" xml:id="vid-diffeq-model-newton-cooling" label="vid-diffeq-model-newton-cooling" component="video"/>
       </solution>
     </example>
     <p>
@@ -345,10 +348,7 @@
           <idx><h>differential equation</h><h>logistic</h></idx>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="vV8Jy231gLk" xml:id="vid-diffeq-model-disease3" label="vid-diffeq-model-disease3" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The differential equation is
@@ -493,6 +493,10 @@
         </figure>
 
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="vV8Jy231gLk" xml:id="vid-diffeq-model-disease3" label="vid-diffeq-model-disease3" component="video"/>
+      </solution>
     </example>
   </subsection>
   <subsection>
@@ -562,10 +566,7 @@
           Find a function that gives the amount of salt in the tank at time <m>t</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="Au4n_QP73Ko" xml:id="vid-diffeq-model-ratein-rateout-example1" label="vid-diffeq-model-ratein-rateout-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We use the rate in - rate out setup described above.
@@ -694,9 +695,11 @@
           </image>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="Au4n_QP73Ko" xml:id="vid-diffeq-model-ratein-rateout-example1" label="vid-diffeq-model-ratein-rateout-example1" component="video"/>
+      </solution>
     </example>
-
-
 
     <example xml:id="ex_unequal_flow">
       <title>Unequal Flow Rates</title>
@@ -708,10 +711,7 @@
           What is the salt concentration when the solution ceases to be valid?
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="P3fkhn-TQEk" xml:id="vid-diffeq-model-ratein-ratout-example2" label="vid-diffeq-model-ratein-ratout-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Because the inflow and outflow rates no longer match,
@@ -775,6 +775,10 @@
           At that time, there are 25 g of salt in the tank.
           The volume of liquid is 10 L, resulting in a salt concentration of <m>2.5</m> g/L.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="P3fkhn-TQEk" xml:id="vid-diffeq-model-ratein-ratout-example2" label="vid-diffeq-model-ratein-ratout-example2" component="video"/>
       </solution>
     </example>
     <p>

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -30,10 +30,10 @@
         </shortdescription>
         <description>
           <p>
-            Image shows the equation of derivative of population with respect to time, and it being 
+            Image shows the equation of derivative of population with respect to time, and it being
             proportional to the population.
           </p>
-        </description>  
+        </description>
         <latex-image>
           \begin{tikzpicture}
 
@@ -91,7 +91,7 @@
           <idx><h>bacterial growth</h></idx>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We already know that the population at time <m>t</m> is given by
@@ -124,7 +124,7 @@
         <video width="98%" youtube="EC18tbH7SQw" xml:id="vid-diffeq-model-bacterial-growth" label="vid-diffeq-model-bacterial-growth" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       Another example of porportional change is
       <em>Newton's Law of Cooling.</em>
@@ -186,7 +186,7 @@
           how long will the impatient coffee drinker have to wait until the coffee has cooled to 165<m>^\circ</m>?
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Since we have already solved the differential equation for Newton's Law of Cooling,
@@ -348,7 +348,7 @@
           <idx><h>differential equation</h><h>logistic</h></idx>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The differential equation is
@@ -416,16 +416,16 @@
                   </shortdescription>
                   <description>
                   <p>
-                  The <m>y</m> axis is drawn from <m>0</m> to <m>0.1</m> and the <m>t</m> axis is drawn from 
-                  <m>0</m> to <m>1.2</m>. The first function is a straight line that is positively inclined, 
-                  it starts from the point <m>(0, 0.05)</m> and moves away from the <m>t</m> axis with increasing 
-                  values of <m>t</m>. The exponential and logistic functions are indistinguishable and they 
-                  also begin from the point <m>(0,0.05)</m>, they also have a positive slope but they have a dip 
-                  and separates from the line before merging again at point <m>(1,1)</m> after which they are 
-                  above the line.   
+                  The <m>y</m> axis is drawn from <m>0</m> to <m>0.1</m> and the <m>t</m> axis is drawn from
+                  <m>0</m> to <m>1.2</m>. The first function is a straight line that is positively inclined,
+                  it starts from the point <m>(0, 0.05)</m> and moves away from the <m>t</m> axis with increasing
+                  values of <m>t</m>. The exponential and logistic functions are indistinguishable and they
+                  also begin from the point <m>(0,0.05)</m>, they also have a positive slope but they have a dip
+                  and separates from the line before merging again at point <m>(1,1)</m> after which they are
+                  above the line.
                   </p>
                   </description>
-                  
+
                 <latex-image>
                   \begin{tikzpicture}
 
@@ -458,15 +458,15 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is drawn from 
-                    <m>0</m> to <m>50</m>. The three functions in the previous examples are shown. The three 
-                    curves are aligned till about <m>x=2</m> after which they diverge. The exponential curve 
-                    moves vertically, very close to the <m>y</m> axis. The logistic curve diverges to the left 
-                    from the exponential curve at about point <m>(3,0.3)</m>, it acquires a sharp bend at point 
-                    <m>(10,1)</m> after which it runs parallel to the <m>x</m> axis. The third curve is below the 
+                    The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is drawn from
+                    <m>0</m> to <m>50</m>. The three functions in the previous examples are shown. The three
+                    curves are aligned till about <m>x=2</m> after which they diverge. The exponential curve
+                    moves vertically, very close to the <m>y</m> axis. The logistic curve diverges to the left
+                    from the exponential curve at about point <m>(3,0.3)</m>, it acquires a sharp bend at point
+                    <m>(10,1)</m> after which it runs parallel to the <m>x</m> axis. The third curve is below the
                     other two and starts close to the origin and curves up to reach point <m>(50, 0.9)</m>.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
                   \begin{tikzpicture}
 
@@ -566,7 +566,7 @@
           Find a function that gives the amount of salt in the tank at time <m>t</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We use the rate in - rate out setup described above.
@@ -672,11 +672,11 @@
             </shortdescription>
             <description>
               <p>
-              The <m>y</m> axis is drawn from <m>0</m> to <m>15</m> and the <m>x</m> axis is drawn from 
-              <m>0</m> to <m>10</m>. The function starts at point <m>(0, 5)</m> and curves up with a great 
+              The <m>y</m> axis is drawn from <m>0</m> to <m>15</m> and the <m>x</m> axis is drawn from
+              <m>0</m> to <m>10</m>. The function starts at point <m>(0, 5)</m> and curves up with a great
               positive slope then the slope decreases.
               </p>
-            </description>              
+            </description>
             <latex-image>
               \begin{tikzpicture}
 
@@ -711,7 +711,7 @@
           What is the salt concentration when the solution ceases to be valid?
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Because the inflow and outflow rates no longer match,

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -135,10 +135,7 @@
           Find the general solution to the differential equation <m>\yp = x^2y</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="pDXfO52xNVw" xml:id="vid-diffeq-separable-example1" label="vid-diffeq-separable-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Using the informal solution method outlined above,
@@ -223,6 +220,10 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="pDXfO52xNVw" xml:id="vid-diffeq-separable-example1" label="vid-diffeq-separable-example1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_separable_IVP">
@@ -234,10 +235,7 @@
           with <m>y(0) = -3</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="Bl3ugfR-Guw" xml:id="vid-diffeq-separable-example-ivp" label="vid-diffeq-separable-example-ivp" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We first put the differential equation in separated form
@@ -269,6 +267,10 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="Bl3ugfR-Guw" xml:id="vid-diffeq-separable-example-ivp" label="vid-diffeq-separable-example-ivp" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_separable_DE2">
@@ -278,10 +280,7 @@
           Find the general solution to the differential equation <m>\displaystyle \frac{dy}{dx} = \frac{(x^2 + 1)e^{y}}{y}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="OharserepNU" xml:id="vido-diffeq-separable-example3" label="vido-diffeq-separable-example3" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by observing that there are no constant solutions to this differential equation because there are no constant <m>y</m>
@@ -304,6 +303,10 @@
           we cannot find an explicit form of the solution.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="OharserepNU" xml:id="vido-diffeq-separable-example3" label="vido-diffeq-separable-example3" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_logistic">
@@ -313,10 +316,7 @@
           Solve the logistic differential equation <m>\displaystyle \frac{dy}{dt} = ky\left( 1 - \frac{y}{M}\right)</m>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="nLItalqug6A" xml:id="vid-diffeq-separable-example-logistic" label="vid-diffeq-separable-example-logistic" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We looked at a slope field for this equation in <xref ref="sec_Graphical_Numerical"/>
@@ -373,6 +373,10 @@
           and has been lost.
           The general solution the logistic differential equation is the set containing <m>\displaystyle y = \frac{M}{1 + be^{-kt}}</m> and <m>y=0</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="nLItalqug6A" xml:id="vid-diffeq-separable-example-logistic" label="vid-diffeq-separable-example-logistic" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -135,7 +135,7 @@
           Find the general solution to the differential equation <m>\yp = x^2y</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Using the informal solution method outlined above,
@@ -235,7 +235,7 @@
           with <m>y(0) = -3</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We first put the differential equation in separated form
@@ -280,7 +280,7 @@
           Find the general solution to the differential equation <m>\displaystyle \frac{dy}{dx} = \frac{(x^2 + 1)e^{y}}{y}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We start by observing that there are no constant solutions to this differential equation because there are no constant <m>y</m>
@@ -316,7 +316,7 @@
           Solve the logistic differential equation <m>\displaystyle \frac{dy}{dt} = ky\left( 1 - \frac{y}{M}\right)</m>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We looked at a slope field for this equation in <xref ref="sec_Graphical_Numerical"/>

--- a/ptx/sec_alt_series.ptx
+++ b/ptx/sec_alt_series.ptx
@@ -270,7 +270,7 @@
               While the test does not state what the series converges to, we will see later that <m>\ds \infser (-1)^{n+1}\frac1n=\ln(2)</m>.
             </p>
           </li>
-          
+
           <li>
             <p>
               The underlying sequence is <m>\{a_n\} = \{\ln(n) /n\}</m>.
@@ -280,7 +280,7 @@
               It is straightforward to compute <m>a_1=0</m>, <m>a_2\approx0.347</m>,
               <m>a_3\approx 0.366</m>, and <m>a_4\approx 0.347</m>:
               the sequence is increasing for at least the first 3 terms.
-              
+
               We do not immediately conclude that we cannot apply the Alternating Series Test. Rather, consider the long-term behavior of <m>\{a_n\}</m>. Treating <m>a_n=a(n)</m> as a continuous function of <m>n</m> defined on <m>[1,\infty)</m>, we can take its derivative:
               <me>
                 a'(n) = \frac{1-\ln(n) }{n^2}
@@ -454,7 +454,7 @@
               so <m>n=9</m>).
               We can compute <m>S_9=0.902116</m>,
               which our theorem states is within <m>0.001</m> of the total sum.
-              
+
               We can use Part 2 of the theorem to obtain an even more accurate result. As we know the <m>10</m>th term of the series is <m>(-1)^n/10^3=-1/1000</m>, we can easily compute <m>S_{10} = 0.901116</m>. Part 2 of the theorem states that <m>L</m> is between <m>S_9</m> and <m>S_{10}</m>, so <m>0.901116 \lt L\lt 0.902116</m>.
             </p>
           </li>
@@ -467,7 +467,7 @@
               so we will use Newton's Method to approximate a solution.
               (Note: we can also use a <q>Brute Force</q> technique.
               That is, we can guess and check numerically until we find a solution.)
-              
+
               Let <m>f(x) = \ln(x)/x-0.001</m>; we want to know where <m>f(x) = 0</m>. We make a guess that <m>x</m> must be <q>large,</q> so our initial guess will be <m>x_1=1000</m>. Recall how Newton's Method works: given an approximate solution <m>x_n</m>, our next approximation <m>x_{n+1}</m> is given by
               <me>
                 x_{n+1} = x_n - \frac{f(x_n)}{\fp(x_n)}
@@ -482,13 +482,13 @@
               we find that Newton's Method seems to converge to a solution <m>x=9118.01</m> after 8 iterations.
               Taking the next integer higher,
               we have <m>n=9119</m>, where <m>\ln(9119)/9119 =0.000999903\lt 0.001</m>.
-              
+
               Again using a computer, we find <m>S_{9118} = -0.160369</m>. Part 1 of the theorem states that this is within <m>0.001</m> of the actual sum <m>L</m>. Already knowing the <m>9{,}119</m>th term, we can compute <m>S_{9119} = -0.159369</m>, meaning <m>-0.159369 \lt  L \lt  -0.160369</m>.
             </p>
           </li>
         </ol>
       </p>
-      
+
       <p>
         Notice how the first series converged quite quickly,
         where we needed only 10 terms to reach the desired accuracy,
@@ -500,7 +500,7 @@
       <video width="98%" youtube="f_iiMYNpqXE" xml:id="vid-seqseries-ast-approx-example" label="vid-seqseries-ast-approx-example" component="video"/>
     </solution>
   </example>
-  
+
   <p>
     One of the famous results of mathematics is that the Harmonic Series,
     <m>\ds \infser \frac1n</m> diverges,
@@ -584,11 +584,11 @@
               </me>
               diverges using the Limit Comparison Test,
               comparing with <m>1/n</m>.
-              
+
               The series <m>\ds \infser (-1)^n\frac{n+3}{n^2+2n+5}</m> converges using the Alternating Series Test; we conclude it converges conditionally.
             </p>
           </li>
-          
+
           <li>
             <p>
               We can show the series
@@ -596,11 +596,11 @@
                 \ds \infser \abs{(-1)^n\frac{n^2+2n+5}{2^n}}=\infser \frac{n^2+2n+5}{2^n}
               </me>
               converges using the Ratio Test.
-              
+
               Therefore we conclude <m>\ds \infser (-1)^n\frac{n^2+2n+5}{2^n}</m> converges absolutely.
             </p>
           </li>
-          
+
           <li>
             <p>
               The series
@@ -1126,7 +1126,7 @@
           <!--</webwork>-->
         </exercise>
 
-        <exercise label="ex-alternating-series-conditional-7"> 
+        <exercise label="ex-alternating-series-conditional-7">
           <!--<webwork xml:id="webwork-ex-alternating-series-conditional-7">
               <pg-code>
               </pg-code>-->

--- a/ptx/sec_alt_series.ptx
+++ b/ptx/sec_alt_series.ptx
@@ -256,10 +256,6 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="WmsfSSlc-W0" xml:id="vid-seqseries-ast-example1" label="vid-seqseries-ast-example1" component="video"/>
-    </solution>
     <solution>
       <p>
         <ol>
@@ -274,7 +270,7 @@
               While the test does not state what the series converges to, we will see later that <m>\ds \infser (-1)^{n+1}\frac1n=\ln(2)</m>.
             </p>
           </li>
-
+          
           <li>
             <p>
               The underlying sequence is <m>\{a_n\} = \{\ln(n) /n\}</m>.
@@ -284,7 +280,7 @@
               It is straightforward to compute <m>a_1=0</m>, <m>a_2\approx0.347</m>,
               <m>a_3\approx 0.366</m>, and <m>a_4\approx 0.347</m>:
               the sequence is increasing for at least the first 3 terms.
-
+              
               We do not immediately conclude that we cannot apply the Alternating Series Test. Rather, consider the long-term behavior of <m>\{a_n\}</m>. Treating <m>a_n=a(n)</m> as a continuous function of <m>n</m> defined on <m>[1,\infty)</m>, we can take its derivative:
               <me>
                 a'(n) = \frac{1-\ln(n) }{n^2}
@@ -314,6 +310,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="WmsfSSlc-W0" xml:id="vid-seqseries-ast-example1" label="vid-seqseries-ast-example1" component="video"/>
     </solution>
   </example>
 
@@ -434,10 +434,6 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="f_iiMYNpqXE" xml:id="vid-seqseries-ast-approx-example" label="vid-seqseries-ast-approx-example" component="video"/>
-    </solution>
     <solution>
       <p>
         <ol>
@@ -458,7 +454,7 @@
               so <m>n=9</m>).
               We can compute <m>S_9=0.902116</m>,
               which our theorem states is within <m>0.001</m> of the total sum.
-
+              
               We can use Part 2 of the theorem to obtain an even more accurate result. As we know the <m>10</m>th term of the series is <m>(-1)^n/10^3=-1/1000</m>, we can easily compute <m>S_{10} = 0.901116</m>. Part 2 of the theorem states that <m>L</m> is between <m>S_9</m> and <m>S_{10}</m>, so <m>0.901116 \lt L\lt 0.902116</m>.
             </p>
           </li>
@@ -471,7 +467,7 @@
               so we will use Newton's Method to approximate a solution.
               (Note: we can also use a <q>Brute Force</q> technique.
               That is, we can guess and check numerically until we find a solution.)
-
+              
               Let <m>f(x) = \ln(x)/x-0.001</m>; we want to know where <m>f(x) = 0</m>. We make a guess that <m>x</m> must be <q>large,</q> so our initial guess will be <m>x_1=1000</m>. Recall how Newton's Method works: given an approximate solution <m>x_n</m>, our next approximation <m>x_{n+1}</m> is given by
               <me>
                 x_{n+1} = x_n - \frac{f(x_n)}{\fp(x_n)}
@@ -486,21 +482,25 @@
               we find that Newton's Method seems to converge to a solution <m>x=9118.01</m> after 8 iterations.
               Taking the next integer higher,
               we have <m>n=9119</m>, where <m>\ln(9119)/9119 =0.000999903\lt 0.001</m>.
-
+              
               Again using a computer, we find <m>S_{9118} = -0.160369</m>. Part 1 of the theorem states that this is within <m>0.001</m> of the actual sum <m>L</m>. Already knowing the <m>9{,}119</m>th term, we can compute <m>S_{9119} = -0.159369</m>, meaning <m>-0.159369 \lt  L \lt  -0.160369</m>.
             </p>
           </li>
         </ol>
       </p>
-
+      
       <p>
         Notice how the first series converged quite quickly,
         where we needed only 10 terms to reach the desired accuracy,
         whereas the second series took over 9,000 terms.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="f_iiMYNpqXE" xml:id="vid-seqseries-ast-approx-example" label="vid-seqseries-ast-approx-example" component="video"/>
+    </solution>
   </example>
-
+  
   <p>
     One of the famous results of mathematics is that the Harmonic Series,
     <m>\ds \infser \frac1n</m> diverges,
@@ -573,10 +573,6 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="l02aGt0Ce5M" xml:id="vid-seqseries-ast-abs-conv-example" label="vid-seqseries-ast-abs-conv-example" component="video"/>
-    </solution>
     <solution>
       <p>
         <ol>
@@ -588,11 +584,11 @@
               </me>
               diverges using the Limit Comparison Test,
               comparing with <m>1/n</m>.
-
+              
               The series <m>\ds \infser (-1)^n\frac{n+3}{n^2+2n+5}</m> converges using the Alternating Series Test; we conclude it converges conditionally.
             </p>
           </li>
-
+          
           <li>
             <p>
               We can show the series
@@ -600,11 +596,11 @@
                 \ds \infser \abs{(-1)^n\frac{n^2+2n+5}{2^n}}=\infser \frac{n^2+2n+5}{2^n}
               </me>
               converges using the Ratio Test.
-
+              
               Therefore we conclude <m>\ds \infser (-1)^n\frac{n^2+2n+5}{2^n}</m> converges absolutely.
             </p>
           </li>
-
+          
           <li>
             <p>
               The series
@@ -624,6 +620,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="l02aGt0Ce5M" xml:id="vid-seqseries-ast-abs-conv-example" label="vid-seqseries-ast-abs-conv-example" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -217,12 +217,8 @@
           Evaluate <m> \int \sin(x) \,dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="W-FUL0ApGL8" xml:id="vid_int_antider_ex_1" label="vid_int_antider_ex_1" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           We are asked to find all functions <m>F(x)</m> such that
           <m>\Fp(x) = \sin(x)</m>.
@@ -238,14 +234,18 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="W-FUL0ApGL8" xml:id="vid_int_antider_ex_1" label="vid_int_antider_ex_1" component="video"/>
+      </solution>
     </example>
-
+    
     <p>
       A commonly asked question is <q>What happened to the <m>dx</m>?</q>
       The unenlightened response is <q>Don't worry about it.
-      It just goes away.</q> A full understanding includes the following.
-    </p>
-    <p>
+        It just goes away.</q> A full understanding includes the following.
+      </p>
+      <p>
       This process of <em>antidifferentiation</em>
       is really solving a <em>differential</em> question.
       The integral
@@ -291,10 +291,6 @@
           Evaluate <m>\int\left(3x^2 + 4x+5\right)\,dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="3DFPqGHX7Yw" xml:id="vid_int_antider_ex_2" label="vid_int_antider_ex_2" component="video"/>
-      </solution>
       <solution>
 
         <p>
@@ -339,6 +335,10 @@
           take the derivative of <m>x^3+2x^3+5x+C</m> and see we indeed get
           <m>3x^2+4x+5</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="3DFPqGHX7Yw" xml:id="vid_int_antider_ex_2" label="vid_int_antider_ex_2" component="video"/>
       </solution>
     </example>
 
@@ -567,10 +567,6 @@
           Find the equation of the object's velocity.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="3K_gWY4lmOs" xml:id="vid_int_antider_ex_3" label="vid_int_antider_ex_3" component="video"/>
-      </solution>
       <solution>
 
         <p>
@@ -630,6 +626,10 @@
           point in time.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="3K_gWY4lmOs" xml:id="vid_int_antider_ex_3" label="vid_int_antider_ex_3" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_anti5">
@@ -640,10 +640,6 @@
           <m>\fp(0) = 3</m> and <m>f(0) = 5</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="MB1dLY4lOew" xml:id="vid_int_antider_ex_4" label="vid_int_antider_ex_4" component="video"/>
-      </solution>
       <solution>
 
         <p>
@@ -683,6 +679,10 @@
         <p>
           Thus <m>f(t) = -\cos(t) + 3t + 6</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="MB1dLY4lOew" xml:id="vid_int_antider_ex_4" label="vid_int_antider_ex_4" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -218,7 +218,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           We are asked to find all functions <m>F(x)</m> such that
           <m>\Fp(x) = \sin(x)</m>.
@@ -239,7 +239,7 @@
         <video width="98%" youtube="W-FUL0ApGL8" xml:id="vid_int_antider_ex_1" label="vid_int_antider_ex_1" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       A commonly asked question is <q>What happened to the <m>dx</m>?</q>
       The unenlightened response is <q>Don't worry about it.

--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -76,7 +76,7 @@
           <image xml:id="img_arcintroa">
             <description>
               Graph of the function <m>y=\sin(x)</m> on <m>[0,\pi]</m>.
-              The curve <m>y=\sin(x)</m> begins at the point <m>(0,0)</m>, from which it slopes upwards until reaching a peak at the point <m>(\frac{\pi}{2},1)</m>. 
+              The curve <m>y=\sin(x)</m> begins at the point <m>(0,0)</m>, from which it slopes upwards until reaching a peak at the point <m>(\frac{\pi}{2},1)</m>.
               From the point, the curve slopes downwards until reaching the <m>x</m>-axis at the point <m>(\pi,0)</m>.
             </description>
             <shortdescription>Graph of the sine function for x between 0 and pi.</shortdescription>
@@ -111,11 +111,11 @@
             <description>
               Graph of the function <m>y=\sin(x)</m> on <m>[0,\pi]</m>, with four straight lines which will be used to approximate the length of this curve.
               The four lines are evenly spaced out in intervals of <m>\frac{\pi}{4}</m> on the <m>x</m>-axis.
-              Each line begins at a point on the curve <m>y=\sin(x)</m>, and ends at a point on the same curve after travelling a distance of <m>\frac{\pi}{4}</m> on the <m>x</m>-axis. 
-              The first line begins at the same point <m>(0,0)</m> as the curve, from which it linearly increases until reaching the point <m>(\frac{\pi}{4},\frac{sqrt2}{2})</m>, which is also a point on the curve. 
-              The second line begins at the same point the first line ends, given by <m>(\frac{\pi}{4},\frac{sqrt2}{2})</m>, from which it linearly increases until reaching the point <m>(\frac{\pi}{2},1)</m>, which is the peak of the curve. 
-              The third line begins at the same point the second line ends, given by <m>(\frac{\pi}{2},1)</m>, from which it linearly decreases until reaching the point <m>(\frac{3\pi}{4},\frac{sqrt2}{2})</m>, which is also a point on the curve. 
-              The fourth line begins at the same point the third line ends, given by <m>(\frac{3\pi}{4},\frac{sqrt2}{2})</m>, from which it linearly decreases until reaching the point <m>(\pi,0)</m>, which is the end of the curve. 
+              Each line begins at a point on the curve <m>y=\sin(x)</m>, and ends at a point on the same curve after travelling a distance of <m>\frac{\pi}{4}</m> on the <m>x</m>-axis.
+              The first line begins at the same point <m>(0,0)</m> as the curve, from which it linearly increases until reaching the point <m>(\frac{\pi}{4},\frac{sqrt2}{2})</m>, which is also a point on the curve.
+              The second line begins at the same point the first line ends, given by <m>(\frac{\pi}{4},\frac{sqrt2}{2})</m>, from which it linearly increases until reaching the point <m>(\frac{\pi}{2},1)</m>, which is the peak of the curve.
+              The third line begins at the same point the second line ends, given by <m>(\frac{\pi}{2},1)</m>, from which it linearly decreases until reaching the point <m>(\frac{3\pi}{4},\frac{sqrt2}{2})</m>, which is also a point on the curve.
+              The fourth line begins at the same point the third line ends, given by <m>(\frac{3\pi}{4},\frac{sqrt2}{2})</m>, from which it linearly decreases until reaching the point <m>(\pi,0)</m>, which is the end of the curve.
             </description>
             <shortdescription>Graph of the sine function for x between 0 and pi and four straight lines approximating this curve.</shortdescription>
             <latex-image>
@@ -175,7 +175,7 @@
       <!-- START figures/fig_arcintrod.tex -->
       <image xml:id="img_arcintro2" width="47%">
         <description>
-          Graph of the <m>i</m>th subinterval of the function <m>y=f(x)</m>, which is graphed on the interval <m>[x_{i-1},x_{i}]</m>. 
+          Graph of the <m>i</m>th subinterval of the function <m>y=f(x)</m>, which is graphed on the interval <m>[x_{i-1},x_{i}]</m>.
           The graph contains a line between the start and endpoint of the curve, which will be used to approximate the length of the <m>i</m>th subinterval curve.
           The <m>i</m>th subinterval of the curve <m>y=f(x)</m> begins at the point <m>(x_{i-1},y_{i-1})</m> from which it heads upwards in a concave arc until reaching the point <m>(x_{i},y_{i})</m>.
           The straight line then passes through the start and endpoints of the curve, <m>(x_{i-1},y_{i-1})</m> and <m>(x_{i},y_{i})</m> respectively.
@@ -332,23 +332,23 @@
           <!-- START figures/fig_arc1.tex -->
           <image xml:id="img_arc1" width="47%">
             <description>
-              Graph of the function <m>f(x) = x^{3/2}</m> on the interval between <m>x=0</m> and <m>x=4</m>. 
+              Graph of the function <m>f(x) = x^{3/2}</m> on the interval between <m>x=0</m> and <m>x=4</m>.
               The curve <m>f(x) = x^{3/2}</m> begins at the point <m>(0,0)</m> from which it heads upwards in a convex arc until reaching the point <m>(4,8)</m>.
               A straight line plotted between the start and endpoints of the curve would lie entirely above the curve on the interval between <m>x=0</m> and <m>x=4</m> and would showcase the shortest distance between the two points.
             </description>
             <shortdescription>Graph of the function from the example.</shortdescription>
             <latex-image>
-              
+
               \begin{tikzpicture}
-              
+
               \begin{axis}[
               axis on top,
               ymin=-.2,ymax=8.5,
               xmin=-.1,xmax=4.5,
               ]
-              
+
               \addplot+ [-,domain=0:4] {x^(3/2)};
-              
+
             \end{axis}
 
             \end{tikzpicture}
@@ -357,7 +357,7 @@
           </image>
           <!-- figures/fig_arc1.tex END -->
         </figure>
-        
+
         <p>
           A graph of <m>f</m> is given in <xref ref="fig_arc1"/>.
         </p>
@@ -367,7 +367,7 @@
         <video width="98%" youtube="0NPr4wZlTi8" xml:id="vid-intapp-arclength-example1" label="vid-intapp-arclength-example1" component="video"/>
       </solution>
     </example>
-    
+
     <example xml:id="ex_arc2">
       <title>Finding arc length</title>
       <statement>
@@ -398,16 +398,16 @@
           <!-- START figures/fig_arc2.tex -->
           <image xml:id="img_arc2" width="47%">
             <description>
-              Graph of the function <m>f(x) =\frac18x^2-\ln(x)</m>. 
-              The curve is highlighted on the interval between <m>x=1</m> and <m>x=2</m>. 
+              Graph of the function <m>f(x) =\frac18x^2-\ln(x)</m>.
+              The curve is highlighted on the interval between <m>x=1</m> and <m>x=2</m>.
               The curve <m>f(x) =\frac18x^2-\ln(x)</m> begins near the point <m>(0.4,1)</m> from which it heads downwards in a convex arc until crossing the <m>x</m>-axis at approximately <m>x=1.25</m>.
               The curve then continues in the convex arc, until it once again reaches the <m>x</m>-axis at approximately <m>x=3</m>.
             </description>
             <shortdescription>Graph of the function from the example.</shortdescription>
             <latex-image>
-              
+
               \begin{tikzpicture}
-              
+
               \begin{axis}[
               axis on top,
             ymin=-.26,ymax=1.2,
@@ -425,7 +425,7 @@
           </image>
           <!-- figures/fig_arc2.tex END -->
         </figure>
-        
+
         <p>
           A graph of <m>f</m> is given in <xref ref="fig_arc2"/>;
           the portion of the curve measured in this problem is in bold.
@@ -436,7 +436,7 @@
         <video width="98%" youtube="mJlyz_9yiao" xml:id="vid-intapp-arclength-example2" label="vid-intapp-arclength-example2" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       The previous examples found the arc length exactly through careful choice of the functions.
       In general, exact answers are much more difficult to come by and numerical approximations are necessary.
@@ -534,8 +534,8 @@
         <!-- START figures/fig_arc4b.tex -->
           <image xml:id="img_arc4a">
             <description>
-              Graph of an arbitrary function <m>y=f(x)</m> on the interval <m>[a,b]</m>. 
-              The curve is a concave arc starting at <m>x=a</m> at some arbitrary <m>y</m> value from which it slopes upwards until ending at <m>x=b</m> at some slightly higher <m>y</m> value. 
+              Graph of an arbitrary function <m>y=f(x)</m> on the interval <m>[a,b]</m>.
+              The curve is a concave arc starting at <m>x=a</m> at some arbitrary <m>y</m> value from which it slopes upwards until ending at <m>x=b</m> at some slightly higher <m>y</m> value.
               The plot of the graph also contains a subinterval on the <m>x</m>-axis, given by <m>[x_{i-1},x_{i}]</m>.
               A line is drawn through the points <m>(x_{i-1},f(x_{i-1}))</m> and <m>(x_{i},f(x_{i}))</m>, which approximates the length of the curve <m>y=f(x)</m> on the interval <m>[x_{i-1},x_{i}]</m>.
             </description>
@@ -582,13 +582,13 @@
         <!-- START figures/figarc4_3D.asy -->
           <image xml:id="img_arc4b_3D">
             <description>
-              Graph of an arbitrary function <m>y=f(x)</m> on the interval <m>[a,b]</m>. 
+              Graph of an arbitrary function <m>y=f(x)</m> on the interval <m>[a,b]</m>.
               The line drawn through the points <m>(x_{i-1},f(x_{i-1}))</m> and <m>(x_{i},f(x_{i}))</m> is then rotated about the <m>x</m>-axis.
-              The resulting shape resembles a part of a cone which is lying horizontally, and can be used to approximate the surface area of the function <m>y=f(x)</m> being rotated about the <m>x</m>-axis on the interval <m>[x_{i-1},x_{i}]</m>. 
+              The resulting shape resembles a part of a cone which is lying horizontally, and can be used to approximate the surface area of the function <m>y=f(x)</m> being rotated about the <m>x</m>-axis on the interval <m>[x_{i-1},x_{i}]</m>.
               The plot also contains two vertical measurements.
               The first vertical measurement is <m>r</m>, which gives the radius of the cone at <m>x=x_{i-1}</m> and the second is <m>R</m>, which gives the radius of the cone at <m>x=x_{i}</m>
               The plot also contains an additional measurement <m>L</m> which gives the length of the line connecting <m>f(x_{i-1})</m> and <m>f(x_{i})</m>.
-              The measurement <m>L</m> is also the length of the part of the resulting part of a cone that comes from rotating the line about the <m>x</m>-axis. 
+              The measurement <m>L</m> is also the length of the part of the resulting part of a cone that comes from rotating the line about the <m>x</m>-axis.
             </description>
             <shortdescription>Graph of a function with the line approximating the length of a part of the curve being rotated about the x axis.</shortdescription>
             <asymptote>
@@ -790,9 +790,9 @@
           <!-- START figures/figsa1_3D.asy -->
           <image xml:id="img_sa1_3D" width="47%">
             <description>
-              Three dimensional graph of the shape coming from revolving <m>y=\sin(x)</m> on <m>[0,\pi]</m> about the <m>x</m>-axis. 
-              The curve <m>y=\sin(x)</m> is drawn on the interval <m>[0,\pi]</m>. 
-              This concave curve begins at the point <m>(0,0)</m>, from which it increases until reaching a maximum at the point <m>(\frac{\pi}{2},1)</m>. 
+              Three dimensional graph of the shape coming from revolving <m>y=\sin(x)</m> on <m>[0,\pi]</m> about the <m>x</m>-axis.
+              The curve <m>y=\sin(x)</m> is drawn on the interval <m>[0,\pi]</m>.
+              This concave curve begins at the point <m>(0,0)</m>, from which it increases until reaching a maximum at the point <m>(\frac{\pi}{2},1)</m>.
               The curve then decreases until ending at the <m>x</m>-axis at the point <m>(\pi,0)</m>.
               The curve is then rotated about the <m>x</m>-axis, which creates the solid of revolution.
               This solid has the largest diameter and is symmetric about <m>x=\frac{pi}{2}</m>, from which it shrinks down until closing in on itself at <m>x=0</m> and <m>x=\pi</m>.
@@ -869,7 +869,7 @@
             <mrow>\amp \approx 14.42\,\text{units}^2</mrow>
           </md>.
         </p>
-        
+
         <p>
           The integration step above is nontrivial,
           utilizing the integration method of Trigonometric Substitution from <xref ref="sec_trig_sub"/>.
@@ -886,7 +886,7 @@
         <video width="98%" youtube="ehC1adQ-pTs" xml:id="vid-intapp-surfarea-example1" label="vid-intapp-surfarea-example1" component="video"/>
       </solution>
     </example>
-    
+
     <example xml:id="ex_sa2">
       <title>Finding surface area of a solid of revolution</title>
       <statement>
@@ -919,9 +919,9 @@
               <caption/>
               <image xml:id="img_sa2a_3D">
                 <description>
-                  Three dimensional graph of the shape coming from revolving <m>y=x^2</m> on <m>[0,1]</m> about the <m>x</m>-axis. 
-                  The quadratic function <m>y=x^2</m> is drawn on the interval <m>[0,1]</m>. 
-                  This curve begins at the point <m>(0,0)</m>, from which it quadratically increases until reaching a maximum at the point <m>(1,1)</m>. 
+                  Three dimensional graph of the shape coming from revolving <m>y=x^2</m> on <m>[0,1]</m> about the <m>x</m>-axis.
+                  The quadratic function <m>y=x^2</m> is drawn on the interval <m>[0,1]</m>.
+                  This curve begins at the point <m>(0,0)</m>, from which it quadratically increases until reaching a maximum at the point <m>(1,1)</m>.
                   The curve is then rotated about the <m>x</m>-axis, creating a solid of revolution.
                   This shape has a circular vertical cross-section which has a radius of <m>r(x)=x^2</m> and is hollow on the inside.
                   The shape also is not closed off on its rightmost boundary at <m>x=1</m>.
@@ -979,8 +979,8 @@
               <!-- START figures/figsa2b_3D.asy -->
               <image xml:id="img_sa2b_3D">
                 <description>
-                  Three dimensional graph of the shape coming from revolving <m>y=x^2</m> on <m>[0,1]</m> about the <m>y</m>-axis. 
-                  The quadratic function <m>y=x^2</m> is drawn on the interval <m>[0,1]</m>. 
+                  Three dimensional graph of the shape coming from revolving <m>y=x^2</m> on <m>[0,1]</m> about the <m>y</m>-axis.
+                  The quadratic function <m>y=x^2</m> is drawn on the interval <m>[0,1]</m>.
                   The curve is then rotated about the <m>y</m>-axis, creating a solid of revolution.
                   This shape has a circular horizontal cross-section, which has a radius of <m>r(x)=x</m> and is hollow on the inside.
                   The shape also is not closed off on its top boundary at <m>y=1</m>.
@@ -1100,8 +1100,8 @@
           <!-- START figures/figgabriel_3D.asy -->
           <image xml:id="img_gabriel" width="47%">
             <description>
-              Three dimensional graph of the shape coming from revolving <m>y=1/x</m> on <m>[1,\infty)</m> about the <m>x</m>-axis. 
-              The function <m>y=1/x</m> is drawn on the interval <m>[1,\infty)</m>. 
+              Three dimensional graph of the shape coming from revolving <m>y=1/x</m> on <m>[1,\infty)</m> about the <m>x</m>-axis.
+              The function <m>y=1/x</m> is drawn on the interval <m>[1,\infty)</m>.
               The curve is then rotated about the <m>x</m>-axis, creating the shape called Gabriel's Horn.
               This shape has a circular vertical cross-section, which has a radius of <m>r(x)=1/x</m> and is hollow on the inside.
               The shape also is not closed off on its leftmost boundary at <m>x=1</m>.
@@ -1174,7 +1174,7 @@
           Since we have already seen that regions with infinite length can have a finite area,
           this is not too difficult to accept.
         </p>
-        
+
         <p>
           We now consider its surface area.
           The integral is straightforward to setup:
@@ -1184,7 +1184,7 @@
             <mrow>2\pi\int_1^\infty \frac{1}{x}\, dx \amp \lt 2\pi\int_1^\infty \frac{1}{x}\sqrt{1+1/x^4}\, dx </mrow>
           </md>.
         </p>
-        
+
         <p>
           By <xref ref="idea_impint1"/>,
           the improper integral on the left diverges.
@@ -1192,7 +1192,7 @@
           we conclude it also diverges,
           meaning Gabriel's Horn has infinite surface area.
         </p>
-        
+
         <p>
           Hence the <q>paradox</q>:
           we can fill Gabriel's Horn with a finite amount of paint,
@@ -1212,7 +1212,7 @@
         <video width="98%" youtube="L4ogGgyzmvs" xml:id="vid-intapp-surfarea-example3" label="vid-intapp-surfarea-example3" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       A standard equation from physics is
       <q>Work = force <times /> distance</q>,
@@ -1286,7 +1286,7 @@
                 Context("Numeric");
                 Context()->functions->set(sqrt=>{class=>'my::Function::numeric'});
                 Context()->flags->set(reduceConstantFunctions=>0);
-                
+
                 $ans = Compute("sqrt(2)");
               </pg-code>
               <statement>
@@ -1308,7 +1308,7 @@
 
         <exercise label="ex-arc-length-compute-2">
           <webwork xml:id="webwork-ex-arc-length-compute-2">
-              <pg-code>                
+              <pg-code>
               </pg-code>
               <statement>
                 <p>
@@ -1526,7 +1526,7 @@
               </answer>
           <!-- </webwork> -->
         </exercise>
-        
+
         <exercise label="ex-arclength-setup-9">
           <!-- <webwork xml:id="webwork-ex-arclength-setup-9">
             <pg-code>
@@ -1778,7 +1778,7 @@
               </answer>
           <!-- </webwork> -->
         </exercise>
-        
+
         <exercise label="ex-arclength-setup-5">
           <!-- <webwork xml:id="webwork-ex-arclength-setup-5">
               <pg-code>
@@ -1797,7 +1797,7 @@
               </answer>
           <!-- </webwork> -->
         </exercise>
-        
+
         <exercise label="ex-arclength-setup-6">
           <!-- <webwork xml:id="webwork-ex-arclength-setup-6">
               <pg-code>

--- a/ptx/sec_arc_length.ptx
+++ b/ptx/sec_arc_length.ptx
@@ -312,10 +312,6 @@
           Find the arc length of <m>f(x) = x^{3/2}</m> from <m>x=0</m> to <m>x=4</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="0NPr4wZlTi8" xml:id="vid-intapp-arclength-example1" label="vid-intapp-arclength-example1" component="video"/>
-      </solution>
       <solution>
         <p>
           We find <m>\fp(x)= \frac32x^{1/2}</m>;
@@ -342,17 +338,17 @@
             </description>
             <shortdescription>Graph of the function from the example.</shortdescription>
             <latex-image>
-
-            \begin{tikzpicture}
-
-            \begin{axis}[
-            axis on top,
-		      	ymin=-.2,ymax=8.5,
-		      	xmin=-.1,xmax=4.5,
-            ]
-
-            \addplot+ [-,domain=0:4] {x^(3/2)};
-
+              
+              \begin{tikzpicture}
+              
+              \begin{axis}[
+              axis on top,
+              ymin=-.2,ymax=8.5,
+              xmin=-.1,xmax=4.5,
+              ]
+              
+              \addplot+ [-,domain=0:4] {x^(3/2)};
+              
             \end{axis}
 
             \end{tikzpicture}
@@ -361,13 +357,17 @@
           </image>
           <!-- figures/fig_arc1.tex END -->
         </figure>
-
+        
         <p>
           A graph of <m>f</m> is given in <xref ref="fig_arc1"/>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="0NPr4wZlTi8" xml:id="vid-intapp-arclength-example1" label="vid-intapp-arclength-example1" component="video"/>
+      </solution>
     </example>
-
+    
     <example xml:id="ex_arc2">
       <title>Finding arc length</title>
       <statement>
@@ -375,10 +375,6 @@
           Find the arc length of <m>\ds f(x) =\frac18x^2-\ln(x)</m> from <m>x=1</m> to <m>x=2</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="mJlyz_9yiao" xml:id="vid-intapp-arclength-example2" label="vid-intapp-arclength-example2" component="video"/>
-      </solution>
       <solution>
         <p>
           This function was chosen specifically because the resulting integral can be evaluated exactly.
@@ -409,11 +405,11 @@
             </description>
             <shortdescription>Graph of the function from the example.</shortdescription>
             <latex-image>
-
-            \begin{tikzpicture}
-
-            \begin{axis}[
-            axis on top,
+              
+              \begin{tikzpicture}
+              
+              \begin{axis}[
+              axis on top,
             ymin=-.26,ymax=1.2,
             xmin=-.1,xmax=3.1,
             ]
@@ -429,14 +425,18 @@
           </image>
           <!-- figures/fig_arc2.tex END -->
         </figure>
-
+        
         <p>
           A graph of <m>f</m> is given in <xref ref="fig_arc2"/>;
           the portion of the curve measured in this problem is in bold.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="mJlyz_9yiao" xml:id="vid-intapp-arclength-example2" label="vid-intapp-arclength-example2" component="video"/>
+      </solution>
     </example>
-
+    
     <p>
       The previous examples found the arc length exactly through careful choice of the functions.
       In general, exact answers are much more difficult to come by and numerical approximations are necessary.
@@ -857,10 +857,6 @@
           <!-- figures/figsa1_3D.asy END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="ehC1adQ-pTs" xml:id="vid-intapp-surfarea-example1" label="vid-intapp-surfarea-example1" component="video"/>
-      </solution>
       <solution>
         <p>
           The setup is relatively straightforward.
@@ -873,7 +869,7 @@
             <mrow>\amp \approx 14.42\,\text{units}^2</mrow>
           </md>.
         </p>
-
+        
         <p>
           The integration step above is nontrivial,
           utilizing the integration method of Trigonometric Substitution from <xref ref="sec_trig_sub"/>.
@@ -885,8 +881,12 @@
           involves both a square root and an inverse hyperbolic trigonometric function.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="ehC1adQ-pTs" xml:id="vid-intapp-surfarea-example1" label="vid-intapp-surfarea-example1" component="video"/>
+      </solution>
     </example>
-
+    
     <example xml:id="ex_sa2">
       <title>Finding surface area of a solid of revolution</title>
       <statement>
@@ -1034,10 +1034,6 @@
           </sidebyside>
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="jK04gmbaTtE" xml:id="vid-intapp-surfarea-example2" label="vid-intapp-surfarea-example2" component="video"/>
-      </solution>
       <solution>
         <p>
           <ol>
@@ -1073,6 +1069,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="jK04gmbaTtE" xml:id="vid-intapp-surfarea-example2" label="vid-intapp-surfarea-example2" component="video"/>
       </solution>
     </example>
 
@@ -1156,10 +1156,6 @@
           <!-- figures/figgabriel_3D.asy END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="L4ogGgyzmvs" xml:id="vid-intapp-surfarea-example3" label="vid-intapp-surfarea-example3" component="video"/>
-      </solution>
       <solution>
         <p>
           To compute the volume it is natural to use the Disk Method.
@@ -1178,7 +1174,7 @@
           Since we have already seen that regions with infinite length can have a finite area,
           this is not too difficult to accept.
         </p>
-
+        
         <p>
           We now consider its surface area.
           The integral is straightforward to setup:
@@ -1188,7 +1184,7 @@
             <mrow>2\pi\int_1^\infty \frac{1}{x}\, dx \amp \lt 2\pi\int_1^\infty \frac{1}{x}\sqrt{1+1/x^4}\, dx </mrow>
           </md>.
         </p>
-
+        
         <p>
           By <xref ref="idea_impint1"/>,
           the improper integral on the left diverges.
@@ -1196,7 +1192,7 @@
           we conclude it also diverges,
           meaning Gabriel's Horn has infinite surface area.
         </p>
-
+        
         <p>
           Hence the <q>paradox</q>:
           we can fill Gabriel's Horn with a finite amount of paint,
@@ -1211,8 +1207,12 @@
           Strange things can occur when we deal with the infinite.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="L4ogGgyzmvs" xml:id="vid-intapp-surfarea-example3" label="vid-intapp-surfarea-example3" component="video"/>
+      </solution>
     </example>
-
+    
     <p>
       A standard equation from physics is
       <q>Work = force <times /> distance</q>,

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -333,10 +333,6 @@
           Give the equation of the parabola with focus at <m>(1,2)</m> and directrix at <m>y=3</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="dk8lrQac8Qg" xml:id="vid-planecurves-conic-parabola-example1" label="vid-planecurves-conic-parabola-example1" component="video"/>
-      </solution>
       <solution>
         <p>
           The vertex is located halfway between the focus and directrix,
@@ -348,7 +344,7 @@
             y=\frac{1}{4(-0.5)}(x-1)^2+2.5 = -\frac12(x-1)^2+2.5
           </me>.
         </p>
-
+        
         <figure xml:id="fig_conic1">
           <caption>The parabola described in <xref ref="ex_conic1"/></caption>
           <!-- START figures/fig_conic1.tex -->
@@ -362,31 +358,35 @@
               </p>
             </description>
             <latex-image>
-
+              
             \begin{tikzpicture}
 
             \begin{axis}[
             ymin=-6.5,ymax=3.0,
             xmin=-3.5,xmax=5.5
             ]
-
+            
             \addplot+ [-,domain=-3:5,samples=40] {-.5*(x-1)^2+2.5};
 
             \end{axis}
 
             \end{tikzpicture}
 
-            </latex-image>
+          </latex-image>
           </image>
           <!-- figures/fig_conic1.tex END -->
         </figure>
-
+        
         <p>
           The parabola is sketched in <xref ref="fig_conic1"/>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="dk8lrQac8Qg" xml:id="vid-planecurves-conic-parabola-example1" label="vid-planecurves-conic-parabola-example1" component="video"/>
+      </solution>
     </example>
-
+    
     <example xml:id="ex_conic2">
       <title>Finding the focus and directrix of a parabola</title>
       <statement>
@@ -396,10 +396,6 @@
           verify that it is equidistant from the focus and directrix.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="R8oJdTbZXh4" xml:id="vid-planecurves-conic-parabola-example2" label="vid-planecurves-conic-parabola-example2" component="video"/>
-      </solution>
       <solution>
         <p>
           We need to put the equation of the parabola in its general form.
@@ -420,7 +416,7 @@
           The parabola is graphed in <xref ref="fig_conic2"/>,
           along with its focus and directrix.
         </p>
-
+        
         <figure xml:id="fig_conic2">
           <caption>The parabola described in <xref ref="ex_conic2"/>. The distances from a point on the parabola to the focus and directrix are given.</caption>
           <!-- START figures/fig_conic2.tex -->
@@ -439,13 +435,13 @@
             </description>
             <latex-image>
 
-            \begin{tikzpicture}
-
-            \begin{axis}[
-            ymin=-5.5,ymax=14.5,
-            xmin=-11,xmax=14
-            ]
-
+              \begin{tikzpicture}
+              
+              \begin{axis}[
+              ymin=-5.5,ymax=14.5,
+              xmin=-11,xmax=14
+              ]
+              
             \addplot+ [-,domain=-5:14,samples=40] ({x^2/8-x+1},x);
             \addplot+ [solid,-,domain=-5:14] (-3,x);
 
@@ -454,14 +450,14 @@
             \filldraw [secondcolor] (axis cs: 1,4) circle (1.5pt) (axis cs: 7,12) circle (1.5pt);
 
             \end{axis}
-
+            
             \end{tikzpicture}
-
+            
             </latex-image>
           </image>
           <!-- figures/fig_conic2.tex END -->
         </figure>
-
+        
         <p>
           The point <m>(7,12)</m> lies on the graph and is
           <m>7-(-3)=10</m> units from the directrix.
@@ -470,13 +466,17 @@
             \sqrt{(7-1)^2 + (12-4)^2} = \sqrt{100}=10
           </me>.
         </p>
-
+        
         <p>
           Indeed, the point on the parabola is equidistant from the focus and directrix.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="R8oJdTbZXh4" xml:id="vid-planecurves-conic-parabola-example2" label="vid-planecurves-conic-parabola-example2" component="video"/>
+      </solution>
     </example>
-
+    
     <paragraphs>
       <title>Reflective Property</title>
       <p>
@@ -835,10 +835,6 @@
           <!-- figures/fig_conic3.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="NVqlZCWDDnI" xml:id="vid-planecurves-conic-ellipse-example1" label="vid-planecurves-conic-ellipse-example1" component="video"/>
-      </solution>
       <solution>
         <p>
           The center is located at <m>(-3,1)</m>.
@@ -850,8 +846,12 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="NVqlZCWDDnI" xml:id="vid-planecurves-conic-ellipse-example1" label="vid-planecurves-conic-ellipse-example1" component="video"/>
+      </solution>
     </example>
-
+    
     <example xml:id="ex_conic4">
       <title>Graphing an ellipse</title>
       <statement>
@@ -859,10 +859,6 @@
           Graph the ellipse defined by <m>4x^2+9y^2-8x-36y=-4</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="U3uhopYrG8o" xml:id="vid-planecurves-conic-ellipse-example2" label="vid-planecurves-conic-ellipse-example2" component="video"/>
-      </solution>
       <solution>
         <p>
           It is simple to graph an ellipse once it is in standard form.
@@ -873,7 +869,7 @@
             4x^2+9y^2-8x-36y=-4  \Rightarrow  (4x^2-8x) + (9y^2-36y) = -4
           </me>.
         </p>
-
+        
         <p>
           Now we complete the squares.
           <md>
@@ -886,7 +882,7 @@
             <mrow>\frac{(x-1)^2}{9} + \frac{(y-2)^2}{4} \amp = 1</mrow>
           </md>.
         </p>
-
+        
         <p>
           We see the center of the ellipse is at <m>(1,2)</m>.
           We have <m>a=3</m> and <m>b=2</m>;
@@ -897,7 +893,7 @@
           approximately <m>2.24</m> units from the center, at <m>(1\pm 2.24,2)</m>.
           This is all graphed in <xref ref="fig_conic4"/>
         </p>
-
+        
         <figure xml:id="fig_conic4">
           <caption>Graphing the ellipse in <xref ref="ex_conic4"/></caption>
           <!-- START figures/fig_conic4.tex -->
@@ -913,8 +909,8 @@
             </description>
             <latex-image>
 
-            \begin{tikzpicture}
-
+              \begin{tikzpicture}
+              
             \begin{axis}[
             xtick={-2,-1,1,2,3,4},
             ytick={-1,1,2,3,4},
@@ -927,22 +923,26 @@
             \filldraw (axis cs:1,2) circle (1.5pt)
                       (axis cs:3.24,2) circle (1pt)
                       (axis cs:-1.24,2) circle (1pt);
-
-            \filldraw [firstcolor] (axis cs: 4,2) circle (1.5pt)
-                                   (axis cs: -2,2) circle (1.5pt);
-
-            \end{axis}
-
-            \end{tikzpicture}
-
-            </latex-image>
-          </image>
-          <!-- figures/fig_conic4.tex END -->
-        </figure>
-      </solution>
-    </example>
-
-    <paragraphs>
+                      
+                      \filldraw [firstcolor] (axis cs: 4,2) circle (1.5pt)
+                      (axis cs: -2,2) circle (1.5pt);
+                      
+                      \end{axis}
+                      
+                      \end{tikzpicture}
+                      
+                    </latex-image>
+                  </image>
+                  <!-- figures/fig_conic4.tex END -->
+                </figure>
+              </solution>
+              <solution component="video">
+                <title>Video solution</title>
+                <video width="98%" youtube="U3uhopYrG8o" xml:id="vid-planecurves-conic-ellipse-example2" label="vid-planecurves-conic-ellipse-example2" component="video"/>
+              </solution>
+            </example>
+            
+            <paragraphs>
       <title>Eccentricity</title>
       <p>
         When <m>a=b</m>, we have a circle.
@@ -1525,10 +1525,6 @@
             Sketch the hyperbola given by <m>\ds \frac{(y-2)^2}{25}-\frac{(x-1)^2}{4}=1</m>.
           </p>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="0YVNci7ZOfo" xml:id="vid-planecurves-conic-hyperbola-example1" label="vid-planecurves-conic-hyperbola-example1" component="video"/>
-        </solution>
         <solution>
           <p>
             The hyperbola is centered at <m>(1,2)</m>;
@@ -1539,7 +1535,7 @@
             so the vertices are located at <m>(1,7)</m> and <m>(1,-3)</m>.
             This is enough to make a good sketch.
           </p>
-
+          
           <figure xml:id="fig_conic5">
             <caption>Graphing the hyperbola in <xref ref="ex_conic5"/></caption>
             <!-- START figures/fig_conic5.tex -->
@@ -1571,7 +1567,7 @@
 
               \addplot [firstcurvestyle,-,domain=-70:70,samples=40] ({2*tan(x)+1},{5*sec(x)+2});
               \addplot [firstcurvestyle,-,domain=-70:70,samples=40] ({2*tan(x)+1},{-5*sec(x)+2});
-
+              
               \draw [thick,dashed] (axis cs: -1,7) -- (axis cs:3,7) -- (axis cs:3,-3) -- (axis cs: -1,-3) -- cycle;
 
               \addplot [secondcurvestyle,-,domain=-3:13] {5*(x-1)/2+2};
@@ -1587,8 +1583,8 @@
               \end{axis}
 
               \end{tikzpicture}
-
-              </latex-image>
+              
+            </latex-image>
             </image>
             <!-- figures/fig_conic5.tex END -->
           </figure>
@@ -1600,8 +1596,12 @@
             <m>(1,2\pm 5.4)</m> as shown in the figure.
           </p>
         </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="0YVNci7ZOfo" xml:id="vid-planecurves-conic-hyperbola-example1" label="vid-planecurves-conic-hyperbola-example1" component="video"/>
+        </solution>
       </example>
-
+      
       <example xml:id="ex_conic6">
         <title>Graphing a hyperbola</title>
         <statement>
@@ -1609,10 +1609,6 @@
             Sketch the hyperbola given by <m>9x^2-y^2+2y=10</m>.
           </p>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="b-1_3ATvn9A" xml:id="vid-planecurves-conic-hyperbola-example2" label="vid-planecurves-conic-hyperbola-example2" component="video"/>
-        </solution>
         <solution>
           <p>
             We must complete the square to put the equation in general form.
@@ -1626,7 +1622,7 @@
               <mrow>x^2 - \frac{(y-1)^2}{9} \amp =1</mrow>
             </md>
           </p>
-
+          
           <figure xml:id="fig_conic6">
             <caption>Graphing the hyperbola in <xref ref="ex_conic6"/></caption>
             <!-- START figures/fig_conic6.tex -->
@@ -1645,14 +1641,14 @@
               </description>
               <latex-image>
 
-              \begin{tikzpicture}
-
-              \begin{axis}[
-              minor y tick num=4,
+                \begin{tikzpicture}
+                
+                \begin{axis}[
+                minor y tick num=4,
               ymin=-10.9,ymax=11.9,
               xmin=-4.2,xmax=4.2
               ]
-
+              
               \addplot [firstcurvestyle,-,domain=-75:75,samples=40] ({sec(x)},{3*tan(x)+1});
               \addplot [firstcurvestyle,-,domain=-75:75,samples=40] ({-sec(x)},{3*tan(x)+1});
 
@@ -1662,12 +1658,12 @@
               \addplot [secondcurvestyle,-,domain=-4:4] {-3*(x-0)/1+1};
 
               \filldraw (axis cs:0,1) circle (1.5pt);
-
+              
               \filldraw [firstcolor] (axis cs:-1,1) circle (1.5pt);
               \filldraw [firstcolor] (axis cs:1,1) circle (1.5pt);
               \filldraw [secondcolor] (axis cs:3.2,1) circle (1.5pt);
               \filldraw [secondcolor] (axis cs:-3.2,1) circle (1.5pt);
-
+              
               \end{axis}
 
               \end{tikzpicture}
@@ -1676,7 +1672,7 @@
             </image>
             <!-- figures/fig_conic6.tex END -->
           </figure>
-
+          
           <p>
             We see the hyperbola is centered at <m>(0,1)</m>,
             with a horizontal transverse axis,
@@ -1689,9 +1685,13 @@
             <m>(\pm 3.2,1)</m> as shown in the figure.
           </p>
         </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="b-1_3ATvn9A" xml:id="vid-planecurves-conic-hyperbola-example2" label="vid-planecurves-conic-hyperbola-example2" component="video"/>
+        </solution>
       </example>
     </paragraphs>
-
+    
     <paragraphs>
       <title>Eccentricity</title>
       <definition xml:id="def_hyperbola_eccentricity">

--- a/ptx/sec_conic_sections.ptx
+++ b/ptx/sec_conic_sections.ptx
@@ -112,7 +112,7 @@
               <shortdescription>A diagonal plane intersecting a double napped cone, forming a line in the plane</shortdescription>
               <description>
                 <p>
-                  Two cones stacked tip-to-tip, intersected by a diagonal plane. 
+                  Two cones stacked tip-to-tip, intersected by a diagonal plane.
                   The plane extends diagonally through the point where the tips of the cones are touching.
                   The plane only touches the outer edges of the cones.
                   The parts of the plane touching the cones are highlighted, forming a straight line in the plane.
@@ -128,7 +128,7 @@
               <description>
                 <p>
                   Two cones stacked tip-to-tip, intersected by a vertical plane.
-                  The plane extends vertically, passing through the points at which the tips of the cones touch. 
+                  The plane extends vertically, passing through the points at which the tips of the cones touch.
                   The parts of the plane intersecting the cones are highlighted, forming crossed straight lines in the plane.
                   The image on the plane is straight lines in an X shape.
                 </p>
@@ -205,7 +205,7 @@
         <description>
           <p>
             An upward opening parabola with labels for key components.
-            At the bottom of the parabola a point is labeled as the vertex. 
+            At the bottom of the parabola a point is labeled as the vertex.
             A dashed vertical line, labeled the axis of symmetry, separates the parabola into two halves.
             The axis of symmetry crosses the parabola through the vertex.
             Below the parabola, a horizontal line is labeled the Directrix.
@@ -344,7 +344,7 @@
             y=\frac{1}{4(-0.5)}(x-1)^2+2.5 = -\frac12(x-1)^2+2.5
           </me>.
         </p>
-        
+
         <figure xml:id="fig_conic1">
           <caption>The parabola described in <xref ref="ex_conic1"/></caption>
           <!-- START figures/fig_conic1.tex -->
@@ -358,14 +358,14 @@
               </p>
             </description>
             <latex-image>
-              
+
             \begin{tikzpicture}
 
             \begin{axis}[
             ymin=-6.5,ymax=3.0,
             xmin=-3.5,xmax=5.5
             ]
-            
+
             \addplot+ [-,domain=-3:5,samples=40] {-.5*(x-1)^2+2.5};
 
             \end{axis}
@@ -376,7 +376,7 @@
           </image>
           <!-- figures/fig_conic1.tex END -->
         </figure>
-        
+
         <p>
           The parabola is sketched in <xref ref="fig_conic1"/>.
         </p>
@@ -386,7 +386,7 @@
         <video width="98%" youtube="dk8lrQac8Qg" xml:id="vid-planecurves-conic-parabola-example1" label="vid-planecurves-conic-parabola-example1" component="video"/>
       </solution>
     </example>
-    
+
     <example xml:id="ex_conic2">
       <title>Finding the focus and directrix of a parabola</title>
       <statement>
@@ -416,7 +416,7 @@
           The parabola is graphed in <xref ref="fig_conic2"/>,
           along with its focus and directrix.
         </p>
-        
+
         <figure xml:id="fig_conic2">
           <caption>The parabola described in <xref ref="ex_conic2"/>. The distances from a point on the parabola to the focus and directrix are given.</caption>
           <!-- START figures/fig_conic2.tex -->
@@ -436,12 +436,12 @@
             <latex-image>
 
               \begin{tikzpicture}
-              
+
               \begin{axis}[
               ymin=-5.5,ymax=14.5,
               xmin=-11,xmax=14
               ]
-              
+
             \addplot+ [-,domain=-5:14,samples=40] ({x^2/8-x+1},x);
             \addplot+ [solid,-,domain=-5:14] (-3,x);
 
@@ -450,14 +450,14 @@
             \filldraw [secondcolor] (axis cs: 1,4) circle (1.5pt) (axis cs: 7,12) circle (1.5pt);
 
             \end{axis}
-            
+
             \end{tikzpicture}
-            
+
             </latex-image>
           </image>
           <!-- figures/fig_conic2.tex END -->
         </figure>
-        
+
         <p>
           The point <m>(7,12)</m> lies on the graph and is
           <m>7-(-3)=10</m> units from the directrix.
@@ -466,7 +466,7 @@
             \sqrt{(7-1)^2 + (12-4)^2} = \sqrt{100}=10
           </me>.
         </p>
-        
+
         <p>
           Indeed, the point on the parabola is equidistant from the focus and directrix.
         </p>
@@ -476,7 +476,7 @@
         <video width="98%" youtube="R8oJdTbZXh4" xml:id="vid-planecurves-conic-parabola-example2" label="vid-planecurves-conic-parabola-example2" component="video"/>
       </solution>
     </example>
-    
+
     <paragraphs>
       <title>Reflective Property</title>
       <p>
@@ -851,7 +851,7 @@
         <video width="98%" youtube="NVqlZCWDDnI" xml:id="vid-planecurves-conic-ellipse-example1" label="vid-planecurves-conic-ellipse-example1" component="video"/>
       </solution>
     </example>
-    
+
     <example xml:id="ex_conic4">
       <title>Graphing an ellipse</title>
       <statement>
@@ -869,7 +869,7 @@
             4x^2+9y^2-8x-36y=-4  \Rightarrow  (4x^2-8x) + (9y^2-36y) = -4
           </me>.
         </p>
-        
+
         <p>
           Now we complete the squares.
           <md>
@@ -882,7 +882,7 @@
             <mrow>\frac{(x-1)^2}{9} + \frac{(y-2)^2}{4} \amp = 1</mrow>
           </md>.
         </p>
-        
+
         <p>
           We see the center of the ellipse is at <m>(1,2)</m>.
           We have <m>a=3</m> and <m>b=2</m>;
@@ -893,7 +893,7 @@
           approximately <m>2.24</m> units from the center, at <m>(1\pm 2.24,2)</m>.
           This is all graphed in <xref ref="fig_conic4"/>
         </p>
-        
+
         <figure xml:id="fig_conic4">
           <caption>Graphing the ellipse in <xref ref="ex_conic4"/></caption>
           <!-- START figures/fig_conic4.tex -->
@@ -910,7 +910,7 @@
             <latex-image>
 
               \begin{tikzpicture}
-              
+
             \begin{axis}[
             xtick={-2,-1,1,2,3,4},
             ytick={-1,1,2,3,4},
@@ -923,14 +923,14 @@
             \filldraw (axis cs:1,2) circle (1.5pt)
                       (axis cs:3.24,2) circle (1pt)
                       (axis cs:-1.24,2) circle (1pt);
-                      
+
                       \filldraw [firstcolor] (axis cs: 4,2) circle (1.5pt)
                       (axis cs: -2,2) circle (1.5pt);
-                      
+
                       \end{axis}
-                      
+
                       \end{tikzpicture}
-                      
+
                     </latex-image>
                   </image>
                   <!-- figures/fig_conic4.tex END -->
@@ -941,7 +941,7 @@
                 <video width="98%" youtube="U3uhopYrG8o" xml:id="vid-planecurves-conic-ellipse-example2" label="vid-planecurves-conic-ellipse-example2" component="video"/>
               </solution>
             </example>
-            
+
             <paragraphs>
       <title>Eccentricity</title>
       <p>
@@ -1304,7 +1304,7 @@
             The axis dividing th ehyperbola in half horizontally is labeled as the "transverse axis."
             The point in which the axes touch is the center of the hyperbola.
             The points in which the curves intersect the transverse axis are labeled as foci.
-            Two foci lie on the transverse axis. 
+            Two foci lie on the transverse axis.
             The first focus is to the left of the left curve.
             The right focus is to the right of the right curve.
             The distance between the left vertex and the center is labeled as <m>a</m>.
@@ -1535,7 +1535,7 @@
             so the vertices are located at <m>(1,7)</m> and <m>(1,-3)</m>.
             This is enough to make a good sketch.
           </p>
-          
+
           <figure xml:id="fig_conic5">
             <caption>Graphing the hyperbola in <xref ref="ex_conic5"/></caption>
             <!-- START figures/fig_conic5.tex -->
@@ -1567,7 +1567,7 @@
 
               \addplot [firstcurvestyle,-,domain=-70:70,samples=40] ({2*tan(x)+1},{5*sec(x)+2});
               \addplot [firstcurvestyle,-,domain=-70:70,samples=40] ({2*tan(x)+1},{-5*sec(x)+2});
-              
+
               \draw [thick,dashed] (axis cs: -1,7) -- (axis cs:3,7) -- (axis cs:3,-3) -- (axis cs: -1,-3) -- cycle;
 
               \addplot [secondcurvestyle,-,domain=-3:13] {5*(x-1)/2+2};
@@ -1583,7 +1583,7 @@
               \end{axis}
 
               \end{tikzpicture}
-              
+
             </latex-image>
             </image>
             <!-- figures/fig_conic5.tex END -->
@@ -1601,7 +1601,7 @@
           <video width="98%" youtube="0YVNci7ZOfo" xml:id="vid-planecurves-conic-hyperbola-example1" label="vid-planecurves-conic-hyperbola-example1" component="video"/>
         </solution>
       </example>
-      
+
       <example xml:id="ex_conic6">
         <title>Graphing a hyperbola</title>
         <statement>
@@ -1622,7 +1622,7 @@
               <mrow>x^2 - \frac{(y-1)^2}{9} \amp =1</mrow>
             </md>
           </p>
-          
+
           <figure xml:id="fig_conic6">
             <caption>Graphing the hyperbola in <xref ref="ex_conic6"/></caption>
             <!-- START figures/fig_conic6.tex -->
@@ -1642,13 +1642,13 @@
               <latex-image>
 
                 \begin{tikzpicture}
-                
+
                 \begin{axis}[
                 minor y tick num=4,
               ymin=-10.9,ymax=11.9,
               xmin=-4.2,xmax=4.2
               ]
-              
+
               \addplot [firstcurvestyle,-,domain=-75:75,samples=40] ({sec(x)},{3*tan(x)+1});
               \addplot [firstcurvestyle,-,domain=-75:75,samples=40] ({-sec(x)},{3*tan(x)+1});
 
@@ -1658,12 +1658,12 @@
               \addplot [secondcurvestyle,-,domain=-4:4] {-3*(x-0)/1+1};
 
               \filldraw (axis cs:0,1) circle (1.5pt);
-              
+
               \filldraw [firstcolor] (axis cs:-1,1) circle (1.5pt);
               \filldraw [firstcolor] (axis cs:1,1) circle (1.5pt);
               \filldraw [secondcolor] (axis cs:3.2,1) circle (1.5pt);
               \filldraw [secondcolor] (axis cs:-3.2,1) circle (1.5pt);
-              
+
               \end{axis}
 
               \end{tikzpicture}
@@ -1672,7 +1672,7 @@
             </image>
             <!-- figures/fig_conic6.tex END -->
           </figure>
-          
+
           <p>
             We see the hyperbola is centered at <m>(0,1)</m>,
             with a horizontal transverse axis,
@@ -1691,7 +1691,7 @@
         </solution>
       </example>
     </paragraphs>
-    
+
     <paragraphs>
       <title>Eccentricity</title>
       <definition xml:id="def_hyperbola_eccentricity">
@@ -3427,6 +3427,6 @@
             </answer>
         <!-- </webwork> -->
       </exercise>
-    </subexercises>      
+    </subexercises>
   </exercises>
 </section>

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -65,10 +65,6 @@
           and verify that it is orthogonal to both <m>\vec u</m> and <m>\vec v</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="kFpmnYBVQt4" xml:id="vid-vectors-crossprod-example" label="vid-vectors-crossprod-example" component="video"/>
-      </solution>
       <solution>
         <p>
           Using <xref ref="def_cross_product"/>, we have
@@ -76,12 +72,12 @@
             \crossp uv = \la (-1)5-(4)2,-\big((2)5-(4)3\big), (2)2-(-1)3\ra = \la -13,2,7\ra
           </me>.
         </p>
-
+        
         <p>
           (We encourage the reader to compute this product on their own,
           then verify their result.)
         </p>
-
+        
         <p>
           We test whether or not <m>\crossp uv</m> is orthogonal to <m>\vec u</m> and <m>\vec v</m> using the dot product:
           <me>
@@ -91,14 +87,18 @@
             \big(\crossp uv\big) \cdot \vec v = \la -13,2,7\ra \cdot \la 3,2,5 \ra = 0
           </me>.
         </p>
-
+        
         <p>
           Since both dot products are zero,
           <m>\crossp uv</m> is indeed orthogonal to both <m>\vec u</m> and <m>\vec v</m>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="kFpmnYBVQt4" xml:id="vid-vectors-crossprod-example" label="vid-vectors-crossprod-example" component="video"/>
+      </solution>
     </example>
-
+    
     <p>
       A convenient method of computing the cross product starts with forming a particular <m>3\times 3</m>
       <em>matrix</em>, or rectangular array.
@@ -127,17 +127,17 @@
       Compute the products along each diagonal,
       then add the products on the right and subtract the products on the left:
     </p>
-
+    
     <image xml:id="img_intro3" width="47%">
       <description></description>
       <latex-image>
 
-      \begin{tikzpicture}[&gt;=stealth]
+        \begin{tikzpicture}[&gt;=stealth]
 
-      \node at (0,0) {\(\begin{array}{ccccc} \ \veci\ \amp \ \vecj\ \amp \ \veck\ \amp \ \veci\ \amp \ \vecj\ \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
-      \end{array} \)};
-
-      \draw[-&gt;, thin] (-1.3,.4) -- (.5,-.8) node[below] {\(-5\veci\)};
+        \node at (0,0) {\(\begin{array}{ccccc} \ \veci\ \amp \ \vecj\ \amp \ \veck\ \amp \ \veci\ \amp \ \vecj\ \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
+        \end{array} \)};
+        
+        \draw[-&gt;, thin] (-1.3,.4) -- (.5,-.8) node[below] {\(-5\veci\)};
       \draw[-&gt;, thin] (-.7,.4) -- (1.3,-.8) node[below] {\(12\vecj\)};
       \draw[-&gt;, thin] (0,.4) -- (2,-.8) node[below] {\(4\veck\)};
       \draw[-&gt;, thin] (0,.4) -- (-2,-.8) node[below] {\(-3\veck\)};
@@ -145,9 +145,9 @@
       \draw[-&gt;, thin] (1.3,.4) -- (-.5,-.8) node[below] {\(10\vecj\)};
 
       \end{tikzpicture}
-
-      </latex-image>
-    </image>
+      
+    </latex-image>
+  </image>
 
     <p>
       <me>
@@ -172,10 +172,6 @@
           Compute both <m>\crossp uv</m> and <m>\crossp vu</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="6-PGDOhhYbg" xml:id="vid-vectors-crossprod-det-eg" label="vid-vectors-crossprod-det-eg" component="video"/>
-      </solution>
       <solution>
         <p>
           To compute <m>\crossp uv</m>,
@@ -193,7 +189,7 @@
             \crossp uv = \big(3\veci-6\vecj+2\veck\,\big) - \big(-3\veck + 12\veci+\vecj\,\big) = \la -9,-7,5\ra
           </me>.
         </p>
-
+        
         <p>
           To compute <m>\crossp vu</m>,
           we switch the second and third rows of the above matrix,
@@ -202,7 +198,7 @@
             \begin{matrix} \ \veci\ \amp \ \vecj\ \amp \ \veck\ \amp \ \veci\ \amp \ \vecj\ \\-1\amp 2\amp 1\amp -1\amp 2\\  1\amp 3\amp 6\amp 1\amp 3 \end{matrix}
           </me>
         </p>
-
+        
         <p>
           Note how with the rows being switched,
           the products that once appeared on the right now appear on the left,
@@ -214,6 +210,10 @@
           which is the opposite of <m>\crossp uv</m>.
           We leave it to the reader to verify that each of these vectors is orthogonal to <m>\vec u</m> and <m>\vec v</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="6-PGDOhhYbg" xml:id="vid-vectors-crossprod-det-eg" label="vid-vectors-crossprod-det-eg" component="video"/>
       </solution>
     </example>
   </introduction>
@@ -635,10 +635,6 @@
             </ol>
           </p>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="CYboFA8zYBs" xml:id="vid-vectors-crossprod-paralleogram" label="vid-vectors-crossprod-paralleogram" component="video"/>
-        </solution>
         <solution>
           <p>
             <ol>
@@ -660,10 +656,10 @@
                     <figure xml:id="fig_crossp4a">
                       <caption/>
                     <!-- START figures/fig_crossp4b.tex -->
-                      <image xml:id="img_crossp4a">
-                        <description></description>
-                        <latex-image>
-
+                    <image xml:id="img_crossp4a">
+                      <description></description>
+                      <latex-image>
+                        
                         \begin{tikzpicture}[&gt;=stealth]
 
                         \begin{axis}[
@@ -686,11 +682,11 @@
                         </latex-image>
                       </image>
                     <!-- figures/fig_crossp4b.tex END -->
-                    </figure>
-
-                    <figure xml:id="fig_crossp4b_3D">
-                      <caption/>
-
+                  </figure>
+                  
+                  <figure xml:id="fig_crossp4b_3D">
+                    <caption/>
+                    
                     <!-- START figures/figcrossp4a_3D.asy -->
                       <image xml:id="img_crossp4b_3D">
                         <description></description>
@@ -760,6 +756,10 @@
             </ol>
           </p>
         </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="CYboFA8zYBs" xml:id="vid-vectors-crossprod-paralleogram" label="vid-vectors-crossprod-paralleogram" component="video"/>
+        </solution>
       </example>
 
       <p>
@@ -806,10 +806,6 @@
             <!-- figures/fig_crossp5.tex END -->
           </figure>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="GuEn2qOey2U" xml:id="vid-vectors-crossprod-triangle" label="vid-vectors-crossprod-triangle" component="video"/>
-        </solution>
         <solution>
           <p>
             We found the area of this triangle in <xref ref="ex_abc4"/>
@@ -820,7 +816,7 @@
             which generally involves finding angles, etc.
             Using a cross product is much more direct.
           </p>
-
+          
           <p>
             We can choose any two sides of the triangle to use to form vectors;
             we choose <m>\overrightarrow{AB} = \la 1,1\ra</m> and <m>\overrightarrow{AC}=\la 2,-1\ra</m>.
@@ -831,10 +827,14 @@
               \frac12\norm{\overrightarrow{AB}\times\overrightarrow{AC}} = \frac12\norm{\la 1,1,0\ra \times \la 2,-1,0\ra} = \frac12\norm{\la 0,0,-3\ra} = \frac32
             </me>.
           </p>
-
+          
           <p>
             We arrive at the same answer as before with less work.
           </p>
+        </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="GuEn2qOey2U" xml:id="vid-vectors-crossprod-triangle" label="vid-vectors-crossprod-triangle" component="video"/>
         </solution>
       </example>
     </paragraphs>
@@ -975,10 +975,6 @@
             <m>\vecv = \la -1,1,0\ra</m> and <m>\vecw = \la 0,1,1\ra</m>.
           </p>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="r2_dGc1KWEc" xml:id="vid-vectors-crossprod-volume" label="vid-vectors-crossprod-volume" component="video"/>
-        </solution>
         <solution>
           <p>
             We apply <xref ref="eq_crossp2">Equation</xref>.
@@ -1015,19 +1011,19 @@
                 real[] myychoice={2};
                 real[] myzchoice={0.5,1};
                 defaultpen(0.5mm);
-
+                
                 pair xbounds=(-1.5,1.5);
                 pair ybounds=(0,3);
                 pair zbounds=(-0.5,1.5);
-
+                
                 xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
                 yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
                 zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
+                
                 label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
                 label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
                 label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
+                
                 //Draw the parallelepiped with u=&lt;1,1,0&gt;, v=&lt;-1,1,0&gt;, w=&lt;0,1,1&gt;
                 draw((0,0,0)--(1,1,0), Arrow3(size=3mm));// u
                 label("$\vec{u}$",(1,1,0),W);
@@ -1047,7 +1043,7 @@
                 draw((1,1,0)--(1,2,1),bluepen);// w shifted to u
                 draw((-1,1,0)--(-1,2,1),bluepen);// w shifted to v
                 draw((0,2,0)--(0,3,1),bluepen);// w shifted to u+v
-
+                
                 //my try at shading.
                 import three;
                 path3 p =  (0,0,0)-- (1,1,0) -- (0,2,0) -- (-1,1,0); //Left
@@ -1067,6 +1063,10 @@
             </image>
             <!-- figures/figcrossp6_3D.asy END -->
           </figure>
+        </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="r2_dGc1KWEc" xml:id="vid-vectors-crossprod-volume" label="vid-vectors-crossprod-volume" component="video"/>
         </solution>
       </example>
     </paragraphs>

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -72,12 +72,12 @@
             \crossp uv = \la (-1)5-(4)2,-\big((2)5-(4)3\big), (2)2-(-1)3\ra = \la -13,2,7\ra
           </me>.
         </p>
-        
+
         <p>
           (We encourage the reader to compute this product on their own,
           then verify their result.)
         </p>
-        
+
         <p>
           We test whether or not <m>\crossp uv</m> is orthogonal to <m>\vec u</m> and <m>\vec v</m> using the dot product:
           <me>
@@ -87,7 +87,7 @@
             \big(\crossp uv\big) \cdot \vec v = \la -13,2,7\ra \cdot \la 3,2,5 \ra = 0
           </me>.
         </p>
-        
+
         <p>
           Since both dot products are zero,
           <m>\crossp uv</m> is indeed orthogonal to both <m>\vec u</m> and <m>\vec v</m>.
@@ -98,7 +98,7 @@
         <video width="98%" youtube="kFpmnYBVQt4" xml:id="vid-vectors-crossprod-example" label="vid-vectors-crossprod-example" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       A convenient method of computing the cross product starts with forming a particular <m>3\times 3</m>
       <em>matrix</em>, or rectangular array.
@@ -127,7 +127,7 @@
       Compute the products along each diagonal,
       then add the products on the right and subtract the products on the left:
     </p>
-    
+
     <image xml:id="img_intro3" width="47%">
       <description></description>
       <latex-image>
@@ -136,7 +136,7 @@
 
         \node at (0,0) {\(\begin{array}{ccccc} \ \veci\ \amp \ \vecj\ \amp \ \veck\ \amp \ \veci\ \amp \ \vecj\ \\  2\amp -1\amp 4\amp 2\amp -1\\3\amp 2\amp 5\amp 3\amp 2
         \end{array} \)};
-        
+
         \draw[-&gt;, thin] (-1.3,.4) -- (.5,-.8) node[below] {\(-5\veci\)};
       \draw[-&gt;, thin] (-.7,.4) -- (1.3,-.8) node[below] {\(12\vecj\)};
       \draw[-&gt;, thin] (0,.4) -- (2,-.8) node[below] {\(4\veck\)};
@@ -145,7 +145,7 @@
       \draw[-&gt;, thin] (1.3,.4) -- (-.5,-.8) node[below] {\(10\vecj\)};
 
       \end{tikzpicture}
-      
+
     </latex-image>
   </image>
 
@@ -189,7 +189,7 @@
             \crossp uv = \big(3\veci-6\vecj+2\veck\,\big) - \big(-3\veck + 12\veci+\vecj\,\big) = \la -9,-7,5\ra
           </me>.
         </p>
-        
+
         <p>
           To compute <m>\crossp vu</m>,
           we switch the second and third rows of the above matrix,
@@ -198,7 +198,7 @@
             \begin{matrix} \ \veci\ \amp \ \vecj\ \amp \ \veck\ \amp \ \veci\ \amp \ \vecj\ \\-1\amp 2\amp 1\amp -1\amp 2\\  1\amp 3\amp 6\amp 1\amp 3 \end{matrix}
           </me>
         </p>
-        
+
         <p>
           Note how with the rows being switched,
           the products that once appeared on the right now appear on the left,
@@ -659,7 +659,7 @@
                     <image xml:id="img_crossp4a">
                       <description></description>
                       <latex-image>
-                        
+
                         \begin{tikzpicture}[&gt;=stealth]
 
                         \begin{axis}[
@@ -683,10 +683,10 @@
                       </image>
                     <!-- figures/fig_crossp4b.tex END -->
                   </figure>
-                  
+
                   <figure xml:id="fig_crossp4b_3D">
                     <caption/>
-                    
+
                     <!-- START figures/figcrossp4a_3D.asy -->
                       <image xml:id="img_crossp4b_3D">
                         <description></description>
@@ -816,7 +816,7 @@
             which generally involves finding angles, etc.
             Using a cross product is much more direct.
           </p>
-          
+
           <p>
             We can choose any two sides of the triangle to use to form vectors;
             we choose <m>\overrightarrow{AB} = \la 1,1\ra</m> and <m>\overrightarrow{AC}=\la 2,-1\ra</m>.
@@ -827,7 +827,7 @@
               \frac12\norm{\overrightarrow{AB}\times\overrightarrow{AC}} = \frac12\norm{\la 1,1,0\ra \times \la 2,-1,0\ra} = \frac12\norm{\la 0,0,-3\ra} = \frac32
             </me>.
           </p>
-          
+
           <p>
             We arrive at the same answer as before with less work.
           </p>
@@ -848,7 +848,7 @@
         as illustrated in <xref ref="fig_crossp_parallelepiped"/>.
         By crossing <m>\vec v</m> and <m>\vec w</m>,
         one gets a vector whose magnitude is the area of the base.
-        Dotting this vector with <m>\vecu</m> computes the volume 
+        Dotting this vector with <m>\vecu</m> computes the volume
 				of the parallelepiped! (Up to a sign;
         take the absolute value.)
       </p>
@@ -1011,19 +1011,19 @@
                 real[] myychoice={2};
                 real[] myzchoice={0.5,1};
                 defaultpen(0.5mm);
-                
+
                 pair xbounds=(-1.5,1.5);
                 pair ybounds=(0,3);
                 pair zbounds=(-0.5,1.5);
-                
+
                 xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
                 yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
                 zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-                
+
                 label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
                 label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
                 label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-                
+
                 //Draw the parallelepiped with u=&lt;1,1,0&gt;, v=&lt;-1,1,0&gt;, w=&lt;0,1,1&gt;
                 draw((0,0,0)--(1,1,0), Arrow3(size=3mm));// u
                 label("$\vec{u}$",(1,1,0),W);
@@ -1043,7 +1043,7 @@
                 draw((1,1,0)--(1,2,1),bluepen);// w shifted to u
                 draw((-1,1,0)--(-1,2,1),bluepen);// w shifted to v
                 draw((0,2,0)--(0,3,1),bluepen);// w shifted to u+v
-                
+
                 //my try at shading.
                 import three;
                 path3 p =  (0,0,0)-- (1,1,0) -- (0,2,0) -- (-1,1,0); //Left

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -179,7 +179,7 @@
             \vec r(s) = \la 3(s/5)-1, 4(s/5)+2\ra = \la \frac35s-1,\frac45s+2\ra
           </me>.
         </p>
-        
+
         <p>
           Clearly, as shown in <xref ref="fig_vvfarc1"/>,
           the graph of <m>\vec r</m> is a line,
@@ -187,24 +187,24 @@
           What point on the line is 2 units away from this initial point?
           We find it with <m>\vec r(2) = \la 1/5, 18/5\ra</m>.
         </p>
-        
+
         <figure xml:id="fig_vvfarc1">
           <caption>Graphing <m>\vec r</m> in <xref ref="ex_vvfarc1"/> with parameters <m>t</m> and <m>s</m></caption>
           <!-- START figures/fig_vvfarc1.tex -->
           <image xml:id="img_vvfarc1" width="47%">
             <description></description>
             <latex-image>
-              
+
               \begin{tikzpicture}
-              
+
               \begin{axis}[
               xtick={1,2,-1,-2},
               ymin=-1.1,ymax=6.5,
               xmin=-2.1,xmax=2.9
               ]
-              
+
               \addplot+ [-,domain=-2.5:2.5] ({3*x-1},{4*x+2});
-              
+
               \filldraw (axis cs:-1,2) circle (1.5pt) node [left] { $t=0$}
               (axis cs:2,6) circle (1.5pt) node [left] { $t=1$}
               (axis cs: -.4,2.8) circle (1.5pt) node [right,secondcolor] { $s=1$}
@@ -212,18 +212,18 @@
               (axis cs: .8,4.4) circle (1.5pt) node [right,secondcolor] { $s=3$}
               (axis cs: 1.4,5.2) circle (1.5pt) node [right,secondcolor] { $s=4$}
               (axis cs: 2,6) circle (1.5pt) node [right,secondcolor] { $s=5$};
-              
+
               \draw (axis cs:-1,2) node [secondcolor,shift={(10pt,-5pt)}]  { $s=0$};
-              
+
               \end{axis}
-              
+
               \end{tikzpicture}
-              
+
             </latex-image>
           </image>
           <!-- figures/fig_vvfarc1.tex END -->
         </figure>
-        
+
         <p>
           Is the point <m>(1/5,18/5)</m> really 2 units away from <m>(-1,2)</m>?
           We use the Distance Formula to check:
@@ -231,7 +231,7 @@
             d = \sqrt{\left(\frac15-(-1)\right)^2+ \left(\frac{18}5-2\right)^2} = \sqrt{\frac{36}{25}+\frac{64}{25}} = \sqrt{4}=2
           </me>.
         </p>
-        
+
         <p>
           Yes, <m>\vec r(2)</m> is indeed 2 units away,
           in the direction of travel, from the initial point.
@@ -242,7 +242,7 @@
         <video width="98%" youtube="UZkbOv5zW1U" xml:id="vid-vvf-curv-arclen-eg" label="vid-vvf-curv-arclen-eg" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       Things worked out very nicely in <xref ref="ex_vvfarc1"/>;
       we were able to establish directly that <m>s=5t</m>.
@@ -566,7 +566,7 @@
             <mrow>\amp = \frac{r^2}{r^3} = \frac1r</mrow>
           </md>.
         </p>
-        
+
         <p>
           We have found that a circle with radius <m>r</m> has curvature <m>\kappa = 1/r</m>.
         </p>

--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -153,10 +153,6 @@
           Parametrize <m>\vec r</m> with the arc length parameter <m>s</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="UZkbOv5zW1U" xml:id="vid-vvf-curv-arclen-eg" label="vid-vvf-curv-arclen-eg" component="video"/>
-      </solution>
       <solution>
         <p>
           Using <xref ref="eq_vvfarc">Equation</xref>, we write
@@ -183,7 +179,7 @@
             \vec r(s) = \la 3(s/5)-1, 4(s/5)+2\ra = \la \frac35s-1,\frac45s+2\ra
           </me>.
         </p>
-
+        
         <p>
           Clearly, as shown in <xref ref="fig_vvfarc1"/>,
           the graph of <m>\vec r</m> is a line,
@@ -191,43 +187,43 @@
           What point on the line is 2 units away from this initial point?
           We find it with <m>\vec r(2) = \la 1/5, 18/5\ra</m>.
         </p>
-
+        
         <figure xml:id="fig_vvfarc1">
           <caption>Graphing <m>\vec r</m> in <xref ref="ex_vvfarc1"/> with parameters <m>t</m> and <m>s</m></caption>
           <!-- START figures/fig_vvfarc1.tex -->
           <image xml:id="img_vvfarc1" width="47%">
             <description></description>
             <latex-image>
-
-            \begin{tikzpicture}
-
-            \begin{axis}[
-            xtick={1,2,-1,-2},
-            ymin=-1.1,ymax=6.5,
-            xmin=-2.1,xmax=2.9
-            ]
-
-            \addplot+ [-,domain=-2.5:2.5] ({3*x-1},{4*x+2});
-
-            \filldraw (axis cs:-1,2) circle (1.5pt) node [left] { $t=0$}
-                      (axis cs:2,6) circle (1.5pt) node [left] { $t=1$}
-                      (axis cs: -.4,2.8) circle (1.5pt) node [right,secondcolor] { $s=1$}
-                      (axis cs: .2,3.6) circle (1.5pt) node [right,secondcolor] { $s=2$}
-                      (axis cs: .8,4.4) circle (1.5pt) node [right,secondcolor] { $s=3$}
-                      (axis cs: 1.4,5.2) circle (1.5pt) node [right,secondcolor] { $s=4$}
-                      (axis cs: 2,6) circle (1.5pt) node [right,secondcolor] { $s=5$};
-
-            \draw (axis cs:-1,2) node [secondcolor,shift={(10pt,-5pt)}]  { $s=0$};
-
-            \end{axis}
-
-            \end{tikzpicture}
-
+              
+              \begin{tikzpicture}
+              
+              \begin{axis}[
+              xtick={1,2,-1,-2},
+              ymin=-1.1,ymax=6.5,
+              xmin=-2.1,xmax=2.9
+              ]
+              
+              \addplot+ [-,domain=-2.5:2.5] ({3*x-1},{4*x+2});
+              
+              \filldraw (axis cs:-1,2) circle (1.5pt) node [left] { $t=0$}
+              (axis cs:2,6) circle (1.5pt) node [left] { $t=1$}
+              (axis cs: -.4,2.8) circle (1.5pt) node [right,secondcolor] { $s=1$}
+              (axis cs: .2,3.6) circle (1.5pt) node [right,secondcolor] { $s=2$}
+              (axis cs: .8,4.4) circle (1.5pt) node [right,secondcolor] { $s=3$}
+              (axis cs: 1.4,5.2) circle (1.5pt) node [right,secondcolor] { $s=4$}
+              (axis cs: 2,6) circle (1.5pt) node [right,secondcolor] { $s=5$};
+              
+              \draw (axis cs:-1,2) node [secondcolor,shift={(10pt,-5pt)}]  { $s=0$};
+              
+              \end{axis}
+              
+              \end{tikzpicture}
+              
             </latex-image>
           </image>
           <!-- figures/fig_vvfarc1.tex END -->
         </figure>
-
+        
         <p>
           Is the point <m>(1/5,18/5)</m> really 2 units away from <m>(-1,2)</m>?
           We use the Distance Formula to check:
@@ -235,14 +231,18 @@
             d = \sqrt{\left(\frac15-(-1)\right)^2+ \left(\frac{18}5-2\right)^2} = \sqrt{\frac{36}{25}+\frac{64}{25}} = \sqrt{4}=2
           </me>.
         </p>
-
+        
         <p>
           Yes, <m>\vec r(2)</m> is indeed 2 units away,
           in the direction of travel, from the initial point.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="UZkbOv5zW1U" xml:id="vid-vvf-curv-arclen-eg" label="vid-vvf-curv-arclen-eg" component="video"/>
+      </solution>
     </example>
-
+    
     <p>
       Things worked out very nicely in <xref ref="ex_vvfarc1"/>;
       we were able to establish directly that <m>s=5t</m>.
@@ -460,10 +460,6 @@
           to find the curvature of <m>\vrt = \la 3t-1,4t+2\ra</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="SZigON0uhqU" xml:id="vid-vvf-curv-line" label="vid-vvf-curv-line" component="video"/>
-      </solution>
       <solution>
         <p>
           In <xref ref="ex_vvfarc1"/>,
@@ -485,6 +481,10 @@
           <q>curvy</q> is a line?
           It is not curvy at all.)
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="SZigON0uhqU" xml:id="vid-vvf-curv-line" label="vid-vvf-curv-line" component="video"/>
       </solution>
     </example>
 
@@ -551,10 +551,6 @@
               <idx><h>curvature</h><h>of circle</h></idx>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="NgffyzJBrTc" xml:id="vid-vvf-curv-circle" label="vid-vvf-curv-circle" component="video"/>
-      </solution>
       <solution>
         <p>
           Before we start,
@@ -570,10 +566,14 @@
             <mrow>\amp = \frac{r^2}{r^3} = \frac1r</mrow>
           </md>.
         </p>
-
+        
         <p>
           We have found that a circle with radius <m>r</m> has curvature <m>\kappa = 1/r</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="NgffyzJBrTc" xml:id="vid-vvf-curv-circle" label="vid-vvf-curv-circle" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -1598,9 +1598,9 @@
             <solution>
               <p>
                 Cylindrical:
-                <m>(2\sqrt 2,\pi/4,1)</m> and <m>(2,5\pi/6,0)</m> 
+                <m>(2\sqrt 2,\pi/4,1)</m> and <m>(2,5\pi/6,0)</m>
               </p>
-              
+
               <p>
                 Spherical:
                 <m>(3,\pi/4,\cos^{-1}(3))</m> and <m>(2,5\pi/6,0)</m>
@@ -1619,7 +1619,7 @@
                 Rectangular:
                 <m>(\sqrt 2,\sqrt 2,2)</m> and <m>(0,-3,-4)</m>
               </p>
-              
+
               <p>
                 Spherical:
                 <m>(2\sqrt 2,\pi/4,\pi/4)</m> and <m>(5,3\pi/2,-\tan^{-1}(4/3))</m>
@@ -1638,7 +1638,7 @@
                 Rectangular:
                 <m>(1,1,\sqrt{2})</m> and <m>(1,0,0)</m>
               </p>
-              
+
               <p>
                 Cylindrical:
                 <m>(\sqrt{2},\pi/4,\sqrt{2})</m> and <m>(1,0,0)</m>

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -46,13 +46,13 @@
     <caption>The area under a constant velocity function corresponds to distance traveled</caption>
     <image xml:id="img_defint1" width="47%">
       <shortdescription>
-        Graph of a linear function, the area under the curve is rectangular in shape. 
+        Graph of a linear function, the area under the curve is rectangular in shape.
       </shortdescription>
       <description>
         <p>
-        The <m>y</m> axis is drawn from <m>0</m> to <m>5</m> represents velocity in feets per second 
+        The <m>y</m> axis is drawn from <m>0</m> to <m>5</m> represents velocity in feets per second
         and the <m>x</m> axis is drawn from <m>0</m> to <m>10</m> represents time in second.
-        The function <m>y=5</m> for all values of <m>x</m> until <m>10</m>, the function 
+        The function <m>y=5</m> for all values of <m>x</m> until <m>10</m>, the function
         is a straight line parallel to the <m>x</m> axis.
         The area under the line to the <m>x</m> axis is shaded, and is drawn between <m>x=0</m> and <m>x=10</m>.
         </p>
@@ -124,17 +124,17 @@
     <caption>The total displacement is the area above the <m>t</m>-axis minus the area below the <m>t</m>-axis</caption>
     <image xml:id="img_defint2" width="47%">
       <shortdescription>
-       The graph has two areas shaded that are rectangular in shape. 
+       The graph has two areas shaded that are rectangular in shape.
       </shortdescription>
       <description>
       <p>
-        The <m>y</m> axis is drawn from <m>0</m> to <m>5</m> represents velocity in feets per second 
+        The <m>y</m> axis is drawn from <m>0</m> to <m>5</m> represents velocity in feets per second
         and the <m>x</m> axis is drawn from <m>0</m> to <m>14</m> represents time in seconds.
-        There are two areas in the graph both rectangular in shape, 
+        There are two areas in the graph both rectangular in shape,
         the bigger one lies in the first quadrant and the smaller one lies in the fourth quadrant.
-        The function <m>y=5</m> is a straight line parallel to the <m>x</m> axis and creates the bigger area under graph, 
+        The function <m>y=5</m> is a straight line parallel to the <m>x</m> axis and creates the bigger area under graph,
         and is drawn between <m>x=0</m> and <m>x=10</m>.
-        The function <m>y=-2</m>, is a straight line parallel to the <m>x</m> axis and creates the smaller area, 
+        The function <m>y=-2</m>, is a straight line parallel to the <m>x</m> axis and creates the smaller area,
         and is drawn between <m>x=10</m> and <m>x = 14</m>.
       </p>
       </description>
@@ -200,7 +200,7 @@
       </p>
     </statement>
     <solution>
-      
+
       <p>
         It is straightforward to find the initial velocity; at time <m>t=0</m>,
         <md>
@@ -225,12 +225,12 @@
           <mrow>\amp = -16t^2+48t+C</mrow>
         </md>.
       </p>
-      
+
       <p>
         Since <m>s(0) = 0</m>,
         we conclude that <m>C=0</m> and <m>s(t) = -16t^2+48t</m>.
       </p>
-      
+
       <p>
         To find the maximum height of the object,
         we need to find the maximum of <m>s</m>.
@@ -244,7 +244,7 @@
           <mrow>\amp = 1.5\text{ s }</mrow>
         </md>.
       </p>
-      
+
       <p>
         (Notice how we ended up just finding when the velocity was 0ft/s!)
         The first derivative test shows this is a maximum,
@@ -253,7 +253,7 @@
           s(1.5) = -16(1.5)^2+48(1.5)=36\text{ ft }
         </me>.
       </p>
-      
+
       <p>
         The height at time <m>t=2</m> is now straightforward to compute:
         <md>
@@ -263,7 +263,7 @@
         The height is <quantity><mag>32</mag><unit base="foot"/></quantity>
         after <m>2</m> seconds.
       </p>
-      
+
       <p>
         While we have answered all three questions
         (using derivatives and antiderivatives),
@@ -277,7 +277,7 @@
         It is again straightforward to find <m>v(0)</m>.
         How can we use the graph to find the maximum height of the object?
       </p>
-      
+
       <figure xml:id="fig_defint3">
         <caption>A graph of <m>v(t)=-32t+48</m>; the shaded areas help determine displacement</caption>
         <image xml:id="img_defint3" width="47%">
@@ -286,14 +286,14 @@
           </shortdescription>
           <description>
             <p>
-              The <m>y</m> axis is drawn from <m>-40</m> to <m>40</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m>. 
-              The line starts from point <m>(0, 48)</m> and crosses  the <m>x</m> axis at <m>x=1.5</m>, 
-              the area under the curve forms a right angled triangle in the first quadrant with the positive <m>x</m> and <m>y</m> axes. 
-              After crossing the <m>x</m> axis at <m>x=1.5</m> the line goes down to point <m>(3,-48)</m>. 
+              The <m>y</m> axis is drawn from <m>-40</m> to <m>40</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m>.
+              The line starts from point <m>(0, 48)</m> and crosses  the <m>x</m> axis at <m>x=1.5</m>,
+              the area under the curve forms a right angled triangle in the first quadrant with the positive <m>x</m> and <m>y</m> axes.
+              After crossing the <m>x</m> axis at <m>x=1.5</m> the line goes down to point <m>(3,-48)</m>.
               Another right angle is formed on the <m>x</m> axis but in the fourth quadrant with the <m>x</m> axis and line <m>x=3</m>.
             </p>
           </description>
-          
+
           <latex-image>
             \begin{tikzpicture}
             \begin{axis}[
@@ -312,7 +312,7 @@
           </latex-image>
         </image>
       </figure>
-      
+
       <p>
         Recall how in our previous work that the displacement of the object
         (in this case, its height)
@@ -332,7 +332,7 @@
         </md>
         which matches our previous calculation of the maximum height.
       </p>
-      
+
       <p>
         Finally, to find the height of the object at time <m>t=2</m> we
         calculate the total <q>signed area</q>
@@ -343,12 +343,12 @@
         <m>t=0</m> to the position at time <m>t=2</m>.
         That is,
       </p>
-      
+
       <p>
         Displacement = Area above the <m>t</m>-axis <m>-</m> Area below
         <m>t</m>-axis.
       </p>
-      
+
       <p>
         The regions are triangles, and we find
         <md>
@@ -356,11 +356,11 @@
           <mrow>\amp = 32\text{ ft }</mrow>
         </md>.
       </p>
-      
+
       <p>
         This also matches our previous calculation of the height at <m>t=2</m>.
       </p>
-      
+
       <p>
         Notice how we answered each question in this example in two ways.
         Our first method was to manipulate equations using our understanding of
@@ -476,16 +476,16 @@
           <description>
           <p>
           The <m>y</m> axis is drawn between <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn between <m>0</m> to <m>5</m>.
-          There is a triangle in the first quadrant drawn on the <m>x</m> axis 
-          with its base from <m>x=0</m> to <m>x=3</m> the peak of the triangle is at point <m>(1,1)</m>. 
+          There is a triangle in the first quadrant drawn on the <m>x</m> axis
+          with its base from <m>x=0</m> to <m>x=3</m> the peak of the triangle is at point <m>(1,1)</m>.
           The area in the first quadrant is the shaded portion inside the triangle.
           </p>
           <p>
-          The second area is a right angle triangle and is drawn on the <m>x</m> axis between <m>x=3</m> and <m>x=5</m>. 
-          The triangle lies in the fourth quadrant with its peak at point <m>(5,-1)</m> and the function forming the hypotenuse. 
+          The second area is a right angle triangle and is drawn on the <m>x</m> axis between <m>x=3</m> and <m>x=5</m>.
+          The triangle lies in the fourth quadrant with its peak at point <m>(5,-1)</m> and the function forming the hypotenuse.
           </p>
           </description>
-          
+
           <latex-image>
           \begin{tikzpicture}
           \begin{axis}[
@@ -519,7 +519,7 @@
         </ol>
       </p>
     </statement>
-    <solution>      
+    <solution>
       <p>
         <ol>
           <li>
@@ -530,7 +530,7 @@
               so the area is <m>\int_0^3 f(x)\, dx=\frac12(3)(1) = 1.5</m>.
             </p>
           </li>
-          
+
           <li>
             <p>
               <m>\int_3^5 f(x)\, dx</m> represents the area of the triangle
@@ -581,8 +581,8 @@
           <description>
           <p>
           The <m>y</m> axis is drawn between <m>-5</m> to <m>5</m> and the <m>x</m> axis is drawn between <m>0</m> to <m>5</m>.
-          There is a triangle in the first quadrant drawn on the <m>x</m> axis with 
-          its base from <m>x=0</m> to <m>x=3</m> the peak of the triangle is at point <m>(1,5)</m>. 
+          There is a triangle in the first quadrant drawn on the <m>x</m> axis with
+          its base from <m>x=0</m> to <m>x=3</m> the peak of the triangle is at point <m>(1,5)</m>.
           The area in the first quadrant is the shaded portion inside the triangle.
           </p>
         </description>
@@ -735,21 +735,21 @@
 
       <figure xml:id="fig_defint5">
         <caption>A graph of a function in <xref ref="ex_defint5"/></caption>
-        <image xml:id="img_defint5" width="47%">         
+        <image xml:id="img_defint5" width="47%">
         <shortdescription>
         The graph of function in this example.
         </shortdescription>
         <description>
         <p>
-        The <m>x</m> and the <m>y</m> axes are uncalibrated, there are three positions <m>a</m>, 
+        The <m>x</m> and the <m>y</m> axes are uncalibrated, there are three positions <m>a</m>,
         <m>b</m> and <m>c</m>  in order on the <m>x</m> axis where the inflection changes.
-        The curve in the first quadrant is  smaller, the area under the curve forms a bell jar shape 
-        it extends from <m>x=a</m> to <m>x=b</m>. 
+        The curve in the first quadrant is  smaller, the area under the curve forms a bell jar shape
+        it extends from <m>x=a</m> to <m>x=b</m>.
         The other curve is twice in height as the first and lies in the fourth quadrant.
         It is also bell jar shaped, but is inverted on the positive <m>x</m> axis and extends between <m>x=b</m> to <m>x=c</m>.
-        </p> 
+        </p>
         </description>
-  
+
           <latex-image>
           \begin{tikzpicture}
           \begin{axis}[
@@ -849,7 +849,7 @@
       </p>
     </statement>
     <solution>
-      
+
       <p>
         <ol>
           <li>
@@ -886,32 +886,32 @@
           </li>
         </ol>
       </p>
-            
+
       <sidebyside widths="47% 47%" margins="0%">
         <figure xml:id="fig_defint8a">
           <caption><m>f(x) = 2x-4</m></caption>
           <image xml:id="img_defint8a">
             <shortdescription>
-              Graph of function of a positive sloped straight line along with the areas it forms on the x axis. 
+              Graph of function of a positive sloped straight line along with the areas it forms on the x axis.
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the 
+                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the
                 <m>x</m> axis is drawn from <m>-3</m> to <m>5</m>.
-                The function is a straight line that starts from point <m>(-2,-8)</m> and ends at point <m>(5,6)</m>. 
-                The function intersects the <m>x</m> axis at <m>x=2</m>. 
+                The function is a straight line that starts from point <m>(-2,-8)</m> and ends at point <m>(5,6)</m>.
+                The function intersects the <m>x</m> axis at <m>x=2</m>.
               </p>
               <p>
-                The function, below the <m>x</m> axis creates a right angled triangle 
-                with the <m>x</m> axis and line <m>x=-2</m> from <m>y=0</m> to <m>y=-8</m>,  
+                The function, below the <m>x</m> axis creates a right angled triangle
+                with the <m>x</m> axis and line <m>x=-2</m> from <m>y=0</m> to <m>y=-8</m>,
                 with its base from <m>x=-2</m> to <m>x=2</m>. This area is named R1.
               </p>
               <p>
-                The function above the <m>x</m> axis forms a right angled triangle with the <m>x</m> axis and line <m>x=5</m>  
+                The function above the <m>x</m> axis forms a right angled triangle with the <m>x</m> axis and line <m>x=5</m>
                 from <m>y=0</m> to <m>y=6</m>, with its base from <m>x=2</m> and <m>x=5</m>. This area is named R2.
               </p>
             </description>
-              
+
             <latex-image>
               \begin{tikzpicture}
               \begin{axis}[
@@ -934,13 +934,13 @@
           <caption><m>f(x) = \sqrt{9-x^2}</m></caption>
           <image xml:id="img_defint8b">
             <shortdescription>
-              The graph area under the curve is a semicircle with radius 3 on the x axis with centre at origin. 
+              The graph area under the curve is a semicircle with radius 3 on the x axis with centre at origin.
             </shortdescription>
             <description>
-              The graph shows the area under the curve that is a semicircle with radius <m>3</m> on the <m>x</m> axis 
+              The graph shows the area under the curve that is a semicircle with radius <m>3</m> on the <m>x</m> axis
               with centre at origin. It lies on the first and the second quadrant.
             </description>
-              
+
             <latex-image>
               \begin{tikzpicture}
               \begin{axis}[
@@ -987,24 +987,24 @@
             </shortdescription>
             <description>
             <p>
-            The <m>y</m> axis is drawn from <m>-10</m> to <m>15</m> and 
-            it represents velocity in feets per second, the <m>x</m> axis is uncalibrated and represents time in seconds. 
+            The <m>y</m> axis is drawn from <m>-10</m> to <m>15</m> and
+            it represents velocity in feets per second, the <m>x</m> axis is uncalibrated and represents time in seconds.
             There are three points on the <m>x</m> axis marked <m>a</m>, <m>b</m> and <m>c</m> in that order.
             </p>
             <p>
-            In the fourth quadrant, on the <m>x</m> axis from <m>0</m> to <m>a</m>, a parabola is drawn with its peak at 
+            In the fourth quadrant, on the <m>x</m> axis from <m>0</m> to <m>a</m>, a parabola is drawn with its peak at
             <m>y=-10</m>. The number <m>11</m> is written inside the shaded portion.
             </p>
             <p>
-            From <m>a</m> to <m>b</m> there is a second parabola in the first quadrant with its peak at <m>y= 15</m>, 
+            From <m>a</m> to <m>b</m> there is a second parabola in the first quadrant with its peak at <m>y= 15</m>,
             the number <m>38</m> is written inside it.
             </p>
             <p>
-            From <m>b</m> to <m>c</m> the third parabola is located in the fourth quadrant with its peak at <m>x=-10</m>, 
+            From <m>b</m> to <m>c</m> the third parabola is located in the fourth quadrant with its peak at <m>x=-10</m>,
             the number <m>11</m> is written inside it, indicating same size as the first parabola.
             </p>
             </description>
-            
+
           <latex-image>
           \begin{tikzpicture}
           \begin{axis}[
@@ -1077,14 +1077,14 @@
         <description>
         <p>
         The <m>y</m> axis is drawn from <m>0</m> to <m>10</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m>.
-        The curve is drawn in the first quadrant, it starts at the origin and 
+        The curve is drawn in the first quadrant, it starts at the origin and
         increases gently until <m>x=1</m> and steeply from <m>x=1</m> to <m>x=3</m> and ends at point <m>(3,9)</m>.
         </p>
         <p>
         The area under the curve roughly looks like a right angled triangle.
         </p>
         </description>
-        
+
       <latex-image>
       \begin{tikzpicture}
       \begin{axis}[
@@ -1188,12 +1188,12 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>-4</m> to <m>4</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>4</m>. 
-                    The function <m>y=-2x+4</m> is a line that decreases from point <m>(0,4)</m> to point <m>(4,-4)</m>. 
+                    The <m>y</m> axis is drawn from <m>-4</m> to <m>4</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>4</m>.
+                    The function <m>y=-2x+4</m> is a line that decreases from point <m>(0,4)</m> to point <m>(4,-4)</m>.
                     The function is linear hence the graph is a straight line between the two points.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1287,14 +1287,14 @@
                     <description>
                     <p>
                     The <m>y</m> axis is drawn from <m>-2</m> to <m>2</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>5</m>.
-                    The graph of function is drawn in the fourth and the first quadrants. In the fourth quadrant, 
-                    the function is a straight line <m>y=-2</m>, from <m>x=0</m> to <m>x=2</m>. 
-                    Then the function increases steeply and meets the <m>x</m> axis at <m>x=3</m>. 
-                    After intersecting the <m>x</m> axis at <m>3</m>, 
+                    The graph of function is drawn in the fourth and the first quadrants. In the fourth quadrant,
+                    the function is a straight line <m>y=-2</m>, from <m>x=0</m> to <m>x=2</m>.
+                    Then the function increases steeply and meets the <m>x</m> axis at <m>x=3</m>.
+                    After intersecting the <m>x</m> axis at <m>3</m>,
                     the function assumes a gentler slope and increases until point <m>(5,2)</m>.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1385,20 +1385,20 @@
               <!-- webwork graph was not randomized -->
                 <image xml:id="img_05_02_ex_07">
                   <shortdescription>
-                    The graph has two triangles from 0 to 2 and from 2 to 4, 
+                    The graph has two triangles from 0 to 2 and from 2 to 4,
                     the first one is twice the height of the second.
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>x</m> axis is drawn from <m>0</m> to <m>4</m> and the <m>y</m> axis 
+                    The <m>x</m> axis is drawn from <m>0</m> to <m>4</m> and the <m>y</m> axis
                     is drawn from <m>0</m> to <m>4</m>.
-                    The function increases from the origin to peak at <m>(1,4)</m> 
+                    The function increases from the origin to peak at <m>(1,4)</m>
                     then it decreases sharply to point <m>(2,0)</m>.
-                    Then it increases again, gently to the second peak at <m>(3,2)</m> 
+                    Then it increases again, gently to the second peak at <m>(3,2)</m>
                     after which it decreases to point <m>(4,0)</m>.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1495,14 +1495,14 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>-1</m> to <m>3</m> and the <m>x</m> axis 
+                    The <m>y</m> axis is drawn from <m>-1</m> to <m>3</m> and the <m>x</m> axis
                     is drawn from <m>0</m> to <m>4</m>.
-                    The graph of function <m>y=x-1</m> is a straight line that 
-                    increases from point <m>(0,-1)</m> to point <m>(4,3)</m>, 
+                    The graph of function <m>y=x-1</m> is a straight line that
+                    increases from point <m>(0,-1)</m> to point <m>(4,3)</m>,
                     and it crosses the <m>x</m> axis at <m>x=1</m>.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1592,18 +1592,18 @@
               <!-- webwork graph was not randomized -->
                 <image xml:id="img_05_02_ex_09">
                   <shortdescription>
-                    Graph of function that is a semicircle on the x axis. 
+                    Graph of function that is a semicircle on the x axis.
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>0</m> to <m>3</m> and the <m>x</m> axis is 
+                    The <m>y</m> axis is drawn from <m>0</m> to <m>3</m> and the <m>x</m> axis is
                     drawn from <m>0</m> to <m>4</m>.
                     The graph of function <m>f(x) = \sqrt{4-(x-2)^2}</m>
-                    is a semi circle drawn on the <m>x</m> axis with centre at point 
+                    is a semi circle drawn on the <m>x</m> axis with centre at point
                     <m>(2,0)</m> and radius of <m>2</m>.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1678,13 +1678,13 @@
                       </shortdescription>
                       <description>
                       <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and
                       the <m>x</m> axis is drawn from <m>0</m> to <m>10</m>.
-                      The graph of function <m>f(x) = 3</m> is a straight 
+                      The graph of function <m>f(x) = 3</m> is a straight
                       line parallel to the <m>x</m> axis and goes from <m>x=0</m> to <m>x=10</m>.
                       </p>
                       </description>
-                      
+
                     <latex-image>
                       \begin{tikzpicture}
                         \begin{axis}[
@@ -1768,26 +1768,26 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>-100</m> to <m>50</m> and the 
-                    <m>x</m> axis is drawn from <m>0</m> to <m>3</m>. The function 
-                    forms three parabolic shapes. The areas inside the parabolas 
-                    until the <m>x</m> axis are shaded. The biggest one lies in the 
+                    The <m>y</m> axis is drawn from <m>-100</m> to <m>50</m> and the
+                    <m>x</m> axis is drawn from <m>0</m> to <m>3</m>. The function
+                    forms three parabolic shapes. The areas inside the parabolas
+                    until the <m>x</m> axis are shaded. The biggest one lies in the
                     fourth quadrant and the other two in the first.
                     </p>
                     <p>
-                    Between <m>x=0</m> to <m>x=1</m> the highest parabola is formed 
+                    Between <m>x=0</m> to <m>x=1</m> the highest parabola is formed
                     with peak at <m>y=-100</m>, it is labeled with number <m>59</m>.
                     </p>
                     <p>
-                    Between <m>x=1</m> to <m>x=2</m> the smallest parabola is formed 
+                    Between <m>x=1</m> to <m>x=2</m> the smallest parabola is formed
                     with the peak at nearly <m>y=20</m>, it is labeled with number <m>11</m>.
                     </p>
                     <p>
-                    Between <m>x=2</m> to <m>x=3</m> the third parabola is formed with 
+                    Between <m>x=2</m> to <m>x=3</m> the third parabola is formed with
                     the peak at nearly <m>y=45</m>, it is labeled with number <m>21</m>.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1865,20 +1865,20 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and 
-                    the <m>x</m> axis is drawn from <m>0</m> to <m>4</m>. The function 
+                    The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and
+                    the <m>x</m> axis is drawn from <m>0</m> to <m>4</m>. The function
                     crosses the <m>x</m> axis at <m>0</m>, <m>2</m> and <m>4</m>.
                     </p>
                     <p>
-                    There is a downward facing parabola between <m>x=0</m> and <m>x=2</m> with 
+                    There is a downward facing parabola between <m>x=0</m> and <m>x=2</m> with
                     peak at point <m>(1,1)</m> and it lies in the first quadrant.
-                    The shaded portion inside this downward facing parabola until the <m>x</m> axis is labeled <m>4/\pi</m>. 
-                    From <m>x=2</m> and <m>x=4</m> the secong prabola is present 
+                    The shaded portion inside this downward facing parabola until the <m>x</m> axis is labeled <m>4/\pi</m>.
+                    From <m>x=2</m> and <m>x=4</m> the secong prabola is present
                     in the fourth quadrant.
-                    The shaded portion inside this parabola until the <m>x</m> axis is labeled <m>4/\pi</m>. 
+                    The shaded portion inside this parabola until the <m>x</m> axis is labeled <m>4/\pi</m>.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -1955,18 +1955,18 @@
                   </shortdescription>
                   <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>-5</m> to <m>10</m> and the <m>x</m> axis 
+                    The <m>y</m> axis is drawn from <m>-5</m> to <m>10</m> and the <m>x</m> axis
                     is drawn from <m>-2</m> to <m>2</m>.
                     The function <m>f(x) = 3x^2 -3</m> is  parabolic, with vertex at point <m>(0,-3)</m>.
                     It has <m>x</m> intercepts at <m>x=-1</m> and <m>x=1</m>.
                                 </p>
                     <p>
-                        There are three distinct shaded regions, from <m>x=-1</m> to  <m>x=-2</m> and from 
-                        <m>x=1</m> to  <m>x=2</m> the area under the arms of the parabola to the <m>x</m> 
+                        There are three distinct shaded regions, from <m>x=-1</m> to  <m>x=-2</m> and from
+                        <m>x=1</m> to  <m>x=2</m> the area under the arms of the parabola to the <m>x</m>
                         axis are shaded and both are labeled with number <m>4</m>.
                     </p>
                     <p>
-                    From <m>x=-1</m> to  <m>x=1</m>, the area from above the parabola to the <m>x</m> axis 
+                    From <m>x=-1</m> to  <m>x=1</m>, the area from above the parabola to the <m>x</m> axis
                     is shaded and labeled as <m>-4</m>.
                     </p>
                   </description>
@@ -2048,22 +2048,22 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>0</m> to 
+                    The <m>y</m> axis is drawn from <m>0</m> to
                     <m>4</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>2</m>.
-                    The function <m>f(x)=x^2</m> is drawn in the first quadrant, 
-                    it starts at the origin and gently curves up  to point <m>(1,1)</m> 
-                    then steeply to point <m>(2,4)</m>. The area under the curve is 
-                    shaded from <m>x=0</m> to <m>x=2</m>. It forms a roughly right-angled 
+                    The function <m>f(x)=x^2</m> is drawn in the first quadrant,
+                    it starts at the origin and gently curves up  to point <m>(1,1)</m>
+                    then steeply to point <m>(2,4)</m>. The area under the curve is
+                    shaded from <m>x=0</m> to <m>x=2</m>. It forms a roughly right-angled
                     triangle shape.
                     </p>
                     <p>
-                      From <m>x=0</m> to <m>x=1</m>, the number <m>1/3</m> is written 
-                      inside the shaded region, and from <m>x=1</m> to <m>x=2</m>, 
-                      the number <m>7/3</m> is written. 
+                      From <m>x=0</m> to <m>x=1</m>, the number <m>1/3</m> is written
+                      inside the shaded region, and from <m>x=1</m> to <m>x=2</m>,
+                      the number <m>7/3</m> is written.
                      </p>
-        
+
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -2152,15 +2152,15 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>-1</m> to <m>3</m> and represents velocity in 
-                    feets per second and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m> and 
+                    The <m>y</m> axis is drawn from <m>-1</m> to <m>3</m> and represents velocity in
+                    feets per second and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m> and
                     it represents time in seconds.
-                    The graph of the function is an inclined line. It starts from point <m>(0,2)</m> 
-                    then decreases in the first quadrant, crosses the <m>x</m> axis at <m>x=2</m> 
+                    The graph of the function is an inclined line. It starts from point <m>(0,2)</m>
+                    then decreases in the first quadrant, crosses the <m>x</m> axis at <m>x=2</m>
                     and continues decreasing in the fourth quadrant.
                     </p>
                     </description>
-                    
+
                   <latex-image>
                     \begin{tikzpicture}
                       \begin{axis}[
@@ -2226,11 +2226,11 @@
                     </shortdescription>
                     <description>
                     <p>
-                    The <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and represents velocity 
-                    in feets per second and the <m>x</m> axis is drawn from <m>0</m> to <m>5</m> 
+                    The <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and represents velocity
+                    in feets per second and the <m>x</m> axis is drawn from <m>0</m> to <m>5</m>
                     and it represents time in seconds.
-                    The graph is a straight line <m>y=3</m> from <m>x=0</m> to <m>x=1</m> then 
-                    it decreases to point <m>(2,0)</m>. The function then increases to <m>(3,2)</m> 
+                    The graph is a straight line <m>y=3</m> from <m>x=0</m> to <m>x=1</m> then
+                    it decreases to point <m>(2,0)</m>. The function then increases to <m>(3,2)</m>
                     then it becomes a straight line <m>y=2</m>.
                     </p>
                     </description>
@@ -2553,7 +2553,7 @@
             Evaluate the given indefinite integral.
           </p>
         </introduction>
-        
+
         <exercise label="ex-definite-integral-review-1">
           <webwork xml:id="webwork-ex-definite-integral-review-1">
             <pg-code>
@@ -2577,7 +2577,7 @@
             </statement>
           </webwork>
         </exercise>
-        
+
         <exercise label="ex-definite-integral-review-2">
           <webwork xml:id="webwork-ex-definite-integral-review-2">
             <pg-code>
@@ -2602,7 +2602,7 @@
             </statement>
           </webwork>
         </exercise>
-        
+
         <exercise label="ex-definite-integral-review-3">
           <webwork xml:id="webwork-ex-definite-integral-review-3">
             <pg-code>
@@ -2629,7 +2629,7 @@
             </statement>
           </webwork>
         </exercise>
-        
+
         <exercise label="ex-definite-integral-review-4">
           <webwork xml:id="webwork-ex-definite-integral-review-4">
             <pg-code>

--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -199,12 +199,8 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="MUx3n9511e8" xml:id="vid_int_def_int_ex_vel" label="vid_int_def_int_ex_vel" component="video"/>
-    </solution>
     <solution>
-
+      
       <p>
         It is straightforward to find the initial velocity; at time <m>t=0</m>,
         <md>
@@ -229,12 +225,12 @@
           <mrow>\amp = -16t^2+48t+C</mrow>
         </md>.
       </p>
-
+      
       <p>
         Since <m>s(0) = 0</m>,
         we conclude that <m>C=0</m> and <m>s(t) = -16t^2+48t</m>.
       </p>
-
+      
       <p>
         To find the maximum height of the object,
         we need to find the maximum of <m>s</m>.
@@ -248,7 +244,7 @@
           <mrow>\amp = 1.5\text{ s }</mrow>
         </md>.
       </p>
-
+      
       <p>
         (Notice how we ended up just finding when the velocity was 0ft/s!)
         The first derivative test shows this is a maximum,
@@ -257,7 +253,7 @@
           s(1.5) = -16(1.5)^2+48(1.5)=36\text{ ft }
         </me>.
       </p>
-
+      
       <p>
         The height at time <m>t=2</m> is now straightforward to compute:
         <md>
@@ -267,7 +263,7 @@
         The height is <quantity><mag>32</mag><unit base="foot"/></quantity>
         after <m>2</m> seconds.
       </p>
-
+      
       <p>
         While we have answered all three questions
         (using derivatives and antiderivatives),
@@ -281,42 +277,42 @@
         It is again straightforward to find <m>v(0)</m>.
         How can we use the graph to find the maximum height of the object?
       </p>
-
+      
       <figure xml:id="fig_defint3">
         <caption>A graph of <m>v(t)=-32t+48</m>; the shaded areas help determine displacement</caption>
         <image xml:id="img_defint3" width="47%">
           <shortdescription>
             The graph of the function is a straight line that intersects the x axis. There are two triangular areas.
-           </shortdescription>
-         <description>
-         <p>
-          The <m>y</m> axis is drawn from <m>-40</m> to <m>40</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m>. 
-          The line starts from point <m>(0, 48)</m> and crosses  the <m>x</m> axis at <m>x=1.5</m>, 
-          the area under the curve forms a right angled triangle in the first quadrant with the positive <m>x</m> and <m>y</m> axes. 
-         After crossing the <m>x</m> axis at <m>x=1.5</m> the line goes down to point <m>(3,-48)</m>. 
-         Another right angle is formed on the <m>x</m> axis but in the fourth quadrant with the <m>x</m> axis and line <m>x=3</m>.
-         </p>
-         </description>
-         
+          </shortdescription>
+          <description>
+            <p>
+              The <m>y</m> axis is drawn from <m>-40</m> to <m>40</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>3</m>. 
+              The line starts from point <m>(0, 48)</m> and crosses  the <m>x</m> axis at <m>x=1.5</m>, 
+              the area under the curve forms a right angled triangle in the first quadrant with the positive <m>x</m> and <m>y</m> axes. 
+              After crossing the <m>x</m> axis at <m>x=1.5</m> the line goes down to point <m>(3,-48)</m>. 
+              Another right angle is formed on the <m>x</m> axis but in the fourth quadrant with the <m>x</m> axis and line <m>x=3</m>.
+            </p>
+          </description>
+          
           <latex-image>
-          \begin{tikzpicture}
-          \begin{axis}[
-          axis on top,
-          ymin=-55,ymax=55,
-          xmin=-.5,xmax=3.2,
-          x label style={at={(axis description cs:0.85,0.3)},anchor=south},
-          y label style={at={(axis description cs:0,.85)},rotate=90,anchor=south},
-          xlabel={$t$ (s)},
-          ylabel={$v$ (ft/s)},
-          ]
-          \addplot [firstcurvestyle,areastyle,domain=0:3] {-32*x+48} \closedcycle;
-          \addplot [firstcurvestyle,-,domain=0:3] {-32*x+48};
-          \end{axis}
-          \end{tikzpicture}
+            \begin{tikzpicture}
+            \begin{axis}[
+            axis on top,
+            ymin=-55,ymax=55,
+            xmin=-.5,xmax=3.2,
+            x label style={at={(axis description cs:0.85,0.3)},anchor=south},
+            y label style={at={(axis description cs:0,.85)},rotate=90,anchor=south},
+            xlabel={$t$ (s)},
+            ylabel={$v$ (ft/s)},
+            ]
+            \addplot [firstcurvestyle,areastyle,domain=0:3] {-32*x+48} \closedcycle;
+            \addplot [firstcurvestyle,-,domain=0:3] {-32*x+48};
+            \end{axis}
+            \end{tikzpicture}
           </latex-image>
         </image>
       </figure>
-
+      
       <p>
         Recall how in our previous work that the displacement of the object
         (in this case, its height)
@@ -336,7 +332,7 @@
         </md>
         which matches our previous calculation of the maximum height.
       </p>
-
+      
       <p>
         Finally, to find the height of the object at time <m>t=2</m> we
         calculate the total <q>signed area</q>
@@ -347,12 +343,12 @@
         <m>t=0</m> to the position at time <m>t=2</m>.
         That is,
       </p>
-
+      
       <p>
         Displacement = Area above the <m>t</m>-axis <m>-</m> Area below
         <m>t</m>-axis.
       </p>
-
+      
       <p>
         The regions are triangles, and we find
         <md>
@@ -360,11 +356,11 @@
           <mrow>\amp = 32\text{ ft }</mrow>
         </md>.
       </p>
-
+      
       <p>
         This also matches our previous calculation of the height at <m>t=2</m>.
       </p>
-
+      
       <p>
         Notice how we answered each question in this example in two ways.
         Our first method was to manipulate equations using our understanding of
@@ -373,6 +369,10 @@
         we answered questions looking at a graph and finding the areas of
         certain regions of this graph.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="MUx3n9511e8" xml:id="vid_int_def_int_ex_vel" label="vid_int_def_int_ex_vel" component="video"/>
     </solution>
   </example>
 
@@ -519,12 +519,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="jrjjVT1j9uw" xml:id="vid_int_def_int_ex_1" label="vid_int_def_int_ex_1" component="video"/>
-    </solution>
-    <solution>
-
+    <solution>      
       <p>
         <ol>
           <li>
@@ -535,7 +530,7 @@
               so the area is <m>\int_0^3 f(x)\, dx=\frac12(3)(1) = 1.5</m>.
             </p>
           </li>
-
+          
           <li>
             <p>
               <m>\int_3^5 f(x)\, dx</m> represents the area of the triangle
@@ -590,27 +585,27 @@
           its base from <m>x=0</m> to <m>x=3</m> the peak of the triangle is at point <m>(1,5)</m>. 
           The area in the first quadrant is the shaded portion inside the triangle.
           </p>
-          <p>
-          The second area is a right angle triangle and is drawn on the <m>x</m> axis between <m>x=3</m> and <m>x=5</m>. 
-          The triangle lies in the fourth quadrant with its peak at point <m>(5,-5)</m> and the function forming the hypotenuse. 
-          </p>
-          </description>
+        </description>
         <latex-image>
-                \begin{tikzpicture}
-                \begin{axis}[
-                axis on top,
-                ymin=-5.5,ymax=5.5,
-                xmin=-.5,xmax=5.5
-                ]
-                \addplot [firstcurvestyle,areastyle] coordinates {(0,0) (1,5) (5,-5)} \closedcycle;
-                \addplot [firstcurvestyle,-] coordinates {(0,0) (1,5) (5,-5)};
-                \end{axis}
-                \end{tikzpicture}
+          \begin{tikzpicture}
+          \begin{axis}[
+          axis on top,
+          ymin=-5.5,ymax=5.5,
+          xmin=-.5,xmax=5.5
+          ]
+          \addplot [firstcurvestyle,areastyle] coordinates {(0,0) (1,5) (5,-5)} \closedcycle;
+          \addplot [firstcurvestyle,-] coordinates {(0,0) (1,5) (5,-5)};
+          \end{axis}
+          \end{tikzpicture}
         </latex-image>
       </image>
     </figure>
-    </solution>
-  </example>
+  </solution>
+  <solution component="video">
+    <title>Video solution</title>
+    <video width="98%" youtube="jrjjVT1j9uw" xml:id="vid_int_def_int_ex_1" label="vid_int_def_int_ex_1" component="video"/>
+  </solution>
+</example>
 
   <p>
     This example illustrates some of the properties of the definite integral,
@@ -853,12 +848,8 @@
         </me>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="AuGASVXd3qA" xml:id="vid_int_def_int_geo_ex" label="vid_int_def_int_geo_ex" component="video"/>
-    </solution>
     <solution>
-
+      
       <p>
         <ol>
           <li>
@@ -895,78 +886,83 @@
           </li>
         </ol>
       </p>
-            <sidebyside widths="47% 47%" margins="0%">
-              <figure xml:id="fig_defint8a">
-                <caption><m>f(x) = 2x-4</m></caption>
-                <image xml:id="img_defint8a">
-                  <shortdescription>
-                    Graph of function of a positive sloped straight line along with the areas it forms on the x axis. 
-                    </shortdescription>
-                    <description>
-                    <p>
-                     The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the 
-                     <m>x</m> axis is drawn from <m>-3</m> to <m>5</m>.
-                    The function is a straight line that starts from point <m>(-2,-8)</m> and ends at point <m>(5,6)</m>. 
-                    The function intersects the <m>x</m> axis at <m>x=2</m>. 
-                    </p>
-                    <p>
-                    The function, below the <m>x</m> axis creates a right angled triangle 
-                    with the <m>x</m> axis and line <m>x=-2</m> from <m>y=0</m> to <m>y=-8</m>,  
-                    with its base from <m>x=-2</m> to <m>x=2</m>. This area is named R1.
-                    </p>
-                    <p>
-                    The function above the <m>x</m> axis forms a right angled triangle with the <m>x</m> axis and line <m>x=5</m>  
-                    from <m>y=0</m> to <m>y=6</m>, with its base from <m>x=2</m> and <m>x=5</m>. This area is named R2.
-                    </p>
-                    </description>
-                    
-                  <latex-image>
-                  \begin{tikzpicture}
-                  \begin{axis}[
-                  axis on top,
-                  ymin=-11,ymax=11,
-                  xmin=-3.5,xmax=5.5
-                  ]
-                  \addplot [firstcurvestyle,areastyle,domain=-2:5] {2*x-4} \closedcycle;
-                  \addplot [firstcurvestyle,-,domain=-2:5] {2*x-4};
-                  \addplot [soliddot] coordinates {(-2,-8)} node[right] {\small $(-2,-8)$};
-                  \addplot [soliddot] coordinates {(5,6)} node[left] {\small $(5,6)$};
-                  \draw (axis cs:-1,-2) node { $R_1$};
-                  \draw (axis cs:4.2,2) node { $R_2$};
-                  \end{axis}
-                  \end{tikzpicture}
-                  </latex-image>
-                </image>
-              </figure>
-              <figure xml:id="fig_defint8b">
-                <caption><m>f(x) = \sqrt{9-x^2}</m></caption>
-                <image xml:id="img_defint8b">
-                  <shortdescription>
-                    The graph area under the curve is a semicircle with radius 3 on the x axis with centre at origin. 
-                    </shortdescription>
-                    <description>
-                    The graph shows the area under the curve that is a semicircle with radius <m>3</m> on the <m>x</m> axis 
-                    with centre at origin. It lies on the first and the second quadrant.
-                    </description>
-                    
-                  <latex-image>
-                  \begin{tikzpicture}
-                  \begin{axis}[
-                  axis on top,
-                  xtick={-3,3},
-                  extra y ticks={1,2,3,4},
-                  extra y tick labels=\empty,
-                  ytick={5},
-                  ymin=-.5,ymax=5.5,
-                  xmin=-3.5,xmax=3.5]
-                  \addplot [firstcurvestyle,areastyle,domain=0:180] ({3*cos (x)},{3*sin(x)}) \closedcycle;
-                  \addplot [firstcurvestyle,-,domain=0:180,samples=40] ({3*cos (x)},{3*sin(x)});
-                  \end{axis}
-                  \end{tikzpicture}
-                  </latex-image>
-                </image>
-              </figure>
-            </sidebyside>
+            
+      <sidebyside widths="47% 47%" margins="0%">
+        <figure xml:id="fig_defint8a">
+          <caption><m>f(x) = 2x-4</m></caption>
+          <image xml:id="img_defint8a">
+            <shortdescription>
+              Graph of function of a positive sloped straight line along with the areas it forms on the x axis. 
+            </shortdescription>
+            <description>
+              <p>
+                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the 
+                <m>x</m> axis is drawn from <m>-3</m> to <m>5</m>.
+                The function is a straight line that starts from point <m>(-2,-8)</m> and ends at point <m>(5,6)</m>. 
+                The function intersects the <m>x</m> axis at <m>x=2</m>. 
+              </p>
+              <p>
+                The function, below the <m>x</m> axis creates a right angled triangle 
+                with the <m>x</m> axis and line <m>x=-2</m> from <m>y=0</m> to <m>y=-8</m>,  
+                with its base from <m>x=-2</m> to <m>x=2</m>. This area is named R1.
+              </p>
+              <p>
+                The function above the <m>x</m> axis forms a right angled triangle with the <m>x</m> axis and line <m>x=5</m>  
+                from <m>y=0</m> to <m>y=6</m>, with its base from <m>x=2</m> and <m>x=5</m>. This area is named R2.
+              </p>
+            </description>
+              
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+              axis on top,
+              ymin=-11,ymax=11,
+              xmin=-3.5,xmax=5.5
+              ]
+              \addplot [firstcurvestyle,areastyle,domain=-2:5] {2*x-4} \closedcycle;
+              \addplot [firstcurvestyle,-,domain=-2:5] {2*x-4};
+              \addplot [soliddot] coordinates {(-2,-8)} node[right] {\small $(-2,-8)$};
+              \addplot [soliddot] coordinates {(5,6)} node[left] {\small $(5,6)$};
+              \draw (axis cs:-1,-2) node { $R_1$};
+              \draw (axis cs:4.2,2) node { $R_2$};
+              \end{axis}
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
+        <figure xml:id="fig_defint8b">
+          <caption><m>f(x) = \sqrt{9-x^2}</m></caption>
+          <image xml:id="img_defint8b">
+            <shortdescription>
+              The graph area under the curve is a semicircle with radius 3 on the x axis with centre at origin. 
+            </shortdescription>
+            <description>
+              The graph shows the area under the curve that is a semicircle with radius <m>3</m> on the <m>x</m> axis 
+              with centre at origin. It lies on the first and the second quadrant.
+            </description>
+              
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+              axis on top,
+              xtick={-3,3},
+              extra y ticks={1,2,3,4},
+              extra y tick labels=\empty,
+              ytick={5},
+              ymin=-.5,ymax=5.5,
+              xmin=-3.5,xmax=3.5]
+              \addplot [firstcurvestyle,areastyle,domain=0:180] ({3*cos (x)},{3*sin(x)}) \closedcycle;
+              \addplot [firstcurvestyle,-,domain=0:180,samples=40] ({3*cos (x)},{3*sin(x)});
+              \end{axis}
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+        </figure>
+      </sidebyside>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="AuGASVXd3qA" xml:id="vid_int_def_int_geo_ex" label="vid_int_def_int_geo_ex" component="video"/>
     </solution>
   </example>
 
@@ -1035,10 +1031,6 @@
         </image>
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="2zJzbg0hNXE" xml:id="vid_int_def_int_motion" label="vid_int_def_int_motion" component="video"/>
-    </solution>
     <solution>
 
       <p>
@@ -1057,6 +1049,10 @@
         From <m>t=b</m> to <m>t=c</m> the object is moving backwards again,
         hence its maximum displacement is 27 feet from its starting position.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="2zJzbg0hNXE" xml:id="vid_int_def_int_motion" label="vid_int_def_int_motion" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -186,10 +186,6 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="lyAEJSmSr-A" xml:id="vid_deriv_basic_rules_ex" label="vid_deriv_basic_rules_ex" component="video"/>
-      </solution>
       <solution>
         <p>
           <ol>
@@ -227,7 +223,7 @@
             </li>
           </ol>
         </p>
-
+        
         <figure xml:id="fig_xcubedwithderiv">
           <caption>A graph of <m>f(x) = x^3</m>, along with its derivative <m>\fp(x) = 3x^2</m> and its tangent line at <m>x=-1</m></caption>          <!-- START figures/fig_xcubedwithderiv.tex -->
           <image xml:id="img_xcubedwithderiv" width="47%">
@@ -240,7 +236,7 @@
                 is drawn between <m>-2</m> and <m>2</m>.
                 The graph of function <m>f(x)=x^3</m> is a curve that appears to conincide the 
                 <m>x</m> axis from <m>x=-0.5</m> to <m>x=0.5</m>,
-                 then it appears to increase to infinity from <m>x=0.5</m> in the first quadrant,
+                then it appears to increase to infinity from <m>x=0.5</m> in the first quadrant,
                 and curves downward from to infinity from <m>x=-0.5</m> in the third quadrant.
               </p>
               <p>
@@ -256,10 +252,10 @@
             </description>
             <latex-image>
               \begin{tikzpicture}
-                \begin{axis}[
-                    xmin=-2.1,
-                    xmax=2.1,
-                    ymin=-5.1,
+              \begin{axis}[
+              xmin=-2.1,
+              xmax=2.1,
+              ymin=-5.1,
                     ymax=5.1,
                     clip=false
                   ]
@@ -273,6 +269,10 @@
           </image>
           <!-- figures/fig_xcubedwithderiv.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="lyAEJSmSr-A" xml:id="vid_deriv_basic_rules_ex" label="vid_deriv_basic_rules_ex" component="video"/>
       </solution>
     </example>
 
@@ -371,10 +371,6 @@
           Approximate <m>f(3)</m> using an appropriate tangent line.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="a0hsWtT74jM" xml:id="vid_deriv_basic_rules_examples_1" label="vid_deriv_basic_rules_examples_1" component="video"/>
-      </solution>
       <solution>
         <p>
           This problem is intentionally ambiguous;
@@ -383,7 +379,7 @@
           How good of an approximation are we seeking?
           What does <q>appropriate</q> mean?
         </p>
-
+        
         <p>
           In the <q>real world,</q> people solving problems deal with these issues all time.
           One must make a judgment using whatever seems reasonable.
@@ -391,7 +387,7 @@
           where the real problem spot is <m>\sin(3)</m>.
           What is <m>\sin(3)</m>?
         </p>
-
+        
         <p>
           Since <m>3</m> is close to <m>\pi</m>,
           we can assume <m>\sin(3) \approx \sin(\pi) = 0</m>.
@@ -400,7 +396,7 @@
           Let's use a tangent line as instructed and examine the results;
           it seems best to find the tangent line at <m>x=\pi</m>.
         </p>
-
+        
         <p>
           Using <xref ref="thm_deriv_common"/>
           we find <m>\fp(x) = \cos(x) + 2</m>.
@@ -411,7 +407,7 @@
           Using the tangent line,
           our final approximation is that <m>f(3) \approx 7.14</m>.
         </p>
-
+        
         <p>
           Using a calculator,
           we get an answer accurate to four places after the decimal:
@@ -429,7 +425,7 @@
           engineers and mathematicians often face problems too hard to solve directly.
           So they approximate.
         </p>
-
+        
         <p>
           The graphs in <xref ref="fig_sintangapprox"/>
           shows the graph of the function <m>f(x)</m> along with the tangent line constructed at <m>x=\pi</m>.
@@ -456,12 +452,12 @@
                 </p>
                 <p>
                 A tangent line is drawn on the curve at approximately point <m>(3,7)</m> or <m>x=\pi</m>.
-                </p>              
+              </p>              
               </description>
               <latex-image>
                 \begin{tikzpicture}
-                  \begin{axis}[
-                      xmin=-1.1,
+                \begin{axis}[
+                xmin=-1.1,
                       xmax=5.1,
                       ymin=-1,
                       ymax=10,
@@ -477,7 +473,7 @@
             </image>
             <!-- figures/fig_xcubedwithderiv.tex END -->
           </figure>
-
+          
           <figure xml:id="fig_sintangapproxzoom">
             <caption>A graph of <m>f(x) = \sin(x)+2x+1</m> along with its tangent line approximation at <m>x=\pi</m>, zoomed in</caption>
             <image xml:id="img_sintangapproxzoom">
@@ -491,13 +487,13 @@
                 The graph of <m>f(x)</m> is drawn in the first quadrant, the curve and 
                 its tangent line are aligned except near shifted origin around point <m>(2.6, 6.8)</m> 
                 where they are slightly apart. 
-                </p>
-              </description>
-              <latex-image>
-                \begin{tikzpicture}
-                  \begin{axis}[
-                      ymin=6.7,
-                      ymax=7.4,
+              </p>
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+              ymin=6.7,
+              ymax=7.4,
                       xmin=2.5,
                       xmax=3.5,
                       xdiscontinuity,
@@ -508,13 +504,17 @@
                     \addplot[soliddot] coordinates {(3,7.1411) (3.14,7.28)};
                     %\draw (axis cs:0.5,1.2) node { $f(x)$};
                     %\draw (axis cs:0.5,5) node { $l(x)$};
-                  \end{axis}
+                    \end{axis}
                 \end{tikzpicture}
               </latex-image>
             </image>
             <!-- figures/fig_xcubedwithderiv.tex END -->
           </figure>
         </sidebyside>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="a0hsWtT74jM" xml:id="vid_deriv_basic_rules_examples_1" label="vid_deriv_basic_rules_examples_1" component="video"/>
       </solution>
     </example>
   </introduction>
@@ -620,10 +620,6 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="nF2-IrvHmqc" xml:id="vid_deriv_basic_rules_examples_2" label="vid_deriv_basic_rules_examples_2" component="video"/>
-      </solution>
       <solution>
         <p>
           <ol>
@@ -659,6 +655,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="nF2-IrvHmqc" xml:id="vid_deriv_basic_rules_examples_2" label="vid_deriv_basic_rules_examples_2" component="video"/>
       </solution>
     </example>
   </subsection>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -223,7 +223,7 @@
             </li>
           </ol>
         </p>
-        
+
         <figure xml:id="fig_xcubedwithderiv">
           <caption>A graph of <m>f(x) = x^3</m>, along with its derivative <m>\fp(x) = 3x^2</m> and its tangent line at <m>x=-1</m></caption>          <!-- START figures/fig_xcubedwithderiv.tex -->
           <image xml:id="img_xcubedwithderiv" width="47%">
@@ -232,21 +232,21 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn between <m>-4</m> and <m>4</m> and the <m>x</m> axis 
+                The <m>y</m> axis is drawn between <m>-4</m> and <m>4</m> and the <m>x</m> axis
                 is drawn between <m>-2</m> and <m>2</m>.
-                The graph of function <m>f(x)=x^3</m> is a curve that appears to conincide the 
+                The graph of function <m>f(x)=x^3</m> is a curve that appears to conincide the
                 <m>x</m> axis from <m>x=-0.5</m> to <m>x=0.5</m>,
                 then it appears to increase to infinity from <m>x=0.5</m> in the first quadrant,
                 and curves downward from to infinity from <m>x=-0.5</m> in the third quadrant.
               </p>
               <p>
                 The derivative <m>\fp(x)</m> is a parabola opening upwards.
-                It intersects the function <m>f(x)</m> at the origin and increases to infinity on 
+                It intersects the function <m>f(x)</m> at the origin and increases to infinity on
                 either side of the positive <m>y</m> axis.
               </p>
               <p>
                 A tangent line <m>l(x)</m>is drawn on the function at point <m>(-1,-1)</m>.
-                It has a positive slope and and intersects the <m>x</m> axis at approximately 
+                It has a positive slope and and intersects the <m>x</m> axis at approximately
                 <m>x=-0.6</m> and the <m>y</m> axis at <m>y=2</m>.
               </p>
             </description>
@@ -379,7 +379,7 @@
           How good of an approximation are we seeking?
           What does <q>appropriate</q> mean?
         </p>
-        
+
         <p>
           In the <q>real world,</q> people solving problems deal with these issues all time.
           One must make a judgment using whatever seems reasonable.
@@ -387,7 +387,7 @@
           where the real problem spot is <m>\sin(3)</m>.
           What is <m>\sin(3)</m>?
         </p>
-        
+
         <p>
           Since <m>3</m> is close to <m>\pi</m>,
           we can assume <m>\sin(3) \approx \sin(\pi) = 0</m>.
@@ -396,7 +396,7 @@
           Let's use a tangent line as instructed and examine the results;
           it seems best to find the tangent line at <m>x=\pi</m>.
         </p>
-        
+
         <p>
           Using <xref ref="thm_deriv_common"/>
           we find <m>\fp(x) = \cos(x) + 2</m>.
@@ -407,7 +407,7 @@
           Using the tangent line,
           our final approximation is that <m>f(3) \approx 7.14</m>.
         </p>
-        
+
         <p>
           Using a calculator,
           we get an answer accurate to four places after the decimal:
@@ -425,7 +425,7 @@
           engineers and mathematicians often face problems too hard to solve directly.
           So they approximate.
         </p>
-        
+
         <p>
           The graphs in <xref ref="fig_sintangapprox"/>
           shows the graph of the function <m>f(x)</m> along with the tangent line constructed at <m>x=\pi</m>.
@@ -446,13 +446,13 @@
               <description>
                 <p>
                 The <m>y</m> axis is drawn from <m>-1</m> to <m>10</m> and <m>x</m> axis is drawn from <m>-1</m> to <m>5</m>.
-                The graph of <m>f(x)</m>is drawn in the first quadrant, the curve passes the 
+                The graph of <m>f(x)</m>is drawn in the first quadrant, the curve passes the
                 <m>y</m> axis at <m>y=1</m>, it increases until point <m>(5,10)</m>.
                 It has a slight undulation between <m>x=2</m> to <m>x=4</m>.
                 </p>
                 <p>
                 A tangent line is drawn on the curve at approximately point <m>(3,7)</m> or <m>x=\pi</m>.
-              </p>              
+              </p>
               </description>
               <latex-image>
                 \begin{tikzpicture}
@@ -473,7 +473,7 @@
             </image>
             <!-- figures/fig_xcubedwithderiv.tex END -->
           </figure>
-          
+
           <figure xml:id="fig_sintangapproxzoom">
             <caption>A graph of <m>f(x) = \sin(x)+2x+1</m> along with its tangent line approximation at <m>x=\pi</m>, zoomed in</caption>
             <image xml:id="img_sintangapproxzoom">
@@ -482,11 +482,11 @@
               </shortdescription>
               <description>
                 <p>
-                The <m>y</m> axis is drawn from <m>6.8</m> to <m>7.4</m> and <m>x</m> axis 
+                The <m>y</m> axis is drawn from <m>6.8</m> to <m>7.4</m> and <m>x</m> axis
                 is drawn from <m>2.6</m> to <m>3.4</m>.
-                The graph of <m>f(x)</m> is drawn in the first quadrant, the curve and 
-                its tangent line are aligned except near shifted origin around point <m>(2.6, 6.8)</m> 
-                where they are slightly apart. 
+                The graph of <m>f(x)</m> is drawn in the first quadrant, the curve and
+                its tangent line are aligned except near shifted origin around point <m>(2.6, 6.8)</m>
+                where they are slightly apart.
               </p>
             </description>
             <latex-image>

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -351,12 +351,8 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="yW1BbOeDFcM" xml:id="vid_deriv_chain_examples_1" label="vid_deriv_chain_examples_1" component="video"/>
-    </solution>
     <solution>
-
+      
       <p>
         <ol>
           <li>
@@ -394,7 +390,7 @@
               so the result of <m>y'=\frac{2(3x-1)}{2x^2-x}</m> is only valid for <m>x \gt 1/2</m> as well.
             </p>
           </li>
-
+          
           <li>
             <p>
               Recognize  that <m>y = e^{-x^2}</m> is the composition of
@@ -409,6 +405,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="yW1BbOeDFcM" xml:id="vid_deriv_chain_examples_1" label="vid_deriv_chain_examples_1" component="video"/>
     </solution>
   </example>
 
@@ -541,12 +541,8 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="2QJLR-Y-Ht8" xml:id="vid_deriv_chain_examples_2" label="vid_deriv_chain_examples_2" component="video"/>
-    </solution>
     <solution>
-
+      
       <p>
         <ol>
           <li>
@@ -580,6 +576,10 @@
         </ol>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="2QJLR-Y-Ht8" xml:id="vid_deriv_chain_examples_2" label="vid_deriv_chain_examples_2" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -612,12 +612,8 @@
         Find the derivative of <m>y = \tan^5(6x^3-7x)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="JeLuSDqqFPA" xml:id="vid_deriv_chain_examples_3_func" label="vid_deriv_chain_examples_3_func" component="video"/>
-    </solution>
     <solution>
-
+      
       <p>
         Recognize that we have the
         <m>g(x)=\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}</m> function <q>inside</q>
@@ -630,7 +626,7 @@
           y' = 5\left(\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}\right)^4\cdot g'(x)
         </me>.
       </p>
-
+      
       <p>
         We now find <m>g'(x)</m>.
         We again need the <xref ref="thm_chain_rule" text="title"/>;
@@ -639,7 +635,7 @@
           <mrow>\amp = \sec^2\mathopen{}\left(6x^3-7x\right)\mathclose{}\cdot\left(18x^2-7\right)</mrow>
         </md>.
       </p>
-
+      
       <p>
         Combine this with what we found above to give
         <md>
@@ -647,7 +643,7 @@
           <mrow>\amp = \left(90x^2-35\right)\sec^2\mathopen{}\left(6x^3-7x\right)\mathclose{}\tan^4\mathopen{}\left(6x^3-7x\right)\mathclose{}</mrow>
         </md>.
       </p>
-
+      
       <p>
         This function is frankly a ridiculous function,
         possessing no real practical value.
@@ -657,6 +653,10 @@
         In fact, it is not <q>hard</q>;
         one can take several simple steps and should be careful to keep track of how to apply each of these steps.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="JeLuSDqqFPA" xml:id="vid_deriv_chain_examples_3_func" label="vid_deriv_chain_examples_3_func" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_deriv_chainrule.ptx
+++ b/ptx/sec_deriv_chainrule.ptx
@@ -352,7 +352,7 @@
       </p>
     </statement>
     <solution>
-      
+
       <p>
         <ol>
           <li>
@@ -390,7 +390,7 @@
               so the result of <m>y'=\frac{2(3x-1)}{2x^2-x}</m> is only valid for <m>x \gt 1/2</m> as well.
             </p>
           </li>
-          
+
           <li>
             <p>
               Recognize  that <m>y = e^{-x^2}</m> is the composition of
@@ -542,7 +542,7 @@
       </p>
     </statement>
     <solution>
-      
+
       <p>
         <ol>
           <li>
@@ -613,7 +613,7 @@
       </p>
     </statement>
     <solution>
-      
+
       <p>
         Recognize that we have the
         <m>g(x)=\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}</m> function <q>inside</q>
@@ -626,7 +626,7 @@
           y' = 5\left(\tan\mathopen{}\left(6x^3-7x\right)\mathclose{}\right)^4\cdot g'(x)
         </me>.
       </p>
-      
+
       <p>
         We now find <m>g'(x)</m>.
         We again need the <xref ref="thm_chain_rule" text="title"/>;
@@ -635,7 +635,7 @@
           <mrow>\amp = \sec^2\mathopen{}\left(6x^3-7x\right)\mathclose{}\cdot\left(18x^2-7\right)</mrow>
         </md>.
       </p>
-      
+
       <p>
         Combine this with what we found above to give
         <md>
@@ -643,7 +643,7 @@
           <mrow>\amp = \left(90x^2-35\right)\sec^2\mathopen{}\left(6x^3-7x\right)\mathclose{}\tan^4\mathopen{}\left(6x^3-7x\right)\mathclose{}</mrow>
         </md>.
       </p>
-      
+
       <p>
         This function is frankly a ridiculous function,
         possessing no real practical value.

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -121,12 +121,8 @@
           Find <m>y'</m> given that <m>\sin(y) + y^3=6-x^3</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="0baXlbhup0o" xml:id="vid_deriv_impl_ex_1" label="vid_deriv_impl_ex_1" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           We start by taking the derivative of both sides
           (thus maintaining the equality.)
@@ -135,7 +131,7 @@
             \lzoo{x}{\sin(y) + y^3}=\lzoo{x}{6-x^3}
           </me>.
         </p>
-
+        
         <p>
           The right hand side is easy;
           it returns <m>-3x^2</m>.
@@ -150,21 +146,21 @@
             \lzoo{x}{\sin(y)} = \cos(y) \cdot y'
           </me>.
         </p>
-
+        
         <p>
           We apply the same process to the <m>y^3</m> term.
           <me>
             \lzoo{x}{y^3} = \lzoo{(y)^3} = 3(y)^2\cdot y'
           </me>.
         </p>
-
+        
         <p>
           Putting this together with the right hand side, we have
           <me>
             \cos(y)y'+3y^2y' = -3x^2
           </me>.
         </p>
-
+        
         <p>
           Now solve for <m>y'</m>.
           It's important to treat <m>y'</m> as an algebraically independent variable from <m>y</m> and <m>x</m>.
@@ -174,15 +170,19 @@
             <mrow>y'\amp =\frac{-3x^2}{\cos(y) +3y^2}</mrow>
           </md>
         </p>
-
+        
         <p>
           This equation for <m>y'</m> probably seems unusual for it contains both <m>x</m> and <m>y</m> terms.
           How is it to be used?
           We'll address that next.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="0baXlbhup0o" xml:id="vid_deriv_impl_ex_1" label="vid_deriv_impl_ex_1" component="video"/>
+      </solution>
     </example>
-
+    
     <p>
       Implicit functions are generally harder to deal with than explicit functions.
       With an explicit function, given an <m>x</m> value,
@@ -212,12 +212,8 @@
           <m>\sin(y) + y^3=6-x^3</m> at the point <m>\left(\sqrt[3]6,0\right)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="qYrcm4ObwOM" xml:id="vid_deriv_impl_tan_line_prev_ex" label="vid_deriv_impl_tan_line_prev_ex" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           In <xref ref="ex_implicit1"/> we found that
           <me>
@@ -241,11 +237,11 @@
             y = -3\sqrt[3]{36}\left(x-\sqrt[3]{6}\right)+0 \approx -9.91x+18
           </me>.
         </p>
-
+        
         <p>
           The curve and this tangent line are shown in <xref ref="fig_implicit2"/>.
         </p>
-
+        
         <figure xml:id="fig_implicit2">
           <caption>The function <m>\sin(y) +y^3 = 6-x^3</m> and its tangent line at the point <m>(\sqrt[3]{6},0)</m></caption>
           <!-- START figures/fig_implicit2.tex -->
@@ -260,14 +256,14 @@
               </p>
             </description>
             <latex-image>
-
-            \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
-            \begin{axis}[,xmin=-3.2,xmax=3.2,
-            ymin=-3.2,ymax=3.2]
-            \addplot[firstcurvestyle,variable=\t,domain=-2.7:1.5,leftarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
-            \addplot[firstcurvestyle,variable=\t,domain=1.5:1.8,-] ({cbrt(6-sin(deg(t))-t^3)},{t});
-            \addplot[firstcurvestyle,variable=\t,domain=1.8:3,rightarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
-            \addplot [tangentline,domain=1.617:2.017] {-9.9057*x+18};
+              
+              \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
+              \begin{axis}[,xmin=-3.2,xmax=3.2,
+              ymin=-3.2,ymax=3.2]
+              \addplot[firstcurvestyle,variable=\t,domain=-2.7:1.5,leftarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
+              \addplot[firstcurvestyle,variable=\t,domain=1.5:1.8,-] ({cbrt(6-sin(deg(t))-t^3)},{t});
+              \addplot[firstcurvestyle,variable=\t,domain=1.8:3,rightarrow] ({cbrt(6-sin(deg(t))-t^3)},{t});
+              \addplot [tangentline,domain=1.617:2.017] {-9.9057*x+18};
             \end{axis}
             \end{tikzpicture}
 
@@ -275,6 +271,10 @@
           </image>
           <!-- figures/fig_implicit2.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="qYrcm4ObwOM" xml:id="vid_deriv_impl_tan_line_prev_ex" label="vid_deriv_impl_tan_line_prev_ex" component="video"/>
       </solution>
     </example>
 
@@ -325,12 +325,8 @@
           find <m>y'</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="O5OqJ7a_Ovo" xml:id="vid_deriv_impl_ex_2" label="vid_deriv_impl_ex_2" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           We will take the implicit derivatives term by term.
           The derivative of <m>y^3</m> is <m>3y^2y'</m>.
@@ -352,21 +348,21 @@
             3y^2y' + 4x^2y^3y' + 2xy^4 = 2
           </me>.
         </p>
-
+        
         <p>
           Move terms around so that the left side consists only of the <m>y'</m> terms and the right side consists of all the other terms:
           <me>
             3y^2y' + 4x^2y^3y' = 2-2xy^4
           </me>.
         </p>
-
+        
         <p>
           Factor out <m>y'</m> from the left side and solve to get
           <me>
             y' = \frac{2-2xy^4}{3y^2+4x^2y^3}
           </me>.
         </p>
-
+        
         <p>
           To confirm the validity of our work,
           let's find the equation of a tangent line to this function at a point.
@@ -396,25 +392,25 @@
               The entire second curve lies in the fourth quadrant.
             </description>
             <latex-image>
+              
+              \begin{tikzpicture}
+              \begin{axis}[xmin=-1.5,xmax=10.5,
+              ymin=-10.5,ymax=2.49,]
 
-            \begin{tikzpicture}
-            \begin{axis}[xmin=-1.5,xmax=10.5,
-            ymin=-10.5,ymax=2.49,]
+              \addplot[firstcurvestyle,smooth] coordinates {(-0.324,-9.34) (-0.336,-8.66) (-0.351,-7.95) (-0.371,-7.13) (-0.396,-6.3) (-0.414,-5.68) (-0.451,-4.91) (-0.472,-4.48)(-0.497,-4.02) (-0.525,-3.57) (-0.56,-3.15) (-0.61,-2.63)(-0.664,-2.18) (-0.727,-1.71) (-0.762,-1.29) (-0.668,-0.805)(-0.513,-0.29) (-0.453,0.439) (-0.308,0.71) (0.0816,1.05)(0.452,1.15) (0.893,1.13) (1.33,1.08) (1.79,1.02) (2.24,0.975)(2.82,0.925) (3.4,0.881) (4.11,0.844) (4.91,0.781) (5.77,0.766)(6.76,0.74) (7.59,0.722) (8.26,0.706) (8.93,0.689) (9.69,0.671)};
 
-            \addplot[firstcurvestyle,smooth] coordinates {(-0.324,-9.34) (-0.336,-8.66) (-0.351,-7.95) (-0.371,-7.13) (-0.396,-6.3) (-0.414,-5.68) (-0.451,-4.91) (-0.472,-4.48)(-0.497,-4.02) (-0.525,-3.57) (-0.56,-3.15) (-0.61,-2.63)(-0.664,-2.18) (-0.727,-1.71) (-0.762,-1.29) (-0.668,-0.805)(-0.513,-0.29) (-0.453,0.439) (-0.308,0.71) (0.0816,1.05)(0.452,1.15) (0.893,1.13) (1.33,1.08) (1.79,1.02) (2.24,0.975)(2.82,0.925) (3.4,0.881) (4.11,0.844) (4.91,0.781) (5.77,0.766)(6.76,0.74) (7.59,0.722) (8.26,0.706) (8.93,0.689) (9.69,0.671)};
+              \addplot[firstcurvestyle,smooth] coordinates {(9.6,-0.677) (9.13,-0.696) (8.66,-0.697) (8.21,-0.707) (7.72,-0.722)(7.3,-0.738) (6.79,-0.754) (5.98,-0.778) (5.1,-0.81) (4.34,-0.858)(3.84,-0.893) (3.4,-0.927) (2.77,-0.99) (2.27,-1.07) (1.82,-1.17)(1.38,-1.34) (0.97,-1.7) (0.779,-2.1) (0.678,-2.5) (0.593,-3.)(0.534,-3.66) (0.483,-4.38) (0.444,-5.04) (0.415,-5.71) (0.393,-6.38)(0.375,-7.05) (0.362,-7.59) (0.343,-8.38) (0.334,-8.9) (0.322,-9.33)(0.317,-9.83) };
 
-            \addplot[firstcurvestyle,smooth] coordinates {(9.6,-0.677) (9.13,-0.696) (8.66,-0.697) (8.21,-0.707) (7.72,-0.722)(7.3,-0.738) (6.79,-0.754) (5.98,-0.778) (5.1,-0.81) (4.34,-0.858)(3.84,-0.893) (3.4,-0.927) (2.77,-0.99) (2.27,-1.07) (1.82,-1.17)(1.38,-1.34) (0.97,-1.7) (0.779,-2.1) (0.678,-2.5) (0.593,-3.)(0.534,-3.66) (0.483,-4.38) (0.444,-5.04) (0.415,-5.71) (0.393,-6.38)(0.375,-7.05) (0.362,-7.59) (0.343,-8.38) (0.334,-8.9) (0.322,-9.33)(0.317,-9.83) };
-
-            \addplot [tangentline,domain=-1:2] {2/3*(x)+1};
-            \end{axis}
-
-            \end{tikzpicture}
-
+              \addplot [tangentline,domain=-1:2] {2/3*(x)+1};
+              \end{axis}
+              
+              \end{tikzpicture}
+              
             </latex-image>
           </image>
           <!-- figures/fig_implicit4.tex END -->
         </figure>
-
+        
         <p>
           Notice how our curve looks much different than for functions we have seen.
           For one, it fails the vertical line test,
@@ -426,6 +422,10 @@
           so developing tools to deal with them is also important.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="O5OqJ7a_Ovo" xml:id="vid_deriv_impl_ex_2" label="vid_deriv_impl_ex_2" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_implicit5">
@@ -436,12 +436,8 @@
           find <m>y'</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="BMn-BU6VTQU" xml:id="vid_deriv_impl_ex_3" label="vid_deriv_impl_ex_3" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           Differentiating term by term,
           we find the most difficulty in the first term.
@@ -470,7 +466,7 @@
             2x^2y\cos\mathopen{}\left(x^2y^2\right)\mathclose{}y' + 2xy^2\cos\mathopen{}\left(x^2y^2\right)\mathclose{} + 3y^2y' = 1 + y'
           </me>.
         </p>
-
+        
         <p>
           From here we can safely move around terms to get the following:
           <me>
@@ -488,7 +484,7 @@
         <p>
           A graph of this implicit function is given in <xref ref="fig_implicit5"/>.
         </p>
-
+        
         <figure xml:id="fig_implicit5">
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m></caption>
           <!-- START figures/fig_implicit5.tex -->
@@ -510,36 +506,36 @@
               </p>
             </description>
             <latex-image>
-
-            \begin{tikzpicture}
-            \begin{axis}[xmin=-1.95,xmax=1.99,
-            ymin=-1.95,ymax=1.95,]
-            \addplot+[smooth] coordinates {(-1.91,-1.57) (-1.82,-1.61) (-1.68,-1.61) (-1.7,-1.49) (-1.74,-1.38)(-1.76,-1.28) (-1.64,-1.26) (-1.54,-1.29) (-1.36,-1.35) (-1.2,-1.42)(-1.09,-1.46) (-0.989,-1.49) (-0.86,-1.5) (-0.714,-1.45)(-0.566,-1.35) (-0.327,-1.18) (-0.15,-1.08)(0.107,-0.947) (0.216,-0.895) (0.332,-0.832) (0.429,-0.755) (0.464,-0.623) (0.429,-0.52) (0.308,-0.335)(0.142,-0.144) (-0.071,0.0714) (-0.239,0.261) (-0.336,0.45) (-0.336,0.622) (-0.278,0.757) (-0.17,0.884) (-0.046,0.975)(0.0714,1.03) (0.216,1.07) (0.48,1.09) (0.714,1.07) (0.929,1.05)(1.15,1.07) (1.24,1.13) (1.27,1.25) (1.28,1.37) (1.29,1.49)(1.36,1.58) (1.47,1.57) (1.59,1.52) (1.68,1.48) (1.79,1.43)(1.89,1.39) (1.98,1.36) (1.98,1.6)};
-            \end{axis}
-
-            \end{tikzpicture}
-
+              
+              \begin{tikzpicture}
+              \begin{axis}[xmin=-1.95,xmax=1.99,
+              ymin=-1.95,ymax=1.95,]
+              \addplot+[smooth] coordinates {(-1.91,-1.57) (-1.82,-1.61) (-1.68,-1.61) (-1.7,-1.49) (-1.74,-1.38)(-1.76,-1.28) (-1.64,-1.26) (-1.54,-1.29) (-1.36,-1.35) (-1.2,-1.42)(-1.09,-1.46) (-0.989,-1.49) (-0.86,-1.5) (-0.714,-1.45)(-0.566,-1.35) (-0.327,-1.18) (-0.15,-1.08)(0.107,-0.947) (0.216,-0.895) (0.332,-0.832) (0.429,-0.755) (0.464,-0.623) (0.429,-0.52) (0.308,-0.335)(0.142,-0.144) (-0.071,0.0714) (-0.239,0.261) (-0.336,0.45) (-0.336,0.622) (-0.278,0.757) (-0.17,0.884) (-0.046,0.975)(0.0714,1.03) (0.216,1.07) (0.48,1.09) (0.714,1.07) (0.929,1.05)(1.15,1.07) (1.24,1.13) (1.27,1.25) (1.28,1.37) (1.29,1.49)(1.36,1.58) (1.47,1.57) (1.59,1.52) (1.68,1.48) (1.79,1.43)(1.89,1.39) (1.98,1.36) (1.98,1.6)};
+              \end{axis}
+              
+              \end{tikzpicture}
+              
             </latex-image>
           </image>
           <!-- figures/fig_implicit5.tex END -->
         </figure>
-
+        
         <p>
           It is easy to verify that the points <m>(0,0)</m>,
           <m>(0,1)</m> and <m>(0,-1)</m> all lie on the graph.
           We can find the slopes of the tangent lines at each of these points using our formula for <m>y'</m>.
-
+          
           <ul>
             <li>At <m>(0,0)</m>, the slope is <m>-1</m>.</li>
-
+            
             <li>At <m>(0,1)</m>, the slope is <m>1/2</m>.</li>
-
+            
             <li>At <m>(0,-1)</m>, the slope is also <m>1/2</m>.</li>
           </ul>
 
           The tangent lines have been added to the graph of the function in <xref ref="fig_implicit6"/>.
         </p>
-
+        
         <figure xml:id="fig_implicit6">
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m> and certain tangent lines</caption>
           <!-- START figures/fig_implicit6.tex -->
@@ -556,15 +552,15 @@
               </p>
             </description>
             <latex-image>
-
-            \begin{tikzpicture}
-            \begin{axis}[xmin=-1.95,xmax=1.99,
-            ymin=-1.95,ymax=1.95,]
-            \addplot+[smooth] coordinates {(-1.91,-1.57) (-1.82,-1.61) (-1.68,-1.61) (-1.7,-1.49) (-1.74,-1.38)(-1.76,-1.28) (-1.64,-1.26) (-1.54,-1.29) (-1.36,-1.35) (-1.2,-1.42)(-1.09,-1.46) (-0.989,-1.49) (-0.86,-1.5) (-0.714,-1.45)(-0.566,-1.35) (-0.327,-1.18) (-0.15,-1.08)(0.107,-0.947) (0.216,-0.895) (0.332,-0.832) (0.429,-0.755) (0.464,-0.623) (0.429,-0.52) (0.308,-0.335)(0.142,-0.144) (-0.071,0.0714) (-0.239,0.261) (-0.336,0.45) (-0.336,0.622) (-0.278,0.757) (-0.17,0.884) (-0.046,0.975)(0.0714,1.03) (0.216,1.07) (0.48,1.09) (0.714,1.07) (0.929,1.05)(1.15,1.07) (1.24,1.13) (1.27,1.25) (1.28,1.37) (1.29,1.49)(1.36,1.58) (1.47,1.57) (1.59,1.52) (1.68,1.48) (1.79,1.43)(1.89,1.39) (1.98,1.36) (1.98,1.6)};
-
-            \addplot [tangentline,domain=-.5:.5] {-x};
-            \addplot [tangentline,domain=-.5:.5] {0.5*x+1};
-            \addplot [tangentline,domain=-.5:.5] {0.5*(x-0)-1};
+              
+              \begin{tikzpicture}
+              \begin{axis}[xmin=-1.95,xmax=1.99,
+              ymin=-1.95,ymax=1.95,]
+              \addplot+[smooth] coordinates {(-1.91,-1.57) (-1.82,-1.61) (-1.68,-1.61) (-1.7,-1.49) (-1.74,-1.38)(-1.76,-1.28) (-1.64,-1.26) (-1.54,-1.29) (-1.36,-1.35) (-1.2,-1.42)(-1.09,-1.46) (-0.989,-1.49) (-0.86,-1.5) (-0.714,-1.45)(-0.566,-1.35) (-0.327,-1.18) (-0.15,-1.08)(0.107,-0.947) (0.216,-0.895) (0.332,-0.832) (0.429,-0.755) (0.464,-0.623) (0.429,-0.52) (0.308,-0.335)(0.142,-0.144) (-0.071,0.0714) (-0.239,0.261) (-0.336,0.45) (-0.336,0.622) (-0.278,0.757) (-0.17,0.884) (-0.046,0.975)(0.0714,1.03) (0.216,1.07) (0.48,1.09) (0.714,1.07) (0.929,1.05)(1.15,1.07) (1.24,1.13) (1.27,1.25) (1.28,1.37) (1.29,1.49)(1.36,1.58) (1.47,1.57) (1.59,1.52) (1.68,1.48) (1.79,1.43)(1.89,1.39) (1.98,1.36) (1.98,1.6)};
+              
+              \addplot [tangentline,domain=-.5:.5] {-x};
+              \addplot [tangentline,domain=-.5:.5] {0.5*x+1};
+              \addplot [tangentline,domain=-.5:.5] {0.5*(x-0)-1};
             \end{axis}
             \end{tikzpicture}
 
@@ -572,6 +568,10 @@
           </image>
           <!-- figures/fig_implicit6.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="BMn-BU6VTQU" xml:id="vid_deriv_impl_ex_3" label="vid_deriv_impl_ex_3" component="video"/>
       </solution>
     </example>
 
@@ -862,12 +862,8 @@
           Given <m>x^2+y^2=1</m>, find <m>\lzn{2}{y}{x} = y''</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="V6piqsjn2mk" xml:id="vid_deriv_impl_second_deriv" label="vid_deriv_impl_second_deriv" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           We found that <m>y' = \lz{y}{x} = -x/y</m> in <xref ref="ex_implicit7"/>.
           To find <m>y''</m>, we apply implicit differentiation to <m>y'</m>.
@@ -879,7 +875,7 @@
             <mrow>\amp = -\frac{y+x^2/y}{y^2}</mrow>
           </md>.
         </p>
-
+        
         <p>
           While this is not a particularly simple expression, it is usable.
           We can see that <m>y'' \gt 0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y \gt 0</m>.
@@ -897,6 +893,10 @@
           which is a simpler expression.
           Recognizing when simplifications like this are possible is not always easy.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="V6piqsjn2mk" xml:id="vid_deriv_impl_second_deriv" label="vid_deriv_impl_second_deriv" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -977,18 +977,6 @@
           Given <m>y=x^x</m>, use logarithmic differentiation to find <m>y'</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <figure xml:id="vid_deriv_implicit_logarithmic1" component="video">
-          <caption>
-            Two approaches to solving <xref ref="ex_implicit10"/>.
-            First, taking the log of both sides.
-            Second, using the inverse relationship <m>e^{\ln(x)}=x</m>.  
-          </caption>
-          <video youtube="6eL6WBlmItk" label="vid_deriv_implicit_logarithmic1"/>
-        </figure>
-      </solution>
-
       <solution>
         <p>
           As suggested above,
@@ -1004,7 +992,7 @@
             <mrow>y' \amp = x^x\left(\ln(x) +1\right)\amp</mrow>
           </md>.
         </p>
-
+        
         <p>
           To <q>test</q> our answer,
           let's use it to find the equation of the tangent line at <m>x=1.5</m>.
@@ -1020,7 +1008,7 @@
           <xref ref="fig_implicit10"/>
           graphs <m>y=x^x</m> along with this tangent line.
         </p>
-
+        
         <figure xml:id="fig_implicit10">
           <caption>A graph of <m>y=x^x</m> and its tangent line at <m>x=1.5</m></caption>
           <!-- START figures/fig_implicit10.tex -->
@@ -1035,23 +1023,35 @@
               </p>
             </description>
             <latex-image>
-
-            \begin{tikzpicture}
-            \begin{axis}[xmin=-0.1,xmax=2.2,
-            ymin=-.1,ymax=4.2]
-            \addplot+[domain=0.001:2,rightarrow,samples=50] {x^x};
-            \addplot[hollowdot] coordinates{(0,1)};
-            \addplot[tangentline,domain=1:2] {2.582 * (x - 1.5) + 1.837};
-            \addplot[soliddot] coordinates{(1.5,1.837)} node[below right] {$\left(1.5,1.5^{1.5}\right)$};
-            \end{axis}
-            \end{tikzpicture}
-
+              
+              \begin{tikzpicture}
+              \begin{axis}[xmin=-0.1,xmax=2.2,
+              ymin=-.1,ymax=4.2]
+              \addplot+[domain=0.001:2,rightarrow,samples=50] {x^x};
+              \addplot[hollowdot] coordinates{(0,1)};
+              \addplot[tangentline,domain=1:2] {2.582 * (x - 1.5) + 1.837};
+              \addplot[soliddot] coordinates{(1.5,1.837)} node[below right] {$\left(1.5,1.5^{1.5}\right)$};
+              \end{axis}
+              \end{tikzpicture}
+              
             </latex-image>
           </image>
           <!-- figures/fig_implicit10.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <figure xml:id="vid_deriv_implicit_logarithmic1" component="video">
+          <caption>
+            Two approaches to solving <xref ref="ex_implicit10"/>.
+            First, taking the log of both sides.
+            Second, using the inverse relationship <m>e^{\ln(x)}=x</m>.  
+          </caption>
+          <video youtube="6eL6WBlmItk" label="vid_deriv_implicit_logarithmic1"/>
+        </figure>
+      </solution>
     </example>
+    
     <p xml:id="vidint_deriv_impl_ex5" component="video">
       We would not have been able to compute the derivative of the function in <xref ref="ex_implicit10"/>
       without logarithmic differentiation.

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -122,7 +122,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           We start by taking the derivative of both sides
           (thus maintaining the equality.)
@@ -131,7 +131,7 @@
             \lzoo{x}{\sin(y) + y^3}=\lzoo{x}{6-x^3}
           </me>.
         </p>
-        
+
         <p>
           The right hand side is easy;
           it returns <m>-3x^2</m>.
@@ -146,21 +146,21 @@
             \lzoo{x}{\sin(y)} = \cos(y) \cdot y'
           </me>.
         </p>
-        
+
         <p>
           We apply the same process to the <m>y^3</m> term.
           <me>
             \lzoo{x}{y^3} = \lzoo{(y)^3} = 3(y)^2\cdot y'
           </me>.
         </p>
-        
+
         <p>
           Putting this together with the right hand side, we have
           <me>
             \cos(y)y'+3y^2y' = -3x^2
           </me>.
         </p>
-        
+
         <p>
           Now solve for <m>y'</m>.
           It's important to treat <m>y'</m> as an algebraically independent variable from <m>y</m> and <m>x</m>.
@@ -170,7 +170,7 @@
             <mrow>y'\amp =\frac{-3x^2}{\cos(y) +3y^2}</mrow>
           </md>
         </p>
-        
+
         <p>
           This equation for <m>y'</m> probably seems unusual for it contains both <m>x</m> and <m>y</m> terms.
           How is it to be used?
@@ -182,7 +182,7 @@
         <video width="98%" youtube="0baXlbhup0o" xml:id="vid_deriv_impl_ex_1" label="vid_deriv_impl_ex_1" component="video"/>
       </solution>
     </example>
-    
+
     <p>
       Implicit functions are generally harder to deal with than explicit functions.
       With an explicit function, given an <m>x</m> value,
@@ -213,7 +213,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           In <xref ref="ex_implicit1"/> we found that
           <me>
@@ -237,11 +237,11 @@
             y = -3\sqrt[3]{36}\left(x-\sqrt[3]{6}\right)+0 \approx -9.91x+18
           </me>.
         </p>
-        
+
         <p>
           The curve and this tangent line are shown in <xref ref="fig_implicit2"/>.
         </p>
-        
+
         <figure xml:id="fig_implicit2">
           <caption>The function <m>\sin(y) +y^3 = 6-x^3</m> and its tangent line at the point <m>(\sqrt[3]{6},0)</m></caption>
           <!-- START figures/fig_implicit2.tex -->
@@ -256,7 +256,7 @@
               </p>
             </description>
             <latex-image>
-              
+
               \begin{tikzpicture}[declare function = {cbrt(\x) = (\x &lt; 0) * -(-\x)^(1/3) + (\x &gt;= 0) * (\x)^(1/3);}]
               \begin{axis}[,xmin=-3.2,xmax=3.2,
               ymin=-3.2,ymax=3.2]
@@ -326,7 +326,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           We will take the implicit derivatives term by term.
           The derivative of <m>y^3</m> is <m>3y^2y'</m>.
@@ -348,21 +348,21 @@
             3y^2y' + 4x^2y^3y' + 2xy^4 = 2
           </me>.
         </p>
-        
+
         <p>
           Move terms around so that the left side consists only of the <m>y'</m> terms and the right side consists of all the other terms:
           <me>
             3y^2y' + 4x^2y^3y' = 2-2xy^4
           </me>.
         </p>
-        
+
         <p>
           Factor out <m>y'</m> from the left side and solve to get
           <me>
             y' = \frac{2-2xy^4}{3y^2+4x^2y^3}
           </me>.
         </p>
-        
+
         <p>
           To confirm the validity of our work,
           let's find the equation of a tangent line to this function at a point.
@@ -392,7 +392,7 @@
               The entire second curve lies in the fourth quadrant.
             </description>
             <latex-image>
-              
+
               \begin{tikzpicture}
               \begin{axis}[xmin=-1.5,xmax=10.5,
               ymin=-10.5,ymax=2.49,]
@@ -403,14 +403,14 @@
 
               \addplot [tangentline,domain=-1:2] {2/3*(x)+1};
               \end{axis}
-              
+
               \end{tikzpicture}
-              
+
             </latex-image>
           </image>
           <!-- figures/fig_implicit4.tex END -->
         </figure>
-        
+
         <p>
           Notice how our curve looks much different than for functions we have seen.
           For one, it fails the vertical line test,
@@ -437,7 +437,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           Differentiating term by term,
           we find the most difficulty in the first term.
@@ -466,7 +466,7 @@
             2x^2y\cos\mathopen{}\left(x^2y^2\right)\mathclose{}y' + 2xy^2\cos\mathopen{}\left(x^2y^2\right)\mathclose{} + 3y^2y' = 1 + y'
           </me>.
         </p>
-        
+
         <p>
           From here we can safely move around terms to get the following:
           <me>
@@ -484,7 +484,7 @@
         <p>
           A graph of this implicit function is given in <xref ref="fig_implicit5"/>.
         </p>
-        
+
         <figure xml:id="fig_implicit5">
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m></caption>
           <!-- START figures/fig_implicit5.tex -->
@@ -506,36 +506,36 @@
               </p>
             </description>
             <latex-image>
-              
+
               \begin{tikzpicture}
               \begin{axis}[xmin=-1.95,xmax=1.99,
               ymin=-1.95,ymax=1.95,]
               \addplot+[smooth] coordinates {(-1.91,-1.57) (-1.82,-1.61) (-1.68,-1.61) (-1.7,-1.49) (-1.74,-1.38)(-1.76,-1.28) (-1.64,-1.26) (-1.54,-1.29) (-1.36,-1.35) (-1.2,-1.42)(-1.09,-1.46) (-0.989,-1.49) (-0.86,-1.5) (-0.714,-1.45)(-0.566,-1.35) (-0.327,-1.18) (-0.15,-1.08)(0.107,-0.947) (0.216,-0.895) (0.332,-0.832) (0.429,-0.755) (0.464,-0.623) (0.429,-0.52) (0.308,-0.335)(0.142,-0.144) (-0.071,0.0714) (-0.239,0.261) (-0.336,0.45) (-0.336,0.622) (-0.278,0.757) (-0.17,0.884) (-0.046,0.975)(0.0714,1.03) (0.216,1.07) (0.48,1.09) (0.714,1.07) (0.929,1.05)(1.15,1.07) (1.24,1.13) (1.27,1.25) (1.28,1.37) (1.29,1.49)(1.36,1.58) (1.47,1.57) (1.59,1.52) (1.68,1.48) (1.79,1.43)(1.89,1.39) (1.98,1.36) (1.98,1.6)};
               \end{axis}
-              
+
               \end{tikzpicture}
-              
+
             </latex-image>
           </image>
           <!-- figures/fig_implicit5.tex END -->
         </figure>
-        
+
         <p>
           It is easy to verify that the points <m>(0,0)</m>,
           <m>(0,1)</m> and <m>(0,-1)</m> all lie on the graph.
           We can find the slopes of the tangent lines at each of these points using our formula for <m>y'</m>.
-          
+
           <ul>
             <li>At <m>(0,0)</m>, the slope is <m>-1</m>.</li>
-            
+
             <li>At <m>(0,1)</m>, the slope is <m>1/2</m>.</li>
-            
+
             <li>At <m>(0,-1)</m>, the slope is also <m>1/2</m>.</li>
           </ul>
 
           The tangent lines have been added to the graph of the function in <xref ref="fig_implicit6"/>.
         </p>
-        
+
         <figure xml:id="fig_implicit6">
           <caption>A graph of the implicitly defined curve <m>\sin\mathopen{}\left(x^2y^2\right)\mathclose{}+y^3=x+y</m> and certain tangent lines</caption>
           <!-- START figures/fig_implicit6.tex -->
@@ -552,12 +552,12 @@
               </p>
             </description>
             <latex-image>
-              
+
               \begin{tikzpicture}
               \begin{axis}[xmin=-1.95,xmax=1.99,
               ymin=-1.95,ymax=1.95,]
               \addplot+[smooth] coordinates {(-1.91,-1.57) (-1.82,-1.61) (-1.68,-1.61) (-1.7,-1.49) (-1.74,-1.38)(-1.76,-1.28) (-1.64,-1.26) (-1.54,-1.29) (-1.36,-1.35) (-1.2,-1.42)(-1.09,-1.46) (-0.989,-1.49) (-0.86,-1.5) (-0.714,-1.45)(-0.566,-1.35) (-0.327,-1.18) (-0.15,-1.08)(0.107,-0.947) (0.216,-0.895) (0.332,-0.832) (0.429,-0.755) (0.464,-0.623) (0.429,-0.52) (0.308,-0.335)(0.142,-0.144) (-0.071,0.0714) (-0.239,0.261) (-0.336,0.45) (-0.336,0.622) (-0.278,0.757) (-0.17,0.884) (-0.046,0.975)(0.0714,1.03) (0.216,1.07) (0.48,1.09) (0.714,1.07) (0.929,1.05)(1.15,1.07) (1.24,1.13) (1.27,1.25) (1.28,1.37) (1.29,1.49)(1.36,1.58) (1.47,1.57) (1.59,1.52) (1.68,1.48) (1.79,1.43)(1.89,1.39) (1.98,1.36) (1.98,1.6)};
-              
+
               \addplot [tangentline,domain=-.5:.5] {-x};
               \addplot [tangentline,domain=-.5:.5] {0.5*x+1};
               \addplot [tangentline,domain=-.5:.5] {0.5*(x-0)-1};
@@ -863,7 +863,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           We found that <m>y' = \lz{y}{x} = -x/y</m> in <xref ref="ex_implicit7"/>.
           To find <m>y''</m>, we apply implicit differentiation to <m>y'</m>.
@@ -875,7 +875,7 @@
             <mrow>\amp = -\frac{y+x^2/y}{y^2}</mrow>
           </md>.
         </p>
-        
+
         <p>
           While this is not a particularly simple expression, it is usable.
           We can see that <m>y'' \gt 0</m> when <m>y\lt 0</m> and <m>y''\lt 0</m> when <m>y \gt 0</m>.
@@ -935,7 +935,7 @@
           <p>
             The curve is entirely contained within the first quadrant.
             At the point <m>(0,1)</m> there is a discontinuity.
-            The curve begins decreasing, reaching a minimum at around <m>(0.3,0.7)</m>. 
+            The curve begins decreasing, reaching a minimum at around <m>(0.3,0.7)</m>.
             After that point, the curve increases exponentially.
           </p>
         </description>
@@ -969,7 +969,7 @@
       then use implicit differentiation to find <m>y'</m>.
       We demonstrate this in the following example.
     </p>
-    
+
     <example xml:id="ex_implicit10">
       <title>Using Logarithmic Differentiation</title>
       <statement>
@@ -992,7 +992,7 @@
             <mrow>y' \amp = x^x\left(\ln(x) +1\right)\amp</mrow>
           </md>.
         </p>
-        
+
         <p>
           To <q>test</q> our answer,
           let's use it to find the equation of the tangent line at <m>x=1.5</m>.
@@ -1008,7 +1008,7 @@
           <xref ref="fig_implicit10"/>
           graphs <m>y=x^x</m> along with this tangent line.
         </p>
-        
+
         <figure xml:id="fig_implicit10">
           <caption>A graph of <m>y=x^x</m> and its tangent line at <m>x=1.5</m></caption>
           <!-- START figures/fig_implicit10.tex -->
@@ -1023,7 +1023,7 @@
               </p>
             </description>
             <latex-image>
-              
+
               \begin{tikzpicture}
               \begin{axis}[xmin=-0.1,xmax=2.2,
               ymin=-.1,ymax=4.2]
@@ -1033,7 +1033,7 @@
               \addplot[soliddot] coordinates{(1.5,1.837)} node[below right] {$\left(1.5,1.5^{1.5}\right)$};
               \end{axis}
               \end{tikzpicture}
-              
+
             </latex-image>
           </image>
           <!-- figures/fig_implicit10.tex END -->
@@ -1045,13 +1045,13 @@
           <caption>
             Two approaches to solving <xref ref="ex_implicit10"/>.
             First, taking the log of both sides.
-            Second, using the inverse relationship <m>e^{\ln(x)}=x</m>.  
+            Second, using the inverse relationship <m>e^{\ln(x)}=x</m>.
           </caption>
           <video youtube="6eL6WBlmItk" label="vid_deriv_implicit_logarithmic1"/>
         </figure>
       </solution>
     </example>
-    
+
     <p xml:id="vidint_deriv_impl_ex5" component="video">
       We would not have been able to compute the derivative of the function in <xref ref="ex_implicit10"/>
       without logarithmic differentiation.
@@ -1957,10 +1957,10 @@
                     ymin=-1.1,ymax=1.1,%
                     xmin=-1.1,xmax=1.1,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-] coordinates {(1.,0) (0.98901,0.45597) (0.9558,0.63776) (0.89945,0.76667) (0.818,0.86206) (0.70711,0.9306) (0.55589,0.97522) (0.32331,0.99726) (-0.32331,0.99726) (-0.55589,0.97522) (-0.70711,0.9306) (-0.818,0.86206) (-0.89945,0.76667) (-0.9558,0.63776) (-0.98901,0.45597) (-1.,0) (-1.,0) (-0.98901,-0.45597) (-0.9558,-0.63776) (-0.89945,-0.76667) (-0.818,-0.86206)(-0.70711,-0.9306) (-0.55589,-0.97522) (-0.32331,-0.99726)(0.32331,-0.99726) (0.55589,-0.97522) (0.70711,-0.9306)(0.818,-0.86206) (0.89945,-0.76667) (0.9558,-0.63776)(0.98901,-0.45597) (1.,0) };
                   \filldraw [] (axis cs:.775,.894) node [below left] {\((\sqrt{0.6},\sqrt{0.8})\)} circle (1pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -2009,7 +2009,7 @@
                   <p>
                     A curve which seems like two circles combined.
                     Beginning at the top of the curve, at the point <m>(0,4)</m>, the curve decreases towards the right.
-                    It continues to decreases, bending towards the <m>y</m>-axis as the curve nears the <m>x</m>-axis. 
+                    It continues to decreases, bending towards the <m>y</m>-axis as the curve nears the <m>x</m>-axis.
                     The curve passes through the <m>x</m>-axis at a point close to <m>(2.1,0)</m>, forming a cusp at that point.
                     In the fourth quadrant, the curve bends outwards slightly, before curving wide towards the <m>y</m>-axis.
                     The curve passes through the <m>y</m>-axis at the point <m>(0,-4)</m>.
@@ -2024,15 +2024,15 @@
                     ymin=-4.5,ymax=4.5,%
                     xmin=-4.5,xmax=4.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-] coordinates {(-0.22282,-3.9915) (-0.57143,-3.9441) (-1.,-3.8244) (-1.2959,-3.7041)(-1.5714,-3.551) (-1.8453,-3.3571) (-2.0412,-3.1841) (-2.2149,-3.)(-2.3706,-2.7991) (-2.4727,-2.6429) (-2.5832,-2.4403)(-2.7019,-2.1552) (-2.783,-1.8571) (-2.8275,-1.4582)(-2.8002,-1.0859) (-2.7143,-0.74808) (-2.5958,-0.5)(-2.4708,-0.31491) (-2.3571,-0.19279) (-2.2143,-0.081938)(-2.0659,-0.005515) (-2.2078,0.077938) (-2.4036,0.23922)
                   (-2.5608,0.4392) (-2.6877,0.68771) (-2.786,1.) (-2.8262,1.3571)(-2.8065,1.7143) (-2.7075,2.136) (-2.5114,2.5714) (-2.2471,2.9614)(-2.0396,3.1825) (-1.6513,3.5) (-1.2857,3.7088) (-1.0714,3.8007)(-0.78571,3.8938) (-0.52476,3.9533) (-0.28571,3.9855)
                   (-0.070563,3.9991) (0.27289,3.9872) (0.64411,3.9298) (1.082,3.7963)(1.4286,3.6354) (1.7143,3.4554) (1.9675,3.2532) (2.1511,3.0714)(2.3284,2.8571) (2.4288,2.7143) (2.5351,2.5351) (2.6283,2.3426)(2.7079,2.1365) (2.7939,1.7939) (2.8255,1.3969) (2.8017,1.0874)(2.7481,0.85714) (2.6429,0.58296) (2.552,0.42857) (2.438,0.27631)
                   (2.3214,0.16103) (2.1786,0.06028) (2.1143,-0.028574)(2.2857,-0.13046) (2.4439,-0.28571) (2.5958,-0.5) (2.7143,-0.74808)(2.8002,-1.0859) (2.827,-1.4286) (2.7984,-1.773) (2.7079,-2.1365)(2.6052,-2.3948) (2.4292,-2.7137) (2.2453,-2.9596) (2.,-3.2231)(1.7143,-3.4554) (1.4682,-3.611) (1.1839,-3.7553) (0.86968,-3.8697)
                   (0.57143,-3.9441) (0.33765,-3.9805) (0.072336,-3.9991) (-0.22282,-3.9915)};
-                  
+
                   \filldraw [] (axis cs:2,-3.22) node [shift={(15pt,-10pt)}] {\((2,-\sqrt[4]{108})\)} circle (1pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -2095,12 +2095,12 @@
                     ymin=-1.5,ymax=1.5,%
                     xmin=-2.5,xmax=0.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-,samples=150] coordinates {(-2.,0) (-1.9547,-0.34466) (-1.8227,-0.66341) (-1.616,-0.93301)(-1.3529,-1.1352) (-1.056,-1.2584) (-0.75,-1.299) (-0.459,-1.2611)(-0.2038,-1.1558) (0,-1.) (0.14349,-0.8138) (0.22504,-0.6183)(0.25,-0.43301) (0.22961,-0.27364) (0.17922,-0.15038)(0.11603,-0.066987) (0.05667,-0.020626) (0.014961,-0.0026381) (0,0)
                   (0.014961,0.0026381) (0.05667,0.020626) (0.11603,0.066987)(0.17922,0.15038) (0.22961,0.27364) (0.25,0.43301) (0.22504,0.6183)(0.14349,0.8138) (0,1.) (-0.2038,1.1558) (-0.459,1.2611)(-0.75,1.299) (-1.056,1.2584) (-1.3529,1.1352) (-1.616,0.93301)(-1.8227,0.66341) (-1.9547,0.34466) (-2.,0)};
-                  
+
                   \filldraw [] (axis cs:-.75,1.3) node [shift={(0pt,-12pt)}] {\(\left(-\frac{3}{4},\frac{3\sqrt{3}}{4}\right)\)} circle (1pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -2160,11 +2160,11 @@
                     ymin=-.5,ymax=6.5,%
                     xmin=-1.5,xmax=6.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-,samples=100,domain=0:360] ({(2+3*cos(x))},{(3+3*sin(x))});
                   \filldraw [] (axis cs:4.6,1.5) node [left] {\(\left(\frac{4+3\sqrt{3}}{2},1.5\right)\)} circle (1pt);
                   \filldraw [] (axis cs:3.5,5.6) node [below left] {\(\left(3.5,\frac{6+3\sqrt{3}}{2}\right)\)} circle (1pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -2234,7 +2234,7 @@
                   \filldraw [] (axis cs: -1,-1.62)  circle (1pt);
                   \filldraw [->,thin,>=latex] (axis cs:1.25,0.5) node [ fill=white] {\(\left(-1,\frac{-1+\sqrt{5}}2\right)\)} -- (axis cs: -.9,0.62);
                   \filldraw [] (axis cs:-1,0.62)  circle (1pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>

--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -343,7 +343,7 @@
             <shortdescription>A graph of f(x)=x^2</shortdescription>
             <description>
               <p>
-                The curve is parabolic with the focus being at the origin. 
+                The curve is parabolic with the focus being at the origin.
                 As the <m>x</m> values get bigger and bigger the curve gers further from the <m>y</m> axis
                 on both sides as both the ends approach infinity. Both the rate at which
                 it is getting further gets slower as the <m>x</m> values increase.
@@ -387,10 +387,10 @@
             <description>
             <p>
             The curve is parabolic with the focus being at the origin. As the <m>x</m> values get bigger and bigger the curve gets
-            further from the <m>y</m> axis on both sides as both the ends approach infinity. The rate at which it is getting further 
+            further from the <m>y</m> axis on both sides as both the ends approach infinity. The rate at which it is getting further
             gets slower as the <m>x</m> values increase. The tangent lines are drawn at <m>x=1</m> and <m>x=3</m>.
             </p>
-            
+
             </description>
             <latex-image>
               \begin{tikzpicture}
@@ -447,10 +447,10 @@
             <shortdescription> Graphs of a function and its derivative. </shortdescription>
             <description>
               <p>
-                The curve of <m>f(x)</m> intersects <m>y</m> axis at <m>y=4</m> and slopes downwards. After intersecting the <m>x</m> axis at around <m>x=0.5</m>. 
-                It continues sloping downwards in the negative <m>y</m> direction until about <m> y=-2 </m> and then starts sloping upwards again. 
+                The curve of <m>f(x)</m> intersects <m>y</m> axis at <m>y=4</m> and slopes downwards. After intersecting the <m>x</m> axis at around <m>x=0.5</m>.
+                It continues sloping downwards in the negative <m>y</m> direction until about <m> y=-2 </m> and then starts sloping upwards again.
                 This time it intersects the <m>x</m> axis at <m>x=2</m> and then continue upwards until <m>y=5</m> then slope downwards again.
-                The graph of <m>\fp</m> is a downward parabolic curve that intersects <m>f(x)</m> at <m>(2.5, 4)</m> in the positive <m>y</m> direction and 
+                The graph of <m>\fp</m> is a downward parabolic curve that intersects <m>f(x)</m> at <m>(2.5, 4)</m> in the positive <m>y</m> direction and
                 <m>y=-2</m> at negative <m>y</m> direction.
               </p>
             </description>
@@ -515,10 +515,10 @@
             <shortdescription> Graphs of function f and its derivative</shortdescription>
             <description>
               <p>
-                The curve of <m>f(x)</m> starts at at <m>y=4</m> and slopes downwards intersecting the <m>x</m> axis at around <m>x=0.5</m>. 
+                The curve of <m>f(x)</m> starts at at <m>y=4</m> and slopes downwards intersecting the <m>x</m> axis at around <m>x=0.5</m>.
                 It continues sloping downwards in the negative <m>y</m> direction until about <m> y=-2 </m> and then starts sloping upwards again,
                 this time intersecting the <m>x</m> axis at <m>x=2</m> and then continues upwards until <m>y=5</m> then slope downwards again.
-                The graph of <m>\fp</m> is a downward parabolic curve that intersects <m>f(x)</m> at <m>(2.5, 4)</m> in the positive <m>y</m> direction 
+                The graph of <m>\fp</m> is a downward parabolic curve that intersects <m>f(x)</m> at <m>(2.5, 4)</m> in the positive <m>y</m> direction
                 and <m>y=-2</m> at negative <m>y</m> direction. The tangent lines of <m>f</m> are drawn at <m>(1, 2), (2, 0), (3, 4)</m>.
               </p>
             </description>
@@ -1183,18 +1183,18 @@
                 <shortdescription>f(x) is line with slope 2<var name="a"/> and x intercept <var name="h"/>. g(x) is a parabola with vertex at (<var name="h"/>,<var name="k"/>) </shortdescription>
                 <description>
                   <p>
-                    The graph of f is a line with slope <m>2a</m> and the <m>x</m> intercept <m>h</m>. 
-                    The value of the random variable <m>a</m> decides what the graphs look like. 
-                    Note that the graph of <m>f</m> is always a line and the graph of <m>g</m> is always a hyperbola. 
-                    The description below is of one of the randomly generated graphs with <m>h=-2</m>, 
+                    The graph of f is a line with slope <m>2a</m> and the <m>x</m> intercept <m>h</m>.
+                    The value of the random variable <m>a</m> decides what the graphs look like.
+                    Note that the graph of <m>f</m> is always a line and the graph of <m>g</m> is always a hyperbola.
+                    The description below is of one of the randomly generated graphs with <m>h=-2</m>,
                     <m>a=-1</m> and <m>k=1</m>. If <m>h=-2</m> and <m>a=-1</m>, we have a line that intersects
-                    the negative <m>x</m> axis at <m>x=-2</m> and the negative <m>y</m> axis at <m>y=-4</m>. 
+                    the negative <m>x</m> axis at <m>x=-2</m> and the negative <m>y</m> axis at <m>y=-4</m>.
                     The graph of <m>g</m> is a hyperbola. The vertex is at <m>(h, k)</m>.
-                    With <m>h=-2</m>, <m>a=-1</m> and <m>k=1</m> we have the graph of <m>g</m>, 
-                    a downwards parabola with its vertex at <m>(-2, 1)</m>. One of its arms intersect 
-                    the negative <m>x</m> axis at <m>x=-1</m> and the other at <m>x=-1</m>. 
+                    With <m>h=-2</m>, <m>a=-1</m> and <m>k=1</m> we have the graph of <m>g</m>,
+                    a downwards parabola with its vertex at <m>(-2, 1)</m>. One of its arms intersect
+                    the negative <m>x</m> axis at <m>x=-1</m> and the other at <m>x=-1</m>.
                     The graph of <m>f</m> intersects the graph of <m>g</m> twice, once in the second quadrant
-                    and once in the fourth quadrant. 
+                    and once in the fourth quadrant.
                   </p>
                 </description>
                 <latex-image>
@@ -1203,12 +1203,12 @@
                         ymin=-5.1,ymax=5.1,%
                         xmin=-4.3,xmax=4.3,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-,domain=$fpleft:$fpright] {2*$a*(x-$h)};
                   \addplot [secondcurvestyle,-,domain=$fleft:$fright] {$a*(x-$h)^2+$k};
                   \addlegendentry{\(f(x)\)};
                   \addlegendentry{\(g(x)\)};
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1249,19 +1249,19 @@
                 <shortdescription> f is a parabola and g is a cubic graph that has three x intercepts. </shortdescription>
                 <description>
                   <p>
-                    The graph of <m>g</m> is a parabola and the graph of <m>f</m> 
+                    The graph of <m>g</m> is a parabola and the graph of <m>f</m>
                     is a graph of a cubic function that intersects the <m>x</m> axis three times. Note that the graph of <m>f</m> is always
-                    a cubic graph and the graph of <m>g</m> is always a hyperbola. 
-                    The description below describes one of the randomized images for the excercise. The vertex of <m>g</m> is at 
-                    <m>(-0.667,-0.367)</m> in the third qudrant just below the negative <m>x</m> 
+                    a cubic graph and the graph of <m>g</m> is always a hyperbola.
+                    The description below describes one of the randomized images for the excercise. The vertex of <m>g</m> is at
+                    <m>(-0.667,-0.367)</m> in the third qudrant just below the negative <m>x</m>
                     and slightly to the left of the negative <m>y</m> axis.
-                    From there the right arm travels upwards to the right, intersects the positive <m>x</m> 
+                    From there the right arm travels upwards to the right, intersects the positive <m>x</m>
                     axis and continues travelling upwards while also moving to its right. The graph of
-                    <m>g</m> is the graph of a cubic function that travels upwards from the bottom of the fourth quadrant, 
+                    <m>g</m> is the graph of a cubic function that travels upwards from the bottom of the fourth quadrant,
                     intersecting the negative <m>x</m> axis at <m>x=-3</m> it travels upwards
-                    for a shortwhile then slopes down and again intersects the <m>x</m> axis at <m>x=-2</m>. 
+                    for a shortwhile then slopes down and again intersects the <m>x</m> axis at <m>x=-2</m>.
                     Next it travels downwards to the right. After crossing the negative <m>y</m> axis
-                    at <m>y=-0.9</m> and then it slopes upwards again. It intersects the positive <m>x</m> 
+                    at <m>y=-0.9</m> and then it slopes upwards again. It intersects the positive <m>x</m>
                     axis for the last time at <m>x=3</m> and continues upwards.
                   </p>
                 </description>
@@ -1271,12 +1271,12 @@
                     ymin=$ymin,ymax=$ymax,%
                     xmin=$xmin,xmax=$xmax,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-,domain=$xmin:$xmax,samples=100] {$a*(x-$r)*(x-$s)*(x-$t)};
                   \addplot [secondcurvestyle,-,domain=$xmin:$xmax] {$a*(3*x^2-2*($r+$s+$t)*x+$r*$s+$r*$t+$s*$t)};
                   \addlegendentry{\(f(x)\)};
                   \addlegendentry{\(g(x)\)};
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1300,7 +1300,7 @@
               <image xml:id="img_02_02_ex_17">
                 <shortdescription> f is a hyperbola with curves in the first and the third quadrant and g is a hyperbola with curves in the third and the fourth quadrant. </shortdescription>
                 <description>
-                  <p> 
+                  <p>
                     The graph of <m>f</m> is a hyperbola with curves in the first and the third quadrant. The curves look like infinite bows with the branches extending in
                     positive and negative <m>x</m> and <m>y</m> directions. The curve in the first quadrant has its vertex at <m>(1, 1)</m>. The two branches of the curve extend
                     towards positive <m>x</m> and <m>y</m> axis. They continue moving in their respective directions while they get closer to the <m>x</m> and the <m>y</m> axis
@@ -1311,7 +1311,7 @@
                     continues along with it. The other branch moves downwards while moving slightly to its left and then contines vertically downwards parallel to the negative <m>y</m>
                     axis. The curve in the third qudrant is a mirror image of the previous curve. It follows the part of <m>f</m> in the third quadrant closely intersecting <m>f</m>
                     at <m>(-1, -1)</m>.
-                  </p>  
+                  </p>
                 </description>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1319,14 +1319,14 @@
                         ymin=-5.5,ymax=5.5,%
                         xmin=-5.5,xmax=5.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-,domain=-5.5:-.182,samples=40] {1/x};
                   \addplot [secondcurvestyle,-,domain=-5.5:-.426,samples=40] {-1/x^2};
                   \addplot [firstcurvestyle,-,domain=.182:5.5,samples=40] {1/x};
                   \addplot [secondcurvestyle,-,domain=.426:5.5,samples=40] {-1/x^2};
                   \addlegendentry{\(f(x)\)};
                   \addlegendentry{\(g(x)\)};
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1358,12 +1358,12 @@
                 <shortdescription> f is making a curve similar to a sine wave while g looks similar to a cosine wave both intersecting the x axis multiple times as they oscillate. </shortdescription>
                 <description>
                   <p>
-                    The graph of <m>f</m> looks like a sine wave. Starting at <m>(0, -4)</m> it slopes downward in the 
-                    negative y direction until <m>(-2, -1)</m> then starts moving upwards towards the origin. It continues 
-                    upwards through the origin until it reaches <m>(2, 1)</m>, then starts sloping down again and eventually 
-                    intersects the <m>x</m> axis at <m>(4, 0)</m>. <m>g</m> looks similar to a cosine curve. Starting close to <m>(-4, -0.75)</m> 
-                    it slopes upwards intersecting <m>f</m> and then intersecting the <m>x</m> axis at <m>(-2, 0)</m>. It keeps moving 
-                    up and intersects the <m>y</m> axis close to <m>(0, 0.75)</m> which is where the top of the bell is. Then it starts 
+                    The graph of <m>f</m> looks like a sine wave. Starting at <m>(0, -4)</m> it slopes downward in the
+                    negative y direction until <m>(-2, -1)</m> then starts moving upwards towards the origin. It continues
+                    upwards through the origin until it reaches <m>(2, 1)</m>, then starts sloping down again and eventually
+                    intersects the <m>x</m> axis at <m>(4, 0)</m>. <m>g</m> looks similar to a cosine curve. Starting close to <m>(-4, -0.75)</m>
+                    it slopes upwards intersecting <m>f</m> and then intersecting the <m>x</m> axis at <m>(-2, 0)</m>. It keeps moving
+                    up and intersects the <m>y</m> axis close to <m>(0, 0.75)</m> which is where the top of the bell is. Then it starts
                     moving down to the right, crosses the <m>x</m> axis at <m>(2, 0)</m> then slopes down.
                   </p>
                 </description>
@@ -1373,12 +1373,12 @@
                         ymin=$ymin,ymax=$ymax,%
                         xmin=-4,xmax=4,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,-,domain=-4:4,samples=100] {cos(deg((3.14/$p)*(x-$h)))};
                   \addplot [secondcurvestyle,-,domain=-4:4,samples=40] {-(3.14/$p)*sin(deg((3.14/$p)*(x-$h)))};
                   \addlegendentry{\(f(x)\)};
                   \addlegendentry{\(g(x)\)};
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -191,9 +191,9 @@
             </shortdescription>
             <description>
               <p>
-                The graph starts at the origin and is drawn on the first quadrant. 
-                The horizontal <m>t</m> axis is drawn between <m>0</m> to <m>3</m>, 
-                and the <m>y</m> axis is drawn between <m>0</m> to <m>150</m>. 
+                The graph starts at the origin and is drawn on the first quadrant.
+                The horizontal <m>t</m> axis is drawn between <m>0</m> to <m>3</m>,
+                and the <m>y</m> axis is drawn between <m>0</m> to <m>150</m>.
                 The graph has a decreasing slope, gently declining from points <m>(0, 150)</m> to <m>(3,0)</m>.
                 A secant line is drawn on the curve from <m>t=2</m> and <m>t=3</m>.
               </p>
@@ -221,14 +221,14 @@
           <caption>The function <m>f(t)</m> and a secant line corresponding to <m>t=2</m> and <m>t=3</m>, zoomed in near <m>t=2</m></caption>
           <image xml:id="img_derivfalling2">
           <!-- START figures/fig_derivfalling2.tex -->
-            <shortdescription> 
-              The previous graph of function f(t) that is zoomed in near t=2, with its secant line from t=2 to t=3. 
+            <shortdescription>
+              The previous graph of function f(t) that is zoomed in near t=2, with its secant line from t=2 to t=3.
             </shortdescription>
             <description>
               <p>
-                The graph appears to start at the point <m>(1.8,0)</m> and is drawn on the first quadrant. 
-                The horizontal <m>t</m> axis is drawn between <m>1.8</m> to <m>3.4</m>, and the <m>y</m> axis 
-                is drawn between <m>0</m> to <m>120</m>. 
+                The graph appears to start at the point <m>(1.8,0)</m> and is drawn on the first quadrant.
+                The horizontal <m>t</m> axis is drawn between <m>1.8</m> to <m>3.4</m>, and the <m>y</m> axis
+                is drawn between <m>0</m> to <m>120</m>.
                 The curve appears to be coinciding with the secant line.
               </p>
             </description>
@@ -258,14 +258,14 @@
           <caption>The function <m>f(t)</m> with the same secant line, zoomed in further</caption>
           <image xml:id="img_derivfalling3">
           <!-- START figures/fig_derivfalling3.tex -->
-            <shortdescription> 
-              The graph of function f(t) that is further zoomed in near t=2. 
+            <shortdescription>
+              The graph of function f(t) that is further zoomed in near t=2.
             </shortdescription>
             <description>
               <p>
-                The graph appears to start at the point <m>(1.4,0)</m> and is drawn on the first quadrant. 
-                The horizontal <m>t</m> axis is drawn between <m>1.4</m> to <m>2.6</m>, and the <m>y</m> axis 
-                is drawn between <m>0</m> to <m>120</m>. 
+                The graph appears to start at the point <m>(1.4,0)</m> and is drawn on the first quadrant.
+                The horizontal <m>t</m> axis is drawn between <m>1.4</m> to <m>2.6</m>, and the <m>y</m> axis
+                is drawn between <m>0</m> to <m>120</m>.
                 The curve appears to be coinciding with the secant line that is drawn on the function at <m>t=2</m>.
                 The secant line is above the curve on the left of the point of intersection and is below the curve to its right.
               </p>
@@ -294,14 +294,14 @@
           <caption>The function <m>f(t)</m> with its tangent line at <m>t=2</m></caption>
           <!-- START figures/fig_derivfalling4.tex -->
           <image xml:id="img_derivfalling4">
-              <shortdescription> 
-                The graph of function f(t) that is highly zoomed in near t=2. 
+              <shortdescription>
+                The graph of function f(t) that is highly zoomed in near t=2.
               </shortdescription>
               <description>
                 <p>
-                  The graph appears to start at the point <m>(1.4,0)</m> and is drawn on the first quadrant. 
-                  The horizontal <m>t</m> axis is drawn between <m>1.4</m> to <m>2.6</m>, and the <m>y</m> axis 
-                  is drawn between <m>0</m> to <m>120</m>. 
+                  The graph appears to start at the point <m>(1.4,0)</m> and is drawn on the first quadrant.
+                  The horizontal <m>t</m> axis is drawn between <m>1.4</m> to <m>2.6</m>, and the <m>y</m> axis
+                  is drawn between <m>0</m> to <m>120</m>.
                   The curve appears to be coinciding with the tangent line at <m>t=2</m>.
                 </p>
               </description>
@@ -428,7 +428,7 @@
         </p>
       </statement>
       <solution>
-        
+
         <p>
           <ol marker="a">
             <li>
@@ -477,12 +477,12 @@
             </li>
           </ol>
         </p>
-        
+
         <p>
           A graph of <m>f</m> is given in <xref ref="fig_tangent1"/>
           along with the tangent lines at <m>x=1</m> and <m>x=3</m>.
         </p>
-        
+
         <figure xml:id="fig_tangent1">
           <caption>A graph of <m>f(x) = 3x^2+5x-7</m> and its tangent lines at <m>x=1</m> and <m>x=3</m></caption>
           <!-- START figures/fig_tangent1.tex -->
@@ -492,9 +492,9 @@
             </shortdescription>
             <description>
               <p>
-                The graph starts at origin <m>(0,0)</m> the <m>x</m> axis ends at <m>4</m> 
+                The graph starts at origin <m>(0,0)</m> the <m>x</m> axis ends at <m>4</m>
                 while the <m>y</m> axis ends at <m>60</m>.
-                The curve starts in the third quadrant and moves into the first quadrant with an 
+                The curve starts in the third quadrant and moves into the first quadrant with an
                 <m>x</m> intercept at <m>1</m>, the curve reaches point <m>(4,60)</m> and continues further.
                 Two tangents are drawn on the curve at <m>x=1</m> and <m>x=3</m>.
               </p>
@@ -764,13 +764,13 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis of the graph is drawn from <m>-1</m> to <m>1</m> 
+                The <m>y</m> axis of the graph is drawn from <m>-1</m> to <m>1</m>
                 and the <m>x</m> axis is drawn from <m>-\pi</m> and <m>\pi</m>.
-                The sine graph has an <m>x</m> intercept at <m>-\pi</m> then enters the 
-                third quadrant and forms an upward facing parabola 
+                The sine graph has an <m>x</m> intercept at <m>-\pi</m> then enters the
+                third quadrant and forms an upward facing parabola
                 with its vertex at  point <m>(-\pi/2, -1)</m>.
-                It passes throgh the origin then enters the first quadrant forming a downward 
-                facing parabola with vertex at <m>(\pi/2, 1)</m>. 
+                It passes throgh the origin then enters the first quadrant forming a downward
+                facing parabola with vertex at <m>(\pi/2, 1)</m>.
               </p>
             </description>
             <latex-image>
@@ -1077,11 +1077,11 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis of the graph is drawn from <m>-0.2</m> to <m>1</m> 
+                The <m>y</m> axis of the graph is drawn from <m>-0.2</m> to <m>1</m>
                 and the <m>x</m> axis from <m>-1</m> to <m>1</m>.
-                The function is a straight line, in the second quadrant it appears to pass through point 
+                The function is a straight line, in the second quadrant it appears to pass through point
                 <m>(-1,1)</m> and decreases until it meets the origin.
-                From the origin, it steeply increases after it enters the first quadrant 
+                From the origin, it steeply increases after it enters the first quadrant
                 and appears to pass through point <m>(1,1)</m>.
               </p>
             </description>
@@ -1185,12 +1185,12 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis and the <m>x</m> axis are drawn from <m>-1</m> to <m>1</m>. 
+                The <m>y</m> axis and the <m>x</m> axis are drawn from <m>-1</m> to <m>1</m>.
                 In the first quadrant the derivative of the function starts from the open point <m>(0,1)</m>
-                  and continues as a function <m>y=1</m> that moves towards right parallel to the <m>x</m> axis at 
+                  and continues as a function <m>y=1</m> that moves towards right parallel to the <m>x</m> axis at
                   <m>y=1</m> for all values of <m>x</m>, but value for <m>x=0</m> does not exist.
-                In the third quadrant the derivative of the function starts from the open point <m>(0,-1)</m> 
-                and continues as a function <m>y=-1</m> that moves towards left parallel to the <m>x</m> axis at 
+                In the third quadrant the derivative of the function starts from the open point <m>(0,-1)</m>
+                and continues as a function <m>y=-1</m> that moves towards left parallel to the <m>x</m> axis at
                 <m>y=-1</m> for all values of <m>x</m>, but value for <m>x=0</m> does not exist.
               </p>
             </description>
@@ -1239,10 +1239,10 @@
             <shortdescription>
               Graph of function sin(x) until pi/2 and then y = 1.
             </shortdescription>
-            <description> 
+            <description>
               <p>
-                The <m>y</m> axis is from <m>0</m> to <m>1.5</m> and the <m>x</m> axis from <m>0</m> 
-                to <m>\pi/2</m> the curve starts at <m>0</m> and increases until point <m>(\pi/2,1)</m> 
+                The <m>y</m> axis is from <m>0</m> to <m>1.5</m> and the <m>x</m> axis from <m>0</m>
+                to <m>\pi/2</m> the curve starts at <m>0</m> and increases until point <m>(\pi/2,1)</m>
                 and then moves horizontal to the <m>x</m> axis at <m>y=1</m>.
               </p>
             </description>
@@ -1344,9 +1344,9 @@
             </shortdescription>
             <description>
               <p>
-                Graph of the derivative function, the derivative exists at <m>\pi/2</m> 
+                Graph of the derivative function, the derivative exists at <m>\pi/2</m>
                 and follows a curve of <m>\cos(x)</m> for <m>x\leq\pi/2</m> and <m>0</m> after <m>x=\pi</m>.
-                There is a sharp bend at <m>\pi/2</m>, hence it is not differentiable at that point, 
+                There is a sharp bend at <m>\pi/2</m>, hence it is not differentiable at that point,
                 since for <m>x=\pi</m> there exists <m>f(x)=0</m> function is continuous.
               </p>
             </description>
@@ -1518,14 +1518,14 @@
           <caption>A graph of <m>y=x^{1/2}</m> and <m>y=x^{3/2}</m> in <xref ref="ex_diff_closed1"/></caption>
           <image xml:id="img_diff_closed1" width="47%">
             <shortdescription>
-              Two curves, one of function of square root of x and the other of x to the power 3/2.  
+              Two curves, one of function of square root of x and the other of x to the power 3/2.
             </shortdescription>
             <description>
               <p>
                 The graph has two curves that form a leaf shape.
-                The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is 
+                The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is
                 drawn from <m>-0.2</m> to <m>1.2</m>.
-                The curve on top is of function <m>x^(1/2)</m> and its a downward facing curve. 
+                The curve on top is of function <m>x^(1/2)</m> and its a downward facing curve.
                 The one below is of function <m>x^(3/2)</m> and it is an upward facing curve.
                 The two graphs intersect at points <m>(0,0)</m> and <m>(1,1)</m>.
               </p>
@@ -2216,13 +2216,13 @@
             </p>
             <image xml:id="img_02_01_ex_24" width="47%">
               <shortdescription>
-                Graph of function x squared minus 1, curve is U-shaped. 
+                Graph of function x squared minus 1, curve is U-shaped.
               </shortdescription>
               <description>
                 <p>
-                  The <m>x</m> axis is between <m>-2</m> and <m>2</m> and the <m>y</m> axis 
-                  is drawn between <m>-1</m> and <m>3</m>. 
-                  The graph is U-shaped reaching a minimum at <m>(0,-1)</m> and moving 
+                  The <m>x</m> axis is between <m>-2</m> and <m>2</m> and the <m>y</m> axis
+                  is drawn between <m>-1</m> and <m>3</m>.
+                  The graph is U-shaped reaching a minimum at <m>(0,-1)</m> and moving
                   further upwards after crossing point <m>(-1,0)</m> to the left and <m>(1,0)</m> to the right.
                 </p>
               </description>
@@ -2234,9 +2234,9 @@
                       xmin=-2.1,xmax=2.1,%
                       grid=major
                 ]
-                
+
                 \addplot [firstcurvestyle,domain=-2.1:2.1] {x^2-1};
-                
+
                 \end{axis}
                 \end{tikzpicture}
               </latex-image>
@@ -2311,10 +2311,10 @@
               <description>
                 <p>
                   Graph of function <m>f(x) = \frac{1}{x+1}</m>.
-                  The <m>x</m> axis is drawn from <m>-1</m> 
+                  The <m>x</m> axis is drawn from <m>-1</m>
                   to <m>3</m> and the <m>y</m> axis from <m>0</m> to <m>5</m>.
-                  The curve begins in the second quadrant and steeply declines 
-                  from infinty to point <m>(0,1)</m> then it enters the first quadrant declining gently 
+                  The curve begins in the second quadrant and steeply declines
+                  from infinty to point <m>(0,1)</m> then it enters the first quadrant declining gently
                   and seems to come very close to the <m>x</m> axis on the right.
                 </p>
               </description>
@@ -2326,9 +2326,9 @@
                       xmin=-1.1,xmax=3.1,%
                       grid=major
                 ]
-                
+
                 \addplot [firstcurvestyle,domain=-.9:3.1,samples=50] {1/(x+1)};
-                
+
                 \end{axis}
                 \end{tikzpicture}
               </latex-image>
@@ -2399,9 +2399,9 @@
               </shortdescription>
               <description>
                <p>
-                The <m>y</m> axis if drawn from <m>-1</m> to <m>3</m> 
+                The <m>y</m> axis if drawn from <m>-1</m> to <m>3</m>
                 and the <m>x</m> axis from <m>-2</m> to <m>5</m>.
-                The graph is a decreasing straight line primarily in 
+                The graph is a decreasing straight line primarily in
                 the first quadrant that passes through <m>2</m> on the <m>y</m> axis and <m>4</m> on the <m>x</m> axis.
                </p>
               </description>
@@ -2425,12 +2425,12 @@
           <statement>
             <image xml:id="img_02_01_ex_27">
               <shortdescription>
-                Graph of function is U shaped primarily in the second and third quadrant. 
+                Graph of function is U shaped primarily in the second and third quadrant.
               </shortdescription>
               <description>
                 <p>
                   The <m>y</m> axis is from <m>-3</m> to <m>3</m> and the <m>x</m> axis <m>-6</m> and <m>2</m>.
-                  The U-shaped curve has a minimun at point <m>(-2,-3)</m> 
+                  The U-shaped curve has a minimun at point <m>(-2,-3)</m>
                   it intersects the <m>x</m> axis at <m>-4.5</m> on the left and <m>0.5</m> on the right.
                 </p>
               </description>
@@ -2459,10 +2459,10 @@
               <description>
                 <p>
                   The <m>x</m> axis is drawn from <m>-3</m> to <m>3</m> and the <m>y</m> axis from <m>-5</m> to <m>5</m>.
-                  The graph has a maxima near point <m>(-1,3)</m> and a minima near point <m>(1,-3)</m>. 
-                  It crosses the origin then passes the maxima then crosses <m>x</m> axis at <m>-2</m> 
+                  The graph has a maxima near point <m>(-1,3)</m> and a minima near point <m>(1,-3)</m>.
+                  It crosses the origin then passes the maxima then crosses <m>x</m> axis at <m>-2</m>
                   and decreases in the third quadrant and continues to infinity on the left.
-                  On the right side it decreases from the origin passes the minima and goes to infinity 
+                  On the right side it decreases from the origin passes the minima and goes to infinity
                   after crossing the <m>x</m> axis at <m>2</m> in the first quadrant.
                 </p>
               </description>
@@ -2490,17 +2490,17 @@
               </shortdescription>
               <description>
                 <p>
-                 The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn from 
+                 The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn from
                  <m>-2* \pi</m> to <m>2* \pi</m>.
-                 At <m>x=0</m> the function has a maximum of <m>1</m> on the left of the <m>y</m> axis the 
+                 At <m>x=0</m> the function has a maximum of <m>1</m> on the left of the <m>y</m> axis the
                  function decreases from <m>1</m> and reaches a minima of <m>-1</m> at <m>x=-\pi</m> after crossing <m>-\p/2</m>.
-                 Then it increases to cross the <m>x</m> axis at <m>x=-3*\pi/2</m> and increases further 
+                 Then it increases to cross the <m>x</m> axis at <m>x=-3*\pi/2</m> and increases further
                  to reach a maximum of <m>1</m> in the second quadrant.
                 </p>
                 <p>
-                 Similarly, on the right of the <m>y</m> axis the function decreases from <m>1</m> and reaches 
+                 Similarly, on the right of the <m>y</m> axis the function decreases from <m>1</m> and reaches
                  a minima of <m>-1</m> at <m>x=\pi</m> after crossing <m>\p/2</m>.
-                 Then it increases to cross the <m>x</m> axis at <m>x=3*\pi/2</m> and increases further to reach 
+                 Then it increases to cross the <m>x</m> axis at <m>x=3*\pi/2</m> and increases further to reach
                  a maximum of <m>1</m> in the first quadrant.
                 </p>
               </description>
@@ -2580,10 +2580,10 @@
                 <description>
                   <p>
                     The <m>x</m> axis is drawn from <m>-3</m> to <m>3</m> and the <m>y</m> axis from <m>-5</m> to <m>5</m>.
-                    The graph has a maxima near point <m>(-1,3)</m> and a minima near point <m>(1,-3)</m>. 
-                    It crosses the origin passes the maxima, crosses <m>x</m> axis at <m>-2</m> 
+                    The graph has a maxima near point <m>(-1,3)</m> and a minima near point <m>(1,-3)</m>.
+                    It crosses the origin passes the maxima, crosses <m>x</m> axis at <m>-2</m>
                     and decreases in the third quadrant and continues to infinity on the left.
-                    On the right side it decreases from the origin passes the minima and increases 
+                    On the right side it decreases from the origin passes the minima and increases
                     to infinity after crossing the <m>x</m> axis at <m>2</m> in the first quadrant.
                   </p>
                 </description>
@@ -2594,9 +2594,9 @@
                   ymin=-5.6,ymax=5.6,%
                   xmin=-3,xmax=3,%
                   ]
-            
+
                   \addplot [firstcurvestyle,domain=-2.5:2.5,samples=40] {(x-2)*x*(x+2)};
-                        
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -2659,16 +2659,16 @@
             <statement>
               <image xml:id="img_02_01_ex_31">
                 <shortdescription>
-                  An M-shaped graph with two maxima. 
+                  An M-shaped graph with two maxima.
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>y</m> axis is drawn from <m>-2</m> to <m>5</m> and the <m>x</m> axis 
+                    The <m>y</m> axis is drawn from <m>-2</m> to <m>5</m> and the <m>x</m> axis
                     is drawn from <m>-2</m> and <m>2</m>.
-                    At <m>x=0</m> y has a value of <m>4</m>, to the left the function increases to reach a maximum 
-                    of <m>4.5</m> in the second quadrant 
+                    At <m>x=0</m> y has a value of <m>4</m>, to the left the function increases to reach a maximum
+                    of <m>4.5</m> in the second quadrant
                     and decreses and continues into the third quadrant after crossing <m>x</m> axis at <m>-2</m>.
-                    Similarly, on the right side, the function increases to reach a maximum of <m>4.5</m> in the 
+                    Similarly, on the right side, the function increases to reach a maximum of <m>4.5</m> in the
                     first quadrant and decreses and continues into the fourth quadrant after crossing <m>x</m> axis at <m>2</m>.
                   </p>
                 </description>
@@ -2679,9 +2679,9 @@
                   ymin=-3,ymax=6,%
                   xmin=-2.8,xmax=2.8,%
                   ]
-            
+
                   \addplot [firstcurvestyle,domain=-2.2:2.2,samples=50] {(-2)*(x^4/4-x^2/2)+4};
-           
+
                    \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -2969,13 +2969,13 @@
                       ymin=-1.1,ymax=3.3,%
                       xmin=-5.1,xmax=0.5,%
                 ]
-                
+
                 \addplot [firstcurvestyle,-,domain=-4.5:-3] {(x+3)^2+1};
                 \addplot [firstcurvestyle,-,domain=-3:-1] {-(x+3)^2+3};
                 \filldraw [fill=white] (axis cs:-3,1) circle (1.5pt);
                 \filldraw [fill=white] (axis cs:-3,3) circle (1.5pt);
                 \filldraw [fill=black] (axis cs:-3,2) circle (1.5pt);
-                
+
                 \end{axis}
                 \end{tikzpicture}
               </latex-image>

--- a/ptx/sec_deriv_intro.ptx
+++ b/ptx/sec_deriv_intro.ptx
@@ -427,12 +427,8 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="4OMc0gJWcb0" xml:id="vid_deriv_intro_ex_v1" label="vid_deriv_intro_ex_v1" component="video"/>
-      </solution>
       <solution>
-
+        
         <p>
           <ol marker="a">
             <li>
@@ -481,12 +477,12 @@
             </li>
           </ol>
         </p>
-
+        
         <p>
           A graph of <m>f</m> is given in <xref ref="fig_tangent1"/>
           along with the tangent lines at <m>x=1</m> and <m>x=3</m>.
         </p>
-
+        
         <figure xml:id="fig_tangent1">
           <caption>A graph of <m>f(x) = 3x^2+5x-7</m> and its tangent lines at <m>x=1</m> and <m>x=3</m></caption>
           <!-- START figures/fig_tangent1.tex -->
@@ -521,6 +517,10 @@
           </image>
           <!-- figures/fig_tangent1.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="4OMc0gJWcb0" xml:id="vid_deriv_intro_ex_v1" label="vid_deriv_intro_ex_v1" component="video"/>
       </solution>
     </example>
 
@@ -950,10 +950,6 @@
           Find <m>\fp(x)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="JKHbXYanjDs" xml:id="vid_deriv_intro_ex_1" label="vid_deriv_intro_ex_1" component="video"/>
-      </solution>
       <solution>
 
         <p>
@@ -982,6 +978,10 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="JKHbXYanjDs" xml:id="vid_deriv_intro_ex_1" label="vid_deriv_intro_ex_1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_deriv_sinx">
@@ -991,10 +991,6 @@
           Find the derivative of <m>f(x) = \sin(x)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="vsnDopbWHXQ" xml:id="vid_deriv_intro_deriv_sin" label="vid_deriv_intro_deriv_sin" component="video"/>
-      </solution>
       <solution>
 
         <p>
@@ -1050,6 +1046,10 @@
           <video youtube="-1lOFzhDJAo" label="vid_deriv_intro_deriv_cos"/>
         </figure>
 
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="vsnDopbWHXQ" xml:id="vid_deriv_intro_deriv_sin" label="vid_deriv_intro_deriv_sin" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -304,10 +304,7 @@
         Find <m>y'</m> using <xref ref="thm_deriv_inverse_functions"/>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="xBZqkvQRSG4" xml:id="vid_deriv_inverse_deriv_arcsin" label="vid_deriv_inverse_deriv_arcsin" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -382,6 +379,10 @@
           \lzoo{x}{\arcsin(x)} = \frac{1}{\sqrt{1-x^2}}
         </me>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="xBZqkvQRSG4" xml:id="vid_deriv_inverse_deriv_arcsin" label="vid_deriv_inverse_deriv_arcsin" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_deriv_inverse_function.ptx
+++ b/ptx/sec_deriv_inverse_function.ptx
@@ -83,11 +83,11 @@
       <description>
         <p>
           The graph of <m>f</m> starts at <m>(-1,-0.5)</m> below the negative <m>x</m> axis then slopes upwards while moving to the right.
-          A little after passing throught he point <m>(-0.5,0.375)</m> it slopes further and faster to the right and starts moving 
-          horizontally parallel to the <m>x</m> axis. Then it starts to move upagain continuuing through <m>(1, 1.5)</m>. The graph of <m>g</m> is a 
-          similar curve starting below the <m>x</m> axis close to the <m>y</m> axis in the third quadrant it moves to the right while moving up 
+          A little after passing throught he point <m>(-0.5,0.375)</m> it slopes further and faster to the right and starts moving
+          horizontally parallel to the <m>x</m> axis. Then it starts to move upagain continuuing through <m>(1, 1.5)</m>. The graph of <m>g</m> is a
+          similar curve starting below the <m>x</m> axis close to the <m>y</m> axis in the third quadrant it moves to the right while moving up
           and then after passing through <m>(0.375,-0.5)</m> it moves upwards vertically for a short while and then starts moving to
-          the right while also moving upwards passing through <m>(1.5,1)</m>. 
+          the right while also moving upwards passing through <m>(1.5,1)</m>.
         </p>
       </description>
       <latex-image>
@@ -144,13 +144,13 @@
       <shortdescription>Corresponding tangent lines drawn to f and its inverse</shortdescription>
       <description>
         <p>
-          The graph of <m>f</m> starts close to <m>(-1,-0.5)</m> below the negative <m>x</m> axis and slopes upwards and to the right. 
-          After passing through <m>(-0.5,0.375)</m> it starts moving to the right. After intersecting the <m>y</m> axis at 
+          The graph of <m>f</m> starts close to <m>(-1,-0.5)</m> below the negative <m>x</m> axis and slopes upwards and to the right.
+          After passing through <m>(-0.5,0.375)</m> it starts moving to the right. After intersecting the <m>y</m> axis at
           <m>(0,0.5)</m> it continues to move horizontally for a short while then starts moving upwards to the right
-          and continues upwards through the point <m>(1,1.5)</m>. The tangent line of <m>f</m> is drawn at <m>(1,1.5)</m>, 
+          and continues upwards through the point <m>(1,1.5)</m>. The tangent line of <m>f</m> is drawn at <m>(1,1.5)</m>,
           it is a straight line that slightly touches the the curve at <m>(1,1.5)</m> and keeps moving straight. <m>g</m> starts
-          close to the negative <m>y</m> axis and starts moving to the right while sloping upwards. Once it moves through the point 
-          <m>(0.375,-0.5)</m> then starts moving vertically upward and eventually starts moving again upwards and to the right. 
+          close to the negative <m>y</m> axis and starts moving to the right while sloping upwards. Once it moves through the point
+          <m>(0.375,-0.5)</m> then starts moving vertically upward and eventually starts moving again upwards and to the right.
           The tangent line of the curve is drawn at <m>(1.5,1)</m>.
         </p>
       </description>
@@ -304,7 +304,7 @@
         Find <m>y'</m> using <xref ref="thm_deriv_inverse_functions"/>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -338,9 +338,9 @@
         <image xml:id="img_inverse3" width="47%">
         <shortdescription>The right triangle defined by the equation sin(y)=x/1</shortdescription>
           <description>
-            <p> 
-              The right angle triangle is defined by <m>y=\sin^{-1}(x/1)</m>. 
-              The length of the base is <m>\sqrt{1-x^2}</m> and the length of the perpendicular is <m>x</m>. The length of the 
+            <p>
+              The right angle triangle is defined by <m>y=\sin^{-1}(x/1)</m>.
+              The length of the base is <m>\sqrt{1-x^2}</m> and the length of the perpendicular is <m>x</m>. The length of the
               hypotenuse is <m>1</m>. The angle between the base and the hypotenuse is <m>y</m>.
             </p>
           </description>
@@ -410,9 +410,9 @@
       <image xml:id="img_inverse4">
       <shortdescription>The graph of sin(x) and arcsin(x) with their corresponding tangent line</shortdescription>
         <description>
-          <p> 
+          <p>
             The graph of <m>\sin(x)</m> starts at <m>(-\pi/2,-1)</m>. It first curves upwards to the right
-            and then moves towards the origin making a slope. Once the slope passes through the origin it continues 
+            and then moves towards the origin making a slope. Once the slope passes through the origin it continues
             upwards to the right in the first quadrant. Once it reaches the point <m>(\pi/2,1)</m>, the graph starts
             to move downwards again. The tangent line of the graph is drawn at <m>(\pi/3,\sqrt{3/2})</m>.
           </p>
@@ -438,12 +438,12 @@
       <image xml:id="img_inverse5">
         <shortdescription>Graphs of sin(x) and arcsin (x) with corresponding tangent line</shortdescription>
         <description>
-          <p> 
+          <p>
             Starting at the third quadrant at <m>(-1,-\pi/2)</m> the graph of <m>\arcsin(x)</m>
-            begins with a nearly vertical slope. The slope decreases to <m>1</m> as the graph passes through the origin. 
+            begins with a nearly vertical slope. The slope decreases to <m>1</m> as the graph passes through the origin.
             The graph then moves toward its end at <m>(1, \pi/2)</m> with increasing slope. The tangent line is drawn at
-            <m>(\sqrt{3/2},\pi/3)</m>. The tangent line of <m>\sin^{-1}(x)</m> is steeper than the tangent line of <m>\sin(x)</m>. 
-          </p>        
+            <m>(\sqrt{3/2},\pi/3)</m>. The tangent line of <m>\sin^{-1}(x)</m> is steeper than the tangent line of <m>\sin(x)</m>.
+          </p>
         </description>
         <latex-image>
 
@@ -1442,7 +1442,7 @@
                 <ol>
                   <li>
                     <p>
-                      <m>f(x) = 2\sin(\sin^{-1}(x))\cos(\sin^{-1}(x))=2x\sqrt{1-x^2}</m>, 
+                      <m>f(x) = 2\sin(\sin^{-1}(x))\cos(\sin^{-1}(x))=2x\sqrt{1-x^2}</m>,
                       so <m>\fp(x) = 2\sqrt{1-x^2} -\frac{2x^2}{\sqrt{1-x^2}}</m>.
                     </p>
                   </li>
@@ -1450,7 +1450,7 @@
                     <p>
                       <m>\fp(x) = \cos(2\sin^{-1}(x) ) \frac{2}{\sqrt{1-x^2}}</m>,
                       but to compare, we need to simplify <m>\cos(2\sin^{-1}(x))</m>.
-                      Using <m>\cos(2\theta)=1-2\sin^2(\theta)</m>, 
+                      Using <m>\cos(2\theta)=1-2\sin^2(\theta)</m>,
                       we get <m>\fp(x) = (1-2x^2)\frac{2}{\sqrt{1-x^2}}</m>.
                     </p>
                     <p>
@@ -1458,7 +1458,7 @@
                       <md>
                         <mrow>2\sqrt{1-x^2} -\frac{2x^2}{\sqrt{1-x^2}} \amp = \frac{2(1-x^2)-2x^2}{\sqrt{1-x^2}}</mrow>
                         <mrow> \amp =\frac{2(1-2x^2)}{\sqrt{1-x^2}}</mrow>
-                      </md>.                      
+                      </md>.
                     </p>
                   </li>
                 </ol>

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -56,7 +56,7 @@
         Evaluate the derivative at <m>x=\pi/2</m>.
       </p>
     </statement>
-   
+
     <solution>
 
       <p>
@@ -200,7 +200,7 @@
         Verify that both methods give the same answer.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -243,7 +243,7 @@
         Find <m>y'</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -410,7 +410,7 @@
         Find <m>\fp(x)</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -439,7 +439,7 @@
         Find the derivative of <m>y=\tan(x)</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -603,7 +603,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -708,7 +708,7 @@
         Verify that all three methods give the same result.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>

--- a/ptx/sec_deriv_prodquot.ptx
+++ b/ptx/sec_deriv_prodquot.ptx
@@ -56,10 +56,7 @@
         Evaluate the derivative at <m>x=\pi/2</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="37efDywkDyE" xml:id="vid_deriv_prod_quot_prod_ex" label="vid_deriv_prod_quot_prod_ex" component="video"/>
-    </solution>
+   
     <solution>
 
       <p>
@@ -124,6 +121,10 @@
         </image>
           <!-- figures/fig_5xsquaredsinx.tex END -->
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="37efDywkDyE" xml:id="vid_deriv_prod_quot_prod_ex" label="vid_deriv_prod_quot_prod_ex" component="video"/>
     </solution>
   </example>
 
@@ -199,10 +200,7 @@
         Verify that both methods give the same answer.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="-plvLFQ21Ig" xml:id="vid_deriv_prod_quot_ex_1" label="vid_deriv_prod_quot_ex_1" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -231,6 +229,10 @@
         Obviously this is not correct.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="-plvLFQ21Ig" xml:id="vid_deriv_prod_quot_ex_1" label="vid_deriv_prod_quot_ex_1" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_prod10">
@@ -241,10 +243,7 @@
         Find <m>y'</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="PYK64WB4JUg" xml:id="vid_deriv_prod_quot_ex_3_func" label="vid_deriv_prod_quot_ex_3_func" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -280,6 +279,10 @@
           \yp=-x^2\left[x\ln(x)\sin(x) + \cos(x) + 3\ln(x)\cos(x)\right]
         </me>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="PYK64WB4JUg" xml:id="vid_deriv_prod_quot_ex_3_func" label="vid_deriv_prod_quot_ex_3_func" component="video"/>
     </solution>
   </example>
 
@@ -407,10 +410,7 @@
         Find <m>\fp(x)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="Hr4bt6yFwPg" xml:id="vid_deriv_prod_quot_example_2" label="vid_deriv_prod_quot_example_2" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -420,6 +420,10 @@
           <mrow>\amp =    \frac{10x\sin(x) - 5x^2\cos(x) }{\sin^2(x) }</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="Hr4bt6yFwPg" xml:id="vid_deriv_prod_quot_example_2" label="vid_deriv_prod_quot_example_2" component="video"/>
     </solution>
   </example>
 
@@ -435,10 +439,7 @@
         Find the derivative of <m>y=\tan(x)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="wslbADxDg4c" xml:id="vid_deriv_prod_quot_tanx" label="vid_deriv_prod_quot_tanx" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -501,6 +502,10 @@
         </image>
         <!-- figures/fig_tanx.tex END -->
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="wslbADxDg4c" xml:id="vid_deriv_prod_quot_tanx" label="vid_deriv_prod_quot_tanx" component="video"/>
     </solution>
   </example>
 
@@ -598,10 +603,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="jPqqK-ObPm4" xml:id="vid_deriv_prod_quot_neg_power" label="vid_deriv_prod_quot_neg_power" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -626,6 +628,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="jPqqK-ObPm4" xml:id="vid_deriv_prod_quot_neg_power" label="vid_deriv_prod_quot_neg_power" component="video"/>
     </solution>
   </example>
 
@@ -702,10 +708,7 @@
         Verify that all three methods give the same result.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="ESYjxNMNvh8" xml:id="vid_deriv_prod_quot_ex_simp_first" label="vid_deriv_prod_quot_ex_simp_first" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -748,6 +751,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="ESYjxNMNvh8" xml:id="vid_deriv_prod_quot_ex_simp_first" label="vid_deriv_prod_quot_ex_simp_first" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -343,10 +343,7 @@
         Knowing <m>f(3) = 9</m>, approximate <m>f(3.1)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="KCDezzvfDKA" xml:id="vid_deriv_apps_diff_ex_2" label="vid_deriv_apps_diff_ex_2" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -373,6 +370,10 @@
         One can verify that the tangent line,
         evaluated at <m>x=3.1</m>, also gives <m>y=9.6</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="KCDezzvfDKA" xml:id="vid_deriv_apps_diff_ex_2" label="vid_deriv_apps_diff_ex_2" component="video"/>
     </solution>
   </example>
 
@@ -430,10 +431,7 @@
         Approximate <m>\sqrt{4.5}</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="nFaq1O_wWso" xml:id="vid_deriv_apps_diff_ex_3" label="vid_deriv_apps_diff_ex_3" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -459,6 +457,10 @@
         The approximate change in <m>f</m> from <m>x=4</m> to <m>x=4.5</m> is <m>0.125</m>,
         so we approximate <m>\sqrt{4.5} \approx 2.125</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="nFaq1O_wWso" xml:id="vid_deriv_apps_diff_ex_3" label="vid_deriv_apps_diff_ex_3" component="video"/>
     </solution>
   </example>
 
@@ -595,10 +597,7 @@
         </quantity>, estimate the propagated error in the mass of the ball bearing.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="0_tSaBZZR1s" xml:id="vid_deriv_apps_diff_prop_error" label="vid_deriv_apps_diff_prop_error" component="video"/>
-    </solution>
+    
     <solution>
 
 <!--ToDo: apex-mbx used math mode for the equation below, with \text around each term. Is this better?-->
@@ -656,6 +655,10 @@
         While the amount of error is much greater (<m>12.33 \gt 0.493</m>),
         the percent error is much lower.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="0_tSaBZZR1s" xml:id="vid_deriv_apps_diff_prop_error" label="vid_deriv_apps_diff_prop_error" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -52,7 +52,7 @@
               The graph portrays <m>f(x) = \sin(x)</m> in its typical wave-like form, beginning from <m>x=0</m>. A tangent line intersects the curve at <m>x=\pi/3</m>, giving us an insight into the function's behavior around this point. A small rectangular region on the graph suggests a section of interest, likely to be examined more closely in a subsequent depiction. The overall visualization offers a comprehensive understanding of the sine function's progression and how the tangent line serves as a useful approximation around <m>x=\pi/3</m>.
             </p>
           </description>
-        
+
           <latex-image>
 
           \begin{tikzpicture}
@@ -85,14 +85,14 @@
           </shortdescription>
           <description>
             <p>
-              Zooming in on the small rectangle from the prior graph, 
-              we get a magnified view around the point <m>x=\pi/3</m> for <m>f(x) = \sin(x)</m> and its tangent line. 
-              This zoomed-in perspective demonstrates the precision with which the tangent line estimates <m>\sin(1.1)</m> at <m>x=1.1</m>. 
-              We can see how points on the tangent line lie quite close to the graph of <m>f(x)</m>, 
-              illustrating the fact that the tangent line gives a good approximation to the original graph, 
+              Zooming in on the small rectangle from the prior graph,
+              we get a magnified view around the point <m>x=\pi/3</m> for <m>f(x) = \sin(x)</m> and its tangent line.
+              This zoomed-in perspective demonstrates the precision with which the tangent line estimates <m>\sin(1.1)</m> at <m>x=1.1</m>.
+              We can see how points on the tangent line lie quite close to the graph of <m>f(x)</m>,
+              illustrating the fact that the tangent line gives a good approximation to the original graph,
               near the point where it meets the graph.
             </p>
-          </description>        
+          </description>
           <latex-image>
 
           \begin{tikzpicture}
@@ -343,7 +343,7 @@
         Knowing <m>f(3) = 9</m>, approximate <m>f(3.1)</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -431,7 +431,7 @@
         Approximate <m>\sqrt{4.5}</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -597,7 +597,7 @@
         </quantity>, estimate the propagated error in the mass of the ball bearing.
       </p>
     </statement>
-    
+
     <solution>
 
 <!--ToDo: apex-mbx used math mode for the equation below, with \text around each term. Is this better?-->
@@ -1608,17 +1608,17 @@
               <image xml:id="img_04_04_ex_35" width="47%">
                 <shortdescription>
                   A right-angled triangle representing an approximation challenge for a wall's length.
-                </shortdescription>              
+                </shortdescription>
                 <description>
                   <p>
-                    The diagram presents a right-angled triangle utilized to navigate an approximation problem concerning the length, <m>l</m>, of a long wall. 
+                    The diagram presents a right-angled triangle utilized to navigate an approximation problem concerning the length, <m>l</m>, of a long wall.
                     The angle labeled as <m>\theta</m> is opposite the wall,
-                    and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>. 
-                    The opposite side, representing the wall's length, is denoted by the variable <m>l</m>. 
+                    and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>.
+                    The opposite side, representing the wall's length, is denoted by the variable <m>l</m>.
                     The triangle's hypotenuse is not specified in the given representation.
                   </p>
                 </description>
-              
+
                 <latex-image>
                   \begin{tikzpicture}
                   \draw [ultra thick] (1,-1) -- node [pos=.5,right] {\scriptsize \(l=\)?}(1,1);
@@ -1686,14 +1686,14 @@
               <image xml:id="img-ex-diff-approx1" width="60%">
                 <shortdescription>
                   A right-angled triangle illustrating an approximation problem related to a long wall.
-                </shortdescription>              
+                </shortdescription>
                 <description>
                   <p>
-                    The diagram showcases a right-angled triangle, 
-                    which aids in determining an approximation for the length, <m>l</m>, of a long wall. 
-                    The angle labeled as <m>\theta</m> is opposite the wall, 
-                    and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>. 
-                    The opposite side, representing the wall's length, is denoted by the variable <m>l</m>. 
+                    The diagram showcases a right-angled triangle,
+                    which aids in determining an approximation for the length, <m>l</m>, of a long wall.
+                    The angle labeled as <m>\theta</m> is opposite the wall,
+                    and the adjacent side is marked as <quantity><mag>25</mag><unit base="foot"/></quantity>.
+                    The opposite side, representing the wall's length, is denoted by the variable <m>l</m>.
                     The triangle's hypotenuse is not specified in the given representation.
                   </p>
                 </description>
@@ -1764,16 +1764,16 @@
               <image xml:id="img-ex-diff-approx2" width="60%">
                 <shortdescription>
                   An isosceles triangle used for calculating a wall's length, l.
-                </shortdescription>              
+                </shortdescription>
                 <description>
                   <p>
-                    The diagram illustrates an isosceles triangle to facilitate a calculation related to determining the length, <m>l</m>, of a long wall. 
-                    The triangle's height, perpendicular to the base representing the wall, 
-                    is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>. 
+                    The diagram illustrates an isosceles triangle to facilitate a calculation related to determining the length, <m>l</m>, of a long wall.
+                    The triangle's height, perpendicular to the base representing the wall,
+                    is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>.
                     The angle opposite the wall is labeled as <m>\theta</m>.
                   </p>
                 </description>
-              
+
                 <latex-image>
                   \begin{tikzpicture}
                   \draw [ultra thick] (1,-1) -- node [pos=.5,right] {\scriptsize \(l=\)?}(1,1);
@@ -1863,12 +1863,12 @@
               <image xml:id="img-ex-diff-approx3" width="60%">
                 <shortdescription>
                   An isosceles triangle used for calculating a wall's length, l.
-                </shortdescription>              
+                </shortdescription>
                 <description>
                   <p>
-                    The diagram illustrates an isosceles triangle to facilitate a calculation related to determining the length, <m>l</m>, of a long wall. 
-                    The triangle's height, perpendicular to the base representing the wall, 
-                    is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>. 
+                    The diagram illustrates an isosceles triangle to facilitate a calculation related to determining the length, <m>l</m>, of a long wall.
+                    The triangle's height, perpendicular to the base representing the wall,
+                    is given as <quantity><mag>50</mag><unit base="foot"/></quantity>. The length of the wall is denoted as <m>l</m>.
                     The angle opposite the wall is labeled as <m>\theta</m>.
                   </p>
                 </description>

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -20,16 +20,16 @@
       <description>
         <p>
           An image of a general right cylinder.
-          The area of the base of the cylinder is given to be <m>A</m>. 
+          The area of the base of the cylinder is given to be <m>A</m>.
           The base of the cylinder resemembles a parallelogram with curved edges, with each side slightly bowing in at the half way point between two corners.
           The height of the cylinder is <m>h</m>.
-          The base of the general cylinder is identical to the top of the general cylinder, with the two faces being parallel. 
+          The base of the general cylinder is identical to the top of the general cylinder, with the two faces being parallel.
           These faces also coincide on top of eachother, which leads to right angles when the top and base are connected to form the general right cylinder.
           The volume of the general right cylinder is <m>V=A\cdot h</m>.
         </p>
       </description>
       <shortdescription>An image of a general right cylider with a base area of A and heigh h.</shortdescription>
-         
+
       <asymptote>
 
 
@@ -156,7 +156,7 @@
         and a height of <quantity><mag>5</mag><unit base="inch"/></quantity>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         There are many ways to <q>orient</q>
@@ -476,7 +476,7 @@
         from <m>x=1</m> to <m>x=2</m>, around the <m>x</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         A sketch can help us understand this problem.
@@ -504,7 +504,7 @@
                 <p>
                   Three-dimensional plot the curve <m>y=1/x</m> between <m>x=1</m> and <m>x=2</m> lying in the <m>xy</m> plane.
                   The volume of the inside of the rotated curve is then approximated using thin circular disks.
-                  Taking an arbitrary circular disk, it would have a radius which whose length is equal to the distance between the <m>x</m>-axis and the curve <m>y=1/x</m>. 
+                  Taking an arbitrary circular disk, it would have a radius which whose length is equal to the distance between the <m>x</m>-axis and the curve <m>y=1/x</m>.
                   The image depicts a circular disk centered at some arbitrary value of <m>x</m> between <m>x=1</m> and <m>x=2</m>, with the radius given by the function <m>R(x)=1/x</m>.
                 </p>
               </description>
@@ -586,7 +586,7 @@
                 </p>
               </description>
               <shortdescription>A three-dimensional plot of the solid which comes from rotating the curve from the example.</shortdescription>
-            
+
               <asymptote>
 
 
@@ -698,7 +698,7 @@
         from <m>x=1</m> to <m>x=2</m>, about the <m>y</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         Since the axis of rotation is vertical,
@@ -728,12 +728,12 @@
                 <p>
                   Three-dimensional plot the curve <m>y=1/x</m> between <m>x=1</m> and <m>x=2</m> lying in the <m>xy</m> plane.
                   The volume of the inside of the rotated curve is approximated thin horizontal circular disks.
-                  Taking an arbitrary circular disk, it would have a radius which whose length is equal to the distance between the <m>y</m>-axis and the curve <m>x=1/y</m>. 
+                  Taking an arbitrary circular disk, it would have a radius which whose length is equal to the distance between the <m>y</m>-axis and the curve <m>x=1/y</m>.
                   The image depicts a circular disk centered at some arbitrary value of <m>y</m> between <m>y=\frac12</m> and <m>y=1</m>, with the radius given by the function <m>R(y)=1/y</m>.
                 </p>
               </description>
               <shortdescription>A three-dimensional plot of the curve from the example showing a thin horizontal slice being used to approximate its volume.</shortdescription>
-             
+
               <asymptote>
 
 
@@ -807,13 +807,13 @@
                 <p>
                   Three-dimensional plot the curve <m>y=1/x</m> from <m>x=1</m> and <m>x=2</m> lying in the <m>xy</m> plane.
                   The curve is then rotated in a full circle about the <m>y</m>-axis.
-                  The solid is then bounded on both the top and bottom by the planes <m>y=1</m> and <m>y=\frac12</m>. 
+                  The solid is then bounded on both the top and bottom by the planes <m>y=1</m> and <m>y=\frac12</m>.
                   The plane <m>y=1</m> closes off the top of the solid with a circle of radius <m>1</m>, and the plane <m>y=\frac12</m> closes off the bottom of the solid with a circle of radius <m>2</m>.
                   The volume of the inside of the curve is then approximated using thin circular disks which are contained completely inside the solid as described in the previous image.
                 </p>
               </description>
               <shortdescription>A three-dimensional plot of the solid which comes from rotating the curve from the example.</shortdescription>
-            
+
               <asymptote>
 
 
@@ -1160,7 +1160,7 @@
           The graph also cotains a washer plotted on an arbitrary value of <m>x</m> in the interval <m>[a,b]</m>, which will lie entirely inside the area between the blue and red curve.
           The outside of the washer has a radius of <m>R(x)</m>, while the inside of the washer has a radius of <m>r(x)</m>.
           In other words, the washer is a circle of radius <m>R(x)</m> with a circular hole of radius <m>r(x)</m> in the center.
-          Taking these washers to be arbitrarily thin, we can calculate the volume of the solid which comes from rotating the region. 
+          Taking these washers to be arbitrarily thin, we can calculate the volume of the solid which comes from rotating the region.
         </p>
       </description>
       <shortdescription>Three-dimensional plot of solid coming from rotating the region between the two curves.</shortdescription>
@@ -1286,7 +1286,7 @@
         <m>y=x^2-2x+2</m> and <m>y=2x-1</m> about the <m>x</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -1320,7 +1320,7 @@
                   Graph of the region enclosed by the curves <m>y=x^2-2x+2</m> and <m>y=2x-1</m>.
                   The curves which create an enclosed region both start at the point <m>(1,1)</m> and end at the point <m>(3,5)</m>.
                   The line <m>y=2x-1</m> lies entirely above the curve <m>y=x^2-2x+2</m> for the entirety of the enclosed region.
-                  The radius of the outside of the washer is then given as distance between the <m>x</m>-axis and the line <m>y=2x-1</m>, and is given by the function <m>R(x)=2x-1</m>. 
+                  The radius of the outside of the washer is then given as distance between the <m>x</m>-axis and the line <m>y=2x-1</m>, and is given by the function <m>R(x)=2x-1</m>.
                   The inside radius of the washer is given as the distance between the <m>x</m>-axis and the inside curve <m>y=x^2-2x+2</m>, and is given by the function <m>r(x)=x^2-2x+2</m>.
                 </p>
               </description>
@@ -1381,7 +1381,7 @@
               <description>
                 <p>
                   Graph of the region enclosed by the curves <m>y=x^2-2x+2</m> and <m>y=2x-1</m> with a washer centered at <m>x=2</m>.
-                  The washer lies parallel to the <m>y</m>-axis, and has an outside radius of <m>R(2)=3</m> and an inside radius of <m>r(2)=2</m>. 
+                  The washer lies parallel to the <m>y</m>-axis, and has an outside radius of <m>R(2)=3</m> and an inside radius of <m>r(2)=2</m>.
                   In the original graph of the functions, <m>R(2)=3</m> is the distance between the line <m>y=2x-1</m> and the <m>x</m>-axis, and <m>r(2)=2</m> is the distance between the curve <m>y=x^2-2x+2</m> and the <m>x</m>-axis.
                   The washer will lie entirely in the space enclosed by rotating the region between the two curves.
                 </p>
@@ -1552,7 +1552,7 @@
         <m>(2,1)</m> and <m>(2,3)</m> about the <m>y</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The triangular region is sketched in <xref ref="fig_wash2a_3D"/>;
@@ -1665,7 +1665,7 @@
               <description>
                 <p>
                   Graph of the triangular region with vertices at <m>(1,1)</m>, <m>(2,1)</m> and <m>(2,3)</m> with a washer centered at <m>y=2</m>.
-                  The washer lies parallel to the <m>x</m>-axis, and has an outside radius of <m>R(2)=2</m> and an inside radius of <m>r(2)=\frac32</m>. 
+                  The washer lies parallel to the <m>x</m>-axis, and has an outside radius of <m>R(2)=2</m> and an inside radius of <m>r(2)=\frac32</m>.
                   In the original graph of the functions, <m>R(2)=2</m> is the distance between the rightmost edge of the triangular region and the <m>y</m>-axis.
                   Similarly, <m>r(2)=\frac32</m> is the distance betweeen the leftmost edge of the triangular region given by the line <m>y=2x-1</m>, and the <m>y</m>-axis
                   The washer will lie entirely in the space enclosed by rotating the region between the two curves as described in the following image.
@@ -1983,15 +1983,15 @@
                   <image xml:id="img_07_02_ex_05">
                     <description>
                       <p>
-                        Graph of the region bounded by the curve <m>y=3-x^2</m> and the <m>x</m>-axis. 
+                        Graph of the region bounded by the curve <m>y=3-x^2</m> and the <m>x</m>-axis.
                         The curve <m>y=3-x^2</m> begins at <m>x</m>-axis at the point <m>(-\sqrt{3},0)</m>.
                         From this point the curve rises until reaching the <m>y</m>-axis at the point <m>(0,3)</m>.
-                        After reaching the <m>y</m>-axis, the curve slopes down until reaching the <m>x</m>-axis at the point <m>(\sqrt{3},0)</m>. 
+                        After reaching the <m>y</m>-axis, the curve slopes down until reaching the <m>x</m>-axis at the point <m>(\sqrt{3},0)</m>.
                         The region then contains the entire area below this curve, and above the <m>x</m>-axis.
                       </p>
                     </description>
                     <shortdescription>Graph of the region bounded by the curve and the x axis.</shortdescription>
-                    
+
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -2035,8 +2035,8 @@
                   <image xml:id="img_07_02_ex_06">
                     <description>
                       <p>
-                        Graph of the region between <m>y=5x</m> and the <m>x</m>-axis, for <m>1\leq x\leq 2</m>. 
-                        The line <m>y=5x</m> begins at the point <m>(1,5)</m> from which it linearly increases until reaching the rightmost bound which is at the point <m>(2,10)</m>. 
+                        Graph of the region between <m>y=5x</m> and the <m>x</m>-axis, for <m>1\leq x\leq 2</m>.
+                        The line <m>y=5x</m> begins at the point <m>(1,5)</m> from which it linearly increases until reaching the rightmost bound which is at the point <m>(2,10)</m>.
                         The region then contains the entire area below the line <m>y=5x</m> and above the <m>x</m>-axis for <m>1\leq x\leq 2</m>.
                       </p>
                     </description>
@@ -2084,9 +2084,9 @@
                   <image xml:id="img_07_02_ex_07">
                     <description>
                       <p>
-                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m>-axis, for <m>0\leq x\leq \pi/2</m>. 
-                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>. 
-                        The region then contains the entire area below the curve <m>y=\cos(x)</m> and above the <m>x</m>-axis for <m>0\leq x\leq \pi/2</m>. 
+                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m>-axis, for <m>0\leq x\leq \pi/2</m>.
+                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>.
+                        The region then contains the entire area below the curve <m>y=\cos(x)</m> and above the <m>x</m>-axis for <m>0\leq x\leq \pi/2</m>.
                       </p>
                     </description>
                     <shortdescription>Graph of the region bounded by the the cosine function and the two coordinate axes.</shortdescription>
@@ -2132,13 +2132,13 @@
                   <image xml:id="img_07_02_ex_04">
                     <description>
                       <p>
-                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>. 
-                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin. 
-                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line. 
-                        The region then contains the area below the curve <m>y=\sqrt{x}</m> and above the line <m>y=x</m>. 
+                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin.
+                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line.
+                        The region then contains the area below the curve <m>y=\sqrt{x}</m> and above the line <m>y=x</m>.
                       </p>
                     </description>
-                    <shortdescription>Graph of the region bounded by the two curves.</shortdescription>   
+                    <shortdescription>Graph of the region bounded by the two curves.</shortdescription>
                     <latex-image>
 
                     \begin{tikzpicture}
@@ -2196,9 +2196,9 @@
                   <image xml:id="img_07_02_ex_09">
                     <description>
                       <p>
-                        Graph of the region bounded by the curve <m>y=3-x^2</m>, the <m>x</m>-axis, and the <m>y</m>-axis. 
+                        Graph of the region bounded by the curve <m>y=3-x^2</m>, the <m>x</m>-axis, and the <m>y</m>-axis.
                         Note that this region can reference both the regions to the left or right of the <m>y</m>-axis, but we will consider the region to the right of the <m>y</m>-axis.
-                        The curve <m>y=3-x^2</m> begins at the point <m>(0,3)</m> from which it slopes down until reaching the <m>x</m>-axis. 
+                        The curve <m>y=3-x^2</m> begins at the point <m>(0,3)</m> from which it slopes down until reaching the <m>x</m>-axis.
                         The region then contains the area to the right of the <m>y</m>-axis, and to the left of the curve <m>y=3-x^2</m> for <m>y</m> values between <m>0</m> and <m>3</m>.
                       </p>
                     </description>
@@ -2246,8 +2246,8 @@
                   <image xml:id="img_07_02_ex_10">
                     <description>
                       <p>
-                        Graph of the region between <m>y=5x</m> and the <m>y</m> axis, for <m>5\leq y\leq 10</m>. 
-                        The line <m>y=5x</m> begins at the point <m>(1,5)</m>, from which it linearly increases until ending upper bound for <m>y</m> at the point <m>(2,10)</m>. 
+                        Graph of the region between <m>y=5x</m> and the <m>y</m> axis, for <m>5\leq y\leq 10</m>.
+                        The line <m>y=5x</m> begins at the point <m>(1,5)</m>, from which it linearly increases until ending upper bound for <m>y</m> at the point <m>(2,10)</m>.
                         The region then contains the entire area to the right of <m>x=0</m> and to the left of the line <m>y=5x</m> for <m>y</m> between <m>5</m> and <m>10</m>.
                       </p>
                     </description>
@@ -2300,9 +2300,9 @@
                   <image xml:id="img_07_02_ex_11">
                     <description>
                       <p>
-                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m> axis, for <m>0\leq x\leq \pi/2</m>. 
-                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>. 
-                        The region then contains the entire area to the right of <m>x=0</m> and to the left of of the curve <m>y=\cos(x)</m> for <m>y</m> values between <m>0</m> and <m>1</m>. 
+                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m> axis, for <m>0\leq x\leq \pi/2</m>.
+                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>.
+                        The region then contains the entire area to the right of <m>x=0</m> and to the left of of the curve <m>y=\cos(x)</m> for <m>y</m> values between <m>0</m> and <m>1</m>.
                       </p>
                     </description>
                     <shortdescription>Graph of the region bounded by the cosine curve and the coordinate axes.</shortdescription>
@@ -2348,9 +2348,9 @@
                   <image xml:id="img_07_02_ex_08">
                     <description>
                       <p>
-                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>. 
-                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin. 
-                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line. 
+                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin.
+                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line.
                         The region consists of the area to the right of the curve <m>y=\sqrt{x}</m> and the to the left line <m>y=x</m> for <m>y</m> values between <m>0</m> and <m>1</m>.
                       </p>
                     </description>
@@ -2952,7 +2952,7 @@
                       The square of side length 5 connects to the rectangle on the left side of the solid.
                       The triangle with a base length and height of 5 connects to the rectangle on the right side of the solid.
                       The square and triangle are then connected by two slanted trapezoidal regions on the front and back of the solid.
-                      On top of the solid is a triangle whose base of length 5 is connected to the square, having a height of 10. 
+                      On top of the solid is a triangle whose base of length 5 is connected to the square, having a height of 10.
                     </p>
                   </description>
                   <shortdescription>Image solid with a rectangular base, and a square and triangular sides which are connected by two trapezoids and a triangle.</shortdescription>

--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -156,10 +156,7 @@
         and a height of <quantity><mag>5</mag><unit base="inch"/></quantity>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="JeQve79KVDE" xml:id="vid-intapp-disk-example1" label="vid-intapp-disk-example1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         There are many ways to <q>orient</q>
@@ -436,6 +433,10 @@
         but the calculus-based method can be applied to much more than just cones.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="JeQve79KVDE" xml:id="vid-intapp-disk-example1" label="vid-intapp-disk-example1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -475,10 +476,7 @@
         from <m>x=1</m> to <m>x=2</m>, around the <m>x</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="_a79nyOUVTg" xml:id="vid-intapp-disk-example2" label="vid-intapp-disk-example2" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         A sketch can help us understand this problem.
@@ -678,6 +676,10 @@
         </md>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="_a79nyOUVTg" xml:id="vid-intapp-disk-example2" label="vid-intapp-disk-example2" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -696,10 +698,7 @@
         from <m>x=1</m> to <m>x=2</m>, about the <m>y</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="k9vdYxWD8xc" xml:id="vid-intapp-disk-example3" label="vid-intapp-disk-example3" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         Since the axis of rotation is vertical,
@@ -890,6 +889,10 @@
           <mrow>\amp = \pi\,\text{units}^3</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="k9vdYxWD8xc" xml:id="vid-intapp-disk-example3" label="vid-intapp-disk-example3" component="video"/>
     </solution>
   </example>
 
@@ -1283,10 +1286,7 @@
         <m>y=x^2-2x+2</m> and <m>y=2x-1</m> about the <m>x</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="EcQPsBZwpZ8" xml:id="vid-intapp-washer-example1" label="vid-intapp-washer-example1" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -1533,6 +1533,10 @@
 
       </figure>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="EcQPsBZwpZ8" xml:id="vid-intapp-washer-example1" label="vid-intapp-washer-example1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -1548,10 +1552,7 @@
         <m>(2,1)</m> and <m>(2,3)</m> about the <m>y</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="VO7B1TRcvhM" xml:id="vid-intapp-disk-example5" label="vid-intapp-disk-example5" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The triangular region is sketched in <xref ref="fig_wash2a_3D"/>;
@@ -1848,6 +1849,10 @@
           <mrow>\amp = \frac{10}3\pi \approx 10.47\,\text{units}^3</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="VO7B1TRcvhM" xml:id="vid-intapp-disk-example5" label="vid-intapp-disk-example5" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -78,10 +78,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="NXZz_TGvFZ0" xml:id="vid-vectors-dotprod-example" label="vid-vectors-dotprod-example" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -104,6 +101,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="NXZz_TGvFZ0" xml:id="vid-vectors-dotprod-example" label="vid-vectors-dotprod-example" component="video"/>
       </solution>
     </example>
 
@@ -480,10 +481,7 @@
           <!-- figures/fig_dotp2.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="7bkKYObUxFo" xml:id="vid-vectors-dotprod-angles" label="vid-vectors-dotprod-angles" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by computing the magnitude of each vector.
@@ -507,6 +505,10 @@
             <mrow>\amp \approx 2.1763 \approx 124.7^\circ</mrow>
           </md>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="7bkKYObUxFo" xml:id="vid-vectors-dotprod-angles" label="vid-vectors-dotprod-angles" component="video"/>
       </solution>
     </example>
 
@@ -722,10 +724,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="eXkGPeTjohM" xml:id="vid-vectors-dotprod-orthog" label="vid-vectors-dotprod-orthog" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -772,6 +771,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="eXkGPeTjohM" xml:id="vid-vectors-dotprod-orthog" label="vid-vectors-dotprod-orthog" component="video"/>
       </solution>
     </example>
 
@@ -948,10 +951,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="Pcd-bORHB7o" xml:id="vid-vectors-dotprod-proj-eg" label="vid-vectors-dotprod-proj-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1209,6 +1209,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="Pcd-bORHB7o" xml:id="vid-vectors-dotprod-proj-eg" label="vid-vectors-dotprod-proj-eg" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1358,10 +1362,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="9IxUaJ1M4Jk" xml:id="vid-vectors-dotprod-orthdecomp" label="vid-vectors-dotprod-orthdecomp" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1410,6 +1411,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="9IxUaJ1M4Jk" xml:id="vid-vectors-dotprod-orthdecomp" label="vid-vectors-dotprod-orthdecomp" component="video"/>
       </solution>
     </example>
 
@@ -1515,10 +1520,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="85RquaXgutc" xml:id="vid-vectors-dotprod-work" label="vid-vectors-dotprod-work" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           As the ramp rises 5ft over a horizontal distance of 20ft,
@@ -1561,6 +1563,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="85RquaXgutc" xml:id="vid-vectors-dotprod-work" label="vid-vectors-dotprod-work" component="video"/>
       </solution>
     </example>
   </introduction>

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -78,7 +78,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -192,11 +192,11 @@
         <!-- START figures/fig_dotpangle.tex -->
           <image xml:id="img_dotpanglea">
             <shortdescription>
-              The angle formed by two vectors. 
+              The angle formed by two vectors.
             </shortdescription>
             <description>
               <p>
-                Image shows the angle <m>\theta</m> formed by two vectors, <m>\vec u</m> 
+                Image shows the angle <m>\theta</m> formed by two vectors, <m>\vec u</m>
                 and <m>\vec v</m>.  The angle is formed from <m>\vec u</m> to <m>\vec v</m>.
               </p>
             </description>
@@ -226,9 +226,9 @@
             </shortdescription>
             <description>
               <p>
-                The three axes are shown and all are uncalibrated. Two vectors <m>\vec u</m> and 
-                <m>\vec v</m> are shown, along with the place that contains both vectors. The two 
-                vectors form an angle and it is labeled as <m>\theta</m>. The pane lies at an angle 
+                The three axes are shown and all are uncalibrated. Two vectors <m>\vec u</m> and
+                <m>\vec v</m> are shown, along with the place that contains both vectors. The two
+                vectors form an angle and it is labeled as <m>\theta</m>. The pane lies at an angle
                 in the positive values of all axes.
               </p>
             </description>
@@ -361,11 +361,11 @@
           </shortdescription>
           <description>
           <p>
-            Each image has the two vectors <m>\vec u</m> and <m>\vec v</m> along with <m>\theta</m> shown. 
-            The dot product along with three possible cases of &lt;, &gt; and equal to <m>0</m> are shown. 
+            Each image has the two vectors <m>\vec u</m> and <m>\vec v</m> along with <m>\theta</m> shown.
+            The dot product along with three possible cases of &lt;, &gt; and equal to <m>0</m> are shown.
             In the first image, the dot product has a positive value, the angle between the two vectors is acute.
             In the second image, the dot product is equal to <m>0</m>, the angle is <m>90</m> degrees.
-            In the third image, the dot product has a negative value and the angle is obtuse. 
+            In the third image, the dot product has a negative value and the angle is obtuse.
           </p>
         </description>
         <latex-image>
@@ -433,18 +433,18 @@
             </shortdescription>
             <description>
               <p>
-                The <m>x</m> axis is drawn from <m>-4</m> to <m>4</m> and the <m>y</m> 
-                axis is drawn from <m>0</m> to <m>6</m>. The <m>\vec u</m>, <m>\vec v</m> 
-                and <m>\vec w</m> are shown. 
+                The <m>x</m> axis is drawn from <m>-4</m> to <m>4</m> and the <m>y</m>
+                axis is drawn from <m>0</m> to <m>6</m>. The <m>\vec u</m>, <m>\vec v</m>
+                and <m>\vec w</m> are shown.
               </p>
               <p>
-                The <m>\vec u</m> starts at the origin and ends at point <m>(3, 1)</m>. 
-                The <m>\vec v</m> also starts at the origin and ends at point <m>(-2, 6)</m> 
+                The <m>\vec u</m> starts at the origin and ends at point <m>(3, 1)</m>.
+                The <m>\vec v</m> also starts at the origin and ends at point <m>(-2, 6)</m>
                 and <m>\vec w</m> is also drawn from the origin and ends at point <m>(-4, 3)</m>.
               </p>
               <p>
-                The angle <m>\alpha</m> is drawn between <m>\vec u</m> and <m>\vec v</m>, 
-                angle <m>\beta</m> is drawn between <m>\vec v</m> and <m>\vec w</m> and angle 
+                The angle <m>\alpha</m> is drawn between <m>\vec u</m> and <m>\vec v</m>,
+                angle <m>\beta</m> is drawn between <m>\vec v</m> and <m>\vec w</m> and angle
                 <m>\theta</m> is drawn between <m>\vec u</m> and <m>\vec w</m>.
               </p>
             </description>
@@ -481,7 +481,7 @@
           <!-- figures/fig_dotp2.tex END -->
         </figure>
       </statement>
-      
+
       <solution>
         <p>
           We start by computing the magnitude of each vector.
@@ -541,12 +541,12 @@
             </shortdescription>
             <description>
               <p>
-                The <m>x</m> axis is drawn from <m>-5</m> to <m>5</m>, 
-                the <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and 
-                the <m>z</m> axis is drawn from <m>-2</m> to <m>4</m>. 
-                Three vectors <m>\vec u</m>, <m>\vec v</m> and <m>\vec w</m> are 
-                shown all starting at the origin, along with separate hollow dashed 
-                cuboids that represent their three axes values and its three sides. 
+                The <m>x</m> axis is drawn from <m>-5</m> to <m>5</m>,
+                the <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and
+                the <m>z</m> axis is drawn from <m>-2</m> to <m>4</m>.
+                Three vectors <m>\vec u</m>, <m>\vec v</m> and <m>\vec w</m> are
+                shown all starting at the origin, along with separate hollow dashed
+                cuboids that represent their three axes values and its three sides.
                 The <m>\vec u</m> has value, <m>\vec v</m> has value and <m>\vec w</m> has value.
               </p>
             </description>
@@ -724,7 +724,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -822,9 +822,9 @@
             </shortdescription>
             <description>
               <p>
-                Two vectors <m>\vec u</m> and <m>\vec v</m> are shown that start from the 
-                same position, the angle between them is marked <m>\theta</m>, the vector 
-                <m>\vec u</m> is shorter. From the end of <m>\vec u</m> a dashed perpendicular 
+                Two vectors <m>\vec u</m> and <m>\vec v</m> are shown that start from the
+                same position, the angle between them is marked <m>\theta</m>, the vector
+                <m>\vec u</m> is shorter. From the end of <m>\vec u</m> a dashed perpendicular
                 is drawn on <m>\vec v</m>.
               </p>
             </description>
@@ -855,15 +855,15 @@
             </shortdescription>
             <description>
               <p>
-                Two vectors <m>\vec u</m> and <m>\vec v</m> are shown that 
-                start from the same position, the angle between them is marked 
-                <m>\theta</m>, the vector <m>\vec u</m> is shorter. From the end 
-                of <m>\vec u</m> a dashed perpendicular is drawn on <m>\vec v</m>. 
-                The vector <m>\vec w</m> and <m>\vec z</m> are also added. From the 
-                initial point the vector <m>\vec w</m> is drawn in the same direction 
-                as <m>\vec v</m> but it ends at the start of the perpendicular. The 
-                perpendicular starts at the tip of <m>\vec w</m> and ends at the tip 
-                of <m>\vec u</m> and is labeled <m>\vec z</m>. 
+                Two vectors <m>\vec u</m> and <m>\vec v</m> are shown that
+                start from the same position, the angle between them is marked
+                <m>\theta</m>, the vector <m>\vec u</m> is shorter. From the end
+                of <m>\vec u</m> a dashed perpendicular is drawn on <m>\vec v</m>.
+                The vector <m>\vec w</m> and <m>\vec z</m> are also added. From the
+                initial point the vector <m>\vec w</m> is drawn in the same direction
+                as <m>\vec v</m> but it ends at the start of the perpendicular. The
+                perpendicular starts at the tip of <m>\vec w</m> and ends at the tip
+                of <m>\vec u</m> and is labeled <m>\vec z</m>.
               </p>
             </description>
             <latex-image>
@@ -951,7 +951,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -979,12 +979,12 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>x</m> axis is drawn from <m>-2</m> to <m>3</m> and the 
-                      <m>y</m> axis is drawn from <m>-2</m> to <m>2</m>. Two vectors 
-                      <m>\vec u</m> and <m>\vec v</m> are shown, both start at the origin. 
-                      The vector <m>u</m> ends in point <m>(-2, 1)</m> and lies in the 
-                      second quadrant and <m>\vec v</m> ends in point <m>( 3, 1)</m> and 
-                      lies in the first quadrant. The projection of <m>\vec u</m> on 
+                      The <m>x</m> axis is drawn from <m>-2</m> to <m>3</m> and the
+                      <m>y</m> axis is drawn from <m>-2</m> to <m>2</m>. Two vectors
+                      <m>\vec u</m> and <m>\vec v</m> are shown, both start at the origin.
+                      The vector <m>u</m> ends in point <m>(-2, 1)</m> and lies in the
+                      second quadrant and <m>\vec v</m> ends in point <m>( 3, 1)</m> and
+                      lies in the first quadrant. The projection of <m>\vec u</m> on
                       <m>\vec v</m>is shown and it lies in the third quadrant.
                     </p>
                   </description>
@@ -1042,11 +1042,11 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>0</m> to 
-                          <m>2</m>.  Two vectors <m>\vec w</m> and <m>\vec x</m> are drawn, 
-                          both start at the origin, <m>\vec w</m> ends at <m>(2, 1, 3)</m> 
-                          and <m>\vec x</m> ends at <m>(1, 1, 1)</m>. The projection of 
-                          <m>\vec w</m> on <m>\vec x</m> is shown, it also starts at the 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>0</m> to
+                          <m>2</m>.  Two vectors <m>\vec w</m> and <m>\vec x</m> are drawn,
+                          both start at the origin, <m>\vec w</m> ends at <m>(2, 1, 3)</m>
+                          and <m>\vec x</m> ends at <m>(1, 1, 1)</m>. The projection of
+                          <m>\vec w</m> on <m>\vec x</m> is shown, it also starts at the
                           origin and ends at <m>(2, 2, 2)</m>.
                         </p>
                       </description>
@@ -1128,11 +1128,11 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>0</m> to 
-                          <m>2</m>.  Two vectors <m>\vec w</m> and <m>\vec x</m> are drawn, 
-                          both start at the origin, <m>\vec w</m> ends at <m>(2, 1, 3)</m> 
-                          and <m>\vec x</m> ends at <m>(1, 1, 1)</m>. The projection of 
-                          <m>\vec w</m> on <m>\vec x</m> is shown, it also starts at the 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>0</m> to
+                          <m>2</m>.  Two vectors <m>\vec w</m> and <m>\vec x</m> are drawn,
+                          both start at the origin, <m>\vec w</m> ends at <m>(2, 1, 3)</m>
+                          and <m>\vec x</m> ends at <m>(1, 1, 1)</m>. The projection of
+                          <m>\vec w</m> on <m>\vec x</m> is shown, it also starts at the
                           origin and ends at <m>(2, 2, 2)</m>.
                         </p>
                       </description>
@@ -1257,14 +1257,14 @@
         </shortdescription>
         <description>
           <p>
-            Two vectors <m>\vec u</m> and <m>\vec v</m> are shown that start from the 
-            same position, the angle between them is marked <m>\theta</m>, the vector 
-            <m>u</m> is shorter. From the end of <m>\vec u</m> a dashed perpendicular 
-            is drawn on <m>\vec v</m>. The projection of <m>\vec u</m> and <m>\vec z</m> 
-            are also added. The projection of <m>\vec u</m> is in the same direction as 
-            <m>\vec v</m> but it ends at the start of the perpendicular. The perpendicular 
-            starts at the tip of the projection of <m>\vec u</m> and ends at the tip of 
-            <m>\vec u</m> and is labeled <m>\vec z</m>. 
+            Two vectors <m>\vec u</m> and <m>\vec v</m> are shown that start from the
+            same position, the angle between them is marked <m>\theta</m>, the vector
+            <m>u</m> is shorter. From the end of <m>\vec u</m> a dashed perpendicular
+            is drawn on <m>\vec v</m>. The projection of <m>\vec u</m> and <m>\vec z</m>
+            are also added. The projection of <m>\vec u</m> is in the same direction as
+            <m>\vec v</m> but it ends at the start of the perpendicular. The perpendicular
+            starts at the tip of the projection of <m>\vec u</m> and ends at the tip of
+            <m>\vec u</m> and is labeled <m>\vec z</m>.
           </p>
         </description>
         <latex-image>
@@ -1362,7 +1362,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -1445,9 +1445,9 @@
                 </shortdescription>
                 <description>
                   <p>
-                    Image of a box being placed on an inclined plane. The downward 
-                    force for gravity is marked as <m>\vec g</m>. The surface of the 
-                    ramp is labeled as <m>\vec r</m> base of the ramp is labeled <m>20</m> 
+                    Image of a box being placed on an inclined plane. The downward
+                    force for gravity is marked as <m>\vec g</m>. The surface of the
+                    ramp is labeled as <m>\vec r</m> base of the ramp is labeled <m>20</m>
                     and the height is marked as <m>5</m>.
                   </p>
                 </description>
@@ -1477,9 +1477,9 @@
                 </shortdescription>
                 <description>
                   <p>
-                    Image of a box being placed on an inclined plane. The downward force for 
-                    gravity is marked as <m>\vec g</m>. The surface of the ramp is labeled as 
-                    <m>\vec r</m> base of the ramp is labeled <m>20</m> and the height is marked 
+                    Image of a box being placed on an inclined plane. The downward force for
+                    gravity is marked as <m>\vec g</m>. The surface of the ramp is labeled as
+                    <m>\vec r</m> base of the ramp is labeled <m>20</m> and the height is marked
                     as <m>5</m>. The projection of <m>\vec g</m> on <m>\vec r</m> is shown.
                   </p>
                 </description>
@@ -1520,7 +1520,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           As the ramp rises 5ft over a horizontal distance of 20ft,
@@ -1585,13 +1585,13 @@
       <!-- START figures/fig_dotpwork.tex -->
       <image xml:id="img_dotpwork" width="47%">
         <shortdescription>
-          Diagram showing the two vectors for force and displacement used to find work. 
+          Diagram showing the two vectors for force and displacement used to find work.
         </shortdescription>
         <description>
           <p>
-            A box is shown that is being pushed to the right by a force. The displacement is 
-            shown as a horizontal vector and is labeled <m>\vec d</m>. Force is drawn from the 
-            middle of the box at an angle and is labeled as <m>\vec F</m>. The projection of 
+            A box is shown that is being pushed to the right by a force. The displacement is
+            shown as a horizontal vector and is labeled <m>\vec d</m>. Force is drawn from the
+            middle of the box at an angle and is labeled as <m>\vec F</m>. The projection of
             the <m>\vec F</m> is also shown, it is parallel to the displacement vector.
           </p>
         </description>
@@ -1663,9 +1663,9 @@
             </shortdescription>
             <description>
               <p>
-                Image of a box being placed on an inclined plane or ramp. The base of the 
-                ramp is labeled <m>15</m> and the height is marked as <m>3</m>. Force is 
-                drawn from the middle of the box at an angle of <m>30</m> from the horizontal 
+                Image of a box being placed on an inclined plane or ramp. The base of the
+                ramp is labeled <m>15</m> and the height is marked as <m>3</m>. Force is
+                drawn from the middle of the box at an angle of <m>30</m> from the horizontal
                 and is labeled as <m>\vec F</m>.
               </p>
             </description>

--- a/ptx/sec_fluid_force.ptx
+++ b/ptx/sec_fluid_force.ptx
@@ -68,7 +68,7 @@
               <image xml:id="img_fluid1a" width="33%">
                 <description>
                   <p>
-                    Illustration of a cylindrical storage tank with a radius of <quantity><mag>2</mag><unit base="foot"/></quantity>. 
+                    Illustration of a cylindrical storage tank with a radius of <quantity><mag>2</mag><unit base="foot"/></quantity>.
                     The cylindrical storage tank is then filled with water up to a marked level of <quantity><mag>10</mag><unit base="foot"/></quantity> from the base of the tank.
                     The tank extends slightly above the <quantity><mag>10</mag><unit base="foot"/></quantity> water level, but this region of the tank contains no water.
                   </p>
@@ -125,7 +125,7 @@
               <image xml:id="img_fluid1b" width="47%">
                 <description>
                   <p>
-                    Illustration of a rectangular storage tank with a square base. 
+                    Illustration of a rectangular storage tank with a square base.
                     The square base has a side length of <quantity><mag>5</mag><unit base="foot"/></quantity>.
                     The height of the storage tank extends slightly above the <quantity><mag>10</mag><unit base="foot"/></quantity> mark, which is the amount of water contained in the tank.
                     On the square base of the tank is a centered circular hatch, having a radius of <quantity><mag>2</mag><unit base="foot"/></quantity>.
@@ -273,7 +273,7 @@
     <image xml:id="img_fluid_intro1" width="47%">
       <description>
         <p>
-          Illustration of a thin, vertically oriented plate fully submerged in a fluid with weight-density <m>w</m>. 
+          Illustration of a thin, vertically oriented plate fully submerged in a fluid with weight-density <m>w</m>.
           The plate is in the shape of an acute trapezoid.
           On the plate, the image contains an arbitrarily placed small horizontal strip which stretches horizontally between the two edges of the submerged plate.
           The small strip has a horizontal length measurement of <m>\ell(c_i)</m>, and a vertical height measurement of <m>\Delta y_i</m>.
@@ -418,7 +418,7 @@
         <image xml:id="img_fluid2a" width="30%">
           <description>
             <p>
-              Illustration of a thin plate in the shape of an isosceles triangle. 
+              Illustration of a thin plate in the shape of an isosceles triangle.
               The triangle has one side having a length of <quantity><mag>4</mag><unit base="foot"/></quantity>.
               The height of the triangle is also <quantity><mag>4</mag><unit base="foot"/></quantity>.
               The length of the two remaining sides is equal but is not given in the image.
@@ -476,14 +476,14 @@
               <image xml:id="img_fluid2b" width="47%">
                 <description>
                   <p>
-                    Graph of the thin plate in the shape of an isosceles triangle with the convention that the water level is at <m>y=0</m>. 
+                    Graph of the thin plate in the shape of an isosceles triangle with the convention that the water level is at <m>y=0</m>.
                     The triangle is oriented in the same way as described previously, with the top of the plate being the side having a length of <quantity><mag>4</mag><unit base="foot"/></quantity> running parallel to the water level.
-                    The graph contains the two coordinate axes. 
-                    The bottom of the plate, which is the vertex of the triangle lies <quantity><mag>10</mag><unit base="foot"/></quantity> below the water level, which is marked as the point <m>(0,-10)</m>. 
+                    The graph contains the two coordinate axes.
+                    The bottom of the plate, which is the vertex of the triangle lies <quantity><mag>10</mag><unit base="foot"/></quantity> below the water level, which is marked as the point <m>(0,-10)</m>.
                     The remaining two vertices of the triangle are the points <m>(-2,-6)</m> and <m>(2,-6)</m>, with the line joining these two vertices making up the top of the plate.
                     The graph also contains an arbitrarily chosen thin slice of the plate, which spans the horizontal length of the triangular plate.
                     The red coloured thin slice occurs at the level <m>y</m>, which is an arbitrarily chosen value between <m>y = -6</m> which marks the top of the plate and <m>y = -10</m> which marks the bottom of the plate.
-                    The distance between the water level and the thin horizontal slice is also given as <m>d(y)=-y</m>. 
+                    The distance between the water level and the thin horizontal slice is also given as <m>d(y)=-y</m>.
                   </p>
                 </description>
                 <shortdescription>Graph of a thin plate in the shape of an isosceles triangle.</shortdescription>
@@ -558,14 +558,14 @@
               <image xml:id="img_fluid2c" width="47%">
                 <description>
                   <p>
-                    Graph of the thin plate in the shape of an isosceles triangle with the convention that the water level is at <m>y=10</m>. 
+                    Graph of the thin plate in the shape of an isosceles triangle with the convention that the water level is at <m>y=10</m>.
                     The triangle is oriented in the same way as described previously, with the top of the plate being the side having a length of <quantity><mag>4</mag><unit base="foot"/></quantity> running parallel to the water level.
-                    The graph contains two the coordinate axes. 
-                    The bottom of the plate, which is the vertex of the triangle lies <quantity><mag>10</mag><unit base="foot"/></quantity> below the water level, which is marked as the point <m>(0,0)</m>. 
+                    The graph contains two the coordinate axes.
+                    The bottom of the plate, which is the vertex of the triangle lies <quantity><mag>10</mag><unit base="foot"/></quantity> below the water level, which is marked as the point <m>(0,0)</m>.
                     The remaining two vertices of the triangle are the points <m>(-2,4)</m> and <m>(2,4)</m>, with the line joining these two vertices making up the top of the plate.
                     The graph also contains an arbitrarily chosen thin slice of the plate, which spans the horizontal length of the triangular plate.
                     The red coloured thin slice occurs at the level <m>y</m>, which is an arbitrarily chosen value between <m>y = 0</m> which marks the bottom of the plate and <m>y = 4</m> which marks the top of the plate.
-                    The distance between the water level and the thin horizontal slice is also given as <m>d(y)=10-y</m>. 
+                    The distance between the water level and the thin horizontal slice is also given as <m>d(y)=10-y</m>.
                   </p>
                 </description>
                 <shortdescription>Graph of a thin plate in the shape of an isosceles triangle.</shortdescription>
@@ -677,14 +677,14 @@
         <image xml:id="img_fluid3" width="47%">
           <description>
             <p>
-              Graph of a perfectly rectangular car door submerged in water with the convention that the water level is at <m>y=0</m>. 
+              Graph of a perfectly rectangular car door submerged in water with the convention that the water level is at <m>y=0</m>.
               The coordinate axes are labeled in terms of feet.
               The top of the rectangular door is <m>40</m> inches or <m>3.\overline{3}</m> feet long and perfectly coincides with the water level at <m>y=0</m>.
               The leftmost upper corner of the rectangular door is labeled to be the point <m>(0,0)</m>, while the upper right corner is labeled by the point <m>(3.\overline{3},0)</m>.
               The leftmost bottom corner of the rectangular door is labeled to be the point <m>(0,-2.25)</m>, while the upper right corner is labeled by the point <m>(3.\overline{3},-2.25)</m>.
               The graph also contains an arbitrarily chosen thin slice of the door, which spans the horizontal length of the rectangular door.
               The red coloured thin slice occurs at the level <m>y</m>, which is an arbitrarily chosen value between <m>y = -2.25</m> which marks the distance from the water level and the bottom of the door and <m>y = 0</m> which marks the top of the door.
-              The distance between the water level and the thin horizontal slice will be given by <m>d(y)=-y</m>. 
+              The distance between the water level and the thin horizontal slice will be given by <m>d(y)=-y</m>.
             </p>
           </description>
           <shortdescription>Graph of a perfectly rectangular car door submerged in water.</shortdescription>
@@ -737,13 +737,13 @@
         <image xml:id="img_fluid4" width="40%">
           <description>
             <p>
-              Graph of an underwater circular porthole with the convention that the water level is at <m>y=50</m>. 
+              Graph of an underwater circular porthole with the convention that the water level is at <m>y=50</m>.
               The circular porthole having a diameter of <quantity><mag>3</mag><unit base="foot"/></quantity> is centered at the origin.
               The top of the circular porthole is at the point <m>(0,1.5)</m>, while the bottom is at the point <m>(0,-1.5)</m>.
               The leftmost point of the circle occurs at the point <m>(-1.5,0)</m>, whilet the rightmost point of the circle occurs at the point <m>(-1.5,0)</m>.
               The graph also contains an arbitrarily chosen thin slice of the circular porthole, which spans the horizontal length of the circle.
               The red-coloured thin slice occurs at the level <m>y</m>, which is an arbitrarily chosen value between <m>y = -1.5</m> which marks the bottom of the porthole and <m>y = 1.5</m> which marks the top of the porthole.
-              The distance between the water level and the thin horizontal slice is given by <m>d(y)=50-y</m>. 
+              The distance between the water level and the thin horizontal slice is given by <m>d(y)=50-y</m>.
             </p>
           </description>
           <shortdescription>Graph of a circular underwater porthole.</shortdescription>
@@ -909,7 +909,7 @@
               <image xml:id="img_fluid4X" width="60%">
                 <description>
                   <p>
-                    Image of a submerged square plate having a side length of <quantity><mag>2</mag><unit base="foot"/></quantity>. 
+                    Image of a submerged square plate having a side length of <quantity><mag>2</mag><unit base="foot"/></quantity>.
                     The top side of the square is parallel to the water level and lies <quantity><mag>1</mag><unit base="foot"/></quantity> below the water level.
                   </p>
                 </description>
@@ -947,7 +947,7 @@
                 <description>
                   <p>
                     Image of a submerged rectangular plate.
-                    The rectangle has a horizontal length of <quantity><mag>1</mag><unit base="foot"/></quantity> and a veritcal length of <quantity><mag>2</mag><unit base="foot"/></quantity>. 
+                    The rectangle has a horizontal length of <quantity><mag>1</mag><unit base="foot"/></quantity> and a veritcal length of <quantity><mag>2</mag><unit base="foot"/></quantity>.
                     The shorter side of the rectangle is the top of the plate and is parallel to the water level and lies <quantity><mag>1</mag><unit base="foot"/></quantity> below the water level.
                   </p>
                 </description>
@@ -986,7 +986,7 @@
                 <description>
                   <p>
                     Image of a submerged plate in the shape of an isosceles triangle.
-                    The bottom of the triangle has a horizontal length of <quantity><mag>4</mag><unit base="foot"/></quantity>. 
+                    The bottom of the triangle has a horizontal length of <quantity><mag>4</mag><unit base="foot"/></quantity>.
                     The distance from the bottom of the triangle to the vertex which is the nearest point on the plate to the water level is <quantity><mag>6</mag><unit base="foot"/></quantity>, which is the height of the triangle.
                     This vertex is the top of the plate and lies <quantity><mag>5</mag><unit base="foot"/></quantity> below the water level.
                     The remaining two sides of the triangle have equal but unmarked lengths and connect the vertex to the base of the triangular plate.
@@ -1031,7 +1031,7 @@
                 <description>
                   <p>
                     Image of a submerged plate in the shape of an isosceles triangle.
-                    The top of the triangle has a horizontal length of <quantity><mag>4</mag><unit base="foot"/></quantity>. 
+                    The top of the triangle has a horizontal length of <quantity><mag>4</mag><unit base="foot"/></quantity>.
                     The distance from the top of the triangle to the vertex which is the lowest point below the water level on the plate is <quantity><mag>6</mag><unit base="foot"/></quantity>, which is the height of the triangle.
                     This top side of the plate having a horizontal length of <quantity><mag>4</mag><unit base="foot"/></quantity> lies <quantity><mag>5</mag><unit base="foot"/></quantity> below the water level.
                     The remaining two sides of the triangle have equal but unmarked lengths and connect the vertex to the top of the triangular plate.
@@ -1286,7 +1286,7 @@
                   <p>
                     Image of a submerged plate in the shape of an equilateral right triangle.
                     The right angle occurs at the bottom left part of the triangle.
-                    The two edges connected to the right angle lie parallel and perpendicular to the water level, and both have a side length of <quantity><mag>2</mag><unit base="foot"/></quantity>. 
+                    The two edges connected to the right angle lie parallel and perpendicular to the water level, and both have a side length of <quantity><mag>2</mag><unit base="foot"/></quantity>.
                     The edge that is perpendicular to the water level extends up from the right angle for <quantity><mag>2</mag><unit base="foot"/></quantity>, until reaching the uppermost vertex of the triangle.
                     This uppermost vertex lies <quantity><mag>1</mag><unit base="foot"/></quantity> below the water level.
                     The edge that is connected to the right angle and parallel to the water level extends to the right of the right angle for a distance of <quantity><mag>2</mag><unit base="foot"/></quantity>, until reaching the rightmost vertex of the triangle.

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -565,10 +565,7 @@
           Find the inflection points of <m>f</m> and the intervals on which it is concave up/down.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="n8TRVD_8sY0" xml:id="vid_graphs_concav_ex_1" label="vid_graphs_concav_ex_1" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -670,6 +667,10 @@
           <!-- figures/fig_conc1.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="n8TRVD_8sY0" xml:id="vid_graphs_concav_ex_1" label="vid_graphs_concav_ex_1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_conc2">
@@ -680,10 +681,7 @@
           Find the inflection points of <m>f</m> and the intervals on which it is concave up/down.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="eC6QLbsuRVs" xml:id="vid_graphs_concav_ex_2" label="vid_graphs_concav_ex_2" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -878,6 +876,10 @@
           <!-- figures/fig_conc2.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="eC6QLbsuRVs" xml:id="vid_graphs_concav_ex_2" label="vid_graphs_concav_ex_2" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -942,10 +944,7 @@
           <!-- figures/fig_conc3.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="yjcSXaGkL5Y" xml:id="vid_graphs_concav_ex_3" label="vid_graphs_concav_ex_3" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1011,6 +1010,10 @@
           </image>
           <!-- figures/fig_conc3.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="yjcSXaGkL5Y" xml:id="vid_graphs_concav_ex_3" label="vid_graphs_concav_ex_3" component="video"/>
       </solution>
     </example>
 
@@ -1171,10 +1174,7 @@
           Find the critical points of <m>f</m> and use the <xref ref="thm_second_der" text="title"/> to label them as relative maxima or minima.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="_DhmPXRZfi8" xml:id="vid_graphs_concav_ex_4" label="vid_graphs_concav_ex_4" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1223,6 +1223,10 @@
           </image>
           <!-- figures/fig_conc4.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="_DhmPXRZfi8" xml:id="vid_graphs_concav_ex_4" label="vid_graphs_concav_ex_4" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -246,10 +246,10 @@
         </shortdescription>
         <description>
           <p>
-            The image displays a graph of a concave up function <m>f</m> with tangent lines drawn at various points along the curve. 
-            The function is shown as a continuous curve that opens upwards, like a parabola. 
-            Tangent lines at points with x-values of <m>(-2, -1, 1, 2)</m> are depicted, illustrating how the slope of these lines increases as we move from left to right. 
-            On the left side of the graph, the tangent lines slope downwards, indicating negative slopes, while on the right side, the tangent lines slope upwards, indicating positive slopes. 
+            The image displays a graph of a concave up function <m>f</m> with tangent lines drawn at various points along the curve.
+            The function is shown as a continuous curve that opens upwards, like a parabola.
+            Tangent lines at points with x-values of <m>(-2, -1, 1, 2)</m> are depicted, illustrating how the slope of these lines increases as we move from left to right.
+            On the left side of the graph, the tangent lines slope downwards, indicating negative slopes, while on the right side, the tangent lines slope upwards, indicating positive slopes.
           </p>
         </description>
         <latex-image>
@@ -313,10 +313,10 @@
         </shortdescription>
         <description>
           <p>
-            The image shows a graph of a concave down function <m>f</m> with tangent lines drawn at various points along the curve. 
-            The function forms a continuous curve that opens downwards. 
+            The image shows a graph of a concave down function <m>f</m> with tangent lines drawn at various points along the curve.
+            The function forms a continuous curve that opens downwards.
             Tangent lines at points with x-values of <m>(-2, 1, 1, 2)</m> are shown, demonstrating how the slope of these lines decreases as we move from left to right across the graph.
-            On the left side of the graph, the tangent lines slope upwards, indicating positive slopes, while on the right side, the tangent lines slope downwards, indicating negative slopes. 
+            On the left side of the graph, the tangent lines slope upwards, indicating positive slopes, while on the right side, the tangent lines slope downwards, indicating negative slopes.
           </p>
         </description>
         <latex-image>
@@ -565,7 +565,7 @@
           Find the inflection points of <m>f</m> and the intervals on which it is concave up/down.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -681,7 +681,7 @@
           Find the inflection points of <m>f</m> and the intervals on which it is concave up/down.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -764,7 +764,7 @@
 
         <figure xml:id="fig_concline2">
           <caption>Number line for <m>f</m> in <xref ref="ex_conc2"/></caption>
-          
+
           <!-- START figures/fig_concline2.tex -->
           <image xml:id="img_concline2" width="50%">
             <shortdescription>
@@ -944,7 +944,7 @@
           <!-- figures/fig_conc3.tex END -->
         </figure>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -987,7 +987,7 @@
             <description>
               <p>
                 The graph depicts two curves: the blue curve represents the sales function <m>S(t)</m>, and the red curve represents its rate of change, <m>S'(t)</m>, over a time period <m>t</m>.
-                The sales function curve shows a parabolic shape, indicating a period of declining sales followed by an upturn. 
+                The sales function curve shows a parabolic shape, indicating a period of declining sales followed by an upturn.
                 The rate of change curve <m>S'(t)</m> crosses the <m>t</m>-axis at its lowest point, signifying the moment when the sales rate is changing from decreasing to increasing.
                 The point where <m>S'(t)</m> is most negative corresponds to the fastest rate of decrease in sales, which is the primary point of interest in this example.
               </p>
@@ -1082,9 +1082,9 @@
         <description>
           <p>
             The figure showcases a curve that illustrates the concepts of relative maxima and minima in relation to concavity.
-            The curve rises upwards, dips downward and then rises upward again, forming a valley-like shape. 
+            The curve rises upwards, dips downward and then rises upward again, forming a valley-like shape.
             At the peak of the first curve, where the shape is bending downwards indicating concave down, a point is marked at <m>(-1, 10)</m> signifying a relative maximum.
-            Similarly, at the lowest point in the valley at <m>(1,-10)</m>, where the curve starts to bend upwards denoted as concave up, a point signifies a relative minimum. 
+            Similarly, at the lowest point in the valley at <m>(1,-10)</m>, where the curve starts to bend upwards denoted as concave up, a point signifies a relative minimum.
           </p>
         </description>
         <latex-image>
@@ -1174,7 +1174,7 @@
           Find the critical points of <m>f</m> and use the <xref ref="thm_second_der" text="title"/> to label them as relative maxima or minima.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -654,7 +654,7 @@
           <!-- figures/fig_extval4.tex END -->
       </figure>
     </statement>
-    
+
     <solution>
       <p>
         We follow the steps outlined in <xref ref="idea_extrema"/>.
@@ -734,7 +734,7 @@
 
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -857,7 +857,7 @@
         Find the extrema of <m>f(x) = \cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We again use <xref ref="idea_extrema"/>.
@@ -1220,7 +1220,7 @@
                   </p>
 
                   <p>
-                    From <m>D</m> the graph goes down until it reaches <m>E</m>, which is a solid dot. 
+                    From <m>D</m> the graph goes down until it reaches <m>E</m>, which is a solid dot.
                     To the right of <m>E</m>, the graph continues to go down,
                     until it reaches <m>F</m>.
                     The point <m>F</m> is also a solid dot. To the right of <m>F</m> the graph goes back up, until ending at the point <m>G</m>.
@@ -1232,18 +1232,18 @@
                         ymin=-2.5,ymax=3.5,%
                         xmin=-.5,xmax=6.5,%
                   ]
-                  
+
                   \draw [firstcolor] (axis cs:.1,-2) parabola [bend at end] (axis cs:1,3) parabola (axis cs:2,1) parabola [bend at end] (axis cs:3,2) parabola (axis cs:4,1) parabola [bend at end] (axis cs:5,-1) parabola (axis cs:6,2.5);
-                  
-                  \draw [firstcolor,fill=white] (axis cs: .1,-2) node [black,right] {\(A\)} circle (1.5pt) 
+
+                  \draw [firstcolor,fill=white] (axis cs: .1,-2) node [black,right] {\(A\)} circle (1.5pt)
                                           (axis cs:3,2) node [above,black] {\(D\)} circle (1.5pt);
-                  
-                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,3) node [above,black] {\(B\)} circle (1.5pt) 
+
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,3) node [above,black] {\(B\)} circle (1.5pt)
                                 (axis cs:2,1) node [below,black] {\(C\)} circle (1.5pt)
                                 (axis cs:4,1) node [right,black] {\(E\)} circle (1.5pt)
                                 (axis cs:5,-1) node [below,black] {\(F\)} circle (1.5pt)
                                 (axis cs:6,2.5) node [left,black] {\(G\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1309,18 +1309,18 @@
                         ymin=-2.5,ymax=2.5,%
                         xmin=-.5,xmax=5.5,%
                   ]
-                  
-                  \draw [firstcolor] (axis cs:1,-2)	parabola 	(axis cs:2,1) 
-                                                                  -- 	(axis cs:3,2) 
-                                                            parabola [bend at end] (axis cs:4,1) 
+
+                  \draw [firstcolor] (axis cs:1,-2)	parabola 	(axis cs:2,1)
+                                                                  -- 	(axis cs:3,2)
+                                                            parabola [bend at end] (axis cs:4,1)
                                                             -- (axis cs:5,-1);
-                  
-                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,-2) node [above,black] {\(A\)} circle (1.5pt) 
+
+                  \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,-2) node [above,black] {\(A\)} circle (1.5pt)
                                 (axis cs:2,1) node [left,black] {\(B\)} circle (1.5pt)
                                 (axis cs:3,2) node [above,black] {\(C\)} circle (1.5pt)
                                 (axis cs:4,1) node [right,black] {\(D\)} circle (1.5pt)
                                 (axis cs:5,-1) node [below,black] {\(E\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1387,11 +1387,11 @@
                         ymin=-.5,ymax=2.5,%
                         xmin=-5.5,xmax=5.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,samples=100] {2/((x^2+1))};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,2) node [above right,black] {\((0,2)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1436,12 +1436,12 @@
                         ymin=-.9,ymax=6.5,%
                         xmin=-3.5,xmax=3.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,closed,domain=-2.44948:2.449489743,samples=100] {x^2*sqrt(6-x^2)};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 2,5.66) node [left,black] {\((2,4\sqrt{2})\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1488,12 +1488,12 @@
                     ymin=-1.5,ymax=1.5,%
                     xmin=-.5,xmax=6.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,closed,domain=0:6.28] {sin(deg(x))};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 1.57,1) node [above,black] {\((\pi/2,1)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 4.71,-1) node [below,black] {\((3\pi/2,-1)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1530,7 +1530,7 @@
                 <description>
                   <p>
                     The graph of <m>f(x)=x^2\sqrt{4-x}</m> is plotted for <m>x</m> between <m>-2</m> and <m>4</m>.
-                    There are three marked points: a relative minimum at <m>(0,0)</m>, 
+                    There are three marked points: a relative minimum at <m>(0,0)</m>,
                     a relative maximum at <m>\left(\frac{16}{5},\frac{512}{25\sqrt{5}}\right)</m>,
                     and the point <m>(4,0)</m>, which is an endpoint, since the domain of <m>f(x)</m> is <m>(-\infty, 4]</m>.
                   </p>
@@ -1541,13 +1541,13 @@
                     ymin=-1.8,ymax=11,%
                     xmin=-2.5,xmax=4.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,infiniteclosed,domain=-2:4,samples=100] {x^2*sqrt(4-x)};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 3.2,9.16) node [above,black] {\(\left(\frac{16}{5},\frac{512}{25\sqrt{5}}\right)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 4,0) node [above left,black] {\((4,0)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1602,12 +1602,12 @@
                     ymin=-.5,ymax=6.5,%
                     xmin=-1,xmax=11,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,domain=.2:11,samples=100] {(((x-2)^2)^(1/3))/x+1};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 2,1) node [below,black] {\((2,1)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 6,1.42) node [above,black] {\(\left(6,1+\frac{\sqrt[3]{2}}{3}\right)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
 
@@ -1657,14 +1657,14 @@
                   ymin=-.5,ymax=3.5,%
                   xmin=-2.5,xmax=2.5,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,infiniteleft,domain=-2:-1,samples=25] {(x^4-2*x^2+1)^(1/3)};
                   \addplot [firstcurvestyle,-,domain=-1:1,samples=50] {(x^4-2*x^2+1)^(1/3)};
                   \addplot [firstcurvestyle,infiniteright,domain=1:2,samples=25] {(x^4-2*x^2+1)^(1/3)};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 1,0) node [above right,black] {\((1,0)\)} circle (1.5pt);
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: -1,0) node [above left,black] {\((-1,0)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
 
@@ -1716,12 +1716,12 @@
                     ymin=-.5,ymax=1.1,%
                     xmin=-1.1,xmax=1.1,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,{Kite}-,domain=-1:0] {x^2};
                   \addplot [firstcurvestyle,-{Kite},domain=0:1] {x^5};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>
@@ -1762,12 +1762,12 @@
                     ymin=-.5,ymax=1.1,%
                     xmin=-1.1,xmax=1.1,%
                   ]
-                  
+
                   \addplot [firstcurvestyle,{Kite}-,domain=-1:0] {x^2};
                   \addplot [firstcurvestyle,-{Kite},domain=0:1] {x};
-                  
+
                   \draw [firstcolor,fill=firstcolor] 	(axis cs: 0,0) node [below right,black] {\((0,0)\)} circle (1.5pt);
-                  
+
                   \end{axis}
                   \end{tikzpicture}
                 </latex-image>

--- a/ptx/sec_graph_extreme_values.ptx
+++ b/ptx/sec_graph_extreme_values.ptx
@@ -654,10 +654,7 @@
           <!-- figures/fig_extval4.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="LyhHlreZvhc" xml:id="vid_graphs_extreme_val_ex_1" label="vid_graphs_extreme_val_ex_1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We follow the steps outlined in <xref ref="idea_extrema"/>.
@@ -708,6 +705,10 @@
       </figure>
 
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="LyhHlreZvhc" xml:id="vid_graphs_extreme_val_ex_1" label="vid_graphs_extreme_val_ex_1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -733,10 +734,7 @@
 
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="zn--ShSSMqk" xml:id="vid_graphs_extreme_val_ex_2" label="vid_graphs_extreme_val_ex_2" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -846,6 +844,10 @@
         </figure>
       </sidebyside>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="zn--ShSSMqk" xml:id="vid_graphs_extreme_val_ex_2" label="vid_graphs_extreme_val_ex_2" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_extval6">
@@ -855,10 +857,7 @@
         Find the extrema of <m>f(x) = \cos\mathopen{}\left(x^2\right)\mathclose{}</m> on <m>[-2,2]</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="sT_3kVSsbz4" xml:id="vid_graphs_extreme_val_ex_3" label="vid_graphs_extreme_val_ex_3" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We again use <xref ref="idea_extrema"/>.
@@ -951,6 +950,10 @@
             <!-- figures/fig_extval6.tex END -->
         </figure>
       </sidebyside>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="sT_3kVSsbz4" xml:id="vid_graphs_extreme_val_ex_3" label="vid_graphs_extreme_val_ex_3" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -363,7 +363,7 @@
         Find intervals on which <m>f</m> is increasing or decreasing.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -385,7 +385,7 @@
 
       <figure xml:id="fig_incrline1">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr1"/></caption>
-        
+
         <image xml:id="img_incrline1" width="47%">
           <shortdescription>Number line showing the critical points of f</shortdescription>
           <description>
@@ -464,7 +464,7 @@
 
       <figure xml:id="fig_incrline1a">
         <caption>Completed number line for <m>f</m> in <xref ref="ex_incr1"/></caption>
-        
+
         <!-- START figures/fig_incrline1.tex -->
         <image xml:id="img_incrline1a" width="47%">
           <description>
@@ -489,7 +489,7 @@
                     and <m>f</m> is increasing.
                   </p>
                 </li>
-                
+
                 <li>
                   <p>
                     For <m>-1\lt x\lt 1/3</m>, <m>\fp(x)\lt 0</m>,
@@ -744,7 +744,7 @@
         </me>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -856,7 +856,7 @@
 
       <figure xml:id="fig_incrline2">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr2"/></caption>
-        
+
         <!-- START figures/fig_incrline2.tex -->
         <image xml:id="img_incrline2" width="47%">
           <shortdescription>Number line for this example, showing critical points of f and intervals of increase and decrease</shortdescription>
@@ -949,7 +949,7 @@
           <description>
             <p>
               The graphs of <m>f(x)=x^{8/3}-4x^{2/3}</m> (solid, in blue) and its derivative (dash-dotted, in red) are shown.
-              The graph of <m>f</m> resembles a large letter W. 
+              The graph of <m>f</m> resembles a large letter W.
               It has two relative minima, at <m>x=1</m> and <m>x=-1</m>, both with horizontal tangents,
               and a relative maximum at <m>x=0</m>, where there is a cusp.
             </p>
@@ -1008,7 +1008,7 @@
         <m>f(x) = x^{8/3}-4x^{2/3}</m> is increasing and decreasing and identify the relative extrema.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -1088,7 +1088,7 @@
 
       <figure xml:id="fig_incrline3">
         <caption>Number line for <m>f</m> in <xref ref="ex_incr3"/></caption>
-        
+
         <!-- START figures/fig_incrline3.tex -->
         <image xml:id="img_incrline3" width="47%">
           <shortdescription>Number line showing critical points and intervals of increase and decrease</shortdescription>

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -363,10 +363,7 @@
         Find intervals on which <m>f</m> is increasing or decreasing.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="DW6qcgE1TZ0" xml:id="vid_graphs_incr_decr_ex_1" label="vid_graphs_incr_decr_ex_1" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -573,6 +570,10 @@
         <!-- figures/fig_incr1.tex END -->
       </figure>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="DW6qcgE1TZ0" xml:id="vid_graphs_incr_decr_ex_1" label="vid_graphs_incr_decr_ex_1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -743,10 +744,7 @@
         </me>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="94iCiIX07R0" xml:id="vid_graphs_incr_decr_ex_2" label="vid_graphs_incr_decr_ex_2" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -981,6 +979,10 @@
         <!-- figures/fig_incr2.tex END -->
       </figure>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="94iCiIX07R0" xml:id="vid_graphs_incr_decr_ex_2" label="vid_graphs_incr_decr_ex_2" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -1006,10 +1008,7 @@
         <m>f(x) = x^{8/3}-4x^{2/3}</m> is increasing and decreasing and identify the relative extrema.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="T4RxcQnNotc" xml:id="vid_graphs_incr_decr_ex_3" label="vid_graphs_incr_decr_ex_3" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -1203,6 +1202,10 @@
         </image>
         <!-- figures/fig_incr3.tex END -->
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="T4RxcQnNotc" xml:id="vid_graphs_incr_decr_ex_3" label="vid_graphs_incr_decr_ex_3" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -110,11 +110,11 @@
             </shortdescription>
             <description>
               <p>
-                The graph illustrates the function <m>f_1(x) = \frac{1}{x^2}</m>, showcasing a scenario where the Mean Value Theorem is not applicable. 
+                The graph illustrates the function <m>f_1(x) = \frac{1}{x^2}</m>, showcasing a scenario where the Mean Value Theorem is not applicable.
                 As <m>x</m> approaches zero, the function demonstrates a vertical asymptote, highlighting its discontinuity and the tendency of the values to become infinite.
               </p>
               <p>
-                Within the interval <m>[-1, 1]</m>, although the function's value is the same at both endpoints, there is no point where the function's derivative, which represents the slope of the tangent, is zero. 
+                Within the interval <m>[-1, 1]</m>, although the function's value is the same at both endpoints, there is no point where the function's derivative, which represents the slope of the tangent, is zero.
                 This absence violates the Mean Value Theorem's requirement for the function to be both continuous on the closed interval and differentiable on the open interval, specifically at <m>x = 0</m>.
               </p>
             </description>
@@ -144,13 +144,13 @@
             </shortdescription>
             <description>
               <p>
-                Displayed is the function <m>f_2(x) = \abs{x}</m>, chosen to highlight a case where the Mean Value Theorem cannot be applied. 
-                The graph forms a V shape, characteristic of the absolute value function, and is continuous over the interval <m>[-1, 1]</m>. 
+                Displayed is the function <m>f_2(x) = \abs{x}</m>, chosen to highlight a case where the Mean Value Theorem cannot be applied.
+                The graph forms a V shape, characteristic of the absolute value function, and is continuous over the interval <m>[-1, 1]</m>.
               </p>
               <p>
-                At the endpoints of the interval, the function attains the same value, yielding a secant line with a slope of zero. 
-                However, due to the sharp corner at the origin <m>x = 0</m>, the function is not differentiable at this point. 
-                This lack of differentiability means that there does not exist a point in the interval where the slope of the tangent line is equal to the slope of the secant line, as required by the Mean Value Theorem. 
+                At the endpoints of the interval, the function attains the same value, yielding a secant line with a slope of zero.
+                However, due to the sharp corner at the origin <m>x = 0</m>, the function is not differentiable at this point.
+                This lack of differentiability means that there does not exist a point in the interval where the slope of the tangent line is equal to the slope of the secant line, as required by the Mean Value Theorem.
                 Thus, the function <m>f_2(x)</m> serves as an example of when the Mean Value Theorem's conditions are not fulfilled.
               </p>
             </description>
@@ -246,7 +246,7 @@
       </shortdescription>
       <description>
         <p>
-          The image showcases a graph of the polynomial function <m>f(x) = x^3 - 5x^2 + 3x + 5</m>, which is used to illustrate Rolle's Theorem. The function is plotted to show the existence of at least one point <m>c</m> in the open interval <m>(a, b)</m> where the derivative <m>\fp(c)</m> is zero, indicated by the horizontal tangent at the peak of the curve. 
+          The image showcases a graph of the polynomial function <m>f(x) = x^3 - 5x^2 + 3x + 5</m>, which is used to illustrate Rolle's Theorem. The function is plotted to show the existence of at least one point <m>c</m> in the open interval <m>(a, b)</m> where the derivative <m>\fp(c)</m> is zero, indicated by the horizontal tangent at the peak of the curve.
           The points labeled <m>a</m> and <m>b</m> on the x-axis denote the interval on which the function's endpoints have equal values, satisfying the precondition for Rolle's Theorem.
         </p>
         <p>
@@ -397,7 +397,7 @@
         Find <m>c</m> in <m>[-3,3]</m> that satisfies the <xref ref="thm_mvt"/>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The average rate of change of <m>f</m> on <m>[-3,3]</m> is:
@@ -494,7 +494,7 @@
     establishes our intuition about objects in (or, actually, <em>not</em> in)
     motion: if the velocity of an object is <m>0</m>, then the object's position is
     unchanged; it is constant.
-    Second, if two functions <m>f</m> and <m>g</m> have the same derivative, 
+    Second, if two functions <m>f</m> and <m>g</m> have the same derivative,
     what does this tell us about <m>f</m> and <m>g</m>?
     The Mean Value Theorem implies that these functions must only differ by a constant;
     that is, <m>f(x)=g(x)+C</m>, for some constant <m>C</m>.
@@ -502,9 +502,9 @@
 
   <p>
     This has an application to motion that is not intuitive to some. Suppose
-    two objects start moving while <quantity><mag>5</mag><unit base="foot"/></quantity> apart, 
-    and always move with the same velocity. 
-    Then the two objects will <em>always</em> be <quantity><mag>5</mag><unit base="foot"/></quantity> apart. 
+    two objects start moving while <quantity><mag>5</mag><unit base="foot"/></quantity> apart,
+    and always move with the same velocity.
+    Then the two objects will <em>always</em> be <quantity><mag>5</mag><unit base="foot"/></quantity> apart.
     (If two pennies are dropped from the 30th and 31st stories of a tall building at
     the same time, they will always be 1 story apart as they fall.)
   </p>
@@ -571,7 +571,7 @@
       </p>
     </proof>
   </theorem>
-  
+
 
   <figure xml:id="vid_graphs_MVT_func_deriv_0_const" component="video">
     <caption>Showing that a function with zero derivative is constant</caption>

--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -397,10 +397,7 @@
         Find <m>c</m> in <m>[-3,3]</m> that satisfies the <xref ref="thm_mvt"/>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="ON7WYLJY2tE" xml:id="vid_graphs_MVT_ex_3" label="vid_graphs_MVT_ex_3" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The average rate of change of <m>f</m> on <m>[-3,3]</m> is:
@@ -467,6 +464,10 @@
         </image>
           <!-- figures/fig_mvt4.tex END -->
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="ON7WYLJY2tE" xml:id="vid_graphs_MVT_ex_3" label="vid_graphs_MVT_ex_3" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -110,10 +110,7 @@
         to sketch <m>f(x) = 3x^3-10x^2+7x+5</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="41XMvSHgl-Y" xml:id="vid_graphs_sketch_poly" label="vid_graphs_sketch_poly" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -375,6 +372,10 @@
         </sidebyside>
       </figure>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="41XMvSHgl-Y" xml:id="vid_graphs_sketch_poly" label="vid_graphs_sketch_poly" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_sketch2">
@@ -384,10 +385,7 @@
         Sketch <m>\ds f(x) = \frac{x^2-x-2}{x^2-x-6}</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="t3VI2oTmOiA" xml:id="vid_graphs_sketch_rational" label="vid_graphs_sketch_rational" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -555,7 +553,7 @@
 
       <figure xml:id="fig_sketch2">
         <caption>Sketching <m>f</m> in <xref ref="ex_sketch2"/></caption>
-    <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
+        <sidebyside widths="31% 31% 31%" valign="bottom" margins="0%">
           <figure xml:id="fig_sketch2a">
             <caption/>
               <!-- START figures/fig_sketch2a.tex -->
@@ -654,6 +652,10 @@
           </figure>
         </sidebyside>
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="t3VI2oTmOiA" xml:id="vid_graphs_sketch_rational" label="vid_graphs_sketch_rational" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_graph_sketch.ptx
+++ b/ptx/sec_graph_sketch.ptx
@@ -110,7 +110,7 @@
         to sketch <m>f(x) = 3x^3-10x^2+7x+5</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -290,7 +290,7 @@
               <!-- START figures/fig_sketch1a.tex -->
             <image xml:id="img_sketch1a">
               <shortdescription> A hand-drawn graph based on the critical points from the number line. </shortdescription>
-              <description> 
+              <description>
                 <p>
                   The graph is hand-drawn with plotted significant points from the number line.
                   It connects these points with straight lines to give a general impression of the graph's shape.
@@ -352,7 +352,7 @@
                   showing that accounting for concavity helps to ensure an accurate sketch.
                 </p>
               </description>
-            
+
               <latex-image>
                 \begin{tikzpicture}
                 \begin{axis}[ymin=-5.5,ymax=10.9,xmin=-1.2,xmax=3.2,]
@@ -385,7 +385,7 @@
         Sketch <m>\ds f(x) = \frac{x^2-x-2}{x^2-x-6}</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -559,7 +559,7 @@
               <!-- START figures/fig_sketch2a.tex -->
             <image xml:id="img_sketch2a">
               <shortdescription> A linear piecewise graph showing changes in concavity. </shortdescription>
-              <description> 
+              <description>
                 <p>
                   The figure shows a linear piecewise graph on a Cartesian plane with the <m>x</m>-axis ranging from <m>-5</m> to <m>5</m>,
                   and the <m>y</m>-axis from <m>-5</m> to <m>5</m>.
@@ -852,7 +852,7 @@
             </latex-image>
           </image>
         </figure>
-        
+
 
       <figure xml:id="fig_sketch3">
         <caption>Sketching <m>f</m> in <xref ref="ex_sketch3"/></caption>
@@ -862,7 +862,7 @@
               <!-- START figures/fig_sketch3a.tex -->
             <image xml:id="img_sketch3a">
               <shortdescription> A hand-drawn graph based on the critical points from the number line. </shortdescription>
-              <description> 
+              <description>
                 <p>
                   The graph is hand-drawn with plotted significant points from the number line.
                   It connects these points with straight lines to give a general impression of the graph's shape.
@@ -893,13 +893,13 @@
               <!-- START figures/fig_sketch3b.tex -->
             <image xml:id="img_sketch3b">
               <shortdescription> A hand-drawn graph with concavity. </shortdescription>
-              <description> 
+              <description>
                 <p>
                   The graph is hand-drawn with plotted significant points from the number line.
                   It connects these points with smooth curves to give a general impression of the graph's shape.
                 </p>
               </description>
-              
+
               <latex-image>
 
               \begin{tikzpicture}
@@ -940,7 +940,7 @@
                 \addplot [asymptote] coordinates {(-7.5,5) (6.5,5)};
                 \addplot [firstcurvestyle,domain=-7.5:6.5] {(5*(x-2)*(x+1))/(x^2+2*x+4)};
                 \addplot [soliddot] coordinates {(-5.75,7.2) (-4., 7.5) (-1.31, 1.63) (-1,0) (0,-2.5) (1.064, -1.33) (2,0)};
-                \end{axis}  
+                \end{axis}
                 \end{tikzpicture}
               </latex-image>
 
@@ -1041,7 +1041,7 @@
 
           <!-- Include this image as an external asset rather than generated image.
           Otherwise one needs to install Sage just to build this one image. -->
-          
+
             <!-- <sageplot>
               f(x) = sin(x)
               plot(f, (x, 0, 2*pi), marker="o", plot_points=50, randomize=False, adaptive_tolerance=0.01, adaptive_recursion=2, fontsize=20, thickness=2)

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -481,10 +481,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="VunyFD8keVg" xml:id="vid-hyperbolic-ex-properties" label="vid-hyperbolic-ex-properties" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -563,6 +560,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="VunyFD8keVg" xml:id="vid-hyperbolic-ex-properties" label="vid-hyperbolic-ex-properties" component="video"/>
       </solution>
     </example>
 
@@ -663,10 +664,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="MwYZHh9UaRo" xml:id="vid-hyperbolic-ex-deriv-int" label="vid-hyperbolic-ex-deriv-int" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -718,6 +716,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="MwYZHh9UaRo" xml:id="vid-hyperbolic-ex-deriv-int" label="vid-hyperbolic-ex-deriv-int" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -1221,10 +1223,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="vlW6Og4hk-w" xml:id="vid-hyperbolic-ex-deriv-int2" label="vid-hyperbolic-ex-deriv-int2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1276,6 +1275,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="vlW6Og4hk-w" xml:id="vid-hyperbolic-ex-deriv-int2" label="vid-hyperbolic-ex-deriv-int2" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -44,16 +44,16 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axes are drawn from <m>-1</m> to 
-                <m>1</m>. The function <m>x^2+y^2=1</m> represents a circle of 
-                radius <m>1</m> and center at origin. 
+                The <m>y</m> and the <m>x</m> axes are drawn from <m>-1</m> to
+                <m>1</m>. The function <m>x^2+y^2=1</m> represents a circle of
+                radius <m>1</m> and center at origin.
               </p>
               <p>
-                A sector in the circle is shaded, it is present in the first 
-                quadrant and is drawn with one side on the <m>x</m> axis. 
-                It has an angle <m>\theta/2</m> drawn from the <m>x</m> axis 
-                and is marked inside the sector. The points between which the 
-                sector is drawn on the circumference are <m>(1,0)</m> and 
+                A sector in the circle is shaded, it is present in the first
+                quadrant and is drawn with one side on the <m>x</m> axis.
+                It has an angle <m>\theta/2</m> drawn from the <m>x</m> axis
+                and is marked inside the sector. The points between which the
+                sector is drawn on the circumference are <m>(1,0)</m> and
                 <m>(\cos(\theta), \sin(\theta))</m>.
               </p>
             </description>
@@ -96,16 +96,16 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axes are both drawn from <m>-2</m> to <m>2</m>. 
-                The graph of function <m>x^2 -y^2=1</m> has two <m>x</m> intercepts at <m>x=1</m> 
-                and <m>x=-1</m>. The function represents a hyperbola and has two conic sections 
-                facing opposite to each other, opening along the positive and negative <m>x</m> 
-                axis with vertices at the <m>x</m> intercepts. An angle of <m>\theta/2</m> is 
-                marked at the origin starting from the <m>x</m> axis, it is drawn from point 
-                <m>(1,0)</m> to <m>(\cos(\theta), \sin(\theta))</m> on the conic section to the 
+                The <m>y</m> and the <m>x</m> axes are both drawn from <m>-2</m> to <m>2</m>.
+                The graph of function <m>x^2 -y^2=1</m> has two <m>x</m> intercepts at <m>x=1</m>
+                and <m>x=-1</m>. The function represents a hyperbola and has two conic sections
+                facing opposite to each other, opening along the positive and negative <m>x</m>
+                axis with vertices at the <m>x</m> intercepts. An angle of <m>\theta/2</m> is
+                marked at the origin starting from the <m>x</m> axis, it is drawn from point
+                <m>(1,0)</m> to <m>(\cos(\theta), \sin(\theta))</m> on the conic section to the
                 right of the <m>y</m> axis.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -224,26 +224,26 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the <m>x</m> 
-                axis is drawn from <m>-3</m> to <m>3</m>. The function <m>f(x)=\cosh(x)</m> 
-                is shown as a U shaped curve that opens upwards along the positive <m>y</m> 
-                axis, it is symmetrical about the <m>y</m> axis. The graphs of <m>e^{x}/2</m> 
-                and <m>e^{-x}/2</m> are also included. 
+                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the <m>x</m>
+                axis is drawn from <m>-3</m> to <m>3</m>. The function <m>f(x)=\cosh(x)</m>
+                is shown as a U shaped curve that opens upwards along the positive <m>y</m>
+                axis, it is symmetrical about the <m>y</m> axis. The graphs of <m>e^{x}/2</m>
+                and <m>e^{-x}/2</m> are also included.
               </p>
               <p>
-                For large values of <m>x</m> the function <m>f(x)=\cosh(x)</m> is approximately equal 
-                to <m>e^{x}/2</m>. From left to right, the function <m>e^{x}/2</m> appears to 
-                coincide with the <m>x</m> axis in the fourth quadrant, it has a positive slope, 
-                it is some distance apart from <m>f(x)</m> then it rises to coincide with <m>f(x)</m> 
+                For large values of <m>x</m> the function <m>f(x)=\cosh(x)</m> is approximately equal
+                to <m>e^{x}/2</m>. From left to right, the function <m>e^{x}/2</m> appears to
+                coincide with the <m>x</m> axis in the fourth quadrant, it has a positive slope,
+                it is some distance apart from <m>f(x)</m> then it rises to coincide with <m>f(x)</m>
                 after <m>x=1</m>.
               </p>
               <p>
-                For large negative values of <m>x</m>, <m>f(x)</m> becomes equal to the function 
-                <m>e^{-x}/2</m>. From right to left, the function <m>e^{-x}/2</m> appears to start 
-                from the first quadrant and enters the second quadrant with a positive slope. It 
-                coincides with <m>f(x)</m> after approximately <m>x= -1</m>. 
+                For large negative values of <m>x</m>, <m>f(x)</m> becomes equal to the function
+                <m>e^{-x}/2</m>. From right to left, the function <m>e^{-x}/2</m> appears to start
+                from the first quadrant and enters the second quadrant with a positive slope. It
+                coincides with <m>f(x)</m> after approximately <m>x= -1</m>.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -278,26 +278,26 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the <m>x</m> axis is drawn 
-                from <m>-3</m> to <m>3</m>. The function <m>f(x) = \sinh(x)</m>, <m>e^{x}/2</m> 
-                and <m>e^-{x}/2</m> is also shown in the graph. 
+                The <m>y</m> axis is drawn from <m>-10</m> to <m>10</m> and the <m>x</m> axis is drawn
+                from <m>-3</m> to <m>3</m>. The function <m>f(x) = \sinh(x)</m>, <m>e^{x}/2</m>
+                and <m>e^-{x}/2</m> is also shown in the graph.
               </p>
               <p>
-                From left to right, the function <m>e^{x}/2</m> starts in the second quadrant 
-                and gets close to the <m>x</m> axis, it gains the positive slope into the first 
-                quadrant. The function <m>f(x)</m> in the first quadrant, starts at the origin and 
-                rises with a positive slope after a bend.It is separated by a small distance from 
-                <m>e^{x}/2</m>, after approximately <m>x=1</m> the function <m>e^{x}/2</m> coincides 
-                with <m>f(x)</m>. 
+                From left to right, the function <m>e^{x}/2</m> starts in the second quadrant
+                and gets close to the <m>x</m> axis, it gains the positive slope into the first
+                quadrant. The function <m>f(x)</m> in the first quadrant, starts at the origin and
+                rises with a positive slope after a bend.It is separated by a small distance from
+                <m>e^{x}/2</m>, after approximately <m>x=1</m> the function <m>e^{x}/2</m> coincides
+                with <m>f(x)</m>.
               </p>
               <p>
-                From right to left, the function <m>e^{-x}/2</m> starts in the fourth quadrant and 
-                coincides with the <m>x</m> axis, it moves downward after entering the third quadrant. 
-                The function <m>f(x)</m> in the third quadrant, starts at the origin and moves downwards 
-                from right to left. It is separated by a small distance from <m>e^{-x}/2</m> after 
-                approximately <m>x=-1</m> the function <m>e^{-x}/2</m> coincides with <m>f(x)</m>. 
+                From right to left, the function <m>e^{-x}/2</m> starts in the fourth quadrant and
+                coincides with the <m>x</m> axis, it moves downward after entering the third quadrant.
+                The function <m>f(x)</m> in the third quadrant, starts at the origin and moves downwards
+                from right to left. It is separated by a small distance from <m>e^{-x}/2</m> after
+                approximately <m>x=-1</m> the function <m>e^{-x}/2</m> coincides with <m>f(x)</m>.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -355,27 +355,27 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-2</m> to <m>2</m> and the <m>x</m> axis 
-                is drawn from <m>-3</m> to <m>3</m>. The functions <m>\tanh(x)</m> and 
+                The <m>y</m> axis is drawn from <m>-2</m> to <m>2</m> and the <m>x</m> axis
+                is drawn from <m>-3</m> to <m>3</m>. The functions <m>\tanh(x)</m> and
                 <m>\coth(x)</m> are shown. There are two lines drawn at <m>y=-1</m> and <m>y=1</m>.
               </p>
               <p>
-                The <m>\tanh(x)</m> function is drawn in the third and the first quadrant. 
-                In the first quadrant the function starts at the origin and gets a positive 
-                slope then after <m>x=2</m> it becomes parallel to the <m>x</m> axis at 
-                <m>y=1</m>. In the third quadrant the function starts at the origin and 
-                decreases until <m>x=-2</m> after which it becomes parallel to the <m>x</m> 
+                The <m>\tanh(x)</m> function is drawn in the third and the first quadrant.
+                In the first quadrant the function starts at the origin and gets a positive
+                slope then after <m>x=2</m> it becomes parallel to the <m>x</m> axis at
+                <m>y=1</m>. In the third quadrant the function starts at the origin and
+                decreases until <m>x=-2</m> after which it becomes parallel to the <m>x</m>
                 axis as <m>y=-1</m>.
               </p>
               <p>
-                The <m>\coth(x)</m> function is drawn in the first and the third quadrants. 
-                It is hyperbolic in shape with the two parts being symmetrical about the 
-                axis <m>y=-x</m>. It has a horizontal asymptote at <m>x=0</m>. This function 
-                coincides with the <m>\tanh(x)</m> curve after <m>x=2</m> and extends along 
-                the positive <m>x</m> axis and <m>x=-2</m> and extends further along the 
+                The <m>\coth(x)</m> function is drawn in the first and the third quadrants.
+                It is hyperbolic in shape with the two parts being symmetrical about the
+                axis <m>y=-x</m>. It has a horizontal asymptote at <m>x=0</m>. This function
+                coincides with the <m>\tanh(x)</m> curve after <m>x=2</m> and extends along
+                the positive <m>x</m> axis and <m>x=-2</m> and extends further along the
                 negative <m>x</m> axis.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -413,19 +413,19 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-2</m> to <m>2</m> and the <m>x</m> 
-                axis is drawn from <m>-3</m> to <m>3</m>. The functions <m>\sech(x)</m> 
+                The <m>y</m> axis is drawn from <m>-2</m> to <m>2</m> and the <m>x</m>
+                axis is drawn from <m>-3</m> to <m>3</m>. The functions <m>\sech(x)</m>
                 and <m>\csch(x)</m> are shown.
               </p>
               <p>
-                The <m>\sech(x)</m> is drawn in the second and the first quadrant. 
-                From point <m>(1,0)</m> the function slowly decreases moving left to 
-                right, almost touching the <m>x</m> axis at <m>x=3</m>. It is symmetrical 
-                about the <m>x</m> axis and in the third quadrant it decreases from 
-                <m>(1,0)</m>, moving from right to left, and almost touches the <m>x</m> axis at 
+                The <m>\sech(x)</m> is drawn in the second and the first quadrant.
+                From point <m>(1,0)</m> the function slowly decreases moving left to
+                right, almost touching the <m>x</m> axis at <m>x=3</m>. It is symmetrical
+                about the <m>x</m> axis and in the third quadrant it decreases from
+                <m>(1,0)</m>, moving from right to left, and almost touches the <m>x</m> axis at
                 <m>x=-3</m>.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -481,7 +481,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -664,7 +664,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -845,19 +845,19 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axes are drawn from <m>0</m> to <m>10</m>. 
-                The functions <m>y=\cosh(x)</m> and <m>y=\cosh^{-1}(x)</m> are shown. 
+                The <m>y</m> and the <m>x</m> axes are drawn from <m>0</m> to <m>10</m>.
+                The functions <m>y=\cosh(x)</m> and <m>y=\cosh^{-1}(x)</m> are shown.
                 They are symmetrical about the axis <m>y=x</m>.
               </p>
               <p>
-                From left to right, the function <m>y=\cosh(x)</m> starts at point 
-                <m>(0,1)</m> then slowly rises from <m>(1,1)</m> then it rises up 
-                steeply and it appears to run almost parallel to the <m>y</m> axis. 
-                The function <m>\cosh^{-1}(x)</m> starts at point <m>(1,0)</m> and 
-                curves up steeply until <m>(2,1)</m> then it rises very slowly and 
+                From left to right, the function <m>y=\cosh(x)</m> starts at point
+                <m>(0,1)</m> then slowly rises from <m>(1,1)</m> then it rises up
+                steeply and it appears to run almost parallel to the <m>y</m> axis.
+                The function <m>\cosh^{-1}(x)</m> starts at point <m>(1,0)</m> and
+                curves up steeply until <m>(2,1)</m> then it rises very slowly and
                 appears to almost run parallel to the <m>x</m> axis.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -896,23 +896,23 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axes are drawn from <m>-10</m> to 
-                <m>10</m>. The functions <m>y=\sinh(x)</m> and <m>y=\sinh^{-1}(x)</m>. 
+                The <m>y</m> and the <m>x</m> axes are drawn from <m>-10</m> to
+                <m>10</m>. The functions <m>y=\sinh(x)</m> and <m>y=\sinh^{-1}(x)</m>.
                 The axis <m>y=x</m> is shown.
               <p>
               </p>
-                From left to right, the <m>\sinh(x)</m> function starts in the third 
-                quadrant and it rises steeply, very closely to the <m>y</m> axis. It 
-                crosses the origin along the <m>y=x</m> line, has a dip then increases 
+                From left to right, the <m>\sinh(x)</m> function starts in the third
+                quadrant and it rises steeply, very closely to the <m>y</m> axis. It
+                crosses the origin along the <m>y=x</m> line, has a dip then increases
                 very steeply and closely to the <m>y</m> axis in the first quadrant.
               </p>
               <p>
-                From left to right, in the third quadrant, the <m>\sinh{-1}(x)</m> 
-                function runs very closely to the <m>x</m> axis, it crosses the origin 
-                along the <m>y=x</m> line and bends to move very closely to the <m>x</m> 
+                From left to right, in the third quadrant, the <m>\sinh{-1}(x)</m>
+                function runs very closely to the <m>x</m> axis, it crosses the origin
+                along the <m>y=x</m> line and bends to move very closely to the <m>x</m>
                 axis in the first quadrant.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -956,26 +956,26 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axes are drawn from <m>-3</m> to <m>3</m>. 
-                There are two functions drawn, <m>\coth^{-1}(x)</m> and <m>\tanh{-1}(x)</m> 
+                The <m>y</m> and the <m>x</m> axes are drawn from <m>-3</m> to <m>3</m>.
+                There are two functions drawn, <m>\coth^{-1}(x)</m> and <m>\tanh{-1}(x)</m>
                   along with two dashed lines <m>x=-1</m> and <m>x=1</m>.
               </p>
               <p>
-                The <m>\tanh{-1}(x)</m> function is drawn in the third and the first quadrant. 
-                From left to right, in the third quadrant the function is aligned with the line 
-                <m>x=-1</m> at around <m>y=-2</m> it diverges to the right side of the line, it 
-                crosses the origin then bends and merges with the line <m>x=1</m> from its left 
-                in the first quadrant. 
+                The <m>\tanh{-1}(x)</m> function is drawn in the third and the first quadrant.
+                From left to right, in the third quadrant the function is aligned with the line
+                <m>x=-1</m> at around <m>y=-2</m> it diverges to the right side of the line, it
+                crosses the origin then bends and merges with the line <m>x=1</m> from its left
+                in the first quadrant.
               </p>
               <p>
-                The <m>coth^{-1}(x)</m> is also drawn in the third and the first quadrant. From 
-                left to right, in the third quadrant, the function appears to be parallel to the 
-                <m>x</m> axis; it diverges and bends down to join the line <m>x=-1</m>. In the 
-                first quadrant, from left to right the function is along the line <m>x=1</m>, it 
-                decreases and diverges from the line, there is a bend after <m>x=2</m> after which 
-                it becomes parallel to the <m>x</m> axis. 
+                The <m>coth^{-1}(x)</m> is also drawn in the third and the first quadrant. From
+                left to right, in the third quadrant, the function appears to be parallel to the
+                <m>x</m> axis; it diverges and bends down to join the line <m>x=-1</m>. In the
+                first quadrant, from left to right the function is along the line <m>x=1</m>, it
+                decreases and diverges from the line, there is a bend after <m>x=2</m> after which
+                it becomes parallel to the <m>x</m> axis.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -1017,21 +1017,21 @@
             </shortdescription>
             <description>
               <p>
-                The <m>sec{-1}(x)</m> is drawn only in the first quadrant.From left to right, 
-                it starts very close to the <m>y</m> axis without touching it, at around 
-                <m>y=3</m>. It moves away from the <m>y</m> axis while declining then gets 
+                The <m>sec{-1}(x)</m> is drawn only in the first quadrant.From left to right,
+                it starts very close to the <m>y</m> axis without touching it, at around
+                <m>y=3</m>. It moves away from the <m>y</m> axis while declining then gets
                 a small bend before making an <m>x</m> intercept at <m>x=1</m>.
               </p>
               <p>
-                The <m>\csch{-1}(x)</m> is drawn in the third and the first quadrant. In the 
-                third quadrant from left to right the function appears to be parallel to the 
-                <m>x</m> axis. It bends toward the negative <m>y</m> axis and comes very close 
-                to it at <m>y=-3</m>. In the first quadrant from left to right, the function 
-                appears to start very close to the <m>y</m> axis coinciding with the <m>sech{-1}(x)</m> 
-                function. It has a negative slope and it moves down, gets a bend and runs parallel 
+                The <m>\csch{-1}(x)</m> is drawn in the third and the first quadrant. In the
+                third quadrant from left to right the function appears to be parallel to the
+                <m>x</m> axis. It bends toward the negative <m>y</m> axis and comes very close
+                to it at <m>y=-3</m>. In the first quadrant from left to right, the function
+                appears to start very close to the <m>y</m> axis coinciding with the <m>sech{-1}(x)</m>
+                function. It has a negative slope and it moves down, gets a bend and runs parallel
                 to the <m>x</m> axis.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -1223,7 +1223,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>

--- a/ptx/sec_improper_integration.ptx
+++ b/ptx/sec_improper_integration.ptx
@@ -49,13 +49,13 @@
         </shortdescription>
         <description>
           <p>
-            The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is drawn 
+            The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis is drawn
             from <m>0</m> to <m>10</m>.
-            The function <m>f(x)=\frac{1}{1+x^2}</m> starts at point <m>(0,1)</m>, then decreases 
-            sharply, has a dip at <m>(2,0.2)</m> then decreases gently and almost coincides with 
+            The function <m>f(x)=\frac{1}{1+x^2}</m> starts at point <m>(0,1)</m>, then decreases
+            sharply, has a dip at <m>(2,0.2)</m> then decreases gently and almost coincides with
             the <m>x</m> axis after <m>x=6</m>. The area under the curve is shaded.
           </p>
-        </description>  
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -189,7 +189,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -213,15 +213,15 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and 
-                      the <m>x</m> axis is drawn from <m>0</m> to <m>10</m>. The 
-                      function <m>f(x) = \frac{1}{x^2}</m> starts from point 
-                      <m>(1,1)</m>, the curve drops sharply then bends before 
-                      <m>x=5</m> after which it runs very close to the <m>x</m> 
-                      axis. The area under the curve is shaded from <m>x=1</m> to 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and
+                      the <m>x</m> axis is drawn from <m>0</m> to <m>10</m>. The
+                      function <m>f(x) = \frac{1}{x^2}</m> starts from point
+                      <m>(1,1)</m>, the curve drops sharply then bends before
+                      <m>x=5</m> after which it runs very close to the <m>x</m>
+                      axis. The area under the curve is shaded from <m>x=1</m> to
                       <m>x=10</m>.
                     </p>
-                  </description>  
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -274,14 +274,14 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the 
-                      <m>x</m> axis is drawn from <m>0</m> to <m>10</m>. The function 
-                      <m>f(x) = \frac{1}{x}</m> starts from point <m>(1,1)</m>, the 
-                      curve drops sharply then bends before <m>x=5</m> after which it 
-                      runs almost parallel to the <m>x</m> axis about line <m>y=0.2</m>. 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the
+                      <m>x</m> axis is drawn from <m>0</m> to <m>10</m>. The function
+                      <m>f(x) = \frac{1}{x}</m> starts from point <m>(1,1)</m>, the
+                      curve drops sharply then bends before <m>x=5</m> after which it
+                      runs almost parallel to the <m>x</m> axis about line <m>y=0.2</m>.
                       The area under the curve is shaded from <m>x=1</m> to <m>x=10</m>.
                     </p>
-                  </description>  
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -329,15 +329,15 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The graph of function <m>f(x)= e^x</m> is drawn in the 
-                      second quadrant.The <m>y</m> axis is drawn from <m>0</m> 
-                      to <m>1</m> and the <m>x</m> axis is drawn from <m>-10</m> 
-                      to <m>0</m>. From left to right the function appears to 
-                      coincide with the <m>x</m> axis, at about <m>x=5</m> it gets 
+                      The graph of function <m>f(x)= e^x</m> is drawn in the
+                      second quadrant.The <m>y</m> axis is drawn from <m>0</m>
+                      to <m>1</m> and the <m>x</m> axis is drawn from <m>-10</m>
+                      to <m>0</m>. From left to right the function appears to
+                      coincide with the <m>x</m> axis, at about <m>x=5</m> it gets
                       a positive slope and rises sharply until it reaches point <m>(0,1)</m>.
                     </p>
                   </description>
-                    
+
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -391,14 +391,14 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m>
                       axis is drawn from <m>-10</m> to <m>10</m>.The function <m>f(x)= \frac{1}{1+x^2}
-                      </m> is symmetrical about the <m>y</m> axis. From left to right the function 
-                      moves very closely to the <m>x</m> axis after <m>x=-5</m> it bends and sharply 
-                      increases to point <m>(0,1)</m>, from this point it decreases sharply and then 
-                      gets a dip then after <m>x=5</m> runs very closely to the <m>x</m> axis. 
+                      </m> is symmetrical about the <m>y</m> axis. From left to right the function
+                      moves very closely to the <m>x</m> axis after <m>x=-5</m> it bends and sharply
+                      increases to point <m>(0,1)</m>, from this point it decreases sharply and then
+                      gets a dip then after <m>x=5</m> runs very closely to the <m>x</m> axis.
                     </p>
-                  </description>  
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -451,7 +451,7 @@
           Evaluate the improper integral <m>\ds \int_1^\infty \frac{\ln(x) }{x^2}\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           This integral will require the use of Integration by Parts.
@@ -468,14 +468,14 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>0</m> to <m>0.4</m> and the <m>x</m> 
-                axis is drawn from <m>0</m> to <m>10</m>. From left to right, the function 
-                <m>f(x) = \frac{\ln(x) }{x^2}</m> starts at point <m>(1,0)</m> it rises sharply, 
-                reaches a height of <m>0.2</m> near <m>x= 1.5</m> then it decreases gently until 
-                <m>x=10</m> but stays a bit above the <m>x</m> axis. The area under the curve 
+                The <m>y</m> axis is drawn from <m>0</m> to <m>0.4</m> and the <m>x</m>
+                axis is drawn from <m>0</m> to <m>10</m>. From left to right, the function
+                <m>f(x) = \frac{\ln(x) }{x^2}</m> starts at point <m>(1,0)</m> it rises sharply,
+                reaches a height of <m>0.2</m> near <m>x= 1.5</m> then it decreases gently until
+                <m>x=10</m> but stays a bit above the <m>x</m> axis. The area under the curve
                 until <m>x=10</m> is shaded.
               </p>
-            </description>  
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -566,7 +566,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -606,13 +606,13 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>10</m> and the <m>x</m> 
-                      axis is drawn from <m>0</m> to <m>2</m>. The function <m>f(x)=\frac{1}{\sqrt{x}}</m> 
-                      starts at <m>(0,10)</m> then it decreases sharply while being very close to the 
-                      <m>y</m> axis at about <m>y=4</m> it starts diverging away, it moves away from 
-                      the <m>y</m> axis and appears to move almost parallel to the <m>x</m> axis until <m>x=1</m>. 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>10</m> and the <m>x</m>
+                      axis is drawn from <m>0</m> to <m>2</m>. The function <m>f(x)=\frac{1}{\sqrt{x}}</m>
+                      starts at <m>(0,10)</m> then it decreases sharply while being very close to the
+                      <m>y</m> axis at about <m>y=4</m> it starts diverging away, it moves away from
+                      the <m>y</m> axis and appears to move almost parallel to the <m>x</m> axis until <m>x=1</m>.
                     </p>
-                  </description>  
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -664,16 +664,16 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn 
-                      from <m>0</m> to <m>20</m>. The graph of function <m>f(x)=\frac{1}{x^2}</m> is drawn 
-                      in the first and the second quadrants. From left to right, in the second quadrant the 
-                      function starts at <m>x=-1</m> a little above the <m>x</m> axis then it curves up sharply 
-                      and runs parallel to the <m>y</m> axis, at <m>x=-0.4</m>. In the first quadrant, from 
-                      left to right the function runs parallel to the <m>y</m> axis and declines sharply, it 
-                      then bends and moves along the <m>x</m> axis until <m>x=1</m>. Between <m>x=-1</m> and 
+                      The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn
+                      from <m>0</m> to <m>20</m>. The graph of function <m>f(x)=\frac{1}{x^2}</m> is drawn
+                      in the first and the second quadrants. From left to right, in the second quadrant the
+                      function starts at <m>x=-1</m> a little above the <m>x</m> axis then it curves up sharply
+                      and runs parallel to the <m>y</m> axis, at <m>x=-0.4</m>. In the first quadrant, from
+                      left to right the function runs parallel to the <m>y</m> axis and declines sharply, it
+                      then bends and moves along the <m>x</m> axis until <m>x=1</m>. Between <m>x=-1</m> and
                       <m>x=1</m> and from <m>y=0</m> to <m>y=20</m> the area within the curves is shaded.
                     </p>
-                  </description>                    
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -747,7 +747,7 @@
           Determine the values of <m>p</m> for which <m>\ds \int_1^\infty \frac1{x^p}\, dx</m> converges.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We begin by integrating and then evaluating the limit.
@@ -771,20 +771,20 @@
           <!-- START figures/fig_impint4.tex -->
           <image xml:id="img_impint4" width="47%">
             <shortdescription>
-              Graph of two functions 1/x^p and 1/x^q with p &lt;1 &lt;q. 
+              Graph of two functions 1/x^p and 1/x^q with p &lt;1 &lt;q.
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and the <m>x</m> axes are uncalibrated except that <m>1</m> 
-                is marked in the middle of the <m>x</m> axis. There are two functions 
-                <m>f(x) = 1/x^p</m> and <m>1/x^q</m> shown in the graph. The two functions 
-                intersect when <m>x=1</m>. Before <m>x=1</m> both functions have negative 
-                slopes and decline sharply along the <m>y</m> axis then gently as they approach 
-                <m>x=1</m>, <m>p&lt;q</m> hence <m>1/x^p</m> graph is below <m>1/x^q</m>. After 
-                <m>x=1</m>,<m> 1/x^p</m> is above <m>1/x^q</m> but they are only slightly apart. 
+                The <m>y</m> and the <m>x</m> axes are uncalibrated except that <m>1</m>
+                is marked in the middle of the <m>x</m> axis. There are two functions
+                <m>f(x) = 1/x^p</m> and <m>1/x^q</m> shown in the graph. The two functions
+                intersect when <m>x=1</m>. Before <m>x=1</m> both functions have negative
+                slopes and decline sharply along the <m>y</m> axis then gently as they approach
+                <m>x=1</m>, <m>p&lt;q</m> hence <m>1/x^p</m> graph is below <m>1/x^q</m>. After
+                <m>x=1</m>,<m> 1/x^p</m> is above <m>1/x^q</m> but they are only slightly apart.
                 There is a dashed line between the two functions.
               </p>
-            </description>              
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -926,7 +926,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -951,15 +951,15 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis 
-                      is drawn from <m>0</m> to <m>4</m>. There are two functions drawn 
-                      <m>f(x) = e^{-x^2}</m> and <m>f(x)= 1/x^2</m>. The function <m>e</m> appears 
-                      to start from <m>(1,0.4)</m> then decreases and merges with the <m>x</m> axis 
-                      after <m>x=2</m>. The function <m>1/x^2</m> is above the function <m> e^{-x^2}</m>, 
-                      it starts from point <m>(1,1)</m> and curves down and appears to be parallel to the 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>1</m> and the <m>x</m> axis
+                      is drawn from <m>0</m> to <m>4</m>. There are two functions drawn
+                      <m>f(x) = e^{-x^2}</m> and <m>f(x)= 1/x^2</m>. The function <m>e</m> appears
+                      to start from <m>(1,0.4)</m> then decreases and merges with the <m>x</m> axis
+                      after <m>x=2</m>. The function <m>1/x^2</m> is above the function <m> e^{-x^2}</m>,
+                      it starts from point <m>(1,1)</m> and curves down and appears to be parallel to the
                       <m>x</m> axis after <m>x=3</m>.
                     </p>
-                  </description>                    
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -1015,16 +1015,16 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>0</m> to <m>0.4</m> and the <m>x</m> axis is 
-                      drawn from <m>0 </m> to <m> 6</m>. Two functions <m>f(x)=1/x</m> and 
-                      <m>f(x) = 1/\sqrt{x^2-x}</m> are drawn. At <m>x=3</m>, the function <m>1/x</m> 
-                      starts at <m>y=3.33</m> then curves down with a negative slope. The function 
-                      <m>f(x) = 1/\sqrt{x^2-x}</m> at <m>x=3</m> starts at <m>y=0.41</m> and also 
-                      curves down with a negative slope. The function <m>1/x</m> is below function 
-                      <m>f(x) = 1/\sqrt{x^2-x}</m> they are comparatively more apart at <m>x=3</m> 
+                      The <m>y</m> axis is drawn from <m>0</m> to <m>0.4</m> and the <m>x</m> axis is
+                      drawn from <m>0 </m> to <m> 6</m>. Two functions <m>f(x)=1/x</m> and
+                      <m>f(x) = 1/\sqrt{x^2-x}</m> are drawn. At <m>x=3</m>, the function <m>1/x</m>
+                      starts at <m>y=3.33</m> then curves down with a negative slope. The function
+                      <m>f(x) = 1/\sqrt{x^2-x}</m> at <m>x=3</m> starts at <m>y=0.41</m> and also
+                      curves down with a negative slope. The function <m>1/x</m> is below function
+                      <m>f(x) = 1/\sqrt{x^2-x}</m> they are comparatively more apart at <m>x=3</m>
                       than at <m>x=6</m>.
                     </p>
-                  </description>                    
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}
@@ -1111,7 +1111,7 @@
           Determine the convergence of <m>\ds \int_3^{\infty} \frac{1}{\sqrt{x^2+2x+5}}\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           As <m>x</m> gets large,
@@ -1163,13 +1163,13 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn from <m>-0.1</m> to <m>0.3</m> and the <m>x</m> axis 
-                is drawn from <m>0</m> to <m>20</m>. Two functions are drawn <m>f(x)= 1/x</m> 
-                and <m>f(x)=\frac{1}{\sqrt{x^2+2x+5}}</m>. The function <m>f(x)=\frac{1}{\sqrt{x^2+2x+5}}</m> 
-                is drawn below <m>1/x</m>. Both functions have negative slopes, they are apart by a small 
+                The <m>y</m> axis is drawn from <m>-0.1</m> to <m>0.3</m> and the <m>x</m> axis
+                is drawn from <m>0</m> to <m>20</m>. Two functions are drawn <m>f(x)= 1/x</m>
+                and <m>f(x)=\frac{1}{\sqrt{x^2+2x+5}}</m>. The function <m>f(x)=\frac{1}{\sqrt{x^2+2x+5}}</m>
+                is drawn below <m>1/x</m>. Both functions have negative slopes, they are apart by a small
                 distance  around x=4, after <m>x=10</m> they come very close and almost coincide.
               </p>
-            </description>              
+            </description>
             <latex-image>
 
             \begin{tikzpicture}
@@ -1216,7 +1216,7 @@
         however, limit comparison is much more subtle, and prone to incorrect conclusions.
       </p>
     </aside>
-    
+
     <p>
       This chapter has explored many integration techniques.
       We learned Substitution,

--- a/ptx/sec_improper_integration.ptx
+++ b/ptx/sec_improper_integration.ptx
@@ -189,10 +189,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="hXnmu7fZj-E" xml:id="vid-int-improper-ex-at-infinity" label="vid-int-improper-ex-at-infinity" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -435,6 +432,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="hXnmu7fZj-E" xml:id="vid-int-improper-ex-at-infinity" label="vid-int-improper-ex-at-infinity" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -450,10 +451,7 @@
           Evaluate the improper integral <m>\ds \int_1^\infty \frac{\ln(x) }{x^2}\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="hKpXU3fFS6g" xml:id="vid-int-improper-ex-with-lhospital" label="vid-int-improper-ex-with-lhospital" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This integral will require the use of Integration by Parts.
@@ -519,6 +517,10 @@
           </md>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="hKpXU3fFS6g" xml:id="vid-int-improper-ex-with-lhospital" label="vid-int-improper-ex-with-lhospital" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -564,10 +566,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="F46oIXOBjAw" xml:id="vid-int-improper-ex-vert-asy" label="vid-int-improper-ex-vert-asy" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -722,6 +721,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="F46oIXOBjAw" xml:id="vid-int-improper-ex-vert-asy" label="vid-int-improper-ex-vert-asy" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -744,10 +747,7 @@
           Determine the values of <m>p</m> for which <m>\ds \int_1^\infty \frac1{x^p}\, dx</m> converges.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="-W8yESqiexA" xml:id="vid-int-improper-ex-ptest" label="vid-int-improper-ex-ptest" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We begin by integrating and then evaluating the limit.
@@ -829,6 +829,10 @@
           and <m>y=1/x^q</m>, <m>q \gt 1</m>.
           Somehow the dashed line forms a dividing line between convergence and divergence.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="-W8yESqiexA" xml:id="vid-int-improper-ex-ptest" label="vid-int-improper-ex-ptest" component="video"/>
       </solution>
     </example>
 
@@ -922,10 +926,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="356-QIN7fWA" xml:id="vid-int-improper-ex-compare-direct" label="vid-int-improper-ex-compare-direct" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1052,6 +1053,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="356-QIN7fWA" xml:id="vid-int-improper-ex-compare-direct" label="vid-int-improper-ex-compare-direct" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1106,10 +1111,7 @@
           Determine the convergence of <m>\ds \int_3^{\infty} \frac{1}{\sqrt{x^2+2x+5}}\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="nIr1A1Tmako" xml:id="vid-int-improper-ex-limit-compare" label="vid-int-improper-ex-limit-compare" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           As <m>x</m> gets large,
@@ -1192,6 +1194,10 @@
           </image>
           <!-- figures/fig_impint6.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="nIr1A1Tmako" xml:id="vid-int-improper-ex-limit-compare" label="vid-int-improper-ex-limit-compare" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -261,7 +261,7 @@
           <m>\{a_n\} = \{\ln(n) /n^2\}</m> and the <m>n</m>th partial sums are given in <xref ref="fig_itest1"/>.)
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <xref ref="fig_itest1"/>
@@ -370,7 +370,7 @@
           <m>p \gt 1</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Consider the integral <m>\ds\int_1^\infty \frac1{(ax+b)^p}\, dx</m>;
@@ -522,7 +522,7 @@
           Determine the convergence of <m>\ds\infser \frac1{3^n+n^2}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           This series is neither a geometric or <m>p</m>-series,
@@ -553,7 +553,7 @@
           Determine the convergence of <m>\ds\infser \frac{1}{n-\ln(n) }</m>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -676,7 +676,7 @@
           <m>\ds\infser \frac1{n+\ln(n) }</m> using the Limit Comparison Test.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We compare the terms of <m>\ds\infser \frac1{n+\ln(n) }</m> to the terms of the Harmonic Sequence <m>\ds\infser \frac1{n}</m>:
@@ -704,7 +704,7 @@
           Determine the convergence of <m>\ds\infser \frac1{3^n-n^2}</m>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           This series is similar to the one in <xref ref="ex_dct1"/>,
@@ -753,7 +753,7 @@
           Determine the convergence of <m>\ds\infser \frac{\sqrt{n}+3}{n^2-n+1}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We naïvely attempt to apply the rule of thumb given above and note that the dominant term in the expression of the series is <m>1/n^2</m>.

--- a/ptx/sec_int_comp_tests.ptx
+++ b/ptx/sec_int_comp_tests.ptx
@@ -261,10 +261,7 @@
           <m>\{a_n\} = \{\ln(n) /n^2\}</m> and the <m>n</m>th partial sums are given in <xref ref="fig_itest1"/>.)
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="YuAg9zOh2Hk" xml:id="vid-seqseries-intcomp-example1" label="vid-seqseries-intcomp-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <xref ref="fig_itest1"/>
@@ -347,6 +344,10 @@
           so does <m>\ds \infser \frac{\ln(n) }{n^2}</m>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="YuAg9zOh2Hk" xml:id="vid-seqseries-intcomp-example1" label="vid-seqseries-intcomp-example1" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -369,10 +370,7 @@
           <m>p \gt 1</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="fBQkA2ntBuM" xml:id="vid-seqseries-intcomp-ptest" label="vid-seqseries-intcomp-ptest" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Consider the integral <m>\ds\int_1^\infty \frac1{(ax+b)^p}\, dx</m>;
@@ -396,6 +394,10 @@
           and only if,
           <m>p \gt 1</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="fBQkA2ntBuM" xml:id="vid-seqseries-intcomp-ptest" label="vid-seqseries-intcomp-ptest" component="video"/>
       </solution>
     </example>
 
@@ -520,10 +522,7 @@
           Determine the convergence of <m>\ds\infser \frac1{3^n+n^2}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="DAfdDWo948U" xml:id="vid-seqseries-intcomp-comp-example" label="vid-seqseries-intcomp-comp-example" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This series is neither a geometric or <m>p</m>-series,
@@ -541,6 +540,10 @@
           <m>\ds \infser \frac1{3^n+n^2}</m> converges.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="DAfdDWo948U" xml:id="vid-seqseries-intcomp-comp-example" label="vid-seqseries-intcomp-comp-example" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_dct2">
@@ -550,10 +553,7 @@
           Determine the convergence of <m>\ds\infser \frac{1}{n-\ln(n) }</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="G1j5JNagVmU" xml:id="vid-seqseries-intcomp-comp-example2" label="vid-seqseries-intcomp-comp-example2" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -571,6 +571,10 @@
           The Harmonic Series diverges,
           so we conclude that <m>\ds\infser \frac{1}{n-\ln(n) }</m> diverges as well.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="G1j5JNagVmU" xml:id="vid-seqseries-intcomp-comp-example2" label="vid-seqseries-intcomp-comp-example2" component="video"/>
       </solution>
     </example>
 
@@ -672,10 +676,7 @@
           <m>\ds\infser \frac1{n+\ln(n) }</m> using the Limit Comparison Test.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="RBeu0Tgsj_c" xml:id="vid-seqseries-intcomp-limit-example1" label="vid-seqseries-intcomp-limit-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We compare the terms of <m>\ds\infser \frac1{n+\ln(n) }</m> to the terms of the Harmonic Sequence <m>\ds\infser \frac1{n}</m>:
@@ -690,6 +691,10 @@
           we conclude that <m>\ds\infser \frac1{n+\ln(n) }</m> diverges as well.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="RBeu0Tgsj_c" xml:id="vid-seqseries-intcomp-limit-example1" label="vid-seqseries-intcomp-limit-example1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_lct2">
@@ -699,10 +704,7 @@
           Determine the convergence of <m>\ds\infser \frac1{3^n-n^2}</m>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="1qaiCHhP3GE" xml:id="vid-seqseries-intcomp-limit-example2" label="vid-seqseries-intcomp-limit-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This series is similar to the one in <xref ref="ex_dct1"/>,
@@ -723,6 +725,10 @@
           We know <m>\ds\infser \frac1{3^n}</m> is a convergent geometric series,
           hence <m>\ds\infser \frac1{3^n-n^2}</m> converges as well.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="1qaiCHhP3GE" xml:id="vid-seqseries-intcomp-limit-example2" label="vid-seqseries-intcomp-limit-example2" component="video"/>
       </solution>
     </example>
 
@@ -747,10 +753,7 @@
           Determine the convergence of <m>\ds\infser \frac{\sqrt{n}+3}{n^2-n+1}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="D-OsPkY8khE" xml:id="vid-seqseries-intcomp-limit-example3" label="vid-seqseries-intcomp-limit-example3" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We naïvely attempt to apply the rule of thumb given above and note that the dominant term in the expression of the series is <m>1/n^2</m>.
@@ -788,6 +791,10 @@
           Since the <m>p</m>-series <m>\ds\infser \frac1{n^{3/2}}</m> converges,
           we conclude that <m>\ds\infser \frac{\sqrt{n}+3}{n^2-n+1}</m> converges as well.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="D-OsPkY8khE" xml:id="vid-seqseries-intcomp-limit-example3" label="vid-seqseries-intcomp-limit-example3" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_iterated_integrals.ptx
+++ b/ptx/sec_iterated_integrals.ptx
@@ -860,7 +860,7 @@
                 </p>
               </answer>
             </task>
-            
+
             <task label="ex-iterated-integrals-evaluate-1b">
               <statement>
                 <p>
@@ -875,7 +875,7 @@
             </task>
           <!--</webwork>-->
         </exercise>
-        
+
         <exercise label="ex-iterated-integrals-evaluate-2">
           <webwork xml:id="webwork-ex-iterated-integrals-evaluate-2">
 

--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -124,7 +124,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -254,7 +254,7 @@
           <m>\ds 1.\,\lim_{x\to\infty} \frac{3x^2-100x+2}{4x^2+5x-1000} \qquad\qquad 2. \,\lim_{x\to \infty}\frac{e^x}{x^3}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -325,7 +325,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -454,7 +454,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -513,14 +513,14 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and the 
-                        <m>x</m> axis is drawn from <m>0</m> to <m>2</m>. The 
-                        function <m>f(x) = x^x</m> is drawn as a curve opening 
-                        towards the positive <m>y</m> axis with arrows towards the 
-                        ends. The function is drawn from point <m>(0,1)</m> from 
+                        The <m>y</m> axis is drawn from <m>0</m> to <m>4</m> and the
+                        <m>x</m> axis is drawn from <m>0</m> to <m>2</m>. The
+                        function <m>f(x) = x^x</m> is drawn as a curve opening
+                        towards the positive <m>y</m> axis with arrows towards the
+                        ends. The function is drawn from point <m>(0,1)</m> from
                         where it dips gently then rises up slowly.
                       </p>
-                    </description>  
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}

--- a/ptx/sec_lhopitals_rule.ptx
+++ b/ptx/sec_lhopitals_rule.ptx
@@ -124,10 +124,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="Y2O3RD9tt34" xml:id="vid-lhospital-ex-zerzer1" label="vid-lhospital-ex-zerzer1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -176,6 +173,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="Y2O3RD9tt34" xml:id="vid-lhospital-ex-zerzer1" label="vid-lhospital-ex-zerzer1" component="video"/>
       </solution>
     </example>
 
@@ -253,10 +254,7 @@
           <m>\ds 1.\,\lim_{x\to\infty} \frac{3x^2-100x+2}{4x^2+5x-1000} \qquad\qquad 2. \,\lim_{x\to \infty}\frac{e^x}{x^3}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="1WIItaObKQk" xml:id="vid-lhospital-ex-infinf" label="vid-lhospital-ex-infinf" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -288,6 +286,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="1WIItaObKQk" xml:id="vid-lhospital-ex-infinf" label="vid-lhospital-ex-infinf" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -323,10 +325,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="wJzKupOv8cg" xml:id="vid-lhospital-ex-zerinf" label="vid-lhospital-ex-zerinf" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -414,6 +413,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="wJzKupOv8cg" xml:id="vid-lhospital-ex-zerinf" label="vid-lhospital-ex-zerinf" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -451,10 +454,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="wHCd7Wsxzug" xml:id="vid-lhospital-ex-expforms" label="vid-lhospital-ex-expforms" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -548,6 +548,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="wHCd7Wsxzug" xml:id="vid-lhospital-ex-expforms" label="vid-lhospital-ex-expforms" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -161,10 +161,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="8x42kGfu9ts" xml:id="vid_limit_analytic_using_prop" label="vid_limit_analytic_using_prop" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol marker="a">
@@ -208,6 +205,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="8x42kGfu9ts" xml:id="vid_limit_analytic_using_prop" label="vid_limit_analytic_using_prop" component="video"/>
     </solution>
   </example>
 
@@ -583,10 +584,7 @@
         </me>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="pgjv3ojtXh4" xml:id="vid_limit_analytic_sinxoverx" label="vid_limit_analytic_sinxoverx" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We begin by considering the unit circle.
@@ -802,6 +800,10 @@
         Clearly this means that
         <m>\lim\limits_{\theta\to 0} \frac{\sin(\theta)}{\theta}=1</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="pgjv3ojtXh4" xml:id="vid_limit_analytic_sinxoverx" label="vid_limit_analytic_sinxoverx" component="video"/>
     </solution>
   </example>
 
@@ -1039,10 +1041,7 @@
         </me>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="MSckoYqdKH4" xml:id="vid_limit_analytic_alg_ex_1" label="vid_limit_analytic_alg_ex_1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We attempt to apply <xref ref="thm_poly_rat"/>
@@ -1068,6 +1067,10 @@
         </md>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="MSckoYqdKH4" xml:id="vid_limit_analytic_alg_ex_1" label="vid_limit_analytic_alg_ex_1" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_limit_allbut2">
@@ -1080,10 +1083,7 @@
         </me>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="vOW92eipOu4" xml:id="vid_limit_analytic_alg_ex_2" label="vid_limit_analytic_alg_ex_2" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -1108,6 +1108,10 @@
           <mrow>\amp = \frac{1}{6}</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="vOW92eipOu4" xml:id="vid_limit_analytic_alg_ex_2" label="vid_limit_analytic_alg_ex_2" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -161,7 +161,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol marker="a">
@@ -492,11 +492,11 @@
         <p>
           For all values of <m>x \leq c</m> <m>f(x) \leq L</m> and <m>h(x) \geq L</m>.
           For all values of <m>x</m> <m>f(x) \leq g(x) \leq h(x)</m>, that is, the line
-          of the function <m>g(x)</m> is between the lines of the functions <m>g(x)</m> 
+          of the function <m>g(x)</m> is between the lines of the functions <m>g(x)</m>
           and <m>f(x)</m>.
         </p>
         <p>
-          The graph shows that where <m>x = c</m>, <m>f(x)</m> and <m>h(x)</m> converge 
+          The graph shows that where <m>x = c</m>, <m>f(x)</m> and <m>h(x)</m> converge
           on <m>y = L = 4</m>. Because <m>f(x) \leq g(x) \leq h(x)</m>, we can extrapolate
           that <m>\lim\limits_{x\to \c} g(x) = L</m> too.
         </p>
@@ -564,7 +564,7 @@
   </p>
 
   <figure xml:id="vid_limit_analytic_lim_sin_0" component="video">
-    <caption>Using the Squeeze Theorem to take the limit of <m>\sin(x)</m> at <m>0</m></caption>    
+    <caption>Using the Squeeze Theorem to take the limit of <m>\sin(x)</m> at <m>0</m></caption>
     <video youtube="2pVHlrPee2w" label="vid_limit_analytic_lim_sin_0"/>
   </figure>
 
@@ -584,7 +584,7 @@
         </me>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We begin by considering the unit circle.
@@ -604,25 +604,25 @@
         <image xml:id="img_squeeze_sinx" width="47%">
           <description>
             <p>
-              Illustration of a unit circle, with a right and acute triangle in 
+              Illustration of a unit circle, with a right and acute triangle in
               quadrant one. The right triangle purtudes out of the unit circle,
               while the acute triangle stays within the bounds of the circle.
               The acute triangle is also contained within the right triangle.
-              There are horizontal lines and vertical lines inside the circle, 
+              There are horizontal lines and vertical lines inside the circle,
               these lines act only as guides.
               The horizontal and vertical lines intersect at <m>(0, 0)</m>.
               The horizontal line starts at <m>(-1, 0)</m> and ends at <m>1, 0</m>,
               the vertical line starts at <m>(0, 1)</m> and ends at <m>(0, -1)</m>.
             </p>
             <p>
-              The right Triangle is made up of the points <m>(0, 0)</m>, 
+              The right Triangle is made up of the points <m>(0, 0)</m>,
               <m>(1, \tan(\theta))</m>, and <m>(1, 0)</m>. The acute Triangle is made
               of the points <m>(0, 0)</m>, <m>(\cos(\theta), \sin(\theta))</m>, and
               <m>(1, 0)</m>. The angle at point <m>(0, 0)</m> is labeled as <m>\theta</m>
             </p>
           </description>
           <shortdescription>
-            Illustration of a unit Circle, with a right and acute Triangle in 
+            Illustration of a unit Circle, with a right and acute Triangle in
             quadrant one.
           </shortdescription>
           <latex-image>
@@ -706,13 +706,13 @@
               <description>
                 <p>
                   Sector of a circle from <xref ref="fig_squeeze1a"/> with dotted lines
-                  creating the right triangle from <xref ref="fig_squeeze1a"/>, there is 
-                  also a dotted line showing the same acute triangle from 
+                  creating the right triangle from <xref ref="fig_squeeze1a"/>, there is
+                  also a dotted line showing the same acute triangle from
                   <xref ref="fig_squeeze1a"/>. The acute triangle is contained inside
                   the circle sector, while the right triangle purtrudes out of it.
-                </p> 
+                </p>
                 <p>
-                  There is an angle <m>\theta</m> that is shared by both triangles and 
+                  There is an angle <m>\theta</m> that is shared by both triangles and
                   the circle sector. They also share the length 1 for the horizontal line.
                 </p>
               </description>
@@ -738,9 +738,9 @@
               <description>
                 <p>
                   Acute triangle from <xref ref="fig_squeeze1a"/> with dotted lines
-                  representing the circle sector from <xref ref="fig_squeeze1b"/> and 
+                  representing the circle sector from <xref ref="fig_squeeze1b"/> and
                   right triangle from <xref ref="fig_squeeze1a"/>. There is an additional
-                  dotted line that creates a second right triangle within the acute triangle. 
+                  dotted line that creates a second right triangle within the acute triangle.
                   Both the sector of a circle and right triangle fall outside the bounds of the
                   acute triangle.
                 </p>
@@ -956,8 +956,8 @@
           <description>
             <p>
               Graph of the linear equation <m>(x^1-1)/(x-1)</m>, shows the function with
-              the <m>y</m> interval <m>0</m> to <m>3</m> and <m>x</m> interval <m>0</m> 
-              to <m>2</m>. The function has a <m>y</m> intercept at <m>y = 1</m>, and 
+              the <m>y</m> interval <m>0</m> to <m>3</m> and <m>x</m> interval <m>0</m>
+              to <m>2</m>. The function has a <m>y</m> intercept at <m>y = 1</m>, and
               is undefined at <m>x = 1</m>. The graph has a positive slope.
             </p>
           </description>
@@ -1041,7 +1041,7 @@
         </me>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We attempt to apply <xref ref="thm_poly_rat"/>
@@ -1083,7 +1083,7 @@
         </me>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -436,10 +436,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="by3ioPN6KRM" xml:id="vid_limit_con_invertals_con" label="vid_limit_con_invertals_con" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -498,6 +495,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="by3ioPN6KRM" xml:id="vid_limit_con_invertals_con" label="vid_limit_con_invertals_con" component="video"/>
     </solution>
   </example>
 
@@ -699,10 +700,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="6Lm-0eBi-5E" xml:id="vid_limit_con_intervals_again" label="vid_limit_con_intervals_again" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -788,6 +786,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="6Lm-0eBi-5E" xml:id="vid_limit_con_intervals_again" label="vid_limit_con_intervals_again" component="video"/>
     </solution>
   </example>
 
@@ -1153,10 +1155,7 @@
           accurate to three places after the decimal.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="BH6kUpIgcfg" xml:id="vid_limit_con_IVT_bisec" label="vid_limit_con_IVT_bisec" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Consider the graph of <m>f(x) = x-\cos(x)</m>,
@@ -1336,6 +1335,10 @@
           the zero was calculated to <m>100</m> decimal places
           (with less than <m>200</m> iterations).
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="BH6kUpIgcfg" xml:id="vid_limit_con_IVT_bisec" label="vid_limit_con_IVT_bisec" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -105,10 +105,10 @@
         <image xml:id="img_continuous1" width="47%">
           <description>
             <p>
-              Shows a graph with domain <m>0</m> to <m>3</m>. For <m>0 \geq x \lt 1</m> 
+              Shows a graph with domain <m>0</m> to <m>3</m>. For <m>0 \geq x \lt 1</m>
               the graph has a downward curve to it, for <m>1 &gt; x \leq 2</m> the graph
               is a straight line, parallel with the <m>x</m> axis, and for <m>2 \geq x \leq 3</m>.
-              The graph is undefined at <m>x = 1</m>. 
+              The graph is undefined at <m>x = 1</m>.
             </p>
           </description>
           <shortdescription>
@@ -204,9 +204,9 @@
             <p>
               Shows a graph with domain <m>-2</m> to <m>3</m>. There are five
               straight lines, each parallel with the <m>x</m> axis. Each of the lines is
-              one unit in length and undefined on its right side, but defined on 
+              one unit in length and undefined on its right side, but defined on
               their left. Line one is defined by the points <m>(-2, -2), (-1, -2)</m>,
-              line two <m>(-1, -1), (0, -1)</m>, line <m>3</m> <m>(0, 0), (1, 0)</m>, line <m>4</m> 
+              line two <m>(-1, -1), (0, -1)</m>, line <m>3</m> <m>(0, 0), (1, 0)</m>, line <m>4</m>
               <m>(1, 1), (2, 1)</m>, and line <m>5</m> <m>(2, 2), (3, 2)</m>.
             </p>
           </description>
@@ -436,7 +436,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -700,7 +700,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -885,7 +885,7 @@
           <image xml:id="img_discontinuity_rem">
             <description>
               <p>
-                Shows the graph of a function on the domain <m>0</m> to <m>4</m>. 
+                Shows the graph of a function on the domain <m>0</m> to <m>4</m>.
                 The graph is has a downward curve
                 and for <m>x = 2</m> the function is defined by the point <m>(2, 1)</m>.
                 The point <m>(2, 1)</m> shows a removable discontinuity because the graph
@@ -894,7 +894,7 @@
               </p>
             </description>
             <shortdescription>
-              Graph showing a removable discontinuity by having the point (2, 1) 
+              Graph showing a removable discontinuity by having the point (2, 1)
               where f(2) is undefined without the point.
             </shortdescription>
             <latex-image>
@@ -921,13 +921,13 @@
           <image xml:id="img_discontinuity_jump">
             <description>
               <p>
-                Shows the graph of a function on the domain <m>0</m> to <m>4</m>. 
-                When approching <m>x = 2</m> from the left hand side <m>f(x)</m> is 
-                undefined, but when coming from the right hand side <m>f(x) = 1</m>. For the 
-                interval <m>0 \lt x \leq 2</m> the graph is curved downward and for the 
-                interval <m>2 \leq x \leq 4</m> the graph is a straight line with a 
-                positive slope. Because <m>f(x)</m> is undefined at <m>x = 2</m> 
-                when coming from the left, but is defined coming from the right, 
+                Shows the graph of a function on the domain <m>0</m> to <m>4</m>.
+                When approching <m>x = 2</m> from the left hand side <m>f(x)</m> is
+                undefined, but when coming from the right hand side <m>f(x) = 1</m>. For the
+                interval <m>0 \lt x \leq 2</m> the graph is curved downward and for the
+                interval <m>2 \leq x \leq 4</m> the graph is a straight line with a
+                positive slope. Because <m>f(x)</m> is undefined at <m>x = 2</m>
+                when coming from the left, but is defined coming from the right,
                 there is a jump discontinuity.
               </p>
             </description>
@@ -958,19 +958,19 @@
           <image xml:id="img_discontinuity_inf">
             <description>
               <p>
-                Shows the graph of a function on the domain <m>0</m> to <m>4</m>. 
-                There is a 
+                Shows the graph of a function on the domain <m>0</m> to <m>4</m>.
+                There is a
                 vertical dotted line at <m>x = 2</m> illustrating an asymptote.
                 As <m>x</m> approaches <m>2</m> from both sides the value of <m>f(x)</m>
                 approaches infinity. The graph also has an asymptote at <m>y = 0</m>.
-                On both sides of the dotted vertical line the graph has an upward 
+                On both sides of the dotted vertical line the graph has an upward
                 curve with an increasing slope at <m>x</m> gets closer to <m>2</m>.
                 The asymptote at <m>x = 2</m> causes there to be an infinite
                 discontinuity.
               </p>
             </description>
             <shortdescription>
-              Graph of a function with an infinite discontinuity at x = 2, 
+              Graph of a function with an infinite discontinuity at x = 2,
               illustrated by a vertical asymtote.
             </shortdescription>
             <latex-image>
@@ -1030,7 +1030,7 @@
             Two other functions are plotted in red, with a dash-dot line style.
             All three functions are continuous, and satisfy <m>f(1)=-10</m>, and <m>f(2)=5</m>.
           </p>
-          
+
           <p>
             There are other lines marking certain values on the graphs.
             A horizontal line at <m>y=-10</m> indicates that all graphs start at the point <m>(1,-10)</m>.
@@ -1155,7 +1155,7 @@
           accurate to three places after the decimal.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Consider the graph of <m>f(x) = x-\cos(x)</m>,
@@ -1174,15 +1174,15 @@
           <image xml:id="img_xminuscosx" width="47%">
             <description>
               <p>
-                Graph of the function <m>f(x)=x-\cos(x)</m> on <m>[0,1]</m>. 
+                Graph of the function <m>f(x)=x-\cos(x)</m> on <m>[0,1]</m>.
                 The graph has an upward curve and intersects the <m>x</m> axis around
-                <m>x = 0.8</m>. There are two vertical guide lines, one at 
+                <m>x = 0.8</m>. There are two vertical guide lines, one at
                 <m>x = 0.7</m>, the other at <m>x = 0.9</m>. The guide lines
-                mark the interval in which the intercept occurs. 
+                mark the interval in which the intercept occurs.
               </p>
             </description>
             <shortdescription>
-              Graph of f(x) = x - cos(x), showing the x intercept between 
+              Graph of f(x) = x - cos(x), showing the x intercept between
               values x = 0.7 and x = 0.9.
             </shortdescription>
             <latex-image>
@@ -1468,7 +1468,7 @@
           <statement>
             <p>
               <var name="$TF" form="popup"/>
-              If <m>f</m> is defined on an open interval containing <m>c</m>, and 
+              If <m>f</m> is defined on an open interval containing <m>c</m>, and
 							<m>f</m> is continuous at <m>c</m>,
               then <m>\lim\limits_{x\to c}f(x)</m> exists.
             </p>
@@ -1563,9 +1563,9 @@
               <image>
                 <description>
                   <p>
-                    The graph of a piecewise-defined function defined on <m>[0,2]</m>, consisting of two parts. 
-                    The first part is a straight line with intercept <m>(0,1)</m> and a positive 
-                    slope. It ends at <m>(1,2)</m>, but this point is not part of the graph. 
+                    The graph of a piecewise-defined function defined on <m>[0,2]</m>, consisting of two parts.
+                    The first part is a straight line with intercept <m>(0,1)</m> and a positive
+                    slope. It ends at <m>(1,2)</m>, but this point is not part of the graph.
                     The second part begins at <m>(1,2)</m>, but does not include this point, and curves downward, ending at <m>(2,0)</m>.
                     There is also a solid dot at <m>(1,1)</m>, indicating that <m>f(1)=1</m>.
                   </p>
@@ -1619,7 +1619,7 @@
                     Graph of a piecewise-defined function with the domain <m>[0,2]</m>. The graph has
                     two straight lines, the first is defined by the solid point <m>(0 ,0)</m>
                     and the hollo point <m>(1, 1)</m>, and has a positive slope.
-                    The second line is defined by the solid points <m>(1, 2)</m> 
+                    The second line is defined by the solid points <m>(1, 2)</m>
                     and <m>(2, 2)</m>, and has a negative slope.
                   </p>
                 </description>
@@ -1673,10 +1673,10 @@
                   <p>
                     The image shows the graph of a function that is defined on the interval <m>[0,2]</m>,
                     except at <m>x=<var name="$a"/></m>, where it has a vertical asymptote.
-                    On either side of the vertical asymptote, as <m>x</m> gets close to <m><var name="$a"/></m>, 
+                    On either side of the vertical asymptote, as <m>x</m> gets close to <m><var name="$a"/></m>,
                     the <m>y</m> value increases without bound.
                   </p>
-                  
+
                 </description>
                 <shortdescription>
                   The graph used for the current exercise.
@@ -1726,12 +1726,12 @@
                 <description>
                   <p>
                     Graph of a piecewise-defined function with domain <m>[0,2]</m>. The graph has
-                    two lines; the first is straight and defined by the solid 
-                    point <m>(0, </m><var name="$b[0]"/><m>)</m> and hollow point 
+                    two lines; the first is straight and defined by the solid
+                    point <m>(0, </m><var name="$b[0]"/><m>)</m> and hollow point
                     <m>(1, </m><var name="$b[1]"/><m>)</m>. The second line
                     is defined by the hollow point <m>(1,
-                      <var name="$b[3]"/>)</m> and solid point 
-                      <m>(2, <var name="$b[5]"/>)</m>. When 
+                      <var name="$b[3]"/>)</m> and solid point
+                      <m>(2, <var name="$b[5]"/>)</m>. When
                       <m>x = 1 f(x) = <var name="$b[2]"/></m>
                     </p>
                   </description>
@@ -1785,7 +1785,7 @@
                   <p>
                     The graph
                     changes at <m>x = 1</m> and is defined by the solid dots
-                    <m>(0, <var name="$b[5]"/>)</m> and 
+                    <m>(0, <var name="$b[5]"/>)</m> and
                     <m>(2, <var name="$b[0]"/> )</m>.
                     At the interval <m>0 \leq x \lt 1</m> the graph is curved
                     and on the interval <m>1 \lt x \leq 2</m> the line is straight.
@@ -1840,7 +1840,7 @@
                     The graph is made up of two curves. The first is defined
                     by the solid points  <m>(-4, <var name="$b[0]"/>)</m> and
                     <m>(0, <var name="$b[1]"/>)</m>.
-                    The second is defined by the hollow point 
+                    The second is defined by the hollow point
                     <m>(0, <var name="$b[3]"/>)</m> and
                     solid point <m>(4, <var name="$b[4]"/>)</m>.
                   </p>
@@ -1904,10 +1904,10 @@
                 <description>
                   <p>
                     There are four lines that make up this graph. The first
-                    going from left to right is defined by the solid point 
-                    <m>(-4, 0)</m> and hollow point <m>(-2. 2)</m>, and has 
+                    going from left to right is defined by the solid point
+                    <m>(-4, 0)</m> and hollow point <m>(-2. 2)</m>, and has
                     a positive slope. The second line is defined by the points
-                    <m>(-2, 2)</m>, <m>0, 0</m> with a negative slope. The 
+                    <m>(-2, 2)</m>, <m>0, 0</m> with a negative slope. The
                     third line by <m>(0, 0)</m>, <m>2, 2</m> with a positive slope.
                     And the last line is defined by the hollow point <m>(2, 2)</m>
                     and solid point <m>(4, 0)</m>, with a negative slope.
@@ -1976,7 +1976,7 @@
               <image>
                 <description>
                   <p>
-                    The graph has a downward curve on the 
+                    The graph has a downward curve on the
                     interval <m>0 \leq x \leq \pi</m> and an upward curve on
                     the interval <m>\pi \leq x \leq 2\pi</m>. The peak of the
                     graph is at <m>x = \frac{\pi}{2}</m> and the lowest point

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -193,7 +193,7 @@
         Show that <m>\lim\limits_{x\to 4} \sqrt{x} = 2</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         Before we use the formal definition,
@@ -238,11 +238,11 @@
             <image xml:id="img_limit_proof1a">
               <description>
                 <p>
-                  Graph of the function <m>\sqrt{x}</m>. 
-                  There are three points on the graph, the first is at <m>x = 2.25</m>, 
-                  <m>f(2.25) = 1.5</m>, giving the point <m>(2.25, 1.5)</m>. For the 
-                  second point we have <m>x = 4</m>, making <m>f(4) = 2</m>, which gives 
-                  the point <m>(4, 2)</m>. The third point found at <m>x = 6.25</m> 
+                  Graph of the function <m>\sqrt{x}</m>.
+                  There are three points on the graph, the first is at <m>x = 2.25</m>,
+                  <m>f(2.25) = 1.5</m>, giving the point <m>(2.25, 1.5)</m>. For the
+                  second point we have <m>x = 4</m>, making <m>f(4) = 2</m>, which gives
+                  the point <m>(4, 2)</m>. The third point found at <m>x = 6.25</m>
                   which gives <m>f(6.25) = 2.5</m>, giving the point <m>(6.25, 2.5)</m>.
                 </p>
                 <p>
@@ -252,7 +252,7 @@
                 </p>
                 <p>
                   There are two vertical lines near the <m>y</m> axis, at <m>y = 2</m>. One which goes
-                  down and the other goes up. The length of the lines represents 
+                  down and the other goes up. The length of the lines represents
                   <m>\varepsilon = 0.5</m> and are used to show that the points <m>(2.25, 1.5)</m>
                   and <m>(6.25, 2.5)</m> are within <m>\varepsilon</m> of the point
                   <m>(4, 2)</m>.
@@ -294,16 +294,16 @@
               <description>
                 <p>
                   Graph of the equation <m>sqrt{x}</m>.
-                  There are three points on the graph, the first is at <m>x = 2.25</m>, 
-                  <m>f(2.25) = 1.5</m>, giving the point <m>(2.25, 1.5)</m>. For the 
-                  second point we have <m>x = 4</m>, making <m>f(4) = 2</m>, which 
-                  gives the point <m>(4, 2)</m>. The third point found at <m>x = 6.25</m> 
+                  There are three points on the graph, the first is at <m>x = 2.25</m>,
+                  <m>f(2.25) = 1.5</m>, giving the point <m>(2.25, 1.5)</m>. For the
+                  second point we have <m>x = 4</m>, making <m>f(4) = 2</m>, which
+                  gives the point <m>(4, 2)</m>. The third point found at <m>x = 6.25</m>
                   which gives <m>f(6.25) = 2.5</m>, giving the point <m>(6.25, 2.5)</m>.
                 </p>
                 <p>
-                  This graph has the same vertical lines as <xref ref="fig_limit_proof1a"/> 
+                  This graph has the same vertical lines as <xref ref="fig_limit_proof1a"/>
                   There are also horizontal lines near the <m>x</m> axis, showing the distance from
-                  <m>2.25</m> to <m>4</m> is <m>1.75</m> and the distance from <m>6.25</m> to 
+                  <m>2.25</m> to <m>4</m> is <m>1.75</m> and the distance from <m>6.25</m> to
                   <m></m>4 is <m>2.25</m>.
                 </p>
               </description>
@@ -459,7 +459,7 @@
         Show that <m>\lim\limits_{x\to 2} x^2 = 4</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -556,7 +556,7 @@
           <description>
             <p>
               Graph of <m>x^2</m> zoomed in where <m>x = 2</m>. There are three points on
-              the graph: 
+              the graph:
               <ol>
                 <li><m>(1.73, 3)</m>, since when <m>x = 1.73</m> we get <m>f(1.73) = 3</m></li>
                 <li><m>(2, 4)</m>, because when <m>x = 2</m>, <m>f(2) = 4</m></li>
@@ -565,16 +565,16 @@
             </p>
             <p>
               There is a vertial line showing the point <m>(1.73, 3)</m> is <m>\varepsilon</m>
-              from the point <m>(2, 4)</m>, because <m>3 + \varepsilon = 4</m>. Another vertical 
-              line is used to show the point <m>(2.24, 5)</m> is <m>\varepsilon</m> from the 
+              from the point <m>(2, 4)</m>, because <m>3 + \varepsilon = 4</m>. Another vertical
+              line is used to show the point <m>(2.24, 5)</m> is <m>\varepsilon</m> from the
               point <m>2, 4</m>, since <m>5 - \varepsilon = 4</m>.
             </p>
             <p>
-              There are also vertical lines at <m>x = 2.24</m>, <m>x = 1.73</m>, 
+              There are also vertical lines at <m>x = 2.24</m>, <m>x = 1.73</m>,
               <m>x = 2.2</m>, and <m>x = 1.8</m>. This creates two sets of vertical lines,
               the outer set is at <m>x = 1.73</m> and <m>x = 2.24</m>. The inner set
               is at <m>x = 1.8</m> and <m>x = 2.2</m>. The out set of lines mark where
-              <m>\delta = 1</m>, while the inner set marks 
+              <m>\delta = 1</m>, while the inner set marks
               <m>\delta = \epsilon / 5</m>.
             </p>
             <p>
@@ -587,7 +587,7 @@
             </p>
           </description>
           <shortdescription>
-            Graph of x squared, has 3 points. Shows that two points are within epsilon 
+            Graph of x squared, has 3 points. Shows that two points are within epsilon
             and delta of the third point.
           </shortdescription>
           <latex-image>
@@ -703,7 +703,7 @@
         Prove that <m>\lim\limits_{x\to 1}(x^3-2x) = -1</m>.
       </p>
     </statement>
-   
+
     <solution>
 
       <p>

--- a/ptx/sec_limit_def.ptx
+++ b/ptx/sec_limit_def.ptx
@@ -193,10 +193,7 @@
         Show that <m>\lim\limits_{x\to 4} \sqrt{x} = 2</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="qHWI0eha_rA" xml:id="vid_limit_defn_sqrt_epsilon" label="vid_limit_defn_sqrt_epsilon" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         Before we use the formal definition,
@@ -434,6 +431,10 @@
         that <m>\lim_{x\to 4} \sqrt{x} = 2</m>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="qHWI0eha_rA" xml:id="vid_limit_defn_sqrt_epsilon" label="vid_limit_defn_sqrt_epsilon" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -458,10 +459,7 @@
         Show that <m>\lim\limits_{x\to 2} x^2 = 4</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="QGqoq-xEXyk" xml:id="vid_limit_defn_quadratic" label="vid_limit_defn_quadratic" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -637,6 +635,10 @@
         we see that <m>f(x)</m> is within <m>\varepsilon</m> of <m>4</m>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="QGqoq-xEXyk" xml:id="vid_limit_defn_quadratic" label="vid_limit_defn_quadratic" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -701,10 +703,7 @@
         Prove that <m>\lim\limits_{x\to 1}(x^3-2x) = -1</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="-&#45;_Rq2GX9IY" xml:id="vid_limit_defn_polynomial" label="vid_limit_defn_polynomial" component="video"/>
-    </solution>
+   
     <solution>
 
       <p>
@@ -772,6 +771,10 @@
         which is what we wanted to show.
         Thus <m>\lim_{x\to 1}(x^3-2x) = -1</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="-&#45;_Rq2GX9IY" xml:id="vid_limit_defn_polynomial" label="vid_limit_defn_polynomial" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -207,7 +207,7 @@
           <image xml:id="img_inflim1" width="47%">
             <description>
               <p>
-                Graph of <m>f(x)=\frac{1}{(x-1)^2}</m> for <m>x</m> between <m>0</m> and <m>1</m>.  
+                Graph of <m>f(x)=\frac{1}{(x-1)^2}</m> for <m>x</m> between <m>0</m> and <m>1</m>.
                 There is a vertical
                 asymptote at <m>x = 1</m> and a horizontal asymptote at <m>y = 0</m>.
                 As <m>x</m> gets near <m>1</m> from both sides of the vertical asymptote
@@ -236,7 +236,7 @@
           <!-- figures/fig_nolimit2.tex END -->
         </figure>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -282,7 +282,7 @@
           as shown in <xref ref="fig_oneoverx"/>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -302,11 +302,11 @@
             <description>
               <p>
                 Graph of <m>y=1/x</m>, for <m>x</m> between <m>-1</m> and <m>1</m>.
-                There is a vertical asymptote at <m>x = 0</m> and a horizontal asymptote at 
+                There is a vertical asymptote at <m>x = 0</m> and a horizontal asymptote at
                 <m>y = 0</m>. As <m>x</m> approaches <m>0</m> from the left, <m>y</m>
                 approaches <m>-\infty</m> and from the right, <m>y</m> approaches
                 <m>\infty</m>. As <m>y</m> approaches <m>0</m> from the bottom, <m>x</m>
-                approaches <m>-\infty</m> and from the top, <m>x</m> approaches 
+                approaches <m>-\infty</m> and from the top, <m>x</m> approaches
                 <m>\infty</m>. The lines of the equation are in quadrants one and
                 three of the graph.
               </p>
@@ -382,7 +382,7 @@
           Find the vertical asymptotes of <m>f(x)=\frac{3x}{x^2-4}</m>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -403,7 +403,7 @@
           <image xml:id="img_multipleasymptotes" width="47%">
             <description>
               <p>
-                Graph of <m>f(x)=\frac{3x}{x^2-4}</m>. There are 
+                Graph of <m>f(x)=\frac{3x}{x^2-4}</m>. There are
                 two vertical asymptotes, one at <m>x = -2</m> and the other at
                 <m>x = 2</m>. For <m>x</m> values less than <m>-2</m>, <m>f(x)</m> is
                 less than <m>0</m> and the graph is curved downward. For <m>x</m>
@@ -414,7 +414,7 @@
               </p>
               <p>
                 Because of the asymptote at <m>x = -2</m>, as <m>x</m> gets near
-                <m>-2</m> from the left <m>f(x)</m> approaches <m>-\infty</m>. 
+                <m>-2</m> from the left <m>f(x)</m> approaches <m>-\infty</m>.
                 But coming from the right <m>f(x)</m> approaches <m>\infty</m>.
                 Because of the other asymptote at <m>x = 2</m>, as <m>x</m> get near
                 <m>2</m> from the left <m>f(x)</m> approaches <m>-\infty</m>. But
@@ -482,9 +482,9 @@
       <image xml:id="img_noasy" width="47%">
         <description>
           <p>
-            The graph 
+            The graph
             is a single straight line with a positive slope. At <m>x = 1</m>
-            there is a hollow point indicating a discontinuity, the exact 
+            there is a hollow point indicating a discontinuity, the exact
             position of the discontinuity is <m>(1, 2)</m>.
           </p>
         </description>
@@ -794,8 +794,8 @@
           <image xml:id="img_hzasya">
             <description>
               <p>
-                As 
-                <m>x</m> approaches <m>-\infty</m> and <m>\infty, f(x)</m> gets near 
+                As
+                <m>x</m> approaches <m>-\infty</m> and <m>\infty, f(x)</m> gets near
                 <m>0</m>. The graph dips to a minimum value just to the left of the <m>y</m> axis,
                 then crosses the <m>x</m> axis at <m>(0,0)</m>, rising to a maximum value just to the right of the <m>x</m> axis,
                 before falling again toward the horizontal asymptote <m>y=0</m>.
@@ -1018,7 +1018,7 @@
           as approximated in <xref ref="ex_hzasy1"/>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1103,7 +1103,7 @@
               <image xml:id="img_hzasy3a">
                 <description>
                   <p>
-                    Graph of <m>\dfrac{x^2+2x-1}{x^3+1}</m> for <m>x\lt 0</m>. 
+                    Graph of <m>\dfrac{x^2+2x-1}{x^3+1}</m> for <m>x\lt 0</m>.
                     The graph shows that
                     as <m>x</m> approaches <m>-\infty</m>, the limit of <m>f(x)</m>
                     is <m>0</m>.
@@ -1136,11 +1136,11 @@
                 <description>
                   <p>
                     There
-                    is a horizontal asymptote at <m>y = -\frac{1}{3}</m>, helping 
+                    is a horizontal asymptote at <m>y = -\frac{1}{3}</m>, helping
                     illustrate that the limit of <m>f(x) = \frac{1}{3}</m>,
-                    which is the coefficient of the numerator with the highest 
+                    which is the coefficient of the numerator with the highest
                     power of <m>x</m> in <m>\dfrac{x^2+2x-1}{1-x-3x^2}</m>
-                    divided by the coefficient of the dennominator with the 
+                    divided by the coefficient of the dennominator with the
                     highest power of <m>x</m> in <m>\dfrac{x^2+2x-1}{1-x-3x^2}</m>.
                   </p>
                 </description>
@@ -1173,7 +1173,7 @@
                   <p>
                     The graph shows that the limit of <m>f(x)</m> will be determined
                     by dominant terms from the numerator and denominator, which are
-                    <m>x^2</m> and <m>-x</m>. Since <m>\frac{x^2}{-x} = -x</m> for large values 
+                    <m>x^2</m> and <m>-x</m>. Since <m>\frac{x^2}{-x} = -x</m> for large values
                     of <m>x</m>, the graph of <m>f(x)</m> behaves approximately the same as that of <m>y=x</m>.
                   </p>
                 </description>
@@ -1426,14 +1426,14 @@
                 <description>
                   <p>
                     Graph with the domain <var name="$xmin"/> to <var name="$xmax"/>. There
-                    is a vertical asymptote at <m>x = <var name="$a"/></m>, 
+                    is a vertical asymptote at <m>x = <var name="$a"/></m>,
                     and <m>f(x)</m> grows without bound on both sides of the asymptote.
                     To the left of <m>x = <var name="$a"/></m>, <m>f(x)</m> is negative,
                     and to the right of the asymptote, <m>f(x)</m> is positive.
                   </p>
                 </description>
                 <shortdescription>
-                  Graph of a reciprocal power function with a vertical asymptote at x =<var name="$a"/>. 
+                  Graph of a reciprocal power function with a vertical asymptote at x =<var name="$a"/>.
                 </shortdescription>
                 <latex-image>
                   \begin{tikzpicture}
@@ -1515,9 +1515,9 @@
                     two vertical asymptotes, one at <m>x = <var name="$a[0]"/></m>
                     and the other at <m>x = <var name="$a[1]"/></m>. On the interval
                     <m><var name="$a[0]"/> \lt x \lt <var name="$a[1]"/></m> the
-                    graph curves and as <m>x</m> gets near 
+                    graph curves and as <m>x</m> gets near
                     <m><var name="$a[0]"/></m> and <m><var name="$a[1]"/>, f(x)</m>
-                    approaches <m>\infty</m>. For the interval 
+                    approaches <m>\infty</m>. For the interval
                     <m>-\infty \lt x \lt<var name="$a[0]"/></m> as <m>x</m> gets near
                     <m><var name="$a[0]"/>, f(x)</m> approaches <m>-\infty</m>. Lastly,
                     for the interval <m><var name="$a[1]"/> \lt x \lt \infty</m> as <m>x</m>
@@ -1642,7 +1642,7 @@
                     For some versions of this question, the graph <m>f(x)=<var name="$f"/></m> begins with <m>y</m>
                     near <m><var name="$a"/></m> when <m>x</m> is negative, and then descends toward <m>0</m> as <m>x</m> increases.
                   </p>
-                  
+
                   <p>
                     For other versions of this question, <m>f(x)</m> will be close to <m>0</m> when <m>x</m> is negative,
                     and then will rise toward <m><var name="$a"/></m> as <m>x</m> increases.
@@ -1906,9 +1906,9 @@
                 <description>
                   <p>
                     Graph with the domain <m><var name="$start"/></m> to <m><var name="$stop"/></m>. The
-                    line <m>y = <var name="$c"/></m> is a horizontal asymptote, but only in one direction. 
+                    line <m>y = <var name="$c"/></m> is a horizontal asymptote, but only in one direction.
                   </p>
-                  
+
                   <p>
                     In some versions of the question, the function grows without bound as <m>x\to \infty</m>,
                     and approaches the horizontal asymptote as <m>x\to -\infty</m>.

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -236,10 +236,7 @@
           <!-- figures/fig_nolimit2.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="S3dUAUQiKFQ" xml:id="vid_limit_inf_ex_using_defn" label="vid_limit_inf_ex_using_defn" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -271,6 +268,10 @@
           So we may say <m>\lim_{x\to 1}1/{(x-1)^2}=\infty</m>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="S3dUAUQiKFQ" xml:id="vid_limit_inf_ex_using_defn" label="vid_limit_inf_ex_using_defn" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_inflim2">
@@ -281,10 +282,7 @@
           as shown in <xref ref="fig_oneoverx"/>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="JP1k74FZE1I" xml:id="vid_limit_inf_ex_1overx" label="vid_limit_inf_ex_1overx" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -335,6 +333,10 @@
           <!-- figures/fig_oneoverx.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="JP1k74FZE1I" xml:id="vid_limit_inf_ex_1overx" label="vid_limit_inf_ex_1overx" component="video"/>
+      </solution>
     </example>
   </introduction>
 
@@ -380,10 +382,7 @@
           Find the vertical asymptotes of <m>f(x)=\frac{3x}{x^2-4}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="h-1BCF_lsHI" xml:id="vid_limit_inf_vert_asymptotes_ex" label="vid_limit_inf_vert_asymptotes_ex" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -448,6 +447,10 @@
           </image>
           <!-- figures/fig_multipleasymptotes.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="h-1BCF_lsHI" xml:id="vid_limit_inf_vert_asymptotes_ex" label="vid_limit_inf_vert_asymptotes_ex" component="video"/>
       </solution>
     </example>
 
@@ -1015,10 +1018,7 @@
           as approximated in <xref ref="ex_hzasy1"/>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="cmZ39j1YI-o" xml:id="vid_limit_at_inf_rat_func_ex" label="vid_limit_at_inf_rat_func_ex" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1038,8 +1038,12 @@
         <p>
           We can also use <xref ref="thm_lim_rational_fn_at_infty"/> directly;
           in this case <m>n=m</m> so the limit is the ratio of the leading coefficients of the numerator and denominator,
-          <ie/>, 1/1 = 1.
+          <ie/>, <m>1/1 = 1</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="cmZ39j1YI-o" xml:id="vid_limit_at_inf_rat_func_ex" label="vid_limit_at_inf_rat_func_ex" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -38,18 +38,18 @@
         <image xml:id="img_sinx_over_x_full">
           <description>
             <p>
-              Graph of <m>\sin(x)/x</m> showing the domain and range of  
-              <m>-7</m>to <m>7</m> and <m>0</m> to 
-              <m>1</m> respectively. <m>x</m> intercepts are at 
-              <m>x=--2\pi, -\pi, \pi. 2\pi</m> and a <m>y</m> intercept is at <m>y = 1</m>. 
-              The function has a downward curve for <m>-\pi \lt x \lt \pi</m> and an 
-              upward curve for <m>-2\pi \gt x \lt -\pi</m>, and 
+              Graph of <m>\sin(x)/x</m> showing the domain and range of
+              <m>-7</m>to <m>7</m> and <m>0</m> to
+              <m>1</m> respectively. <m>x</m> intercepts are at
+              <m>x=--2\pi, -\pi, \pi. 2\pi</m> and a <m>y</m> intercept is at <m>y = 1</m>.
+              The function has a downward curve for <m>-\pi \lt x \lt \pi</m> and an
+              upward curve for <m>-2\pi \gt x \lt -\pi</m>, and
               <m>\pi \gt x \lt 2\pi</m>. The graph is undefined for <m>x = 0</m>.
             </p>
           </description>
           <shortdescription>
             Graph of sinx/x, shows values for the domain -7 &lt;=x &lt;=7,
-            undefined at x = 0. 
+            undefined at x = 0.
           </shortdescription>
           <latex-image>
             \begin{tikzpicture}[
@@ -75,14 +75,14 @@
         <image xml:id="img_zoom_sinx_over_x">
           <description>
             <p>
-              Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>1</m>. The 
-              domain of the graph is <m>0.5</m> to <m>1.5</m>. 
-              The line has only a slight downward curve. It shows that for <m>x = 1</m>, 
+              Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>1</m>. The
+              domain of the graph is <m>0.5</m> to <m>1.5</m>.
+              The line has only a slight downward curve. It shows that for <m>x = 1</m>,
               <m>\sin(x)/x</m> is approx. <m>0.84</m>
             </p>
           </description>
-          <shortdescription> 
-            Graph of sinx / x zoomed in on values where x is near 1. Shows that for x = 1, 
+          <shortdescription>
+            Graph of sinx / x zoomed in on values where x is near 1. Shows that for x = 1,
             sinx/x is approx. 0.84.
           </shortdescription>
           <latex-image>
@@ -136,15 +136,15 @@
       <image xml:id="img_sinx_over_x_2" width="47%">
         <description>
           <p>
-            Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>0</m>. The 
-            domain of the graph is <m>-1</m> to <m>1</m>. The graph 
+            Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>0</m>. The
+            domain of the graph is <m>-1</m> to <m>1</m>. The graph
             has a downward curve and symmetric, peaking at <m>y = 1</m>. There is a dot at
-            <m>x = 0</m> showing the equation is undefined for values of <m>x = 0</m>, 
+            <m>x = 0</m> showing the equation is undefined for values of <m>x = 0</m>,
             that is, <m>f(0) =</m> undefined.
           </p>
         </description>
-        <shortdescription> 
-          Graph of sinx/x zoomed in on values where x is near 0. Shows that when x = 0 
+        <shortdescription>
+          Graph of sinx/x zoomed in on values where x is near 0. Shows that when x = 0
           sinx/x is undefined.
         </shortdescription>
         <latex-image>
@@ -347,7 +347,7 @@
           </me>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -369,16 +369,16 @@
             <image xml:id="img_limit1">
               <description>
                 <p>
-                  Graph of <m>(x^2 - x - 6)/(6x^2 - 19x + 3)</m>, 
+                  Graph of <m>(x^2 - x - 6)/(6x^2 - 19x + 3)</m>,
                   zoomed on values near <m>x = 3</m>. The domain is approximately
                   <m>2.5</m> to <m>2.5</m>.
-                  There is a slight upward curve to the graph. Shows that the limit of the 
-                  equation as <m>x</m> approaches <m>3</m> is <m>0.294</m>. The graph also 
-                  shows that the equation is undefined for <m>x = 3</m>. 
+                  There is a slight upward curve to the graph. Shows that the limit of the
+                  equation as <m>x</m> approaches <m>3</m> is <m>0.294</m>. The graph also
+                  shows that the equation is undefined for <m>x = 3</m>.
                 </p>
               </description>
-              <shortdescription> 
-                Graph of the equation, shows that when x = 3 the y = undefined, 
+              <shortdescription>
+                Graph of the equation, shows that when x = 3 the y = undefined,
                 but near 0.294.
               </shortdescription>
               <latex-image>
@@ -514,7 +514,7 @@
           </me>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -537,13 +537,13 @@
                 <p>
                   Graph of the piecewise-defined function in <xref ref="ex_limit2"/>.
                   For values of <m>x \lt 0</m> the graph is straight
-                  with a slope of <m>1</m> and for values <m>x \gt 0</m> the graph is 
+                  with a slope of <m>1</m> and for values <m>x \gt 0</m> the graph is
                   curved downward with a negative slope. Shows that at <m>x = 0</m>,
                   <m>y</m> is undefined, but near <m>1</m>.
                 </p>
               </description>
-              <shortdescription> 
-                Graph of the piecewise function, shows that at x = 0, y is undefined, 
+              <shortdescription>
+                Graph of the piecewise function, shows that at x = 0, y is undefined,
                 but is near 1.
               </shortdescription>
               <latex-image>
@@ -699,16 +699,16 @@
             <image xml:id="img_nolimit1">
               <description>
                 <p>
-                  Graph of piecewise function in <xref ref="ex_no_limit1"/>. 
-                  For values of <m>x \leq 1</m> the graph 
-                  has a upward curve, and where <m>x = 1</m> <m>y = 2</m>. 
-                  For values of <m>x \gt 1</m> the graph is straight with a 
+                  Graph of piecewise function in <xref ref="ex_no_limit1"/>.
+                  For values of <m>x \leq 1</m> the graph
+                  has a upward curve, and where <m>x = 1</m> <m>y = 2</m>.
+                  For values of <m>x \gt 1</m> the graph is straight with a
                   positive slope, where <m>x = 1</m>, <m>y</m> is undefined.
                 </p>
               </description>
-              <shortdescription> 
-                Graph of the piecewise function, which shows that as x approaches 1 there 
-                is no limit. 
+              <shortdescription>
+                Graph of the piecewise function, which shows that as x approaches 1 there
+                is no limit.
               </shortdescription>
               <latex-image>
                 \begin{tikzpicture}
@@ -789,14 +789,14 @@
             <image xml:id="img_nolimit2">
               <description>
                 <p>
-                  Graph of the function for <xref ref="ex_no_limit2"/>. 
-                  The graph hows a horizontal 
-                  asymptote at <m>y = 0</m> and a vertical asymptote at <m>x = 1</m>. 
-                  Because of the vertical asymptote at <m>x = 1</m> the equation 
+                  Graph of the function for <xref ref="ex_no_limit2"/>.
+                  The graph hows a horizontal
+                  asymptote at <m>y = 0</m> and a vertical asymptote at <m>x = 1</m>.
+                  Because of the vertical asymptote at <m>x = 1</m> the equation
                   has no limit as <m>x</m> approaches <m>1</m>.
                 </p>
               </description>
-              <shortdescription> 
+              <shortdescription>
                 Graph of the equation showing that as x approaches 1 f(x) asymptotes.
               </shortdescription>
               <latex-image>
@@ -883,7 +883,7 @@
           Explore why <m>\lim_{x\to 0}\sin(1/x)</m> does not exist.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -912,15 +912,15 @@
               <image xml:id="img_nolimit3a">
                 <description>
                   <p>
-                    Graph of <m>sin(1/x)</m> displaying the <m>x</m> and <m>y</m> 
-                    intervals <m>-1</m> to <m>1</m>. As <m>x</m> gets close to 
-                    <m>0</m> the cycles shorten, rendering a wide, vertical line. 
+                    Graph of <m>sin(1/x)</m> displaying the <m>x</m> and <m>y</m>
+                    intervals <m>-1</m> to <m>1</m>. As <m>x</m> gets close to
+                    <m>0</m> the cycles shorten, rendering a wide, vertical line.
                     This line is however not solid as it is just a bunch of lines
                     really close to each other.
                   </p>
                 </description>
                 <shortdescription>
-                  Graph of the equation showing a thick line at x = 0, where the thick 
+                  Graph of the equation showing a thick line at x = 0, where the thick
                   line is just the oscillation of a single thin line on short cycles.
                 </shortdescription>
                 <latex-image>
@@ -985,11 +985,11 @@
               <image xml:id="img_nolimit3b">
                 <description>
                   <p>
-                    Graph of <m>sin(1/x)</m> displaying the <m>y</m> interval <m>-1</m> to 
+                    Graph of <m>sin(1/x)</m> displaying the <m>y</m> interval <m>-1</m> to
                     <m>1</m> and <m>x</m> interval <m>-0.1</m> to <m>0.1</m>. As <m>x</m> gets close
                     to <m>0</m> the cycles shorten, rendering a wide, vertical line.
                     This line is however not solid as it is just a bunch of lines
-                    really close to each other. 
+                    really close to each other.
                   </p>
                 </description>
                 <shortdescription>
@@ -1181,17 +1181,17 @@
       <image xml:id="img_diffquot1" width="47%">
         <description>
           <p>
-            Graph showing a downward curved equation with the domain and range 
-            <m><var name="$xmin"/></m> to <m><var name="$xmax"/></m> and 
-            <m><var name="$ymin"/></m> to <m><var name="$ymax"/></m> respectively. 
-            There are two dots plotted on the line of the equation at 
-            <m>(1, 10)</m> and <m>(5, 20)</m> with a dotted line intercepting the 
-            points. The dotted line has a positive slope. The line of the 
-            equation intercepts the <m>x</m> axis at <m>(0, 0)</m> 
+            Graph showing a downward curved equation with the domain and range
+            <m><var name="$xmin"/></m> to <m><var name="$xmax"/></m> and
+            <m><var name="$ymin"/></m> to <m><var name="$ymax"/></m> respectively.
+            There are two dots plotted on the line of the equation at
+            <m>(1, 10)</m> and <m>(5, 20)</m> with a dotted line intercepting the
+            points. The dotted line has a positive slope. The line of the
+            equation intercepts the <m>x</m> axis at <m>(0, 0)</m>
           </p>
         </description>
         <shortdescription>
-          Graph showing a downward curved equation, with points at (1,10) and (5,20), with a 
+          Graph showing a downward curved equation, with points at (1,10) and (5,20), with a
           dotted line intercepting both points and a positive slope.
         </shortdescription>
         <latex-image>
@@ -1261,12 +1261,12 @@
             <description>
               <p>
                 Graph of the same equation from 1.1.26, with the points <m>(1,10)</m>
-                and <m>(3,21)</m>. The secant line has a steeper slope than in 
+                and <m>(3,21)</m>. The secant line has a steeper slope than in
                 figure 1.1.26. Here the value of h is <m>2</m>.
               </p>
             </description>
             <shortdescription>
-              Graph of the previous equation, with the points (1,10) 
+              Graph of the previous equation, with the points (1,10)
               and (3,21). The secant line has a steeper slope, equal to 5.5.
             </shortdescription>
             <latex-image>
@@ -1293,13 +1293,13 @@
           <image xml:id="img_diff_quot_smallhb">
             <description>
               <p>
-                Graph of the same equation from <xref ref="fig_diff_quot_smallha"/>, but 
+                Graph of the same equation from <xref ref="fig_diff_quot_smallha"/>, but
                 with the points <m>(1,10)</m> and <m>(2,17)</m>. Shows the dotted line with a steeper
                 slope than in figure 1.1.26. Here the value of h is <m>1</m>.
               </p>
             </description>
             <shortdescription>
-              Graph of the same equation, with the points (1,10) 
+              Graph of the same equation, with the points (1,10)
               and (2,17). The secant line has a steeper slope equal to 7.
             </shortdescription>
             <latex-image>
@@ -1327,12 +1327,12 @@
             <description>
               <p>
                 Graph of the same equation from <xref ref="fig_diff_quot_smallhb"/>, but
-                with the points <m>(1,10)</m> and <m>(1.5,13.875)</m>. Shows the dotted line with a 
+                with the points <m>(1,10)</m> and <m>(1.5,13.875)</m>. Shows the dotted line with a
                 steeper slope than in figure 1.1.26. Here the value of h is <m>0.5</m>.
               </p>
             </description>
-            <shortdescription> 
-              Graph of the same equation, with the points (1,10) and 
+            <shortdescription>
+              Graph of the same equation, with the points (1,10) and
               (1.5,13.875). The secant line has a steeper slope equal to 7.75.
             </shortdescription>
             <latex-image>
@@ -1629,7 +1629,7 @@
                     When <m>x</m> is close to <m><var name="$a"/></m>, the value of <m>f(x)</m> appears to be close to <m><var name="$l"/></m>.
                   </p>
                 </description>
-                <shortdescription>A parabola opening upward, with vertex at (<var name="$vx"/>,<var name="$vy"/>), 
+                <shortdescription>A parabola opening upward, with vertex at (<var name="$vx"/>,<var name="$vy"/>),
                   also passing through (<var name="$a"/>,<var name="$l"/>)</shortdescription>
                 <latex-image>
                   \begin{tikzpicture}
@@ -2469,7 +2469,7 @@
                   </p>
                 </description>
                 <shortdescription>A piecewise-defined graph. One part is a parabola, and the other, a cosine wave. The two parts meet when x=<var name="$a"/></shortdescription>
-                
+
                 <latex-image>
                   \begin{tikzpicture}
                     \begin{axis}[

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -347,10 +347,7 @@
           </me>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="eHx3LmrQZXM" xml:id="vid_limit_intro_rational_func" label="vid_limit_intro_rational_func" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -455,6 +452,10 @@
           </me>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="eHx3LmrQZXM" xml:id="vid_limit_intro_rational_func" label="vid_limit_intro_rational_func" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -513,10 +514,7 @@
           </me>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="7RAiKoLCpgU" xml:id="vid_limit_intro_piecewise_func" label="vid_limit_intro_piecewise_func" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -616,6 +614,10 @@
           The graph and table allow us to say that <m>\lim_{x\to 0}f(x) \approx 1</m>;
           in fact, we are probably very sure it <em>equals</em> 1.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="7RAiKoLCpgU" xml:id="vid_limit_intro_piecewise_func" label="vid_limit_intro_piecewise_func" component="video"/>
       </solution>
     </example>
   </introduction>
@@ -881,10 +883,7 @@
           Explore why <m>\lim_{x\to 0}\sin(1/x)</m> does not exist.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="gGvvFX5QyjE" xml:id="vid_limit_intro_limit_oscillation" label="vid_limit_intro_limit_oscillation" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1107,6 +1106,10 @@
           Because of this oscillation,
           <m>\lim_{x\to 0}\sin(1/x)</m> does not exist.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="gGvvFX5QyjE" xml:id="vid_limit_intro_limit_oscillation" label="vid_limit_intro_limit_oscillation" component="video"/>
       </solution>
     </example>
   </subsection>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -227,10 +227,7 @@
         <!-- figures/fig_one_sidedlimit1.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="NdBPwaP4Xkk" xml:id="vid_limit_one_sided_ex_1" label="vid_limit_one_sided_ex_1" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -320,6 +317,10 @@
         </ol>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="NdBPwaP4Xkk" xml:id="vid_limit_one_sided_ex_1" label="vid_limit_one_sided_ex_1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -406,10 +407,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="vE_7FG2h_LU" xml:id="vid_limit_one_sided_ex_2" label="vid_limit_one_sided_ex_2" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -573,6 +571,10 @@
         <!-- figures/fig_one_sidedlimit2.tex END -->
       </figure>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="vE_7FG2h_LU" xml:id="vid_limit_one_sided_ex_2" label="vid_limit_one_sided_ex_2" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_onesidec">
@@ -636,10 +638,7 @@
         <!-- figures/fig_one_sidedlimit3.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="HVFazve-Qxc" xml:id="vid_limit_one_sided_ex_4" label="vid_limit_one_sided_ex_4" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -649,6 +648,10 @@
         <ie/>, <m>\lim_{x\to 1} f(x) = 0</m>.
         It is also clearly stated that <m>f(1) = 1</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="HVFazve-Qxc" xml:id="vid_limit_one_sided_ex_4" label="vid_limit_one_sided_ex_4" component="video"/>
     </solution>
   </example>
 
@@ -716,10 +719,7 @@
         <!-- figures/fig_one_sidedlimit4.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="Nn6JoJRK7nk" xml:id="vid_limit_one_sided_ex_3" label="vid_limit_one_sided_ex_3" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -728,6 +728,10 @@
           \lim_{x\to 1^-} f(x) = \lim_{x\to 1^+} f(x) =\lim_{x\to 1} f(x) =f(1) = 1
         </me>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="Nn6JoJRK7nk" xml:id="vid_limit_one_sided_ex_3" label="vid_limit_one_sided_ex_3" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -181,14 +181,14 @@
         <image xml:id="img_onesided1" width="47%">
           <description>
             <p>
-              Graph of the piecewise function 
+              Graph of the piecewise function
               <m>f(x) = \begin{cases} x \amp 0\leq x\leq 1 \\ 3-x \amp 1\lt x\lt 2 \end{cases}</m>.
-              There are two lines, 
-              one with a positive slope and the other with a negative slope.               
+              There are two lines,
+              one with a positive slope and the other with a negative slope.
             </p>
             <p>
               The line with a positive slope starts at the point <m>(0, 0)</m>
-              and ends at <m>(1, 1)</m>. The line with a negative slope starts 
+              and ends at <m>(1, 1)</m>. The line with a negative slope starts
               at <m>(1, 2)</m> and ends at <m>(2, 1)</m>.
             </p>
             <p>
@@ -200,12 +200,12 @@
               to left and <m>x = 2</m> is undedined as well. Because the
               function is defined at <m>x = 1</m> on the line with a positive
               slope, but is undefined at <m>x = 1</m> on the other line, we can
-              tell the function <m>f</m> has a one-sided limit as <m>x</m> 
+              tell the function <m>f</m> has a one-sided limit as <m>x</m>
               approaches <m>1</m>.
             </p>
           </description>
           <shortdescription>
-            Graph of a piecewise function that has only a left sided limit as x 
+            Graph of a piecewise function that has only a left sided limit as x
             approaches 1.
           </shortdescription>
           <latex-image>
@@ -227,7 +227,7 @@
         <!-- figures/fig_one_sidedlimit1.tex END -->
       </figure>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -407,7 +407,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -608,8 +608,8 @@
             <p>
               The graph of <m>f(x)</m> in <xref ref="ex_onesidec"/>.
               The graph is a parabola, opening upward, plotted from
-              <m>(0, 1)</m> to <m>(2, 1)</m>, with its vertex at <m>(1,0)</m>. 
-              However, there is a hole in the graph at the vertex, indicated by a hollow dot. 
+              <m>(0, 1)</m> to <m>(2, 1)</m>, with its vertex at <m>(1,0)</m>.
+              However, there is a hole in the graph at the vertex, indicated by a hollow dot.
               The function is still defined at <m>x = 1</m>,
               because there is a solid dot at <m>(1, 1)</m>. This shows that
               <m>f(1) = 1</m>, but the limit of <m>f</m> as <m>x</m> approaches <m>1</m>
@@ -617,7 +617,7 @@
             </p>
           </description>
           <shortdescription>
-            Graph of f(x), showing an upward curved line and a solid dot at (1, 1). 
+            Graph of f(x), showing an upward curved line and a solid dot at (1, 1).
             Line of the equation is undefined at x = 1.
           </shortdescription>
           <latex-image>
@@ -638,7 +638,7 @@
         <!-- figures/fig_one_sidedlimit3.tex END -->
       </figure>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -684,13 +684,13 @@
         <image xml:id="img_onesidedd" width="47%">
           <description>
             <p>
-              Graph of a piecewise-defined function, on the interval <m>[0,2]</m>. 
+              Graph of a piecewise-defined function, on the interval <m>[0,2]</m>.
               For <m>x</m> values between <m>0</m>
-              and <m>1</m> (inclusive) the graph is an upward curved parabola. 
+              and <m>1</m> (inclusive) the graph is an upward curved parabola.
               For <m>x</m> values <m>1</m> to <m>2</m> (inclusive) the
-              graph is a straight line with a negative slope. 
+              graph is a straight line with a negative slope.
             </p>
-            
+
             <p>
               The parabola and the line meet at the point <m>(1,1)</m>.
             </p>
@@ -700,7 +700,7 @@
             </p>
           </description>
           <shortdescription>
-            Graph of the piecewise function for the above example. 
+            Graph of the piecewise function for the above example.
           </shortdescription>
           <latex-image>
             \begin{tikzpicture}[declare function = {func(\x) = (\x &lt; 1) * (x^2) + (\x &gt; 1) * (2-x);}]
@@ -719,7 +719,7 @@
         <!-- figures/fig_one_sidedlimit4.tex END -->
       </figure>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -899,20 +899,20 @@
               <image>
                 <description>
                   <p>
-                    Graph that shows the domain <m><var name="$x[0]"/></m> to 
-                    <m><var name="$x[2]"/></m>. For <m>x</m> values less than 
+                    Graph that shows the domain <m><var name="$x[0]"/></m> to
+                    <m><var name="$x[2]"/></m>. For <m>x</m> values less than
                     <m><var name="$x[1]"/></m> the graph is a straight line and for
                     <m>x</m> values where <m><var name="$x[1]"/> \lt x \leq <var name="$x[2]"/></m>
-                    the graph is a slightly curved line. When <m>x</m> equals 
-                    <m><var name="$x[1]"/></m> the graph is defined by the point 
+                    the graph is a slightly curved line. When <m>x</m> equals
+                    <m><var name="$x[1]"/></m> the graph is defined by the point
                     <m>(<var name="$x[1]"/>, <var name="$z"/>)</m>.
                   </p>
                   <p>
                     The straight line is defined by the points
-                    <m>(<var name="$x[0]"/>, <var name="$y[0]"/>)</m> and 
+                    <m>(<var name="$x[0]"/>, <var name="$y[0]"/>)</m> and
                     <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m>.
-                    The curved line is defined by the points 
-                    <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m> and 
+                    The curved line is defined by the points
+                    <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m> and
                     <m>(<var name="$x[2]"/>, <var name="$y[2]"/>)</m>.
                   </p>
                 </description>
@@ -1030,19 +1030,19 @@
               <image>
                 <description>
                   <p>
-                    Graph that shows the domain <m><var name="$x[0]"/></m> to 
-                    <m><var name="$x[2]"/></m>. For <m>x</m> values in the 
+                    Graph that shows the domain <m><var name="$x[0]"/></m> to
+                    <m><var name="$x[2]"/></m>. For <m>x</m> values in the
                     interval <m><var name="$x[0]"/> \leq x \lt <var name="$x[1]"/></m>
                     the graph is straight. At <m>x</m> equals <m><var name="$x[1]"/></m>
                     there is a jump in the <m>y</m> value, and the graph is on the
                     interval <m><var name="$x[1]"/> \leq x \leq <var name="$x[2]"/></m>.
                   </p>
                   <p>
-                    The first line is defined by the points 
+                    The first line is defined by the points
                     <m>(<var name="$x[0]"/>, <var name="$y[0]"/>) </m>
                     and <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m>.
                     The second line is defined by the points
-                    <m>(<var name="$x[1]"/>, <var name="$z"/>)</m>, 
+                    <m>(<var name="$x[1]"/>, <var name="$z"/>)</m>,
                     <m>(<var name="$x[2]"/>, <var name="$y[2]"/>)</m>
                   </p>
                 </description>
@@ -1163,11 +1163,11 @@
               <image>
                 <description>
                   <p>
-                    Graph that shows the domain <m><var name="$x[0]"/></m> to <m><var name="$x[2]"/></m>. There is a 
+                    Graph that shows the domain <m><var name="$x[0]"/></m> to <m><var name="$x[2]"/></m>. There is a
                     vertical asymptote at <m><var name="$x[1]"/></m>. The graph on either side has
-                    an upward curve. The line on the left of the asymptote starts at 
-                    <m>(<var name="$a[0]"/>, <var name="$y[0]"/>)</m> and has a positive slope, 
-                    as <m>x</m> gets closer to <m><var name="$x[1]"/></m> the slope of the line 
+                    an upward curve. The line on the left of the asymptote starts at
+                    <m>(<var name="$a[0]"/>, <var name="$y[0]"/>)</m> and has a positive slope,
+                    as <m>x</m> gets closer to <m><var name="$x[1]"/></m> the slope of the line
                     gets steeper. The line to the right of the asymptote starts at
                     <m>(<var name="$x[2]"/>, <var name="$y[2]"/>)</m> and has a negative slope,
                     as <m>x</m> gets closer to <m><var name="$x[1]"/></m> the slope of the line
@@ -1285,10 +1285,10 @@
               <image>
                 <description>
                   <p>
-                  Graph that shows the domain <m><var name="$x[0]]"/></m> to <m><var name="$x[2]"/></m>. There 
-                  are two lines on the graph. The first is defined by the solid 
+                  Graph that shows the domain <m><var name="$x[0]]"/></m> to <m><var name="$x[2]"/></m>. There
+                  are two lines on the graph. The first is defined by the solid
                   point <m>(<var name="$x[0]"/>, <var name="$y[0]"/>)</m> and hollow
-                  point <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m>. The second 
+                  point <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m>. The second
                   is defined by the hollow point <m>(<var name="$x[1]"/>, <var name="$z"/>)</m>
                   and solid point <m>(<var name="$x[2]"/>, <var name="$y[2]"/>)</m>. There
                   is also a solid point at <m>(<var name="$x[1]"/>, <var name="$w"/>)</m>.
@@ -1385,7 +1385,7 @@
                 <description>
                   <p>
                     Graph that shows the domain <m><var name="$x[0]"/></m> to <m><var name="$x[2]"/></m>. The graph
-                    is defined on the interval <m><var name="$x[0]"/> \leq x \leq  
+                    is defined on the interval <m><var name="$x[0]"/> \leq x \leq
                     <var name="$x[2]"/></m>. At <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m>
                     there is a change in the graphs curve, it goes from a curved line
                     to a straight line.
@@ -1483,8 +1483,8 @@
                 <description>
                   <p>
                     Graph that shows the domain <m><var name="$x[0]"/></m> to <m><var name="$x[2]"/></m>. There are two
-                    lines, one on the interval <m><var name="$x[0]"/> \leq x \lt 
-                    <var name="$x[1]"/></m>.The second line is on the interval 
+                    lines, one on the interval <m><var name="$x[0]"/> \leq x \lt
+                    <var name="$x[1]"/></m>.The second line is on the interval
                     <m><var name="$x[1]"/> \lt x \leq <var name="$x[2]"/></m>.
                   </p>
                   <p>
@@ -1492,7 +1492,7 @@
                     and hollow point <m>(<var name="$x[1]"/>, <var name="$y[1]"/>)</m>.
                     The second line is defined by the hollow point <m>(<var name="$x[1]"/>, <var name="$y[3]"/>)</m>
                     and solid point <m>(<var name="$x[2]"/>, <var name="$y[4]"/>)</m>.
-                    For <m>x = 0</m> the graph is defined by the point 
+                    For <m>x = 0</m> the graph is defined by the point
                     <m>(<var name="$x[1]"/>, <var name="$y[2]"/>)</m>.
                   </p>
                 </description>
@@ -1514,7 +1514,7 @@
                     \end{axis}
                   \end{tikzpicture}
                 </latex-image>
-                
+
               </image>
               <instruction>
                 If you need to enter <m>\infty</m>, you may type <c>infinity</c>, or just <c>INF</c>.
@@ -1578,13 +1578,13 @@
               <image>
                 <description>
                   <p>
-                    Graph that shows the domain <m>-4</m> to 
+                    Graph that shows the domain <m>-4</m> to
                     <m>4</m>.
                     There are four lines that make up this graph. The first
-                    going from left to right is defined by the solid point 
-                    <m>(-4, 0)</m> and hollow point <m>(-2. 2)</m>, and has 
+                    going from left to right is defined by the solid point
+                    <m>(-4, 0)</m> and hollow point <m>(-2. 2)</m>, and has
                     a positive slope. The second line is defined by the points
-                    <m>(-2, 2)</m>, <m>0, 0</m> with a negative slope. The 
+                    <m>(-2, 2)</m>, <m>0, 0</m> with a negative slope. The
                     third line by <m>(0, 0)</m>, <m>2, 2</m> with a positive slope.
                     And the last line is defined by the hollow point <m>(2, 2)</m>
                     and solid point <m>(4, 0)</m>, with a negative slope.
@@ -1722,10 +1722,10 @@
                 <description>
                   <p>
                     The graph is
-                    made up of eight separate lines that do not connect to each 
+                    made up of eight separate lines that do not connect to each
                     other. Each of the lines is parallel with the <m>x</m> axis, defined
                     by a solid dot on its left and a hollow dot on its right, and
-                    has a length of <m>1</m> unit. The first line is inside quadrant <m>3</m> 
+                    has a length of <m>1</m> unit. The first line is inside quadrant <m>3</m>
                     of the graph and the last is in quadrant <m>1</m>, there are no
                     lines in quadrants <m>2</m> or <m>4</m>. Each of the other six lines is between
                     the first and last line moving along a straight diagonal path.
@@ -1759,7 +1759,7 @@
                         \addplot[firstcurvestyle,-, domain=\i:\i+1] {\i};
                         \addplot[soliddot] coordinates {(\i,\i)};
                         \addplot[hollowdot] coordinates {(\i+1,\i)};
-  
+
                       }
                     \end{axis}
                   \end{tikzpicture}

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -252,10 +252,7 @@
           Does the point <m>Q=(-1,6,6)</m> lie on this line?
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="i307pfanflE" xml:id="vid-vectors-lines-example1" label="vid-vectors-lines-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We identify the point <m>P=(2,3,1)</m> with the vector <m>\vec p =\la 2,3,1\ra</m>.
@@ -369,6 +366,10 @@
           We see that <m>Q</m> does not lie on the line as it did not satisfy the symmetric equations.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="i307pfanflE" xml:id="vid-vectors-lines-example1" label="vid-vectors-lines-example1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_lines6">
@@ -379,10 +380,7 @@
           <m>P=(2,-1,2)</m> and <m>Q = (1,3,-1)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="3ROgMsmz0J0" xml:id="vid-vectors-lines-example2" label="vid-vectors-lines-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Recall the statement made at the beginning of this section:
@@ -464,6 +462,10 @@
           resulting in the point <m>Q</m>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="3ROgMsmz0J0" xml:id="vid-vectors-lines-example2" label="vid-vectors-lines-example2" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -536,10 +538,7 @@
           intersect, are parallel, or skew.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="hEYfincwMX0" xml:id="vid-vectors-lines-compare" label="vid-vectors-lines-compare" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by looking at the directions of each line.
@@ -645,6 +644,10 @@
           It does not.
           Therefore, we conclude that the lines <m>\ell_1</m> and <m>\ell_2</m> are skew.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="hEYfincwMX0" xml:id="vid-vectors-lines-compare" label="vid-vectors-lines-compare" component="video"/>
       </solution>
     </example>
 
@@ -1025,10 +1028,7 @@
           <m>Q=(1,1,3)</m> to the line <m>\vec\ell(t) = \la 1,-1,1\ra+t\la 2,3,1\ra</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="xDB7li9crEs" xml:id="vid-vectors-lines-pointdist-eg" label="vid-vectors-lines-pointdist-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The equation of the line gives us the point
@@ -1048,6 +1048,10 @@
           The point <m>Q</m> is approximately <m>1.852</m> units from the line <m>\vec\ell(t)</m>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="xDB7li9crEs" xml:id="vid-vectors-lines-pointdist-eg" label="vid-vectors-lines-pointdist-eg" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_lines5">
@@ -1061,10 +1065,7 @@
           </me>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="h0x9SfUVGVc" xml:id="vid-vectors-lines-skewdist-eg" label="vid-vectors-lines-skewdist-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           These are the sames lines as given in <xref ref="ex_lines2"/>,
@@ -1090,6 +1091,10 @@
         <p>
           The lines are approximately 5.334 units apart.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="h0x9SfUVGVc" xml:id="vid-vectors-lines-skewdist-eg" label="vid-vectors-lines-skewdist-eg" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -252,7 +252,7 @@
           Does the point <m>Q=(-1,6,6)</m> lie on this line?
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We identify the point <m>P=(2,3,1)</m> with the vector <m>\vec p =\la 2,3,1\ra</m>.
@@ -380,7 +380,7 @@
           <m>P=(2,-1,2)</m> and <m>Q = (1,3,-1)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Recall the statement made at the beginning of this section:
@@ -538,7 +538,7 @@
           intersect, are parallel, or skew.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We start by looking at the directions of each line.
@@ -1028,7 +1028,7 @@
           <m>Q=(1,1,3)</m> to the line <m>\vec\ell(t) = \la 1,-1,1\ra+t\la 2,3,1\ra</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The equation of the line gives us the point
@@ -1065,7 +1065,7 @@
           </me>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           These are the sames lines as given in <xref ref="ex_lines2"/>,

--- a/ptx/sec_newton.ptx
+++ b/ptx/sec_newton.ptx
@@ -45,18 +45,18 @@
       <figure xml:id="fig_newt1a">
         <caption/>
         <image xml:id="img_newt1a">
-          <shortdescription> 
+          <shortdescription>
             A tangent line is drawn to the graph at (x_0,f(x_0)) and and meets on the x-axis at point x_1.
           </shortdescription>
           <description>
             <p>
               This graph depicts the iterations of Newton's method for finding the root of a function.
-              The <m>y</m> axis represents function values <m>(1,0.5,0,-0.5,-1)</m>, 
+              The <m>y</m> axis represents function values <m>(1,0.5,0,-0.5,-1)</m>,
               while the <m>x</m> axis represents iterations <m>(x_0, x_1)</m>.
               The graph shows the initial guess <m>x_0</m> and the subsequent approximation <m>x_1</m>.
             </p>
             <p>
-              A tangent line is drawn from the point <m>(x_0,f(x_0))</m>  to intersect the <m>x</m> axis at <m>x_1</m>, 
+              A tangent line is drawn from the point <m>(x_0,f(x_0))</m>  to intersect the <m>x</m> axis at <m>x_1</m>,
               providing a refined approximation of the function’s root.
             </p>
           </description>
@@ -114,8 +114,8 @@
           <shortdescription>A tangent line is drawn to the graph at (x_2,f(x_2)) and and meets on the x-axis at point x_3.</shortdescription>
           <description>
             <p>
-              On the third graph, the <m>y</m> axis has values <m>(1,0.5, 0, -0.5, -1)</m>, 
-              while the <m>x</m> axis represents iterations <m>(x_0,x_1,x_2,x_3)</m>. 
+              On the third graph, the <m>y</m> axis has values <m>(1,0.5, 0, -0.5, -1)</m>,
+              while the <m>x</m> axis represents iterations <m>(x_0,x_1,x_2,x_3)</m>.
               A tangent line is drawn from the point <m>(x_2)</m> to intersect the x-axis and the new point is called <m>x_3</m>.
             </p>
           </description>
@@ -320,7 +320,7 @@
       <figure xml:id="fig_newt2">
         <caption>A graph of <m>f(x) = x^3-x^2-1</m> in <xref ref="ex_newt2"/></caption>
         <image xml:id="img_newt2" width="47%">
-          <shortdescription> 
+          <shortdescription>
             A cubic graph features a curve with two turning points.
           </shortdescription>
           <description>
@@ -528,7 +528,7 @@
     <figure xml:id="fig_newt2a">
       <caption>A graph of <m>f(x) = x^3-x^2-1</m>, showing why an initial approximation of <m>x_0=0</m> with Newton's Method fails</caption>
       <image xml:id="img_newt2a" width="47%">
-        <shortdescription> 
+        <shortdescription>
           A cubic graph features an "S" shaped curve  with two turning points.
         </shortdescription>
         <description>
@@ -607,7 +607,7 @@
               and extends into the positive and negative regions of the <m>x</m> axis.
             </p>
             <p>
-              It starts with an initial guess <m>x_0=0.1</m>. A tangent line is drawn at this point and intersects the <m>x</m> axis at the next 
+              It starts with an initial guess <m>x_0=0.1</m>. A tangent line is drawn at this point and intersects the <m>x</m> axis at the next
               approximation, bringing it further from the root <m>x=0</m>.
             </p>
           </description>
@@ -638,7 +638,7 @@
         <caption/>
         <image xml:id="img_newt4b">
           <shortdescription>
-            The graph illustrates the cube root function with point x_1 
+            The graph illustrates the cube root function with point x_1
           </shortdescription>
           <description>
             <p>
@@ -646,8 +646,8 @@
               and extends into the positive and negative regions of the <m>x</m> axis.
             </p>
             <p>
-              Here <m>x_1</m> is twice as much as the initial guess bringing it more further from the root. 
-              A tangent line is drawn at this point and intersects the <m>x</m> axis at the next 
+              Here <m>x_1</m> is twice as much as the initial guess bringing it more further from the root.
+              A tangent line is drawn at this point and intersects the <m>x</m> axis at the next
               approximation, <m>x_2</m>.
             </p>
           </description>
@@ -678,15 +678,15 @@
         <caption/>
         <image xml:id="img_newt4c">
           <shortdescription>
-            The graph illustrates the cube root function with point x_2 
+            The graph illustrates the cube root function with point x_2
           </shortdescription>
           <description>
             <p>
-              The graph illustrates the cube root function, <m>f(x) = x^{1/3}</m>. It exhibits a curve that passes through the origin <m>(0,0)</m> 
+              The graph illustrates the cube root function, <m>f(x) = x^{1/3}</m>. It exhibits a curve that passes through the origin <m>(0,0)</m>
               and extends into the positive and negative regions of the <m>x</m> axis.
             </p>
             <p>
-              Here <m>x_2</m> is twice as much as the <m>x_1</m>bringing it even more further from the root. 
+              Here <m>x_2</m> is twice as much as the <m>x_1</m>bringing it even more further from the root.
               A tangent line is drawn at this point and intersects the <m>x</m> axis at the next approximation,<m>x_3</m>.
             </p>
 

--- a/ptx/sec_numerical_integration.ptx
+++ b/ptx/sec_numerical_integration.ptx
@@ -65,10 +65,10 @@
         <image xml:id="img_numerical1a">
         <shortdescription>Integral of e^{-x^2} from 0 to 1</shortdescription>
           <description>
-          <p> 
+          <p>
           This is a graph of <m>f(x)=e^{-x^2}</m>.starting at <m>(0, 1)</m> the line slopes down towards the <m>x</m> axis. The line goes from <m>(0, 1)</m> to close
           to <m>(1, 0.75)</m>. We consider the area between <m>(0, 1)</m>, <m>(1, 0.75)</m>,<m>(1, 0)</m> and <m>(0, 0)</m>.
-         
+
           </p>
           </description>
           <latex-image>
@@ -103,11 +103,11 @@
           <description>
           <p>
           The graph of <m>\sin(x^3)</m>. Starting at <m>(-0.75, -0.5)</m> the graph moves upwards to the right. It merges to the <m>x</m> axis close to <m>(-0.25, 0)</m> and
-          continues along the <m>x</m> axis. It goes through and continues along the positive <m>x</m> axis for a short while then rises up until it reaches <m>(1.25, 1)</m> 
-          then sharply descends back towards the <m>x</m> axis. It intersects the <m>y</m> axis close to <m>(1.5, 0)</m> and continues downwards. We consider the area above the part of the 
-          curve that is in the fourth quadrant and below the negative <m>x</m> axis. Then below the curve that rises up from the positive <m>x</m> axis and comes down. And the area above the 
+          continues along the <m>x</m> axis. It goes through and continues along the positive <m>x</m> axis for a short while then rises up until it reaches <m>(1.25, 1)</m>
+          then sharply descends back towards the <m>x</m> axis. It intersects the <m>y</m> axis close to <m>(1.5, 0)</m> and continues downwards. We consider the area above the part of the
+          curve that is in the fourth quadrant and below the negative <m>x</m> axis. Then below the curve that rises up from the positive <m>x</m> axis and comes down. And the area above the
           part of the curve that continues downwards after intersecting the <m>x</m> axis.
-  
+
           </p>
           </description>
           <latex-image>
@@ -142,8 +142,8 @@
           <description>
           <p>
           We consider the area under the graph of <m>\sin(x)/x</m> starting close to <m>(0.5, 0.9)</m> to <m>(12.5, 0)</m>. The structure of the graph is similar to that
-          of a wave. The distance between the highest point of the graph in the positive <m>y</m> axis and the lowest point in the negative <m>y</m> axis shows a 
-          decreasing trend as it continues in the positive <m>x</m> direction but the wavelength increases in the positive <m>x</m> direction.The graph starts at <m>(0.5, 0.9)</m> 
+          of a wave. The distance between the highest point of the graph in the positive <m>y</m> axis and the lowest point in the negative <m>y</m> axis shows a
+          decreasing trend as it continues in the positive <m>x</m> direction but the wavelength increases in the positive <m>x</m> direction.The graph starts at <m>(0.5, 0.9)</m>
           close to the <m>x</m> axis and curves downwards. It crosses the <m>x</m> axis close to <m>(3, 0)</m> while travelling downwards. It continues downwards for
           a short amount and the curves upwards and this time crosses the <m>x</m> axis at <m>(6.25, 0)</m>. From <m>(6.25, 0)</m> it travels another wavelength crossing
           the <m>x</m> axis once close to <m>(10,0)</m> while traveling upwards and at <m>(12.5, 0)</m> where the graph ends. We consider the area under the graph when
@@ -254,7 +254,7 @@
             <image xml:id="img_num1b">
             <shortdescription>Using the Left Hand rule</shortdescription>
               <description>
-              <p> The graph of <m>e^{-x^2}</m> starts at <m>(0, 1)</m> and slowly slopes downwards to the right as it slowly gets closer to the positive <m>x</m> axis. 
+              <p> The graph of <m>e^{-x^2}</m> starts at <m>(0, 1)</m> and slowly slopes downwards to the right as it slowly gets closer to the positive <m>x</m> axis.
               To use the left hand rule we divide the area between <m>[0, 1]</m> five rectangles of equal widhth and decreasing height. As the curve moves closer to the <m>x</m> axis,
               the heights of the rectangles gets shorter even thought the widths stay the same. Because the curve is downwards sloping to the right, the top right corners
               of the rectangles contain a little region which is above the curve. As the curve moves downwards and the height of the rectangles become shorter, the area
@@ -499,11 +499,11 @@
               <p> We calculate <m>\int_{-\frac{\pi}4}^{\frac{\pi}/2}\sin(x^3)\, dx</m> using the left hand rule. The graph of <m>\sin(x^3)</m> starts at <m>(-0.75, -0.5)</m>
               in the fourth quadrant and curves upwards to the right. It merges with the negative <m>x</m> axis close to <m>(-0.25, 0)</m> and continues along the <m>x</m> axis
               until <m>(0.25, 0)</m> and then slopes upwards to the right. The graph continues upwards until <m>(1.25, 1)</m> in the first quadrant and then descends sharply. It
-              crosses the positive <m>x</m> axis close to <m>(1.5, 0)</m> and continues downwards. We divide the areas under the curve into boxes of equal width but varying 
+              crosses the positive <m>x</m> axis close to <m>(1.5, 0)</m> and continues downwards. We divide the areas under the curve into boxes of equal width but varying
               height. The far left side of the graph is divided into three boxes of decreasing length that are below the negative <m>x</m> axis. THe rectangle farthest to the
               left is the tallest and the other two get get shorter as the graph moves upwards towards the negative <m>x</m> axis. The region roughly from <m>(-0.25, 0)</m> to
-              <m>(0.25, 0)</m> where the curve moves along the <m>x</m> axis there are no boxes since the are of that part is zero. Then the part of the graph in the first 
-              quadrant is divided into five rectangles. As the graph rises up, the heights of the rectangles increase. The first one being the shortest and the fourth one 
+              <m>(0.25, 0)</m> where the curve moves along the <m>x</m> axis there are no boxes since the are of that part is zero. Then the part of the graph in the first
+              quadrant is divided into five rectangles. As the graph rises up, the heights of the rectangles increase. The first one being the shortest and the fourth one
               being the tallest. The fifth rectangle is shorter than the fourth one but taller than the first three. We add up the areas of the rectangles to approximate the
               integral.</p>
               </description>
@@ -543,10 +543,10 @@
             <image xml:id="img_num2c">
             <shortdescription>Using the Right Hand rule</shortdescription>
               <description>
-              <p> We calculate <m>\int_{-\frac{\pi}4}^{\frac{\pi}/2}\sin(x^3)\, dx</m> using the Right hand rule. The far left part of the graph is divided into two 
-              rectangles of decreasing height. The region from <m>(-0.25, 0)</m> to <m>(0.25, 0)</m> on the <m>x</m> axis does not contribute to the area since the curve 
-              here continues along the axis and therefore the area is zero. The part in the first quadrant is divided into five adjacent rectangles of increasing height. 
-              The upper left side of the first four rectangles contain some area outside of the curve on the left. As the graph moves up, the heights of the rectangles increase, 
+              <p> We calculate <m>\int_{-\frac{\pi}4}^{\frac{\pi}/2}\sin(x^3)\, dx</m> using the Right hand rule. The far left part of the graph is divided into two
+              rectangles of decreasing height. The region from <m>(-0.25, 0)</m> to <m>(0.25, 0)</m> on the <m>x</m> axis does not contribute to the area since the curve
+              here continues along the axis and therefore the area is zero. The part in the first quadrant is divided into five adjacent rectangles of increasing height.
+              The upper left side of the first four rectangles contain some area outside of the curve on the left. As the graph moves up, the heights of the rectangles increase,
               the fourth one being the tallest. The fifth rectangle is below the graph with its upper right corner touching the inside of the graph. The sixth and the last rectangle
               is below the positive <m>x</m> axis. It captures the area adjacent to the part of the graph that is below the positive <m>x</m> axis.</p></description>
               <latex-image>
@@ -628,7 +628,7 @@
       <image xml:id="img_num3a" width="47%">
       <shortdescription>Approximating the integral of e to the power of negative x squared from 0 to 1 using five trapezoids</shortdescription>
         <description>
-        <p> The graph of <m>e^{-x^2}</m> starts from <m>(0,1)</m> and slopes downwards to the right in the positive x direction. We consider the are under the curve from 
+        <p> The graph of <m>e^{-x^2}</m> starts from <m>(0,1)</m> and slopes downwards to the right in the positive x direction. We consider the are under the curve from
         <m>(0,1)</m> to <m>(1, 0.25)</m> in the first quadrant. The area is approximated with five adjacent trapezoids of equal width but decreasing heights. The upper arms
         of the trapezoids are downwar sloping and they follow the graph of <m>e^{-x^2}</m> very closely which allows for more precise approximation. Both of the upper corners
         of the trapezoids lie on the curve. The first trapezoid is the tallest one and the fifth one is the shortest.
@@ -1161,7 +1161,7 @@
       <image xml:id="img_numsimpsons" width="47%">
       <shortdescription>A parabola approximating the function f on [1, 3].</shortdescription>
         <description>
-        <p> The graph of the function <m>f</m> starts close to <m>(1, 4)</m> in the first quadrant and then slopes downwards to the right towards the <m>x</m> axis. Once 
+        <p> The graph of the function <m>f</m> starts close to <m>(1, 4)</m> in the first quadrant and then slopes downwards to the right towards the <m>x</m> axis. Once
         it reaches the point <m>(2, 1)</m>, the graph starts sloping upwards to the right and continues upwards. It ends close to <m>(3, 2)</m>. The shape of the graph
         resembles the shape of a parabola. We approximate the graph of <m>f</m> using a parabola whose path follows <m>f</m> very closely. The parabola intersects <m>f</m>
         three times, once at <m>(1, 3)</m> then at <m>(2, 1)</m> and at <m>(3, 2)</m>.
@@ -1244,7 +1244,7 @@
         quadratic curve is a downward parabola with its vertex at <m>(3,0.5)</m> which approximates the first two subintervals. The second quadratic curve is also a parabola
         whose vertex is located at <m>(1.5,1)</m>. This parabola approximates the second two subintervals between <m>x=1.25</m> and <m>x=2.5</m>. The next two subintervals are
         are approximated by the left half of a parabola whose vertex is at <m>(3.75,1.25)</m>. The area under the last two subintervals are approximated by a downwards parabola
-        whose vertex is at <m>(3,4.5)</m>. 
+        whose vertex is at <m>(3,4.5)</m>.
         </p></description>
         <latex-image>
 
@@ -1354,7 +1354,7 @@
             <image xml:id="img_num5b">
             <shortdescription>Approximating the integral of e^{-x^2} using Simpson's rule</shortdescription>
               <description>
-              <p> The graph of <m>e^{-x^2}</m> starts from <m>(0, 1)</m> and slopes downwards to the right in the positive <m>x</m> direction. We consider the are under the curve from 
+              <p> The graph of <m>e^{-x^2}</m> starts from <m>(0, 1)</m> and slopes downwards to the right in the positive <m>x</m> direction. We consider the are under the curve from
               <m>(0, 1)</m> to <m>(1, 0.25)</m> in the first quadrant. The area is subdivided into four equally spaced intervals. The top of the intervals are parts of parabolas that
               track the curve of <m>e^{-x^2}</m>. These approximating curves are almost identical to the parts of the graph they are tracking thus resulting in a much more accurate
               approximation.
@@ -1506,7 +1506,7 @@
           <shortdescription>Approximating the integral of sin(x^3) using Simpson's rule</shortdescription>
             <description>
             <p> The area under the graph of <m>\sin(x^3)</m> is subdivided into ten equally spaced subintervals. The leftmost part of the graph that is below the negative
-            <m>x</m> axis is approximated by a straight line and the upper left part of a downward parabola on its right. The part of the graph on the first quadrant is 
+            <m>x</m> axis is approximated by a straight line and the upper left part of a downward parabola on its right. The part of the graph on the first quadrant is
             subdivided into six subintervals. These are approximated by parabolas that are almost identical to the parts of the graphs they are approximating. The last part
             of the graph that is below the positive <m>x</m> axis, is approximated with the descending part of a downward parabola and a straight line.
             </p></description>
@@ -1820,7 +1820,7 @@
           <image xml:id="img_num7a" width="47%">
           <shortdescription>Shows the double derivative of f.</shortdescription>
             <description>
-            <p> The graph of <m>\fpp(x)</m> starts at <m>(0, -2)</m> and curves upwards to the left towards the positive <m>x</m> axis. It intersects the <m>x</m> axis at 
+            <p> The graph of <m>\fpp(x)</m> starts at <m>(0, -2)</m> and curves upwards to the left towards the positive <m>x</m> axis. It intersects the <m>x</m> axis at
             <m>(0.7, 0)</m>. Then it moves futher to the right in the positive <m>x</m> direction while moving upwards and ends at <m>(1, 0.5)</m>.
             </p></description>
             <latex-image>
@@ -1906,7 +1906,7 @@
             <description>
             <p> The graph of <m>f^{(4)}(x)</m> starts from <m>(12,0)</m> in the positive <m>y</m>-axis and curves downwards to the right towards the positive <m>x</m> axis.
             It intersects the <m>x</m> axis close to <m>x=0.5</m> and continues moving downwards while also moving to the right in the positive x direction. It stops at the point
-            <m>(1, -8)</m>. 
+            <m>(1, -8)</m>.
             </p></description>
             <latex-image>
 
@@ -2242,7 +2242,7 @@
               </p>
             </introduction>
 
-            <task label="ex-numerical-integration-approx-exact-1a"> 
+            <task label="ex-numerical-integration-approx-exact-1a">
               <statement>
                 <p>
                   Approximate using the trapezoidal rule: <var name="$trap" width="20"/><!-- 3/4 -->
@@ -3361,7 +3361,7 @@
                 $area = NumberWithUnits("$area cm^2");
                 $area_ft = NumberWithUnits("$area_ft ft^2");
               </pg-code>
-           
+
               <statement>
                 <!-- START figures/fig_05_05_ex_01.tex -->
                   <image xml:id="img_05_05_ex_01">
@@ -3437,7 +3437,7 @@
                 $area = NumberWithUnits("$area cm^2");
                 $area_ft = NumberWithUnits("$area_ft ft^2");
               </pg-code>
-           
+
               <statement>
                 <!-- START figures/fig_05_05_ex_02.tex -->
                   <image xml:id="img_05_05_ex_02">

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -111,7 +111,7 @@
 
           <image xml:id="img_opt1b2">
             <shortdescription>
-               A rectangle shape is drawn with sides labeled <m>x</m> and <m>y</m>. 
+               A rectangle shape is drawn with sides labeled <m>x</m> and <m>y</m>.
             </shortdescription>
             <description>
               <p>
@@ -309,7 +309,7 @@
         What dimensions provide the maximal area?
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -339,7 +339,7 @@
                   </shortdescription>
                   <description>
                     <p>
-                      A rectangular fenced yard with one side open for a stream. The dimensions are labeled <m>x</m> and <m>y</m> and are not provided. 
+                      A rectangular fenced yard with one side open for a stream. The dimensions are labeled <m>x</m> and <m>y</m> and are not provided.
                     </p>
                   </description>
                   <latex-image>
@@ -563,7 +563,7 @@
         </image>
       </figure>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -604,13 +604,13 @@
         <caption>Labeling unknown distances in <xref ref="ex_opt3"/></caption>
         <image xml:id="img_opt3c" width="47%">
           <shortdescription>
-            A power line is ran from the power station to an offshore facility with the distance run along 
+            A power line is ran from the power station to an offshore facility with the distance run along
             the ground and the distance run underwater unknown.
           </shortdescription>
           <description>
             <p>
-              A power line is run from a power station to an offshore facility <quantity><mag>5000</mag><unit base="foot"/></quantity> underwater. Here, the distance run along 
-              the ground and the distance run underwater is unknown and thereby labeled as <m>x</m>. 
+              A power line is run from a power station to an offshore facility <quantity><mag>5000</mag><unit base="foot"/></quantity> underwater. Here, the distance run along
+              the ground and the distance run underwater is unknown and thereby labeled as <m>x</m>.
               It is also run <quantity><mag>1000</mag><unit base="foot"/></quantity> along the offshore facility forming a right angle triangle with the power line.
             </p>
             <p>
@@ -944,7 +944,7 @@
               <shortdescription>
                A rectangle divided into two parts.
               </shortdescription>
-              <description> 
+              <description>
                 A large rectangle divided into two equal rectangles.
               </description>
               <latex-image>
@@ -1153,13 +1153,13 @@
               <shortdescription>
                 A circle with a rectangle divided diagonally inscribed inside it.
               </shortdescription>
-              <description> 
+              <description>
                 <p>
                   A circular log with diameter of <quantity><mag>12</mag><unit base="inch"/></quantity> has rectangle inscribed inside. The rectangle is divided diagonally forming
                   two equal right-angle triangles. The line that divides it is the diameter.
                 </p>
                 <p>
-                  The shorter side of the rectangle is labeled <m>w</m> which serves as the cross sectional width and the 
+                  The shorter side of the rectangle is labeled <m>w</m> which serves as the cross sectional width and the
                   longer side is labelled <m>h</m> which is the height.
                 </p>
               </description>

--- a/ptx/sec_optimization.ptx
+++ b/ptx/sec_optimization.ptx
@@ -309,10 +309,7 @@
         What dimensions provide the maximal area?
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="wIs5N5HOCrc" xml:id="vid_deriv_apps_opt_fence_river" label="vid_deriv_apps_opt_fence_river" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -490,6 +487,10 @@
         </ol>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="wIs5N5HOCrc" xml:id="vid_deriv_apps_opt_fence_river" label="vid_deriv_apps_opt_fence_river" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -562,10 +563,7 @@
         </image>
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="qDK9rqloKRs" xml:id="vid_deriv_apps_opt_power_line" label="vid_deriv_apps_opt_power_line" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -714,6 +712,10 @@
         <m>5000-416.67 = 4583.33</m> ft., and the underwater distance is
         <m>\sqrt{416.67^2+1000^2} \approx 1083</m> ft.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="qDK9rqloKRs" xml:id="vid_deriv_apps_opt_power_line" label="vid_deriv_apps_opt_power_line" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -131,10 +131,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="A62eUDxiOw4" xml:id="vid-planecurves-parcalc-example-tangent" label="vid-planecurves-parcalc-example-tangent" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -249,6 +246,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="A62eUDxiOw4" xml:id="vid-planecurves-parcalc-example-tangent" label="vid-planecurves-parcalc-example-tangent" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_parcalc2">
@@ -272,10 +273,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="PpmsaMVJAZI" xml:id="vid-planecurves-parcalc-circle" label="vid-planecurves-parcalc-circle" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -353,6 +351,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="PpmsaMVJAZI" xml:id="vid-planecurves-parcalc-circle" label="vid-planecurves-parcalc-circle" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_parcalc3">
@@ -396,10 +398,7 @@
           <!-- figures/fig_planecurve1.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-astroid" label="vid-planecurves-parcalc-astroid" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by finding <m>x'(t)</m> and <m>y'(t)</m>:
@@ -438,6 +437,10 @@
           We found the slope of the tangent line at <m>t=0</m> to be 0;
           therefore the tangent line is <m>y=0</m>, the <m>x</m>-axis.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-astroid" label="vid-planecurves-parcalc-astroid" component="video"/>
       </solution>
     </example>
   </introduction>
@@ -505,10 +508,7 @@
           Determine the <m>t</m>-intervals on which the graph is concave up/down.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-concavity" label="vid-planecurves-parcalc-concavity" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Concavity is determined by the second derivative of <m>y</m> with respect to <m>x</m>,
@@ -630,6 +630,10 @@
           <caption>Sketching the curve in <xref ref="ex_parcalc4"/></caption>
           <video youtube="HSBSVFSVqms" label="vid-planecurves-parcalc-sketch"/>
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="rb4wEkhcUtE" xml:id="vid-planecurves-parcalc-concavity" label="vid-planecurves-parcalc-concavity" component="video"/>
       </solution>
     </example>
 
@@ -848,10 +852,7 @@
           <m>y=3\sin(t)</m> on <m>[0,3\pi/2]</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="It8vHw3RHEw" xml:id="vid-planecurves-parcalc-arclength-example1" label="vid-planecurves-parcalc-arclength-example1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           By direct application of <xref ref="thm_arc_length_parametric"/>, we have
@@ -869,6 +870,10 @@
           since we are finding the arc length of <m>3/4</m> of a circle,
           the arc length is <m>3/4\cdot 6\pi = 9\pi/2</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="It8vHw3RHEw" xml:id="vid-planecurves-parcalc-arclength-example1" label="vid-planecurves-parcalc-arclength-example1" component="video"/>
       </solution>
     </example>
 
@@ -913,10 +918,7 @@
           <!-- figures/fig_parcalc7.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="G5U9BVhB3PE" xml:id="vid-planecurves-parcalc-arclength-example2" label="vid-planecurves-parcalc-arclength-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We can see by the parametrizations of <m>x</m> and <m>y</m> that when <m>t=\pm 1</m>,
@@ -938,6 +940,10 @@
           and <m>n=20</m> gives a value of <m>2.71559</m>.
           Increasing <m>n</m> shows that this value is stable and a good approximation of the actual value.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="G5U9BVhB3PE" xml:id="vid-planecurves-parcalc-arclength-example2" label="vid-planecurves-parcalc-arclength-example2" component="video"/>
       </solution>
     </example>
   </subsection>

--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -131,7 +131,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -273,7 +273,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -398,7 +398,7 @@
           <!-- figures/fig_planecurve1.tex END -->
         </figure>
       </statement>
-      
+
       <solution>
         <p>
           We start by finding <m>x'(t)</m> and <m>y'(t)</m>:
@@ -508,7 +508,7 @@
           Determine the <m>t</m>-intervals on which the graph is concave up/down.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Concavity is determined by the second derivative of <m>y</m> with respect to <m>x</m>,
@@ -852,7 +852,7 @@
           <m>y=3\sin(t)</m> on <m>[0,3\pi/2]</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           By direct application of <xref ref="thm_arc_length_parametric"/>, we have
@@ -918,7 +918,7 @@
           <!-- figures/fig_parcalc7.tex END -->
         </figure>
       </statement>
-      
+
       <solution>
         <p>
           We can see by the parametrizations of <m>x</m> and <m>y</m> that when <m>t=\pm 1</m>,

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -164,7 +164,7 @@
           <m>y=t+1</m> for <m>t</m> in <m>[-2,2]</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We plot the graphs of parametric equations in much the same manner as we plotted graphs of functions like <m>y=f(x)</m>:
@@ -690,7 +690,7 @@
           That is, <m>t=a</m> corresponds to the point on the graph whose tangent line has slope <m>a</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We start by computing <m>\frac{dy}{dx}</m>: <m>y' = 2x</m>.
@@ -817,7 +817,7 @@
           </me>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           There is not a set way to eliminate a parameter.
@@ -922,7 +922,7 @@
           <m>x=4\cos(t) +3</m>, <m>y= 2\sin(t) +1</m>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We should not try to solve for <m>t</m> in this situation as the resulting algebra/trig would be messy.
@@ -1245,7 +1245,7 @@
           Determine the points, if any, where it is not smooth.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We begin by taking derivatives.

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -164,10 +164,7 @@
           <m>y=t+1</m> for <m>t</m> in <m>[-2,2]</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="7Ytw9RTrFtM" xml:id="vid-planecurves-parameq-example-plot" label="vid-planecurves-parameq-example-plot" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We plot the graphs of parametric equations in much the same manner as we plotted graphs of functions like <m>y=f(x)</m>:
@@ -278,6 +275,10 @@
             </figure>
           </sidebyside>
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="7Ytw9RTrFtM" xml:id="vid-planecurves-parameq-example-plot" label="vid-planecurves-parameq-example-plot" component="video"/>
       </solution>
     </example>
 
@@ -689,10 +690,7 @@
           That is, <m>t=a</m> corresponds to the point on the graph whose tangent line has slope <m>a</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="YsOEEcCXNb8" xml:id="vid-planecurves-parameq-find-parametrization" label="vid-planecurves-parameq-find-parametrization" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by computing <m>\frac{dy}{dx}</m>: <m>y' = 2x</m>.
@@ -711,6 +709,10 @@
           This gives the point <m>(-1, 1)</m>.
           We can verify that the slope of the line tangent to the curve at this point indeed has a slope of <m>-2</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="YsOEEcCXNb8" xml:id="vid-planecurves-parameq-find-parametrization" label="vid-planecurves-parameq-find-parametrization" component="video"/>
       </solution>
     </example>
 
@@ -815,10 +817,7 @@
           </me>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="8Vgv74zCWFQ" xml:id="vid-planecurves-parameq-elim-param" label="vid-planecurves-parameq-elim-param" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           There is not a set way to eliminate a parameter.
@@ -909,6 +908,10 @@
           the graph defined by <m>y=1-x</m> with unrestricted domain is given in a thin line.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="8Vgv74zCWFQ" xml:id="vid-planecurves-parameq-elim-param" label="vid-planecurves-parameq-elim-param" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_pareq8">
@@ -919,10 +922,7 @@
           <m>x=4\cos(t) +3</m>, <m>y= 2\sin(t) +1</m>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="RYkPHhpgnas" xml:id="vid-planecurves-parameq-ellipse" label="vid-planecurves-parameq-ellipse" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We should not try to solve for <m>t</m> in this situation as the resulting algebra/trig would be messy.
@@ -980,6 +980,10 @@
           plots the parametric equations,
           demonstrating that the graph is indeed of an ellipse with a horizontal major axis and center at <m>(3,1)</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="RYkPHhpgnas" xml:id="vid-planecurves-parameq-ellipse" label="vid-planecurves-parameq-ellipse" component="video"/>
       </solution>
     </example>
 
@@ -1241,10 +1245,7 @@
           Determine the points, if any, where it is not smooth.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="rqhh0McArDM" xml:id="vid-planecurves-parameq-nonsmooth" label="vid-planecurves-parameq-nonsmooth" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We begin by taking derivatives.
@@ -1306,6 +1307,10 @@
           </image>
           <!-- figures/fig_pareq9.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="rqhh0McArDM" xml:id="vid-planecurves-parameq-nonsmooth" label="vid-planecurves-parameq-nonsmooth" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_partial_fraction.ptx
+++ b/ptx/sec_partial_fraction.ptx
@@ -133,10 +133,7 @@
         Decompose <m>\ds f(x)=\frac{1}{(x+5)(x-2)^3(x^2+x+2)(x^2+x+7)^2}</m> without solving for the resulting coefficients.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="9gRlWESr8lM" xml:id="vid-int-partfrac-ex-decomp1" label="vid-int-partfrac-ex-decomp1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The denominator is already factored,
@@ -183,6 +180,10 @@
         <m>B \ldots J</m> would be a bit tedious but not <q>hard.</q>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="9gRlWESr8lM" xml:id="vid-int-partfrac-ex-decomp1" label="vid-int-partfrac-ex-decomp1" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_pf2">
@@ -192,10 +193,7 @@
         Perform the partial fraction decomposition of <m>\ds \frac{1}{x^2-1}</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="u-avVoj3qR0" xml:id="vid-int-partfrac-ex-decomp-method1" label="vid-int-partfrac-ex-decomp-method1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The denominator factors into two linear terms:
@@ -265,6 +263,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="u-avVoj3qR0" xml:id="vid-int-partfrac-ex-decomp-method1" label="vid-int-partfrac-ex-decomp-method1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -281,10 +283,7 @@
         Perform the partial fraction decomposition of <m>\ds \frac{1}{x^2-1}</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="QfEgKEhkL6o" xml:id="vid-int-partfrac-ex-decomp-method2" label="vid-int-partfrac-ex-decomp-method2" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         As we saw in <xref ref="ex_pf2"/>,
@@ -335,6 +334,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="QfEgKEhkL6o" xml:id="vid-int-partfrac-ex-decomp-method2" label="vid-int-partfrac-ex-decomp-method2" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -348,10 +351,7 @@
         Use partial fraction decomposition to integrate <m>\ds\int\frac{1}{(x-1)(x+2)^2}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="LqE8pvIvJco" xml:id="vid-int-partfrac-ex-rep-root1" label="vid-int-partfrac-ex-rep-root1" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -440,6 +440,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="LqE8pvIvJco" xml:id="vid-int-partfrac-ex-rep-root1" label="vid-int-partfrac-ex-rep-root1" component="video"/>
+    </solution>
   </example>
 
   <p xml:id="vidint-int-partfrac-ex-rep-root2" component="video">
@@ -460,10 +464,7 @@
         Use partial fraction decomposition to integrate <m>\ds \int \frac{x^3}{(x-5)(x+3)}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="1cszweGfYR0" xml:id="vid-int-partfrac-ex-divide-first" label="vid-int-partfrac-ex-divide-first" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <xref ref="idea_partial_fraction"/>
@@ -513,6 +514,10 @@
         </md>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="1cszweGfYR0" xml:id="vid-int-partfrac-ex-divide-first" label="vid-int-partfrac-ex-divide-first" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_pf5">
@@ -522,10 +527,7 @@
         Use partial fraction decomposition to evaluate <m>\ds \int\frac{7x^2+31x+54}{(x+1)(x^2+6x+11)}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="KNN0krvf1UE" xml:id="vid-int-partfrac-ex-quadroot" label="vid-int-partfrac-ex-quadroot" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -616,6 +618,10 @@
         we break it down into smaller problems that are easier to solve.
         The final answer is a combination of the answers of the smaller problems.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="KNN0krvf1UE" xml:id="vid-int-partfrac-ex-quadroot" label="vid-int-partfrac-ex-quadroot" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_partial_fraction.ptx
+++ b/ptx/sec_partial_fraction.ptx
@@ -133,7 +133,7 @@
         Decompose <m>\ds f(x)=\frac{1}{(x+5)(x-2)^3(x^2+x+2)(x^2+x+7)^2}</m> without solving for the resulting coefficients.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The denominator is already factored,
@@ -193,7 +193,7 @@
         Perform the partial fraction decomposition of <m>\ds \frac{1}{x^2-1}</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The denominator factors into two linear terms:
@@ -283,7 +283,7 @@
         Perform the partial fraction decomposition of <m>\ds \frac{1}{x^2-1}</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         As we saw in <xref ref="ex_pf2"/>,
@@ -351,7 +351,7 @@
         Use partial fraction decomposition to integrate <m>\ds\int\frac{1}{(x-1)(x+2)^2}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -464,7 +464,7 @@
         Use partial fraction decomposition to integrate <m>\ds \int \frac{x^3}{(x-5)(x+3)}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <xref ref="idea_partial_fraction"/>
@@ -527,7 +527,7 @@
         Use partial fraction decomposition to evaluate <m>\ds \int\frac{7x^2+31x+54}{(x+1)(x^2+6x+11)}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -1131,8 +1131,8 @@
               if($envir{problemSeed}==1){$r=-4;$s=5;};
               $f = Formula("x^3/(x^2-($r+$s)x+$r*$s)")->reduce;
               Context("Fraction");
-              $A = Fraction($r*($r**2+$s**2+$r*$s) - ($r+$s)*$r*$s, $r-$s); 
-              $B = Fraction(-$s*($r**2+$s**2+$r*$s) + ($r+$s)*$r*$s, $r-$s); 
+              $A = Fraction($r*($r**2+$s**2+$r*$s) - ($r+$s)*$r*$s, $r-$s);
+              $B = Fraction(-$s*($r**2+$s**2+$r*$s) + ($r+$s)*$r*$s, $r-$s);
               $F = FormulaUpToConstant("1/2 x^2 + ($r+$s) x + $A ln(abs(x-$r)) + $B ln(abs(x-$s))")->reduce;
               $F->{test_at} = [[$r-0.25],[$r+0.25],[$s-0.25],[$s+0.25]];
             </pg-code>

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -176,10 +176,7 @@
           <m>Q = (1,2,-1)</m> and <m>R = (0,1,2)</m> in standard form.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="oc77R0am1vk" xml:id="vid-vectors-planes-3points" label="vid-vectors-planes-3points" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We need a vector <m>\vec n</m> that is orthogonal to the plane.
@@ -287,6 +284,10 @@
           </image>
           <!-- figures/figplanes1_3D.asy END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="oc77R0am1vk" xml:id="vid-vectors-planes-3points" label="vid-vectors-planes-3points" component="video"/>
       </solution>
     </example>
 
@@ -426,10 +427,7 @@
           <m>P=(-1,0,1)</m> and is orthogonal to the line with vector equation <m>\vec \ell(t) = \la -1,0,1\ra + t\la 1,2,2\ra</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="2diP-H-QLoI" xml:id="vid-vectors-planes-given-normal" label="vid-vectors-planes-given-normal" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           As the plane is to be orthogonal to the line,
@@ -503,6 +501,10 @@
           <!-- figures/figplanes3_3D.asy END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="2diP-H-QLoI" xml:id="vid-vectors-planes-given-normal" label="vid-vectors-planes-given-normal" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_planes4">
@@ -516,10 +518,7 @@
           </md>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="x2HB6huEEmQ" xml:id="vid-vectors-planes-interect1" label="vid-vectors-planes-interect1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           To find an equation of a line,
@@ -645,6 +644,10 @@
           <video width="98%" youtube="tthyDV7cjR8" label="vid-vectors-planes-interection2"/>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="x2HB6huEEmQ" xml:id="vid-vectors-planes-interect1" label="vid-vectors-planes-interect1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_planes5">
@@ -655,10 +658,7 @@
           of the line <m>\ell(t) = \la 3,-3,-1\ra +t\la-1,2,1\ra</m> and the plane with equation in general form <m>2x+y+z=4</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="DjuaixH0ayo" xml:id="vid-vectors-planes-lineint" label="vid-vectors-planes-lineint" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The equation of the plane shows that the vector
@@ -752,6 +752,10 @@
           </image>
           <!-- figures/figplanes5_3D.asy END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="DjuaixH0ayo" xml:id="vid-vectors-planes-lineint" label="vid-vectors-planes-lineint" component="video"/>
       </solution>
     </example>
   </introduction>
@@ -877,10 +881,7 @@
           <m>Q = (2,1,4)</m> and the plane with equation <m>2x-5y+6z=9</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="SqA4OLUmoFk" xml:id="vid-vectors-planes-dist-eg" label="vid-vectors-planes-dist-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Using the equation of the plane,
@@ -903,6 +904,10 @@
             <mrow>\amp \approx 1.74</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="SqA4OLUmoFk" xml:id="vid-vectors-planes-dist-eg" label="vid-vectors-planes-dist-eg" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -176,7 +176,7 @@
           <m>Q = (1,2,-1)</m> and <m>R = (0,1,2)</m> in standard form.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We need a vector <m>\vec n</m> that is orthogonal to the plane.
@@ -427,7 +427,7 @@
           <m>P=(-1,0,1)</m> and is orthogonal to the line with vector equation <m>\vec \ell(t) = \la -1,0,1\ra + t\la 1,2,2\ra</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           As the plane is to be orthogonal to the line,
@@ -518,7 +518,7 @@
           </md>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           To find an equation of a line,
@@ -658,7 +658,7 @@
           of the line <m>\ell(t) = \la 3,-3,-1\ra +t\la-1,2,1\ra</m> and the plane with equation in general form <m>2x+y+z=4</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The equation of the plane shows that the vector
@@ -881,7 +881,7 @@
           <m>Q = (2,1,4)</m> and the plane with equation <m>2x-5y+6z=9</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Using the equation of the plane,

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -265,7 +265,7 @@
           <p>
             An right-angled triangle is shown, with the right angle in the bottom-right corner.
             The vertex on the left is labeled <m>O</m>, and the angle at that vertex is labeled <m>\theta</m>.
-            The label on the hypotenuse indicates a length of <m>r</m>, 
+            The label on the hypotenuse indicates a length of <m>r</m>,
             and the opposite end of the hypotenuse is labeled <m>P</m>.
           </p>
 
@@ -565,7 +565,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -669,7 +669,7 @@
           Sketch the polar function <m>r=1+\cos(\theta)</m> on <m>[0,2\pi]</m> by plotting points.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           A common question when sketching curves by plotting points is
@@ -864,7 +864,7 @@
           Sketch the polar function <m>r=\cos(2\theta)</m> on <m>[0,2\pi]</m> by plotting points.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We start by making a table of
@@ -1087,7 +1087,7 @@
           </p>
         </sidebyside>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -1704,7 +1704,7 @@
               <shortdescription>A rose curve with four leaves, each in one of the quadrants.</shortdescription>
               <description>
                 <p>
-                  The curve <m>r=\sin(2\theta)</m> is a rose curve with four leaves. 
+                  The curve <m>r=\sin(2\theta)</m> is a rose curve with four leaves.
                   It is has the same appearance as the rose curve in <xref ref="fig_polar_rose1"/>,
                   but it is rotated by 45 degrees, so that each leaf lies in one of the four quadrants.
                 </p>
@@ -1877,7 +1877,7 @@
               <description>
                 <p>
                   The lemniscate <m>r^2 = \cos^2(2\theta)</m> is a figure-eight curve.
-                  Since <m>r^2</m> cannot be positive, 
+                  Since <m>r^2</m> cannot be positive,
                   the points on the curve all correspond to angles where <m>\cos(2\theta)</m> is positive.
                   The curve is symmetric about the <m>x</m> axis, and looks much like the symbol for infinity.
                 </p>
@@ -1946,7 +1946,7 @@
           <m>r=1+3\cos(\theta)</m> and <m>r=\cos(\theta)</m> intersect.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           As technology is generally readily available,

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -565,10 +565,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="HTCbzFnW9KU" xml:id="vid-planecurves-polar-basic-graphs" label="vid-planecurves-polar-basic-graphs" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -641,6 +638,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="HTCbzFnW9KU" xml:id="vid-planecurves-polar-basic-graphs" label="vid-planecurves-polar-basic-graphs" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -668,10 +669,7 @@
           Sketch the polar function <m>r=1+\cos(\theta)</m> on <m>[0,2\pi]</m> by plotting points.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="1omaozpN7wI" xml:id="vid-planecurves-polar-cardioid" label="vid-planecurves-polar-cardioid" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           A common question when sketching curves by plotting points is
@@ -787,6 +785,10 @@
         </figure>
 
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="1omaozpN7wI" xml:id="vid-planecurves-polar-cardioid" label="vid-planecurves-polar-cardioid" component="video"/>
+      </solution>
     </example>
 
 
@@ -862,10 +864,7 @@
           Sketch the polar function <m>r=\cos(2\theta)</m> on <m>[0,2\pi]</m> by plotting points.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="DSmu6HQXiS4" xml:id="vid-planecurves-polar-rose" label="vid-planecurves-polar-rose" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by making a table of
@@ -1035,6 +1034,10 @@
 
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="DSmu6HQXiS4" xml:id="vid-planecurves-polar-rose" label="vid-planecurves-polar-rose" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1084,10 +1087,7 @@
           </p>
         </sidebyside>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="kWnHXtXTzSw" xml:id="vid-planecurves-polar-conversions" label="vid-planecurves-polar-conversions" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1197,6 +1197,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="kWnHXtXTzSw" xml:id="vid-planecurves-polar-conversions" label="vid-planecurves-polar-conversions" component="video"/>
       </solution>
     </example>
 
@@ -1942,10 +1946,7 @@
           <m>r=1+3\cos(\theta)</m> and <m>r=\cos(\theta)</m> intersect.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="mI8vfQxub9g" xml:id="vid-planecurves-polar-intersection" label="vid-planecurves-polar-intersection" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           As technology is generally readily available,
@@ -2104,6 +2105,10 @@
           the other angle at which the limaçon is at the pole is the reflection of the first angle across the <m>x</m>-axis.
           That is, <m>\theta = 4.3726 = 250.53^\circ</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="mI8vfQxub9g" xml:id="vid-planecurves-polar-intersection" label="vid-planecurves-polar-intersection" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -87,7 +87,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -270,7 +270,7 @@
           Find the equations of the lines tangent to the graph at the pole.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We need to know when <m>r=0</m>.
@@ -586,7 +586,7 @@
           (Recall this circle has radius <m>1/2</m>.)
         </p>
       </statement>
-      
+
       <solution>
         <p>
           This is a direct application of <xref ref="thm_polar_area"/>.
@@ -681,7 +681,7 @@
           <!-- figures/fig_polcalc4.tex END -->
         </figure>
       </statement>
-      
+
       <solution>
         <p>
           This is again a direct application of <xref ref="thm_polar_area"/>.
@@ -870,7 +870,7 @@
             <!-- figures/fig_polcalc5.tex END -->
           </figure>
         </statement>
-        
+
         <solution>
           <p>
             We need to find the points of intersection between these two functions.
@@ -956,7 +956,7 @@
             </image>
           </figure>
         </statement>
-        
+
         <solution>
           <p>
             We need to find the point of intersection between the two curves.
@@ -1114,7 +1114,7 @@
           Find the arc length of the limaçon <m>r=1+2\sin(\theta)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           With <m>r=1+2\sin(\theta)</m>, we have <m>r\,' = 2\cos(\theta)</m>.
@@ -2013,7 +2013,7 @@
           <!-- <webwork xml:id="webwork-ex-polar-calculus-area-6">
               <pg-code>
               </pg-code> -->
-              
+
               <statement>
                 <p>
                   Enclosed by the inner loop of the lima&#xe7;on <m>\ds r=1+2\cos(\theta)</m>
@@ -2033,7 +2033,7 @@
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("2pi+3sqrt(3)/2");
               </pg-code>
-            
+
               <statement>
                 <p>
                   Find the area enclosed by the outer loop of the lima&#xe7;on <m>r=1+2\cos(\theta)</m>
@@ -2053,7 +2053,7 @@
                 Context()->flags->set(reduceConstants=>0,reduceConstantFormulas=>0);
                 $area=Formula("pi+3sqrt(3)");
               </pg-code>
-            
+
               <statement>
                 <p>
                   Find the area enclosed between the inner and outer loop of the lima&#xe7;on <m>r=1+2\cos(\theta)</m>.
@@ -2099,12 +2099,12 @@
                           ymin=-1.1,ymax=2.1,%
                           xmin=-1.4,xmax=2.4%
                     ]
-                    
+
                     \addplot [firstcurvestyle,areastyle,domain=0:45,samples=20] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)}) -- (axis cs:0,0);
                     \addplot [fill=white, smooth,domain=0:50,samples=20] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
                     \addplot [firstcurvestyle,-,domain=0:180,samples=60] ({cos(x)*2*cos(x)},{sin(x)*2*cos(x)});
                     \addplot [secondcurvestyle,-,domain=0:180,samples=40] ({cos(x)*2*sin(x)},{sin(x)*2*sin(x)});
-                    
+
                     \end{axis}
                     \end{tikzpicture}
                   </latex-image>
@@ -2150,12 +2150,12 @@
                           ymin=-.1,ymax=1.1,%
                           xmin=-.1,xmax=1.34%
                     ]
-                    
+
                     \addplot [firstcurvestyle,areastyle,domain=90:30,samples=20] ({cos(x)*cos(x)},{sin(x)*cos(x)}) -- (axis cs:0,0);
                     \addplot [firstcurvestyle,areastyle,domain=0:30,samples=20] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)}) -- (axis cs:0,0);
                     \addplot [firstcurvestyle,-,domain=0:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
                     \addplot [secondcurvestyle,-,domain=0:90,samples=40] ({cos(x)*sin(2*x)},{sin(x)*sin(2*x)});
-                    
+
                     \end{axis}
                     \end{tikzpicture}
                   </latex-image>
@@ -2167,7 +2167,7 @@
               </statement>
           </webwork>
         </exercise>
-        
+
         <exercise label="ex-polar-calculus-area-11">
           <!-- <webwork xml:id="webwork-ex-polar-calculus-area-11">
               <pg-code>
@@ -2176,7 +2176,7 @@
                 <p>
                   Enclosed by <m>r=\cos(3 \theta)</m> and <m>r=\sin(3\theta)</m>, as shown:
                 </p>
-              
+
                 <image xml:id="img_09_05_ex_26">
                   <shortdescription>Overlapping leaves of two different three-leaf rose curves.</shortdescription>
                   <description>
@@ -2195,12 +2195,12 @@
                           ymin=-.25,ymax=.7,%
                           xmin=-.08,xmax=1.1%
                     ]
-                    
+
                     \addplot [firstcurvestyle,-,areastyle,domain=15:60,samples=20] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)}) -- (axis cs:0,0);
                     \addplot [white,fill=white, smooth,domain=0:30,samples=20] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
                     \addplot [firstcurvestyle,-, domain=0:60,samples=60] ({cos(x)*sin(3*x)},{sin(x)*sin(3*x)});
                     \addplot [secondcurvestyle,-,domain=-30:30,samples=60] ({cos(x)*cos(3*x)},{sin(x)*cos(3*x)});
-                    
+
                     \end{axis}
                     \end{tikzpicture}
                   </latex-image>
@@ -2249,12 +2249,12 @@
                       ymin=-1.4,ymax=1.4,%
                       xmin=-2.2,xmax=1.2%
                     ]
-                    
+
                     \addplot [firstcurvestyle,-,areastyle,domain=60:90,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
                     \addplot [firstcurvestyle,-,areastyle,domain=0:60,samples=40] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
                     \addplot [firstcurvestyle,-,domain=0:180,samples=60] ({cos(x)*cos(x)},{sin(x)*cos(x)});
                     \addplot [secondcurvestyle,-,domain=0:360,samples=60] ({cos(x)*(1-cos(x))},{sin(x)*(1-cos(x))});
-                    
+
                     \end{axis}
                     \end{tikzpicture}
                   </latex-image>

--- a/ptx/sec_polarcalc.ptx
+++ b/ptx/sec_polarcalc.ptx
@@ -87,10 +87,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="QLsLabLb6I4" xml:id="vid-planecurves-polarcalc-example-tangent" label="vid-planecurves-polarcalc-example-tangent" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -239,6 +236,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="QLsLabLb6I4" xml:id="vid-planecurves-polarcalc-example-tangent" label="vid-planecurves-polarcalc-example-tangent" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -269,10 +270,7 @@
           Find the equations of the lines tangent to the graph at the pole.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="1bAf6kE9F1Y" xml:id="vid-planecurves-polarcalc-polar-tangent" label="vid-planecurves-polarcalc-polar-tangent" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We need to know when <m>r=0</m>.
@@ -335,6 +333,10 @@
           </image>
           <!-- figures/fig_polcalc2.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="1bAf6kE9F1Y" xml:id="vid-planecurves-polarcalc-polar-tangent" label="vid-planecurves-polarcalc-polar-tangent" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -584,10 +586,7 @@
           (Recall this circle has radius <m>1/2</m>.)
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="T_z8FNS3Whs" xml:id="vid-planecurves-polarcalc-example-area1" label="vid-planecurves-polarcalc-example-area1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This is a direct application of <xref ref="thm_polar_area"/>.
@@ -604,6 +603,10 @@
           Of course, we already knew the area of a circle with radius <m>1/2</m>.
           We did this example to demonstrate that the area formula is correct.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="T_z8FNS3Whs" xml:id="vid-planecurves-polarcalc-example-area1" label="vid-planecurves-polarcalc-example-area1" component="video"/>
       </solution>
     </example>
 
@@ -678,10 +681,7 @@
           <!-- figures/fig_polcalc4.tex END -->
         </figure>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="yZpBCQnB7r8" xml:id="vid-planecurves-polarcalc-area-example2" label="vid-planecurves-polarcalc-area-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This is again a direct application of <xref ref="thm_polar_area"/>.
@@ -692,6 +692,10 @@
             <mrow>\amp = \frac18\big(\pi+4\sqrt{3}-4\big) \approx 0.7587</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="yZpBCQnB7r8" xml:id="vid-planecurves-polarcalc-area-example2" label="vid-planecurves-polarcalc-area-example2" component="video"/>
       </solution>
     </example>
 
@@ -866,10 +870,7 @@
             <!-- figures/fig_polcalc5.tex END -->
           </figure>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="CM7XsZRRqSI" xml:id="vid-planecurves-polarcalc-example-area3" label="vid-planecurves-polarcalc-example-area3" component="video"/>
-        </solution>
+        
         <solution>
           <p>
             We need to find the points of intersection between these two functions.
@@ -895,6 +896,10 @@
             Amazingly enough,
             the area between these curves has a <q>nice</q> value.
           </p>
+        </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="CM7XsZRRqSI" xml:id="vid-planecurves-polarcalc-example-area3" label="vid-planecurves-polarcalc-example-area3" component="video"/>
         </solution>
       </example>
 
@@ -951,10 +956,7 @@
             </image>
           </figure>
         </statement>
-        <solution component="video">
-          <title>Video solution</title>
-          <video width="98%" youtube="5MHcrQVTjjU" xml:id="vid-planecurves-polarcalc-example-area4" label="vid-planecurves-polarcalc-example-area4" component="video"/>
-        </solution>
+        
         <solution>
           <p>
             We need to find the point of intersection between the two curves.
@@ -1048,6 +1050,10 @@
             the total area is <m>A = \pi/6-\sqrt{3}/8</m>.
           </p>
         </solution>
+        <solution component="video">
+          <title>Video solution</title>
+          <video width="98%" youtube="5MHcrQVTjjU" xml:id="vid-planecurves-polarcalc-example-area4" label="vid-planecurves-polarcalc-example-area4" component="video"/>
+        </solution>
       </example>
     </paragraphs>
   </subsection>
@@ -1108,10 +1114,7 @@
           Find the arc length of the limaçon <m>r=1+2\sin(\theta)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="o-cetriP4Ms" xml:id="vid-planecurves-polarcalc-arclength" label="vid-planecurves-polarcalc-arclength" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           With <m>r=1+2\sin(\theta)</m>, we have <m>r\,' = 2\cos(\theta)</m>.
@@ -1172,6 +1175,10 @@
           Using <m>n=22</m> gives the value above,
           which is accurate to 4 places after the decimal.)
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="o-cetriP4Ms" xml:id="vid-planecurves-polarcalc-arclength" label="vid-planecurves-polarcalc-arclength" component="video"/>
       </solution>
     </example>
   </subsection>

--- a/ptx/sec_power_series.ptx
+++ b/ptx/sec_power_series.ptx
@@ -66,7 +66,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -329,7 +329,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -512,7 +512,7 @@
         along with their respective intervals of convergence.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We find the derivative and indefinite integral of <m>f(x)</m>,
@@ -664,7 +664,7 @@
         and use these to analyze the behavior of <m>f(x)</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We start by making two notes:

--- a/ptx/sec_power_series.ptx
+++ b/ptx/sec_power_series.ptx
@@ -66,10 +66,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="NK8i9T-4hSg" xml:id="vid-seqseries-powerseries-example1" label="vid-seqseries-powerseries-example1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -109,6 +106,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="NK8i9T-4hSg" xml:id="vid-seqseries-powerseries-example1" label="vid-seqseries-powerseries-example1" component="video"/>
     </solution>
   </example>
 
@@ -328,10 +329,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="1YzPDWYUWO8" xml:id="vid-seqseries-powerseries-example-radius" label="vid-seqseries-powerseries-example-radius" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -415,6 +413,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="1YzPDWYUWO8" xml:id="vid-seqseries-powerseries-example-radius" label="vid-seqseries-powerseries-example-radius" component="video"/>
     </solution>
   </example>
 
@@ -510,10 +512,7 @@
         along with their respective intervals of convergence.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="XE6m9CGME5Q" xml:id="vid-seqseries-powerseries-calc-example" label="vid-seqseries-powerseries-calc-example" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We find the derivative and indefinite integral of <m>f(x)</m>,
@@ -570,6 +569,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="XE6m9CGME5Q" xml:id="vid-seqseries-powerseries-calc-example" label="vid-seqseries-powerseries-calc-example" component="video"/>
     </solution>
   </example>
 
@@ -661,10 +664,7 @@
         and use these to analyze the behavior of <m>f(x)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="SQm1BC7bwEw" xml:id="vid-seqseries-powerseries-example-exponential" label="vid-seqseries-powerseries-example-exponential" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We start by making two notes:
@@ -719,6 +719,10 @@
         The integral of <m>f(x)</m> differs from <m>f(x)</m> only by a constant,
         again indicating that <m>f(x) = e^x</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="SQm1BC7bwEw" xml:id="vid-seqseries-powerseries-example-exponential" label="vid-seqseries-powerseries-example-exponential" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_ratio_root_tests.ptx
+++ b/ptx/sec_ratio_root_tests.ptx
@@ -98,10 +98,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="Zpn9qvIGlG0" xml:id="vid-seqseries-ratroot-ratio-example" label="vid-seqseries-ratroot-ratio-example" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -163,6 +160,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="Zpn9qvIGlG0" xml:id="vid-seqseries-ratroot-ratio-example" label="vid-seqseries-ratroot-ratio-example" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -193,10 +194,7 @@
           Determine the convergence of <m>\ds\infser \frac{n!n!}{(2n)!}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="JghEjy4pykA" xml:id="vid-seqseries-ratroot-ratio-example2" label="vid-seqseries-ratroot-ratio-example2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Before we begin,
@@ -227,6 +225,10 @@
           recall that we just need to examine the leading terms of the numerator and denominator,
           which are <m>n^2</m> and <m>4n^2</m> respectively.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="JghEjy4pykA" xml:id="vid-seqseries-ratroot-ratio-example2" label="vid-seqseries-ratroot-ratio-example2" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -312,10 +314,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="Y7IaFXjMLlw" xml:id="vid-seqseries-ratroot-root-example" label="vid-seqseries-ratroot-root-example" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -368,6 +367,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="Y7IaFXjMLlw" xml:id="vid-seqseries-ratroot-root-example" label="vid-seqseries-ratroot-root-example" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_ratio_root_tests.ptx
+++ b/ptx/sec_ratio_root_tests.ptx
@@ -98,7 +98,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -194,7 +194,7 @@
           Determine the convergence of <m>\ds\infser \frac{n!n!}{(2n)!}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Before we begin,
@@ -314,7 +314,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -60,10 +60,7 @@
         At what rate is the circumference growing?
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="Qg3GStrQ8pY" xml:id="vid_deriv_apps_rel_rates_circumference" label="vid_deriv_apps_rel_rates_circumference" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -108,6 +105,10 @@
         <video width="98%" youtube="RDPxSmxqUBs" label="vid_deriv_apps_rel_rates_circ_area"/>
       </figure>
 
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="Qg3GStrQ8pY" xml:id="vid_deriv_apps_rel_rates_circumference" label="vid_deriv_apps_rel_rates_circumference" component="video"/>
     </solution>
   </example>
 
@@ -227,10 +228,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="8ctKxMoFWkU" xml:id="vid_deriv_apps_rel_rates_water_flow" label="vid_deriv_apps_rel_rates_water_flow" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -364,6 +362,10 @@
         </ol>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="8ctKxMoFWkU" xml:id="vid_deriv_apps_rel_rates_water_flow" label="vid_deriv_apps_rel_rates_water_flow" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_rr3">
@@ -462,10 +464,7 @@
         </quantity>, is the other driver speeding?
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="8fFao8XCQC0" xml:id="vid_deriv_apps_rel_rates_speed_radar" label="vid_deriv_apps_rel_rates_speed_radar" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -534,6 +533,10 @@
       <p>
         The other driver appears to be speeding slightly.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="8fFao8XCQC0" xml:id="vid_deriv_apps_rel_rates_speed_radar" label="vid_deriv_apps_rel_rates_speed_radar" component="video"/>
     </solution>
   </example>
 
@@ -611,10 +614,7 @@
         How fast must the camera be able to turn to track the car?
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="B85LlGHgVQo" xml:id="vid_deriv_apps_rel_rates_turning_camera" label="vid_deriv_apps_rel_rates_turning_camera" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -733,6 +733,10 @@
         means <m>14.667/(2\pi)\approx 2.33</m> revolutions per second.
         The negative sign indicates the camera is rotating in a clockwise fashion.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="B85LlGHgVQo" xml:id="vid_deriv_apps_rel_rates_turning_camera" label="vid_deriv_apps_rel_rates_turning_camera" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_related_rates.ptx
+++ b/ptx/sec_related_rates.ptx
@@ -60,7 +60,7 @@
         At what rate is the circumference growing?
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -228,7 +228,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -464,7 +464,7 @@
         </quantity>, is the other driver speeding?
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -590,7 +590,7 @@
                 with a tripod placed <quantity><mag>10</mag><unit base="foot"/></quantity> from the side of the road, set to track the car.
               </p>
               <p>
-                A right triangle is drawn, with the hypotenuse connecting the car to the tripod, and the other two sides parallel to the road and perpendicular to the road. 
+                A right triangle is drawn, with the hypotenuse connecting the car to the tripod, and the other two sides parallel to the road and perpendicular to the road.
                 The side parallel to the road has length <m>x</m>, and the angle between the hypotenuse and the side perpendicular to the road is labeled as <m>\theta</m>. The side perpendicular to the road has a length of <quantity><mag>10</mag><unit base="foot"/></quantity>.
               </p>
           </description>
@@ -614,7 +614,7 @@
         How fast must the camera be able to turn to track the car?
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -819,7 +819,7 @@
               How fast is the radius growing when the radius is:
             </p>
           </introduction>
-          
+
           <task label="ex-related-rates-puddle-a">
             <statement>
               <p>
@@ -1385,7 +1385,7 @@
               <p>
                 What happens when the length of rope pulling in the boat is less than 10 feet long?
               </p>
-              
+
               <p>
                 <var form="essay"/>
               </p>

--- a/ptx/sec_riemann.ptx
+++ b/ptx/sec_riemann.ptx
@@ -232,7 +232,7 @@
           and the Midpoint Rule, using 4 equally spaced subintervals.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -303,7 +303,7 @@
                 The second strip has a height of 3, and an area of 3.
                 The third strip has a height of 4, and an area of 4.
                 The fourth strip has a height of 3, and an area of 3.
-                Each rectangle touches the curve in the top left corner. 
+                Each rectangle touches the curve in the top left corner.
               </p>
             </description>
             <latex-image>
@@ -357,7 +357,7 @@
                 The second strip has height of 4, and an area of 4.
                 The third strip has height of 3, and an area of 3.
                 The fourth strip has height of 0, and an area of 0.
-                Each rectangle touches the curve in the top right corner. 
+                Each rectangle touches the curve in the top right corner.
               </p>
             </description>
             <latex-image>
@@ -411,7 +411,7 @@
                 The second strip has a height and area of 3.75.
                 The third strip has a height and area of 3.75.
                 The fourth strip has a height and area of 1.75.
-                Each rectangle touches the curve in the top center of the rectangle. 
+                Each rectangle touches the curve in the top center of the rectangle.
               </p>
             </description>
             <latex-image>
@@ -527,7 +527,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -823,7 +823,7 @@
           Approximate <m>\int_0^4(4x-x^2)\, dx</m> using the Right Hand Rule and summation formulas with 16 and 1000 equally spaced intervals.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1164,7 +1164,7 @@
           Approximate <m>\int_{-2}^3 (5x+2)\, dx</m> using the Midpoint Rule and 10 equally spaced intervals.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1286,7 +1286,7 @@
           Approximate this definite integral using the Right Hand Rule with <m>n</m> equally spaced subintervals.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1394,7 +1394,7 @@
           then take the limit as <m>n\to\infty</m> to find the exact area.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -3125,7 +3125,7 @@
             Find the general antiderivative of the given function.
           </p>
         </introduction>
-        
+
         <exercise label="ex-riemann-review-1">
           <webwork xml:id="webwork-ex-riemann-review-1">
             <pg-code>

--- a/ptx/sec_riemann.ptx
+++ b/ptx/sec_riemann.ptx
@@ -232,10 +232,7 @@
           and the Midpoint Rule, using 4 equally spaced subintervals.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="qn8Q1i8s5Ng" xml:id="vid_int_rie_approx" label="vid_int_rie_approx" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -458,6 +455,10 @@
           </sidebyside>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="qn8Q1i8s5Ng" xml:id="vid_int_rie_approx" label="vid_int_rie_approx" component="video"/>
+      </solution>
     </example>
   </introduction>
 
@@ -526,10 +527,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="GKaRI_a96-Q" xml:id="vid_int_rie_sum_ex" label="vid_int_rie_sum_ex" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -566,6 +564,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="GKaRI_a96-Q" xml:id="vid_int_rie_sum_ex" label="vid_int_rie_sum_ex" component="video"/>
       </solution>
     </example>
 
@@ -821,10 +823,7 @@
           Approximate <m>\int_0^4(4x-x^2)\, dx</m> using the Right Hand Rule and summation formulas with 16 and 1000 equally spaced intervals.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="urkFFBmu9uQ" xml:id="vid_int_rie_ex_1" label="vid_int_rie_ex_1" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -938,6 +937,10 @@
             \int_0^4(4x-x^2)\, dx \approx 10.666656
           </me>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="urkFFBmu9uQ" xml:id="vid_int_rie_ex_1" label="vid_int_rie_ex_1" component="video"/>
       </solution>
     </example>
 
@@ -1161,10 +1164,7 @@
           Approximate <m>\int_{-2}^3 (5x+2)\, dx</m> using the Midpoint Rule and 10 equally spaced intervals.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="O6S1f6-D8Ls" xml:id="vid_int_rie_ex_2" label="vid_int_rie_ex_2" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1264,6 +1264,10 @@
           when <m>f</m> is negative, the area is counted as negative.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="O6S1f6-D8Ls" xml:id="vid_int_rie_ex_2" label="vid_int_rie_ex_2" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1282,10 +1286,7 @@
           Approximate this definite integral using the Right Hand Rule with <m>n</m> equally spaced subintervals.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="LjMZOVNdRxQ" xml:id="vid_int_rie_ex_n_rect" label="vid_int_rie_ex_n_rect" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1367,6 +1368,10 @@
           As <m>n</m> grows large <mdash/> without bound <mdash/> the error shrinks to zero and we obtain the exact area.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="LjMZOVNdRxQ" xml:id="vid_int_rie_ex_n_rect" label="vid_int_rie_ex_n_rect" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1389,10 +1394,7 @@
           then take the limit as <m>n\to\infty</m> to find the exact area.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="yvWSszI0Xvc" xml:id="vid_int_rie_ex_lim" label="vid_int_rie_ex_lim" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1472,6 +1474,10 @@
             \int_{-1}^5 x^3\, dx = \lim_{n\to\infty} \left(156 + \frac{378}n + \frac{216}{n^2}\right) = 156
           </me>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="yvWSszI0Xvc" xml:id="vid_int_rie_ex_lim" label="vid_int_rie_ex_lim" component="video"/>
       </solution>
     </example>
   </subsection>

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -101,7 +101,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
 
       <p>
@@ -316,7 +316,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We should first note that there is never exactly one function that describes a finite set of numbers as a sequence.
@@ -566,7 +566,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -1001,7 +1001,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We will use <xref ref="thm_seq_properties"/> to answer each of these.
@@ -1098,7 +1098,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -1377,7 +1377,7 @@
         </ol>
       </p>
     </statement>
-   
+
     <solution>
       <p>
         In each of the following, we will examine <m>a_{n+1}-a_n</m>.

--- a/ptx/sec_sequences.ptx
+++ b/ptx/sec_sequences.ptx
@@ -101,10 +101,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="j-iqXR_bANY" xml:id="vid-seqseries-sequences-example1" label="vid-seqseries-sequences-example1" component="video"/>
-    </solution>
+    
     <solution>
 
       <p>
@@ -277,6 +274,10 @@
         </ol>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="j-iqXR_bANY" xml:id="vid-seqseries-sequences-example1" label="vid-seqseries-sequences-example1" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_seq2">
@@ -315,10 +316,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="-Tu12lkQtTs" xml:id="vid-seqseries-sequences-example2" label="vid-seqseries-sequences-example2" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We should first note that there is never exactly one function that describes a finite set of numbers as a sequence.
@@ -394,6 +392,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="-Tu12lkQtTs" xml:id="vid-seqseries-sequences-example2" label="vid-seqseries-sequences-example2" component="video"/>
     </solution>
   </example>
 
@@ -564,10 +566,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="8xE6Sc8U_gU" xml:id="vid-seqseries-sequences-example3" label="vid-seqseries-sequences-example3" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -759,6 +758,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="8xE6Sc8U_gU" xml:id="vid-seqseries-sequences-example3" label="vid-seqseries-sequences-example3" component="video"/>
     </solution>
   </example>
 
@@ -998,10 +1001,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="2PVI6iUVYcI" xml:id="vid-seqseries-sequences-example5" label="vid-seqseries-sequences-example5" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We will use <xref ref="thm_seq_properties"/> to answer each of these.
@@ -1035,6 +1035,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="2PVI6iUVYcI" xml:id="vid-seqseries-sequences-example5" label="vid-seqseries-sequences-example5" component="video"/>
     </solution>
   </example>
 
@@ -1094,10 +1098,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="d_C_rw2LXwk" xml:id="vid-seqseries-sequences-example-bounded" label="vid-seqseries-sequences-example-bounded" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -1207,6 +1208,10 @@
           </figure>
         </sidebyside>
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="d_C_rw2LXwk" xml:id="vid-seqseries-sequences-example-bounded" label="vid-seqseries-sequences-example-bounded" component="video"/>
     </solution>
   </example>
 
@@ -1372,10 +1377,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="F8mDR0ZnMCM" xml:id="vid-seqseries-sequences-monotone-example" label="vid-seqseries-sequences-monotone-example" component="video"/>
-    </solution>
+   
     <solution>
       <p>
         In each of the following, we will examine <m>a_{n+1}-a_n</m>.
@@ -1637,6 +1639,10 @@
           </sidebyside>
         </sbsgroup>
       </figure>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="F8mDR0ZnMCM" xml:id="vid-seqseries-sequences-monotone-example" label="vid-seqseries-sequences-monotone-example" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -151,10 +151,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="NLXq_m8S2tw" xml:id="vid-seqseries-series-example-divergent" label="vid-seqseries-series-example-divergent" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -303,6 +300,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="NLXq_m8S2tw" xml:id="vid-seqseries-series-example-divergent" label="vid-seqseries-series-example-divergent" component="video"/>
       </solution>
     </example>
 
@@ -501,10 +502,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="9_AmxyiKVm8" xml:id="vid-seqseries-sequences-example-geometric" label="vid-seqseries-sequences-example-geometric" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -692,6 +690,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="9_AmxyiKVm8" xml:id="vid-seqseries-sequences-example-geometric" label="vid-seqseries-sequences-example-geometric" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -815,10 +817,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="XYW0z0LMaJc" xml:id="vid-seqseries-series-pseries" label="vid-seqseries-series-pseries" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -880,6 +879,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="XYW0z0LMaJc" xml:id="vid-seqseries-series-pseries" label="vid-seqseries-series-pseries" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -900,10 +903,7 @@
               <idx><h>telescoping series</h></idx>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="ckj4xm6ZHgU" xml:id="vid-seqseries-series-telescoping1" label="vid-seqseries-series-telescoping1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           It will help to write down some of the first few partial sums of this series.
@@ -976,6 +976,10 @@
           <!-- figures/fig_series3.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="ckj4xm6ZHgU" xml:id="vid-seqseries-series-telescoping1" label="vid-seqseries-series-telescoping1" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1020,10 +1024,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-telescoping2" label="vid-seqseries-series-telescoping2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1196,6 +1197,10 @@
           </sidebyside>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-telescoping2" label="vid-seqseries-series-telescoping2" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1319,10 +1324,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-using-properties" label="vid-seqseries-series-using-properties" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1475,6 +1477,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="BMn2QTtTdNQ" xml:id="vid-seqseries-series-using-properties" label="vid-seqseries-series-using-properties" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_series.ptx
+++ b/ptx/sec_series.ptx
@@ -151,7 +151,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -502,7 +502,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -817,7 +817,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -903,7 +903,7 @@
               <idx><h>telescoping series</h></idx>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           It will help to write down some of the first few partial sums of this series.
@@ -1024,7 +1024,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -1107,7 +1107,7 @@
                 <description>
                   <p>
                     The scatter plots given appear very similar to the previous example.
-                    Again, points plotted for the terms in the sequence <m>a_n</m>, 
+                    Again, points plotted for the terms in the sequence <m>a_n</m>,
                     which begin at <m>(1,2/3)</m>, descend toward the <m>n</m> axis,
                     while the points for the sequence of partial sums ascend from the same point,
                     in this case getting closer and closer to the line <m>y=3/2</m>.
@@ -1158,7 +1158,7 @@
                     for <m>n=10,20,\ldots, 100</m>.
                     The points for the sequence <m>a_n</m> are all very close to the <m>n</m> axis.
                     The points for the sequence <m>S_n</m> of partial sums follow the graph <m>y=\ln(x+1)</m>;
-                    although this may appear to be bounded, we know that the value of the logarithm 
+                    although this may appear to be bounded, we know that the value of the logarithm
                     will eventually approach infinity, even if it does so very slowly.
                   </p>
                 </description>
@@ -1324,7 +1324,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -473,10 +473,7 @@
         <m>y=1/(1+x^2)</m>, <m>x=0</m> and <m>x=1</m> about the <m>y</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="WQ3rUzAhgPw" xml:id="vid-intapp-shell-example1" label="vid-intapp-shell-example1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         This is the region used to introduce the Shell Method in <xref ref="fig_shell_intro"/>,
@@ -556,6 +553,10 @@
         two integrals would be needed to account for the regions above and below <m>y=1/2</m>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="WQ3rUzAhgPw" xml:id="vid-intapp-shell-example1" label="vid-intapp-shell-example1" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -572,10 +573,7 @@
         <m>(1,1)</m> and <m>(1,3)</m> about the line <m>x=3</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="wGVmSx1TqQI" xml:id="vid-intapp-shell-example2" label="vid-intapp-shell-example2" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The region is sketched in <xref ref="fig_shell2a"/> along with the differential element,
@@ -849,6 +847,10 @@
         </md>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="wGVmSx1TqQI" xml:id="vid-intapp-shell-example2" label="vid-intapp-shell-example2" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -864,10 +866,7 @@
         Find the volume of the solid formed by rotating the region given in <xref ref="ex_shell2"/> about the <m>x</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="pu80zsXPw5E" xml:id="vid-intapp-shell-example3" label="vid-intapp-shell-example3" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The region is sketched in <xref ref="fig_shell3a"/> with a sample differential element.
@@ -1145,6 +1144,10 @@
         </md>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="pu80zsXPw5E" xml:id="vid-intapp-shell-example3" label="vid-intapp-shell-example3" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -1162,10 +1165,7 @@
         <m>y= \sin(x)</m> and the <m>x</m>-axis from <m>x=0</m> to <m>x=\pi</m> about the <m>y</m>-axis.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="nd16wB-0qIQ" xml:id="vid-intapp-shell-example4" label="vid-intapp-shell-example4" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The region and a differential element,
@@ -1433,6 +1433,10 @@
         This integral isn't terrible given that the <m>\arcsin^2 y</m> terms cancel,
         but it is more onerous than the integral created by the Shell Method.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="nd16wB-0qIQ" xml:id="vid-intapp-shell-example4" label="vid-intapp-shell-example4" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_shell_method.ptx
+++ b/ptx/sec_shell_method.ptx
@@ -45,7 +45,7 @@
         <image xml:id="img_shell_intro_b_3D">
           <description>
             <p>
-              Graph of the function <m>y=\frac{1}{1+x^2} </m>. 
+              Graph of the function <m>y=\frac{1}{1+x^2} </m>.
               The curve begins at the point <m>(0,1)</m>.
               The curve then decreases until it meets the horizontal line <m>x=1</m> where it stops at the point <m> (1,\frac12) </m>.
               The entire area enclosed by <m>y=\frac{1}{1+x^2} </m>, <m>x=0 </m>, <m> x=1 </m> and <m>y=0 </m> is shaded.
@@ -180,7 +180,7 @@
           <description>
             <p>
               The red rectangle from figure (a) is rotated 360 degrees about the <m>y</m>-axis, creating a cylindrical shell.
-              Two circles, one of radius <m>0.5</m> and one of radius <m>0.6</m> are drawn on the <m>xz</m>-plane. 
+              Two circles, one of radius <m>0.5</m> and one of radius <m>0.6</m> are drawn on the <m>xz</m>-plane.
               The area between the circles is shaded, creating a circular disc in the <m>xz</m>-plane.
               The disc then goes up from <m> y=0 </m> until it meets the curve <m>y=\frac{1}{1+x^2} </m>, which creates the cylindrical shell.
               Adding up many of these cylindrical shells will then allow us to approximate the volume of the solid described in the previous images.
@@ -334,10 +334,10 @@
           <description>
            <p>
               The left side of the image contains a cylinder, and the right side of the image shows a rectangle which comes from unraveling the side of the cylinder.
-              The cylinder has a height <m> h </m>, radius <m> r </m> and is pictured lying on its circular base. 
+              The cylinder has a height <m> h </m>, radius <m> r </m> and is pictured lying on its circular base.
               Both the circular base, and the top of the cylinder are shaded, while the curved surface is unshaded, but contains a <q>cut here</q> instruction.
               Once the curved surface of the cylinder is cut, it is unraveled into a rectangular region as seen on the right side of the image.
-              This rectangular region has a height <m> h </m> and a base <m> 2\pi r </m>. 
+              This rectangular region has a height <m> h </m> and a base <m> 2\pi r </m>.
               The area of the rectangle is <m> A=2\pi r h </m>.
            </p>
           </description>
@@ -378,12 +378,12 @@
         <image xml:id="img_shell_unwrapshell">
           <description>
             <p>
-              The left side of the image contains a cylindrical shell, which is just a cylinder with the middle part cut out. 
+              The left side of the image contains a cylindrical shell, which is just a cylinder with the middle part cut out.
               The right side of the image shows a rectangular box which comes from unraveling the cylindrical shell.
-              The cylindrical shell has a height <m> h </m>, radius <m> r </m> which spans from the cut out center to the edge of the shell, and the shell has thickness <m> \dx </m> and is pictured lying on its circular base. 
+              The cylindrical shell has a height <m> h </m>, radius <m> r </m> which spans from the cut out center to the edge of the shell, and the shell has thickness <m> \dx </m> and is pictured lying on its circular base.
               The entire cylindrical shell is shaded, and contains a <q>cut here</q> instruction along the curved surface as in the previous image.
               Once the curved surface of the cylinderical shell is cut, the entire shell is unraveled into a rectangular box as seen on the right side of the image.
-              This rectangular box has a height <m> h </m> and a base length of <m> 2\pi r </m> and a thickness of <m> \dx </m>. 
+              This rectangular box has a height <m> h </m> and a base length of <m> 2\pi r </m> and a thickness of <m> \dx </m>.
               The volume of the unraveled cylindrical shell is approximated the volume of the box given by <m> V=2\pi r h \dx </m>.
             </p>
           </description>
@@ -473,7 +473,7 @@
         <m>y=1/(1+x^2)</m>, <m>x=0</m> and <m>x=1</m> about the <m>y</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         This is the region used to introduce the Shell Method in <xref ref="fig_shell_intro"/>,
@@ -488,12 +488,12 @@
         <image xml:id="img_shell1" width="47%">
           <description>
             <p>
-              Graph of the region bounded by <m>y=0</m>, <m>y=1/(1+x^2)</m>, <m>x=0</m> and <m>x=1</m>. 
-              The curve <m>y=1/(1+x^2)</m> begins at the <m> y</m>-axis at point <m> (0,1) </m> and slopes downwards before ending at the point <m> (1,\frac12) </m>. 
+              Graph of the region bounded by <m>y=0</m>, <m>y=1/(1+x^2)</m>, <m>x=0</m> and <m>x=1</m>.
+              The curve <m>y=1/(1+x^2)</m> begins at the <m> y</m>-axis at point <m> (0,1) </m> and slopes downwards before ending at the point <m> (1,\frac12) </m>.
               The region contains the entire area below the curve, lying above the horizontal line <m> y=0 </m>.
-              On the <m> x</m>-axis, the graph contains an arbitrarily chosen point <m> x </m>. 
-              The distance between the origin and the point <m> x </m> is given as the function <m> r(x) </m>, which will give us the radius of the cylindrical shell once the region is rotated about the <m> y</m>-axis.  
-              Additionally, coming up from the point <m> x </m> is a red vertical line, which ends after meeting the curve <m>y=1/(1+x^2)</m>. 
+              On the <m> x</m>-axis, the graph contains an arbitrarily chosen point <m> x </m>.
+              The distance between the origin and the point <m> x </m> is given as the function <m> r(x) </m>, which will give us the radius of the cylindrical shell once the region is rotated about the <m> y</m>-axis.
+              Additionally, coming up from the point <m> x </m> is a red vertical line, which ends after meeting the curve <m>y=1/(1+x^2)</m>.
               This vertical line is labeled <m>h(x)</m>, and will give the us the height of the cylindrical shell.
             </p>
           </description>
@@ -573,7 +573,7 @@
         <m>(1,1)</m> and <m>(1,3)</m> about the line <m>x=3</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The region is sketched in <xref ref="fig_shell2a"/> along with the differential element,
@@ -593,13 +593,13 @@
             <image xml:id="img_shell2a">
               <description>
                 <p>
-                  Graph of the triangular region with edges on the points <m>(0,1)</m>, <m> (1,1) </m> and <m> (1,3)</m>. 
-                  The leftmost point of the triangular region begins at the <m> y</m>-axis at point <m> (0,1) </m> and linearly increases until the point <m> (1,3) </m>. 
+                  Graph of the triangular region with edges on the points <m>(0,1)</m>, <m> (1,1) </m> and <m> (1,3)</m>.
+                  The leftmost point of the triangular region begins at the <m> y</m>-axis at point <m> (0,1) </m> and linearly increases until the point <m> (1,3) </m>.
                   The equation of the line between the points <m> (0,1) </m> and <m> (1,3) </m> is given to be <m> y=2x+1 </m>.
                   The region contains the entire area below the curve, lying above the horizontal line <m> y=1 </m>.
-                  Above the <m> x</m>-axis, the graph showcases the distance between an arbitrarily chosen value on the <m>x</m>-axis, labeled <m> x </m>, which is between <m> 0 </m> and <m> 1</m>, and the axis of rotation at <m> x=3 </m>. 
+                  Above the <m> x</m>-axis, the graph showcases the distance between an arbitrarily chosen value on the <m>x</m>-axis, labeled <m> x </m>, which is between <m> 0 </m> and <m> 1</m>, and the axis of rotation at <m> x=3 </m>.
                   The distance between these two <m> x </m> values is given as the function <m> r(x) </m>, which will give us the radius of the cylindrical shell once the region is rotated about the vertical line <m> x=3</m>.
-                  Additionally, coming up from the point <m> (x,1) </m> is a red vertical line, which meets the upper bound of the triangular region, which is given by the line <m> y=2x+1 </m>. 
+                  Additionally, coming up from the point <m> (x,1) </m> is a red vertical line, which meets the upper bound of the triangular region, which is given by the line <m> y=2x+1 </m>.
                   This vertical line is labeled <m>h(x)</m>, and will give the us the height of the cylindrical shell.
                 </p>
               </description>
@@ -645,9 +645,9 @@
             <image xml:id="img_shell2b_3D">
               <description>
                 <p>
-                  A three dimensional graph of the same triangular region with edges on the points <m>(0,1)</m>, <m> (1,1) </m> and <m> (1,3)</m> and an arbitrary cylindrical shell which lies inside the triangular region rotated about <m>x=3</m>. 
-                  The cylindrical shell is centered at the line <m> x=3 </m> and radius <m> r(x) </m>, which spans from arbitrarily chosen value on the <m>x</m>-axis between <m> x=0 </m> and <m> x=1</m>, and the axis of rotation at <m> x=3 </m>. 
-                  The height of the cylindrical shell is <m> h(x) </m>, which is the distance between the point <m> (x,1) </m> and upper bound of the triangular region at the particular value of <m>x</m>. 
+                  A three dimensional graph of the same triangular region with edges on the points <m>(0,1)</m>, <m> (1,1) </m> and <m> (1,3)</m> and an arbitrary cylindrical shell which lies inside the triangular region rotated about <m>x=3</m>.
+                  The cylindrical shell is centered at the line <m> x=3 </m> and radius <m> r(x) </m>, which spans from arbitrarily chosen value on the <m>x</m>-axis between <m> x=0 </m> and <m> x=1</m>, and the axis of rotation at <m> x=3 </m>.
+                  The height of the cylindrical shell is <m> h(x) </m>, which is the distance between the point <m> (x,1) </m> and upper bound of the triangular region at the particular value of <m>x</m>.
                 </p>
               </description>
               <shortdescription>Three dimensional depiction of an arbitrary cylindrical shell from rotating the region described in the example.</shortdescription>
@@ -741,10 +741,10 @@
             <image xml:id="img_shell2c_3D">
               <description>
                 <p>
-                  A three dimensional plot showing the same triangular region rotated about <m>x=3</m>. 
+                  A three dimensional plot showing the same triangular region rotated about <m>x=3</m>.
                   The resulting shape lies entirely above <m> x=1 </m>.
                   The leftmost point of the shape is the point <m> (0,1) </m>, which is the leftmost point of the original triangle.
-                  The shape is then rotated in a full circle around the vertical line <m> x=3 </m>.  
+                  The shape is then rotated in a full circle around the vertical line <m> x=3 </m>.
                   The resulting shape has a base of radius of <m> 3 </m>, whose center is an empty central cylinder of radius <m> 2 </m> centered at the axis of rotation.
                   As we move up the shape, the thickness tapers off as the line <m>y=2x+1</m> reaches the point <m>(3,1)</m> in the original triangular region.
                   The point <m>(3,1)</m> rotated about the line <m> x=3 </m> then becomes the top of the resulting shape, while the base of the triangle, which is between the points <m> (0,1) </m> and <m> (1,1) </m> becomes the base.
@@ -866,7 +866,7 @@
         Find the volume of the solid formed by rotating the region given in <xref ref="ex_shell2"/> about the <m>x</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The region is sketched in <xref ref="fig_shell3a"/> with a sample differential element.
@@ -897,14 +897,14 @@
             <image xml:id="img_shell3a">
               <description>
                 <p>
-                  Graph of the triangular region with edges on the points <m>(0,1)</m>, <m> (1,1) </m> and <m> (1,3)</m>. 
-                  The leftmost point of the triangular region begins at the <m> y</m>-axis at point <m> (0,1) </m> and linearly increases until the point <m> (1,3) </m>. 
+                  Graph of the triangular region with edges on the points <m>(0,1)</m>, <m> (1,1) </m> and <m> (1,3)</m>.
+                  The leftmost point of the triangular region begins at the <m> y</m>-axis at point <m> (0,1) </m> and linearly increases until the point <m> (1,3) </m>.
                   The equation of the line between the points <m> (0,1) </m> and <m> (1,3) </m> is given as <m> x=\frac12y-\frac12 </m>.
                   The region contains the entire area to the right of the line <m> x=\frac12y-\frac12 </m> and to the left of the vertical line <m> x=1 </m>.
                   Coming up from the <m> x</m>-axis, the graph contains an arbitrarily chosen value on the <m>y</m>-axis, labeled <m> y </m>, which is between <m> 1 </m> and <m> 3</m>.
-                  The graph showcases the distance between the point labeled <m>y</m> and the axis of rotation which is <m> y=0 </m>. 
+                  The graph showcases the distance between the point labeled <m>y</m> and the axis of rotation which is <m> y=0 </m>.
                   The distance between these two <m> y </m> values is given as the function <m> r(y) </m>, which will give us the radius of the cylindrical shell once the solid is formed by rotating about the <m>x</m>-axis.
-                  Additionally, coming up from the line <m> x=\frac12y-\frac12 </m> is a red horizontal line, which meets the right side of the triangular region, which is given by the vertical line <m> x=1 </m>. 
+                  Additionally, coming up from the line <m> x=\frac12y-\frac12 </m> is a red horizontal line, which meets the right side of the triangular region, which is given by the vertical line <m> x=1 </m>.
                   This vertical line is labeled <m>h(y)</m>, and will give the us the height of the cylindrical shells.
                 </p>
               </description>
@@ -946,10 +946,10 @@
             <image xml:id="img_shell3b_3D">
                <description>
                   <p>
-                    A three dimensional graph of the same triangular region as the previous image and an arbitrary cylindrical shell which lies inside the triangular region rotated about the <m>x</m>-axis. 
+                    A three dimensional graph of the same triangular region as the previous image and an arbitrary cylindrical shell which lies inside the triangular region rotated about the <m>x</m>-axis.
                     The cylindrical shell lies horizontally resting on its curved surface, and is centered at the line <m> y=0 </m>.
-                    The cylindrical shell has radius <m> r(y) </m>, which spans from the <m>y</m>-axis to the arbitrarily chosen value on the <m>y</m>-axis between <m> y=1 </m> and <m> y=3</m>. 
-                    The height of the cylindrical shell is <m> h(y) </m>, which is the distance between the line <m> x=\frac12y-\frac12 </m> and the rightmost bound of the triangular region, which is the vertical line <m>x=1</m>. 
+                    The cylindrical shell has radius <m> r(y) </m>, which spans from the <m>y</m>-axis to the arbitrarily chosen value on the <m>y</m>-axis between <m> y=1 </m> and <m> y=3</m>.
+                    The height of the cylindrical shell is <m> h(y) </m>, which is the distance between the line <m> x=\frac12y-\frac12 </m> and the rightmost bound of the triangular region, which is the vertical line <m>x=1</m>.
                   </p>
                 </description>
               <shortdescription>Three dimensional depiction of an arbitrary cylindrical shell from rotating the region described in the example.</shortdescription>
@@ -1041,11 +1041,11 @@
             <image xml:id="img_shell3c_3D">
               <description>
                 <p>
-                  A three dimensional plot showing the same triangular region rotated about the <m>x</m>-axis. 
+                  A three dimensional plot showing the same triangular region rotated about the <m>x</m>-axis.
                   The resulting shape lies entirely between <m> x=0 </m> and <m> x=1 </m>.
                   The highest point of the shape is the point <m> (1,3) </m>, which is the highest point of the original triangle.
-                  The shape is then rotated in a full circle about the <m>x</m>-axis.  
-                  The resulting shape has a height given by the value <m>h(y)= -\frac12y+\frac32 </m>. 
+                  The shape is then rotated in a full circle about the <m>x</m>-axis.
+                  The resulting shape has a height given by the value <m>h(y)= -\frac12y+\frac32 </m>.
                   The radius of the shape is given by <m>r(y)=y</m>, with the <m>y</m> bounds between <m>y=1</m> and <m>y=3</m> as the center of the shape is an empty central cylinder of radius <m> 1 </m> centered at the axis of rotation.
                 </p>
               </description>
@@ -1165,7 +1165,7 @@
         <m>y= \sin(x)</m> and the <m>x</m>-axis from <m>x=0</m> to <m>x=\pi</m> about the <m>y</m>-axis.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The region and a differential element,
@@ -1182,12 +1182,12 @@
             <image xml:id="img_shell4a">
               <description>
                 <p>
-                  Graph of the region bounded by <m>y= \sin(x)</m> and the <m>x</m>-axis from <m>x=0</m> to <m>x=\pi</m>. 
-                  The leftmost point of the triangular region begins at the origin after which we see a singular sine wave ending at the point <m> (\pi,0) </m>. 
+                  Graph of the region bounded by <m>y= \sin(x)</m> and the <m>x</m>-axis from <m>x=0</m> to <m>x=\pi</m>.
+                  The leftmost point of the triangular region begins at the origin after which we see a singular sine wave ending at the point <m> (\pi,0) </m>.
                   The region contains the entire area to below the curve <m>y= \sin(x)</m>, lying above the <m>x</m>-axis.
                   The graph contains an arbitrarily chosen value on the <m>x</m>-axis, labeled <m> x </m>, which is between <m> 0 </m> and <m> \pi</m>.
-                  The graph showcases the distance between the axis of rotation which is <m> x=0 </m> and the point labeled <m>x</m> as the function <m> r(x) </m>, which will be the radius of the cylindrical shells. 
-                  Additionally, coming up from the <m> x</m>-axis is a red vertical line, which meets the curve <m>y= \sin(x)</m> at the point <m>(x,\sin(x))</m>. 
+                  The graph showcases the distance between the axis of rotation which is <m> x=0 </m> and the point labeled <m>x</m> as the function <m> r(x) </m>, which will be the radius of the cylindrical shells.
+                  Additionally, coming up from the <m> x</m>-axis is a red vertical line, which meets the curve <m>y= \sin(x)</m> at the point <m>(x,\sin(x))</m>.
                   This vertical line is labeled <m>h(x)</m>, and will give the us the height of the cylindrical shells.
                 </p>
               </description>
@@ -1229,11 +1229,11 @@
             <image xml:id="img_shell4b_3D">
               <description>
                 <p>
-                  A three dimensional graph of the same region as the previous image and an arbitrary cylindrical shell which will lie inside the region rotated about the <m>x</m>-axis. 
+                  A three dimensional graph of the same region as the previous image and an arbitrary cylindrical shell which will lie inside the region rotated about the <m>x</m>-axis.
                   The cylindrical shell lies vertically resting on its flat base and is centered on the <m>y</m>-axis.
-                  The cylindrical shell has radius <m> r(x)=x </m>, which spans from the <m>y</m>-axis to the arbitrarily chosen value on the <m>x</m>-axis between <m> x=0 </m> and <m> x=\pi</m>. 
-                  The height of the cylindrical shell is <m> h(x)=\sin(x) </m>, which is the distance between the <m> x</m>-axis and the upper bound of the region, which curve <m>y=\sin(x)</m>. 
-                </p> 
+                  The cylindrical shell has radius <m> r(x)=x </m>, which spans from the <m>y</m>-axis to the arbitrarily chosen value on the <m>x</m>-axis between <m> x=0 </m> and <m> x=\pi</m>.
+                  The height of the cylindrical shell is <m> h(x)=\sin(x) </m>, which is the distance between the <m> x</m>-axis and the upper bound of the region, which curve <m>y=\sin(x)</m>.
+                </p>
                </description>
               <shortdescription>Three dimensional depiction of an arbitrary cylindrical shell lying inside the rotated region described in the example.</shortdescription>
               <asymptote>
@@ -1317,11 +1317,11 @@
             <image xml:id="img_shell4c_3D">
               <description>
                 <p>
-                  A three dimensional plot showing the entire region rotated about the <m>y</m>-axis. 
+                  A three dimensional plot showing the entire region rotated about the <m>y</m>-axis.
                   The base of the shape is a circle of radius <m>\pi</m> centered at the origin.
                   From the outside edge of the circle, the surface curves both upwards and inwards towards the positive <m>y</m>-axis until reaching a peak at <m>y=1</m>.
                   From here, the surface curves downwards and inwards until closing in at the origin.
-                  The cylinderical shells lying inside the shape have a height given by  <m>h(x)= \sin(x) </m> and radius <m>r(x)=x</m>. 
+                  The cylinderical shells lying inside the shape have a height given by  <m>h(x)= \sin(x) </m> and radius <m>r(x)=x</m>.
                 </p>
                </description>
               <shortdescription>Three dimensional plot of the entire space which comes from rotating sine wave.</shortdescription>
@@ -1599,9 +1599,9 @@
                   <image xml:id="img_07_02_ex_09X">
                     <description>
                       <p>
-                        Graph of the region bounded by the curve <m>y=3-x^2</m>, the <m>x</m>-axis, and the <m>y</m>-axis. 
+                        Graph of the region bounded by the curve <m>y=3-x^2</m>, the <m>x</m>-axis, and the <m>y</m>-axis.
                         Note that this region can reference both the regions to the left or right of the <m>y</m>-axis, but we will consider the region to the right of the <m>y</m>-axis.
-                        The curve <m>y=3-x^2</m> begins at the point <m>(0,3)</m> from which it slopes down until reaching the <m>x</m>-axis. 
+                        The curve <m>y=3-x^2</m> begins at the point <m>(0,3)</m> from which it slopes down until reaching the <m>x</m>-axis.
                         The region then contains the entire area below this curve, and above the <m>x</m>-axis.
                       </p>
                     </description>
@@ -1648,8 +1648,8 @@
                   <image xml:id="img_07_02_ex_06X">
                     <description>
                       <p>
-                        Graph of the region between <m>y=5x</m> and the <m>x</m>-axis, for <m>1\leq x\leq 2</m>. 
-                        The line <m>y=5x</m> begins at the point <m>(1,5)</m> from which it linearly increases until reaching the rightmost bound which is at the point <m>(2,10)</m>. 
+                        Graph of the region between <m>y=5x</m> and the <m>x</m>-axis, for <m>1\leq x\leq 2</m>.
+                        The line <m>y=5x</m> begins at the point <m>(1,5)</m> from which it linearly increases until reaching the rightmost bound which is at the point <m>(2,10)</m>.
                         The region then contains the entire area below the line <m>y=5x</m> and above the <m>x</m>-axis for <m>1\leq x\leq 2</m>.
                       </p>
                     </description>
@@ -1696,9 +1696,9 @@
                   <image xml:id="img_07_02_ex_11X">
                     <description>
                       <p>
-                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m>-axis, for <m>0\leq x\leq \pi/2</m>. 
-                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>. 
-                        The region then contains the entire area below the curve <m>y=\cos(x)</m> and above the <m>x</m>-axis for <m>0\leq x\leq \pi/2</m>. 
+                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m>-axis, for <m>0\leq x\leq \pi/2</m>.
+                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>.
+                        The region then contains the entire area below the curve <m>y=\cos(x)</m> and above the <m>x</m>-axis for <m>0\leq x\leq \pi/2</m>.
                         The bound <m>0\leq x\leq \pi/2</m> can also be interpreted as the leftmost bound of the region being the <m>y</m>-axis.
                       </p>
                     </description>
@@ -1744,10 +1744,10 @@
                   <image xml:id="img_07_02_ex_08XX">
                     <description>
                       <p>
-                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>. 
-                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin. 
-                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line. 
-                        The region then contains the area below the curve <m>y=\sqrt{x}</m> and above the line <m>y=x</m>. 
+                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin.
+                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line.
+                        The region then contains the area below the curve <m>y=\sqrt{x}</m> and above the line <m>y=x</m>.
                       </p>
                     </description>
                     <shortdescription>Graph of the region bounded by the two curves.</shortdescription>
@@ -1806,8 +1806,8 @@
                   <image xml:id="img_07_02_ex_05X">
                     <description>
                       <p>
-                        Graph of the region between <m>y=3-x^2</m> and the <m>x</m>-axis. 
-                        The curve <m>y=3-x^2</m> begins at <m>x</m>-axis at the point <m>(-\sqrt{3},0)</m>. 
+                        Graph of the region between <m>y=3-x^2</m> and the <m>x</m>-axis.
+                        The curve <m>y=3-x^2</m> begins at <m>x</m>-axis at the point <m>(-\sqrt{3},0)</m>.
                         From this point the curve rises until reaching the <m>y</m>-axis at the point <m>(0,3)</m>.
                         From this point, the curve slopes downwards until once again reaching the <m>x</m>-axis at the point <m>(\sqrt{3},0)</m>.
                         On both the left and right sides of the region, the area is bounded by the curve <m>y=3-x^2</m>.
@@ -1856,8 +1856,8 @@
                   <image xml:id="img_07_02_ex_10X">
                     <description>
                       <p>
-                        Graph of the region between <m>y=5x</m> and the <m>y</m> axis, for <m>5\leq y\leq 10</m>. 
-                        The line <m>y=5x</m> begins at the point <m>(1,5)</m>, from which it linearly increases until ending upper bound for <m>y</m> at the point <m>(2,10)</m>. 
+                        Graph of the region between <m>y=5x</m> and the <m>y</m> axis, for <m>5\leq y\leq 10</m>.
+                        The line <m>y=5x</m> begins at the point <m>(1,5)</m>, from which it linearly increases until ending upper bound for <m>y</m> at the point <m>(2,10)</m>.
                         The region then contains the entire area to the right of <m>x=0</m> and to the left of the line <m>y=5x</m> for <m>y</m> between <m>5</m> and <m>10</m>.
                       </p>
                     </description>
@@ -1904,9 +1904,9 @@
                   <image xml:id="img_07_02_ex_07X">
                     <description>
                       <p>
-                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m> axis, for <m>0\leq x\leq \pi/2</m>. 
-                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>. 
-                        The region then contains the entire area to the right of <m>x=0</m> and to the left of of the curve <m>y=\cos(x)</m> for <m>y</m> values between <m>0</m> and <m>1</m>. 
+                        Graph of the region between <m>y=\cos(x)</m> and the <m>x</m> axis, for <m>0\leq x\leq \pi/2</m>.
+                        The curve <m>y=\cos(x)</m> begins at the point <m>(0,1)</m> from which it slopes downwards until ending after reaching the <m>x</m>-axis at the point <m>(\pi/2,0)</m>.
+                        The region then contains the entire area to the right of <m>x=0</m> and to the left of of the curve <m>y=\cos(x)</m> for <m>y</m> values between <m>0</m> and <m>1</m>.
                       </p>
                     </description>
                     <shortdescription>Graph of the region bounded by the cosine curve and the coordinate axes.</shortdescription>
@@ -1951,9 +1951,9 @@
                   <image xml:id="img_07_02_ex_04X">
                     <description>
                       <p>
-                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>. 
-                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin. 
-                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line. 
+                        Graph of the region between the curves <m>y=x</m> and <m>y=\sqrt{x}</m>.
+                        The curves <m>y=x</m> and <m>y=\sqrt{x}</m> both begin at the origin.
+                        From this point the curve <m>y=\sqrt{x}</m> rises above the line <m>y=x</m> until reaching the point <m>(1,1)</m>, where the curve once again intersects the line.
                         The region consists of the area to the right of the curve <m>y=\sqrt{x}</m> and the to the left line <m>y=x</m> for <m>y</m> values between <m>0</m> and <m>1</m>.
                       </p>
                     </description>

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -248,10 +248,7 @@
           Draw the line segment <m>\overline{PQ}</m> and find its length.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="EF-aTKoAQsU" xml:id="vid-vectors-spacecoord-linesegment" label="vid-vectors-spacecoord-linesegment" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The points <m>P</m> and <m>Q</m> are plotted in <xref ref="fig_space1"/>;
@@ -336,6 +333,10 @@
           <!-- figures/figspace1_3D.asy END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="EF-aTKoAQsU" xml:id="vid-vectors-spacecoord-linesegment" label="vid-vectors-spacecoord-linesegment" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -387,10 +388,7 @@
           Find the center and radius of the sphere defined by <m>x^2+2x+y^2-4y+z^2-6z=2</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="O0VtyYNXeig" xml:id="vid-vectors-spcaecoord-sphere-eg" label="vid-vectors-spcaecoord-sphere-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           To determine the center and radius,
@@ -407,6 +405,10 @@
         <p>
           The sphere is centered at <m>(-1,2,3)</m> and has a radius of 4.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="O0VtyYNXeig" xml:id="vid-vectors-spcaecoord-sphere-eg" label="vid-vectors-spcaecoord-sphere-eg" component="video"/>
       </solution>
     </example>
 
@@ -673,10 +675,7 @@
           Sketch the region defined by the inequalities <m>-1\leq y\leq 2</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="-9luj-GlMqA" xml:id="vid-vectors-spacecoord-planes-eg" label="vid-vectors-spacecoord-planes-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The region is all points between the planes <m>y=-1</m> and <m>y=2</m>.
@@ -747,6 +746,10 @@
           </image>
           <!-- figures/figspace3_3D.asy END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="-9luj-GlMqA" xml:id="vid-vectors-spacecoord-planes-eg" label="vid-vectors-spacecoord-planes-eg" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -958,10 +961,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="n7Yp4aWqeFc" xml:id="vid-vectors-spacecoord-cylinder-eg" label="vid-vectors-spacecoord-cylinder-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1414,6 +1414,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="n7Yp4aWqeFc" xml:id="vid-vectors-spacecoord-cylinder-eg" label="vid-vectors-spacecoord-cylinder-eg" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -1627,10 +1631,7 @@
           <m>y=\sin(z)</m> about the <m>z</m>-axis.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="jrJXSnHU-0o" xml:id="vid-vectors-spacecoord-surfrev-eg" label="vid-vectors-spacecoord-surfrev-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Using <xref ref="idea_surf_of_revol"/>,
@@ -1767,6 +1768,10 @@
             </figure>
           </sidebyside>
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="jrJXSnHU-0o" xml:id="vid-vectors-spacecoord-surfrev-eg" label="vid-vectors-spacecoord-surfrev-eg" component="video"/>
       </solution>
     </example>
 
@@ -3418,10 +3423,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="7BPClg70Lmg" xml:id="vid-vectors-spacecoord-quadric-eg" label="vid-vectors-spacecoord-quadric-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -3953,6 +3955,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="7BPClg70Lmg" xml:id="vid-vectors-spacecoord-quadric-eg" label="vid-vectors-spacecoord-quadric-eg" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -67,7 +67,7 @@
         <description>
           <p>
             The <m>x</m> and <m>y</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>z</m>
-             axis is drawn from <m>-1</m> to <m>3</m>. The point <m>P= (2,1,3)</m> is drawn in space. 
+             axis is drawn from <m>-1</m> to <m>3</m>. The point <m>P= (2,1,3)</m> is drawn in space.
              A dashed cuboid is drawn with the point <m>P</m> on the corner away from the axes.
           </p>
         </description>
@@ -154,9 +154,9 @@
         </shortdescription>
         <description>
           <p>
-            The <m>x</m> and <m>y</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>z</m> 
-            axis is drawn from <m>-1</m> to <m>3</m>. The point <m>P= (2,1,3)</m> is drawn in space. 
-            A dashed cuboid is drawn with the point <m>P</m> on the corner away from the axes. 
+            The <m>x</m> and <m>y</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>z</m>
+            axis is drawn from <m>-1</m> to <m>3</m>. The point <m>P= (2,1,3)</m> is drawn in space.
+            A dashed cuboid is drawn with the point <m>P</m> on the corner away from the axes.
             The <m>z</m> axis is shown as the vertical line.
           </p>
         </description>
@@ -248,7 +248,7 @@
           Draw the line segment <m>\overline{PQ}</m> and find its length.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The points <m>P</m> and <m>Q</m> are plotted in <xref ref="fig_space1"/>;
@@ -271,10 +271,10 @@
             </shortdescription>
             <description>
               <p>
-                The <m>x</m> axis is drawn from <m>0</m> to <m>2</m>, the <m>z</m> axis is 
-                drawn from <m>-2</m> to <m>2</m> and the <m>y</m> axis is drawn from <m>0</m> 
-                to <m>4</m>. Two points <m>P = (1, 4, -1)</m> and <m>Q = (2, 1, 1)</m> are 
-                drawn in space and are connected by a straight line. 
+                The <m>x</m> axis is drawn from <m>0</m> to <m>2</m>, the <m>z</m> axis is
+                drawn from <m>-2</m> to <m>2</m> and the <m>y</m> axis is drawn from <m>0</m>
+                to <m>4</m>. Two points <m>P = (1, 4, -1)</m> and <m>Q = (2, 1, 1)</m> are
+                drawn in space and are connected by a straight line.
               </p>
             </description>
             <asymptote>
@@ -388,7 +388,7 @@
           Find the center and radius of the sphere defined by <m>x^2+2x+y^2-4y+z^2-6z=2</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           To determine the center and radius,
@@ -452,7 +452,7 @@
             </shortdescription>
             <description>
               <p>
-                The axes are uncalibrated. The plane is drawn along the <m>x</m> and <m>y</m> axes 
+                The axes are uncalibrated. The plane is drawn along the <m>x</m> and <m>y</m> axes
                 at <m>z=0</m>, the normal is along the <m>z</m> axis.
               </p>
             </description>
@@ -506,7 +506,7 @@
             </shortdescription>
             <description>
               <p>
-                The axes are uncalibrated. The plane is drawn along the <m>y</m> and <m>z</m> 
+                The axes are uncalibrated. The plane is drawn along the <m>y</m> and <m>z</m>
                 axes at <m>x=0</m>, the normal is along the <m>x</m> axis.
               </p>
             </description>
@@ -560,7 +560,7 @@
             </shortdescription>
             <description>
               <p>
-                The axes are uncalibrated. The plane is drawn along the <m>x</m> and <m>z</m> axes at 
+                The axes are uncalibrated. The plane is drawn along the <m>x</m> and <m>z</m> axes at
                 <m>y =0</m>, the normal is along the <m>y</m> axis.
               </p>
             </description>
@@ -623,7 +623,7 @@
         </shortdescription>
         <description>
           <p>
-            The <m>y</m> and the <m>z</m> axes are uncalibrated, the <m>x</m> axis is 
+            The <m>y</m> and the <m>z</m> axes are uncalibrated, the <m>x</m> axis is
             drawn from <m>-2</m> to <m>2</m>. The <m>yz</m> plane is drawn at <m>x=-2</m>.
           </p>
         </description>
@@ -675,7 +675,7 @@
           Sketch the region defined by the inequalities <m>-1\leq y\leq 2</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The region is all points between the planes <m>y=-1</m> and <m>y=2</m>.
@@ -694,8 +694,8 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and <m>z</m> axes are uncalibrated, the <m>x</m> axis is drawn 
-                from <m>-2</m> and <m>2</m>. Two planes are drawn parallel to the <m>xz</m> 
+                The <m>y</m> and <m>z</m> axes are uncalibrated, the <m>x</m> axis is drawn
+                from <m>-2</m> and <m>2</m>. Two planes are drawn parallel to the <m>xz</m>
                 plane at <m>y=-1</m> and <m>y =2</m>, with normal along the <m>y</m> axis.
               </p>
             </description>
@@ -793,9 +793,9 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and <m>z</m> axes are uncalibrated, the <m>x</m> axis is drawn from <m>-2</m> 
-                to <m>2</m>. There are three circles with radius of <m>1</m> and centres all along the <m>z</m> 
-                axis and are laid parallel to the <m>xy</m> plane. The circle in the middle has its centre on the origin. 
+                The <m>y</m> and <m>z</m> axes are uncalibrated, the <m>x</m> axis is drawn from <m>-2</m>
+                to <m>2</m>. There are three circles with radius of <m>1</m> and centres all along the <m>z</m>
+                axis and are laid parallel to the <m>xy</m> plane. The circle in the middle has its centre on the origin.
               </p>
             </description>
           <asymptote>
@@ -852,9 +852,9 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and <m>z</m> axes are uncalibrated, the <m>x</m> axis is drawn from <m>-2</m> to <m>2</m>. 
-                There are three circles with radius of <m>1</m> and centres all along the <m>z</m> axis and are laid 
-                parallel to the <m>xy</m> plane. These circles form the area of cross-section and a cylinder of equation 
+                The <m>y</m> and <m>z</m> axes are uncalibrated, the <m>x</m> axis is drawn from <m>-2</m> to <m>2</m>.
+                There are three circles with radius of <m>1</m> and centres all along the <m>z</m> axis and are laid
+                parallel to the <m>xy</m> plane. These circles form the area of cross-section and a cylinder of equation
                 <m>x^2+y^2 =1</m> is drawn that includes all three circles.
               </p>
             </description>
@@ -961,7 +961,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -988,7 +988,7 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> are uncalibrated. The graph shows a parabola <m>z = y^2</m> 
+                          The <m>x</m>, <m>y</m> and <m>z</m> are uncalibrated. The graph shows a parabola <m>z = y^2</m>
                           drawn on the <m>zy</m> plane. The parabola has its vertex on the origin.
                         </p>
                       </description>
@@ -1046,10 +1046,10 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axis are uncalibrated. The parabola is drawn 
-                          on the <m>y</m> and <m>z</m> axis, <m>z</m> being a function of <m>y</m>. There 
-                          is a group of parallel lines called rulings equidistant from each other that are 
-                          drawn on the parabola parallel to the <m>xz</m> plane, these lines give an idea 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axis are uncalibrated. The parabola is drawn
+                          on the <m>y</m> and <m>z</m> axis, <m>z</m> being a function of <m>y</m>. There
+                          is a group of parallel lines called rulings equidistant from each other that are
+                          drawn on the parabola parallel to the <m>xz</m> plane, these lines give an idea
                           of the surface.
                         </p>
                       </description>
@@ -1151,8 +1151,8 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axis are uncalibrated. The parabola is drawn on the <m>y</m> and <m>z</m> axis, 
-                          <m>z</m> being a function of <m>y</m>. A surface with a parabolic area of cross-section parallel to the <m>yz</m> 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axis are uncalibrated. The parabola is drawn on the <m>y</m> and <m>z</m> axis,
+                          <m>z</m> being a function of <m>y</m>. A surface with a parabolic area of cross-section parallel to the <m>yz</m>
                           plane is shown.
                         </p>
                       </description>
@@ -1226,12 +1226,12 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated.  A function <m>x= sin(z)</m> 
-                          is drawn on the <m>xz</m> plane where <m>x</m> is a function of <m>z</m>. The <m>z</m> 
-                          axis is positioned vertically, and two sine waves are drawn on it one along the positive 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated.  A function <m>x= sin(z)</m>
+                          is drawn on the <m>xz</m> plane where <m>x</m> is a function of <m>z</m>. The <m>z</m>
+                          axis is positioned vertically, and two sine waves are drawn on it one along the positive
                           <m>z</m> axis and one along the negative <m>z</m> axis. The two waves connect at the origin.
                         </p>
-                      </description>                        
+                      </description>
                       <asymptote>
 
 
@@ -1292,10 +1292,10 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated.  A function <m>x= sin(z)</m> 
-                          is drawn on the <m>xz</m> plane where <m>x</m> is a function of <m>z</m>. The <m>z</m> 
-                          axis is positioned vertically, and two sine waves are drawn on it one along the positive 
-                          <m>z</m> axis and one along the negative <m>z</m> axis. The two waves connect at the origin. 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated.  A function <m>x= sin(z)</m>
+                          is drawn on the <m>xz</m> plane where <m>x</m> is a function of <m>z</m>. The <m>z</m>
+                          axis is positioned vertically, and two sine waves are drawn on it one along the positive
+                          <m>z</m> axis and one along the negative <m>z</m> axis. The two waves connect at the origin.
                           The rules are drawn on the curve and are parallel to the <m>y</m> axis.
                         </p>
                       </description>
@@ -1359,8 +1359,8 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. The sine function 
-                          <m>x=\sin(z)</m> described previously is used as the area of cross-section to 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. The sine function
+                          <m>x=\sin(z)</m> described previously is used as the area of cross-section to
                           form the surface.
                         </p>
                       </description>
@@ -1457,11 +1457,11 @@
           </shortdescription>
           <description>
             <p>
-              The <m>y</m> and <m>x</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>4</m>. 
-              There are two planes drawn parallel to the <m>yz</m> plane and both of them have circles 
-              outlined inside the plane. The first plane at <m>x=1</m> has a smaller circle, while the 
-              one at <m>x=4</m> is bigger, both circles have formula <m>y^2 + z^2 = r^2</m> for some radius <m>r</m>. 
-              There is also half of a parabola drawn on the <m>xy</m> plane with <m>x</m> being a function of <m>y</m>, 
+              The <m>y</m> and <m>x</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>x</m> axis is drawn from <m>0</m> to <m>4</m>.
+              There are two planes drawn parallel to the <m>yz</m> plane and both of them have circles
+              outlined inside the plane. The first plane at <m>x=1</m> has a smaller circle, while the
+              one at <m>x=4</m> is bigger, both circles have formula <m>y^2 + z^2 = r^2</m> for some radius <m>r</m>.
+              There is also half of a parabola drawn on the <m>xy</m> plane with <m>x</m> being a function of <m>y</m>,
               this half parabola passes through both the circles intersecting them.
             </p>
           </description>
@@ -1533,13 +1533,13 @@
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> and <m>z</m> axes are drawn from <m>-2</m> to <m>2</m> and the 
-                <m>x</m> axis is drawn from <m>0</m> to <m>4</m>. There are two planes drawn 
-                parallel to the <m>yz</m> plane and both of them have circles outlined inside 
-                the plane. The first plane at <m>x =1</m> has a smaller circle, while the one at 
-                <m>x=4</m> is bigger. There is also half of a parabola drawn on the <m>xy</m> 
-                plane with <m>x</m> being a function of <m>y</m>, this half parabola passes 
-                through both the circles intersecting the planes. This half parabola when rotated 
+                The <m>y</m> and <m>z</m> axes are drawn from <m>-2</m> to <m>2</m> and the
+                <m>x</m> axis is drawn from <m>0</m> to <m>4</m>. There are two planes drawn
+                parallel to the <m>yz</m> plane and both of them have circles outlined inside
+                the plane. The first plane at <m>x =1</m> has a smaller circle, while the one at
+                <m>x=4</m> is bigger. There is also half of a parabola drawn on the <m>xy</m>
+                plane with <m>x</m> being a function of <m>y</m>, this half parabola passes
+                through both the circles intersecting the planes. This half parabola when rotated
                 over the <m>x</m> axis gives a hollow dome that opens along the positive <m>x</m> axis.
               </p>
             </description>
@@ -1631,7 +1631,7 @@
           <m>y=\sin(z)</m> about the <m>z</m>-axis.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Using <xref ref="idea_surf_of_revol"/>,
@@ -1657,11 +1657,11 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> and <m>y</m> axes are drawn from <m>-1</m> to <m>1</m> and the 
-                    <m>z</m> axis is drawn from <m>0</m> to <m>3</m>. Two functions <m>x= \sin(z)</m> 
-                    and <m>y= \sin(z)</m> are shown. The two curves are perpendicular to each other as 
-                    <m>x=\sin(z)</m> is drawn on the <m>xz</m> plane and <m>y= \sin(z)</m> is drawn on 
-                    the <m>yz</m> plane. Both curves start at the origin and end at the same point 
+                    The <m>x</m> and <m>y</m> axes are drawn from <m>-1</m> to <m>1</m> and the
+                    <m>z</m> axis is drawn from <m>0</m> to <m>3</m>. Two functions <m>x= \sin(z)</m>
+                    and <m>y= \sin(z)</m> are shown. The two curves are perpendicular to each other as
+                    <m>x=\sin(z)</m> is drawn on the <m>xz</m> plane and <m>y= \sin(z)</m> is drawn on
+                    the <m>yz</m> plane. Both curves start at the origin and end at the same point
                     <m>(0, \pi/2, 0)</m>.
                   </p>
                 </description>
@@ -1717,8 +1717,8 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> and <m>y</m> axes are drawn from <m>-1</m> to <m>1</m> and the <m>z</m> 
-                    axis is drawn from <m>0</m> to <m>3</m>. The function <m>y= \sin(z)</m> is rotated 
+                    The <m>x</m> and <m>y</m> axes are drawn from <m>-1</m> to <m>1</m> and the <m>z</m>
+                    axis is drawn from <m>0</m> to <m>3</m>. The function <m>y= \sin(z)</m> is rotated
                     around the <m>z</m> axis and it forms a sphere with tapering top and bottom.
                   </p>
                 </description>
@@ -1841,11 +1841,11 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> and <m>y</m> axes are drawn from <m>-5</m> to <m>5</m> and the <m>z</m> 
-                    axis is drawn from <m>-1</m> to <m>1</m>. The curve <m>z= \sin(x)</m> is drawn in the 
-                    <m>xz</m> plane, it is a wave with amplitude of <m>z=1</m>. The curve starts at the origin, 
-                    curves up and reaches a peak close to <m>x=2</m>, then it decreases and crosses the <m>x</m> 
-                    axis close to <m>x=4</m>, it decreases till it reaches a depth of <m>z=-1</m>, after which 
+                    The <m>x</m> and <m>y</m> axes are drawn from <m>-5</m> to <m>5</m> and the <m>z</m>
+                    axis is drawn from <m>-1</m> to <m>1</m>. The curve <m>z= \sin(x)</m> is drawn in the
+                    <m>xz</m> plane, it is a wave with amplitude of <m>z=1</m>. The curve starts at the origin,
+                    curves up and reaches a peak close to <m>x=2</m>, then it decreases and crosses the <m>x</m>
+                    axis close to <m>x=4</m>, it decreases till it reaches a depth of <m>z=-1</m>, after which
                     it increases again to meet the <m>x</m> axis close to <m>x=6</m>.
                   </p>
                 </description>
@@ -1895,7 +1895,7 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The surface of equation <m>z= \sin(\sqrt {x^2 +y^2})</m> is made by revolving 
+                    The surface of equation <m>z= \sin(\sqrt {x^2 +y^2})</m> is made by revolving
                     the wave of formula <m>z= \sin(x)</m> about the <m>z</m> axis.
                   </p>
                 </description>
@@ -1998,9 +1998,9 @@
         </shortdescription>
         <description>
           <p>
-            The axes are uncalibrated. There are two parabolas shown one in the plane <m>x=0</m> 
-            and the other in <m>y=0</m>. There is a circle drawn in the plane <m>z=d</m>. The 
-            elliptical paraboloid <m>z= x^2/4 +y^2</m> has both the parabolas and the circle included 
+            The axes are uncalibrated. There are two parabolas shown one in the plane <m>x=0</m>
+            and the other in <m>y=0</m>. There is a circle drawn in the plane <m>z=d</m>. The
+            elliptical paraboloid <m>z= x^2/4 +y^2</m> has both the parabolas and the circle included
             in the surface.
           </p>
         </description>
@@ -2205,9 +2205,9 @@
         </shortdescription>
         <description>
           <p>
-            The axes are uncalibrated. There are two parabolas shown one in the plane <m>x=0</m> 
-            and the other in <m>y=0</m>. There is a circle drawn in the plane <m>z=d</m>. The 
-            elliptical paraboloid has both the parabolas and the circle included in the surface. 
+            The axes are uncalibrated. There are two parabolas shown one in the plane <m>x=0</m>
+            and the other in <m>y=0</m>. There is a circle drawn in the plane <m>z=d</m>. The
+            elliptical paraboloid has both the parabolas and the circle included in the surface.
             It opens along the positive <m>z</m> axis.
           </p>
         </description>
@@ -2299,7 +2299,7 @@
           </shortdescription>
           <description>
             <p>
-              The axes are uncalibrated. Two hollow elliptic cones are drawn with vertices at the origin, 
+              The axes are uncalibrated. Two hollow elliptic cones are drawn with vertices at the origin,
               one opening along the positive <m>z</m> axis and the other along the negative <m>z</m> axis.
             </p>
           </description>
@@ -2396,10 +2396,10 @@
           </shortdescription>
           <description>
             <p>
-              The axes are uncalibrated. Two hollow elliptic cones are drawn with vertices at the origin, 
-              one opening along the positive <m>z</m> axis and the other along the negative <m>z</m> axis. 
-              The graph shows three traces, on the plane <m>y=0</m>, the trace is a straight line passing through 
-              the vertices of the cones, when the plane is <m>z=d</m> the trace is an ellipse. 
+              The axes are uncalibrated. Two hollow elliptic cones are drawn with vertices at the origin,
+              one opening along the positive <m>z</m> axis and the other along the negative <m>z</m> axis.
+              The graph shows three traces, on the plane <m>y=0</m>, the trace is a straight line passing through
+              the vertices of the cones, when the plane is <m>z=d</m> the trace is an ellipse.
             </p>
           </description>
           <asymptote>
@@ -2465,9 +2465,9 @@
           </shortdescription>
           <description>
             <p>
-              The axes are uncalibrated. Two hollow elliptic cones are drawn with vertices at the origin, 
-              one opening along the positive <m>z</m> axis and the other along the negative <m>z</m> axis. 
-              A hyperbola is shown in the <m>y=d</m> plane, the two parts of the hyperbola are traced on the elliptic cone.  
+              The axes are uncalibrated. Two hollow elliptic cones are drawn with vertices at the origin,
+              one opening along the positive <m>z</m> axis and the other along the negative <m>z</m> axis.
+              A hyperbola is shown in the <m>y=d</m> plane, the two parts of the hyperbola are traced on the elliptic cone.
             </p>
           </description>
           <asymptote>
@@ -2551,7 +2551,7 @@
         </shortdescription>
         <description>
           <p>
-            The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. Graph of an ellipsoid with 
+            The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. Graph of an ellipsoid with
             centre at origin.
           </p>
         </description>
@@ -2645,8 +2645,8 @@
         </shortdescription>
         <description>
           <p>
-            The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. There are three ellipses drawn. 
-            The first one is on the <m>xz</m> plane, <m>y=0</m>. The second is on the <m>yz</m> plane, 
+            The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. There are three ellipses drawn.
+            The first one is on the <m>xz</m> plane, <m>y=0</m>. The second is on the <m>yz</m> plane,
             with <m>x=0</m>. The third on the <m>xy</m> plane, with <m>z=0</m>.
             Filling in the traces gives the ellipsoid.
           </p>
@@ -2837,9 +2837,9 @@
         </shortdescription>
         <description>
           <p>
-            The three axes are uncalibrated. Graph shows a hyperboloid of one sheet. The hyperboloid of one sheet 
-            is drawn about the <m>z</m> axis. It appears to be a cylinder with a narrow middle. In the middle of 
-            the sheet there is a circle drawn on the plane <m>z=o</m>. There are two hyperbolas drawn on the plane 
+            The three axes are uncalibrated. Graph shows a hyperboloid of one sheet. The hyperboloid of one sheet
+            is drawn about the <m>z</m> axis. It appears to be a cylinder with a narrow middle. In the middle of
+            the sheet there is a circle drawn on the plane <m>z=o</m>. There are two hyperbolas drawn on the plane
             <m>x=0</m> and <m>y=0</m>.
           </p>
         </description>
@@ -3046,10 +3046,10 @@
         </shortdescription>
         <description>
           <p>
-            The three axes are uncalibrated. Graph shows a hyperboloid of two sheets. The hyperboloids of 
-            two sheets are drawn about the <m>z</m> axis. The first sheet  opens along the positive <m>z</m> 
-            axis. The second sheet to the bottom opens along the negative <m>z</m> axis. Both plates have two 
-            hyperbolas drawn one in the <m>zy</m> plane and one in the <m>xz</m> plane. In the bottom sheet 
+            The three axes are uncalibrated. Graph shows a hyperboloid of two sheets. The hyperboloids of
+            two sheets are drawn about the <m>z</m> axis. The first sheet  opens along the positive <m>z</m>
+            axis. The second sheet to the bottom opens along the negative <m>z</m> axis. Both plates have two
+            hyperbolas drawn one in the <m>zy</m> plane and one in the <m>xz</m> plane. In the bottom sheet
             there is a circle drawn on the plane <m>z=d</m>.
           </p>
         </description>
@@ -3257,9 +3257,9 @@
           </shortdescription>
           <description>
             <p>
-              The three axes are uncalibrated. There are two parabolas drawn, one in plane 
-              <m>y=0</m> opening up along the positive <m>z</m> axis in the <m>yz</m> plane 
-              and the other in <m>x=0</m> opening down along the negative <m>z</m> axis in the 
+              The three axes are uncalibrated. There are two parabolas drawn, one in plane
+              <m>y=0</m> opening up along the positive <m>z</m> axis in the <m>yz</m> plane
+              and the other in <m>x=0</m> opening down along the negative <m>z</m> axis in the
               <m>xz</m> plane. Both parabolas have vertices at the origin.
               Filling the traces gives the hyperbolic paraboloid.
             </p>
@@ -3329,8 +3329,8 @@
           </shortdescription>
           <description>
             <p>
-              The three axes are uncalibrated. Graph shows the hyperbolic paraboloid along with two hyperbolas. There are two hyperbolas drawn, 
-              in plane <m>z=d</m>. For <m>d&gt;0</m> the two hyperbolas opening up along the positive and negative <m>x</m> axis. For  <m>d&lt;0</m> 
+              The three axes are uncalibrated. Graph shows the hyperbolic paraboloid along with two hyperbolas. There are two hyperbolas drawn,
+              in plane <m>z=d</m>. For <m>d&gt;0</m> the two hyperbolas opening up along the positive and negative <m>x</m> axis. For  <m>d&lt;0</m>
               the other hyperbola  opens along the positive and negative <m>y</m> axis.
             </p>
           </description>
@@ -3423,7 +3423,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -3467,8 +3467,8 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m> and <m>z</m> axes are drawn from <m>-4</m> to <m>4</m> and the <m>y</m> axis 
-                          is drawn from <m>0</m> to <m>2</m>. Two parabolas are drawn that are perpendicular to each other, 
+                          The <m>x</m> and <m>z</m> axes are drawn from <m>-4</m> to <m>4</m> and the <m>y</m> axis
+                          is drawn from <m>0</m> to <m>2</m>. Two parabolas are drawn that are perpendicular to each other,
                           one in the <m>xy</m> plane and the other in the <m>yz</m> plane. Both have vertices at origin.
                         </p>
                       </description>
@@ -3537,7 +3537,7 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The three axes are uncalibrated. Two parabolas are drawn that are perpendicular to 
+                          The three axes are uncalibrated. Two parabolas are drawn that are perpendicular to
                           each other, one in the <m>xy</m> plane and the other in the <m>yz</m> plane. Both have vertices at origin.
                           Filling in the trace gives the elliptic paraboloid.
                         </p>
@@ -3639,10 +3639,10 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to <m>3</m>. 
-                          There are three ellipses drawn. The first one is on the <m>xz</m> plane, <m>y=0</m> 
-                          with equation <m>x^2 +  z^2/4 =1</m>. The second is on the <m>yz</m> plane, with <m>x=0</m> 
-                          with the equation <m>y^2/9 + z^2/4 =1</m>. The third on the <m>xy</m> plane, with <m>z=0</m> 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to <m>3</m>.
+                          There are three ellipses drawn. The first one is on the <m>xz</m> plane, <m>y=0</m>
+                          with equation <m>x^2 +  z^2/4 =1</m>. The second is on the <m>yz</m> plane, with <m>x=0</m>
+                          with the equation <m>y^2/9 + z^2/4 =1</m>. The third on the <m>xy</m> plane, with <m>z=0</m>
                           and has an equation <m>x^2 +y^2 /9 =1</m>.
                         </p>
                       </description>
@@ -3715,8 +3715,8 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to <m>3</m>. There are three ellipses drawn. The first one is on the 
-                          <m>xz</m> plane, <m>y=0</m> with equation <m>x^2 +  z^2/4 =1</m>. The second is on the <m>yz</m> plane, with <m>x=0</m> with the equation 
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to <m>3</m>. There are three ellipses drawn. The first one is on the
+                          <m>xz</m> plane, <m>y=0</m> with equation <m>x^2 +  z^2/4 =1</m>. The second is on the <m>yz</m> plane, with <m>x=0</m> with the equation
                           <m>y^2/9 + z^2/4 =1</m>. The third on the <m>xy</m> plane, with <m>z=0</m> and has an equation <m>x^2 +y^2 /9 =1</m>.
                           Filling in the surface gives the ellipsoid.
                         </p>
@@ -3816,10 +3816,10 @@
                         Graph showing traces for a hyperbolic paraboloid.
                       </shortdescription>
                       <description>
-                        <p> 
-                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-1</m> to <m>1</m>. 
-                          There are two parabolas drawn, one in plane <m>x=0</m> with equation <m>z= y^2</m> 
-                          opening up in the <m>yz</m> plane and the other in <m>y=0</m> with equation <m>z=-x^2</m> 
+                        <p>
+                          The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-1</m> to <m>1</m>.
+                          There are two parabolas drawn, one in plane <m>x=0</m> with equation <m>z= y^2</m>
+                          opening up in the <m>yz</m> plane and the other in <m>y=0</m> with equation <m>z=-x^2</m>
                           opening down in the <m>xz</m> plane. Both parabolas have vertices at the origin.
                         </p>
                       </description>
@@ -3888,13 +3888,13 @@
                       </shortdescription>
                       <description>
                         <p>
-                          The three axes are uncalibrated. There are two parabolas drawn, one in 
-                          plane <m>x=0</m> with equation <m>z= y^2</m> opening up in the <m>yz</m> 
-                          plane and the other in <m>y=0</m> with equation <m>z=-x^2</m> opening down 
+                          The three axes are uncalibrated. There are two parabolas drawn, one in
+                          plane <m>x=0</m> with equation <m>z= y^2</m> opening up in the <m>yz</m>
+                          plane and the other in <m>y=0</m> with equation <m>z=-x^2</m> opening down
                           in the <m>xz</m> plane. Both parabolas have vertices at the origin.
                           Filling the traces gives the hyperbolic paraboloid.
                         </p>
-                      </description>                                            
+                      </description>
                       <asymptote>
 
 
@@ -3988,10 +3988,10 @@
             </shortdescription>
             <description>
               <p>
-                The <m>z</m> and <m>y</m> axes are drawn from <m>-3</m> to <m>3</m> and the <m>x</m> axis is 
-                drawn from <m>-1</m> to <m>1</m>. The <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to 
-                <m>3</m>. The hyperboloids of two sheets are drawn about the <m>x</m> axis. The first sheet 
-                has a centre at <m>x =0.5</m> and opens along the positive <m>y</m> axis. The second sheet has 
+                The <m>z</m> and <m>y</m> axes are drawn from <m>-3</m> to <m>3</m> and the <m>x</m> axis is
+                drawn from <m>-1</m> to <m>1</m>. The <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to
+                <m>3</m>. The hyperboloids of two sheets are drawn about the <m>x</m> axis. The first sheet
+                has a centre at <m>x =0.5</m> and opens along the positive <m>y</m> axis. The second sheet has
                 a centre at <m>x=-0.5</m> and opens along the negative <m>y</m> axis.
               </p>
             </description>
@@ -4921,7 +4921,7 @@
                     </shortdescription>
                     <description>
                       <p>
-                      The <m>z</m> and <m>y</m> axes are drawn from <m>-3</m> to <m>3</m> and the <m>x</m> axis is 
+                      The <m>z</m> and <m>y</m> axes are drawn from <m>-3</m> to <m>3</m> and the <m>x</m> axis is
                       drawn from <m>-1</m> to <m>1</m>. The <m>y</m> and <m>z</m> axes are drawn from <m>-3</m> to <m>3</m>. The elliptic paraboloid is shown with centre at the origin and it opens along the positive <m>x</m> axis.
                       </p>
                     </description>
@@ -4996,8 +4996,8 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The axes are drawn from <m>-1</m> to <m>1</m>. Two hollow elliptic cones are drawn with 
-                        vertices at the origin, one opening along the positive <m>y</m> axis and the other along 
+                        The axes are drawn from <m>-1</m> to <m>1</m>. Two hollow elliptic cones are drawn with
+                        vertices at the origin, one opening along the positive <m>y</m> axis and the other along
                         the negative <m>y</m> axis.
                       </p>
                     </description>
@@ -5153,9 +5153,9 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-2</m> to <m>2</m>. 
-                        The hyperboloid of two sheets is drawn about the <m>y</m> axis. The first sheet 
-                        has a centre at <m>y =1</m> and opens along the positive <m>y</m> axis. The second 
+                        The <m>x</m>, <m>y</m> and <m>z</m> axes are drawn from <m>-2</m> to <m>2</m>.
+                        The hyperboloid of two sheets is drawn about the <m>y</m> axis. The first sheet
+                        has a centre at <m>y =1</m> and opens along the positive <m>y</m> axis. The second
                         sheet has a centre at <m>y=-1</m> and opens along the negative <m>y</m> axis.
                       </p>
                     </description>

--- a/ptx/sec_substitution.ptx
+++ b/ptx/sec_substitution.ptx
@@ -309,7 +309,7 @@
           Evaluate <m>\ds \int \sin(x) \cos(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -466,7 +466,7 @@
           Evaluate <m>\int \tan(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -520,7 +520,7 @@
           Evaluate <m>\int \sec(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           This example employs a wonderful trick:
@@ -672,7 +672,7 @@
           Evaluate <m>\ds\int \frac{x^3+4x^2+8x+5}{x^2+2x+1}\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           One may try to start by setting <m>u</m> equal to either the numerator or denominator;
@@ -811,7 +811,7 @@
           Evaluate <m>\ds \int \frac{1}{25+x^2}\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The integrand looks similar to the derivative of the arctangent function.
@@ -933,7 +933,7 @@
           Evaluate <m>\ds \int\frac{1}{x^2-4x+13}\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Initially, this integral seems to have nothing in common with the integrals in <xref ref="thm_int_inverse_trig"/>.
@@ -993,7 +993,7 @@
           Evaluate <m>\ds \int \frac{4-x}{\sqrt{16-x^2}}\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           This integral requires two different methods to evaluate it.
@@ -1166,15 +1166,15 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn from 
-                    <m>-1</m> to <m>5</m>. 
-                    The function <m>y=\cos(3x-1)</m> has several maxima of <m>1</m> and minima of <m>-1</m>. 
-                    The function has several complete waves. At <m>x</m> intercept <m>-0.9</m> the first wave 
-                    starts it forms a <m>y</m> intercept of <m>0.5</m> after which it reaches the maxima, it 
-                    decreases after and crosses the <m>x</m> axis at <m>0.9</m> then it decreases further to 
+                    The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> and the <m>x</m> axis is drawn from
+                    <m>-1</m> to <m>5</m>.
+                    The function <m>y=\cos(3x-1)</m> has several maxima of <m>1</m> and minima of <m>-1</m>.
+                    The function has several complete waves. At <m>x</m> intercept <m>-0.9</m> the first wave
+                    starts it forms a <m>y</m> intercept of <m>0.5</m> after which it reaches the maxima, it
+                    decreases after and crosses the <m>x</m> axis at <m>0.9</m> then it decreases further to
                     reach the minima then it gets a positive slope and meets the <m>x</m> axis again at <m>2</m>.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1206,13 +1206,13 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m> 
-                    and the <m>u</m> axis is drawn from <m>-1</m> to <m>5</m>. 
-                    The area that the curve forms with the <m>u</m> axis is 
-                    shaded between <m>-1</m> and <m>5</m>. The function has 
+                    The <m>y</m> axis is drawn from <m>-1</m> to <m>1</m>
+                    and the <m>u</m> axis is drawn from <m>-1</m> to <m>5</m>.
+                    The area that the curve forms with the <m>u</m> axis is
+                    shaded between <m>-1</m> and <m>5</m>. The function has
                     two <m>u</m> intercepts at <m>u = 1.5</m> and <m>u = 4.6</m>. There is a parabolic curve above the <m>u</m> axis the major part of which is shaded from <m>-1.4</m> to <m>1.5</m>, there is a second shaded inverted parabolic curve of the same size as the first below the <m>u</m> axis, from <m>1.5</m> to <m>4.6</m>. A third parabola is shaded from <m>4.6</m> to <m>5</m>.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1260,7 +1260,7 @@
           Evaluate <m>\ds \int_0^{\pi/2} \sin(x) \cos(x) \, dx</m> using <xref ref="thm_subst_def_int"/>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1303,15 +1303,15 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>y</m> axis is drawn from <m>-0.5</m> to <m>1</m> and the <m>x</m> 
+                    The <m>y</m> axis is drawn from <m>-0.5</m> to <m>1</m> and the <m>x</m>
                     axis is drawn from a little before <m>0</m> to <m>pi/2</m>.
-                    The function <m>y=\sin(x)*\cos(x)</m> has a parabolic shape shown in the 
-                    graph; it is drawn in the first quadrant. The function has two <m>x</m> 
-                    intercepts at <m>x=0</m> and <m>x = \pi/2</m>. The area under the curve 
-                    between the <m>x</m> intercepts until the <m>x</m> axis is shaded. The 
+                    The function <m>y=\sin(x)*\cos(x)</m> has a parabolic shape shown in the
+                    graph; it is drawn in the first quadrant. The function has two <m>x</m>
+                    intercepts at <m>x=0</m> and <m>x = \pi/2</m>. The area under the curve
+                    between the <m>x</m> intercepts until the <m>x</m> axis is shaded. The
                     curve continues from the <m>x</m> intercepts under the <m>x</m> axis.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
 
                 \begin{tikzpicture}
@@ -1346,13 +1346,13 @@
                   </shortdescription>
                   <description>
                     <p>
-                      The <m>y</m> axis is drawn from <m>-0.5</m> to <m>1</m> and the 
-                      <m>u</m> axis is drawn from <m>0</m> to <m>\pi/2</m>. The graph 
-                      of function <m>y=u</m> is a straight line with a positive slope 
-                      and passes through the origin. The area under the line is shaded 
+                      The <m>y</m> axis is drawn from <m>-0.5</m> to <m>1</m> and the
+                      <m>u</m> axis is drawn from <m>0</m> to <m>\pi/2</m>. The graph
+                      of function <m>y=u</m> is a straight line with a positive slope
+                      and passes through the origin. The area under the line is shaded
                       from <m>0</m> to <m>1</m> indicating the limit for the integral.
                     </p>
-                  </description> 
+                  </description>
                   <latex-image>
 
                   \begin{tikzpicture}

--- a/ptx/sec_substitution.ptx
+++ b/ptx/sec_substitution.ptx
@@ -309,10 +309,7 @@
           Evaluate <m>\ds \int \sin(x) \cos(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="UdGVU8H5w3M" xml:id="vid_int_sub_ex_1" label="vid_int_sub_ex_1" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -345,6 +342,10 @@
           <m>u = \cos(x)</m> and discover why the answer is the same,
           yet looks different.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="UdGVU8H5w3M" xml:id="vid_int_sub_ex_1" label="vid_int_sub_ex_1" component="video"/>
       </solution>
     </example>
 
@@ -465,10 +466,7 @@
           Evaluate <m>\int \tan(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="sJryXwwdqM4" xml:id="vid-int-sub-ex-tan" label="vid-int-sub-ex-tan" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -509,6 +507,10 @@
           These two answers are equivalent.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="sJryXwwdqM4" xml:id="vid-int-sub-ex-tan" label="vid-int-sub-ex-tan" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_sub7">
@@ -518,10 +520,7 @@
           Evaluate <m>\int \sec(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="ivQ5GFSvEGg" xml:id="vid-int-sub-ex-sec" label="vid-int-sub-ex-sec" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This example employs a wonderful trick:
@@ -545,6 +544,10 @@
             <mrow>\amp = \ln\abs{\sec(x) +\tan(x) } + C</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="ivQ5GFSvEGg" xml:id="vid-int-sub-ex-sec" label="vid-int-sub-ex-sec" component="video"/>
       </solution>
     </example>
 
@@ -669,10 +672,7 @@
           Evaluate <m>\ds\int \frac{x^3+4x^2+8x+5}{x^2+2x+1}\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="kuHKfsyaOAI" xml:id="vid-int-sub-with-longdiv" label="vid-int-sub-with-longdiv" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           One may try to start by setting <m>u</m> equal to either the numerator or denominator;
@@ -715,6 +715,10 @@
           substitution was able to be done.
           In later sections we'll develop techniques for handling rational functions where substitution is not directly feasible.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="kuHKfsyaOAI" xml:id="vid-int-sub-with-longdiv" label="vid-int-sub-with-longdiv" component="video"/>
       </solution>
     </example>
 
@@ -807,10 +811,7 @@
           Evaluate <m>\ds \int \frac{1}{25+x^2}\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="skYWHK8feRs" xml:id="vid-int-sub-ex-arctan" label="vid-int-sub-ex-arctan" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The integrand looks similar to the derivative of the arctangent function.
@@ -840,6 +841,10 @@
             <mrow>\amp = \frac15\tan^{-1}\left(\frac x5\right)+C</mrow>
           </md>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="skYWHK8feRs" xml:id="vid-int-sub-ex-arctan" label="vid-int-sub-ex-arctan" component="video"/>
       </solution>
     </example>
 
@@ -928,10 +933,7 @@
           Evaluate <m>\ds \int\frac{1}{x^2-4x+13}\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="wSrXvtTvUjI" xml:id="vid-int-sub-ex-complet-square" label="vid-int-sub-ex-complet-square" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Initially, this integral seems to have nothing in common with the integrals in <xref ref="thm_int_inverse_trig"/>.
@@ -978,6 +980,10 @@
           </md>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="wSrXvtTvUjI" xml:id="vid-int-sub-ex-complet-square" label="vid-int-sub-ex-complet-square" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_subst17">
@@ -987,10 +993,7 @@
           Evaluate <m>\ds \int \frac{4-x}{\sqrt{16-x^2}}\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="tEPUnupFCfs" xml:id="vid-int-sub-ex-two-methods" label="vid-int-sub-ex-two-methods" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This integral requires two different methods to evaluate it.
@@ -1030,6 +1033,10 @@
           As with all definite integrals,
           you can check your work by differentiation.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="tEPUnupFCfs" xml:id="vid-int-sub-ex-two-methods" label="vid-int-sub-ex-two-methods" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -1253,10 +1260,7 @@
           Evaluate <m>\ds \int_0^{\pi/2} \sin(x) \cos(x) \, dx</m> using <xref ref="thm_subst_def_int"/>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="U3B47kxjidk" xml:id="vid_int_sub_def_int_ex" label="vid_int_sub_def_int_ex" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1374,6 +1378,10 @@
             </figure>
           </sidebyside>
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="U3B47kxjidk" xml:id="vid_int_sub_def_int_ex" label="vid_int_sub_def_int_ex" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -43,7 +43,7 @@
           <m>\unittangent(0)</m> and <m>\unittangent(1)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We apply <xref ref="def_unit_tangent"/> to find <m>\unittangent(t)</m>.
@@ -153,7 +153,7 @@
           <m>\unittangent(0)</m> and <m>\unittangent(1)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We find <m>\vrp(t) = \la 2t-1,2t+1\ra</m>, and
@@ -324,7 +324,7 @@
           <m>\unitnormal(\pi/2)</m> with initial points at <m>\vec r(\pi/2)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           In <xref ref="ex_tannorm1"/>,
@@ -438,7 +438,7 @@
           Find <m>\unitnormal(t)</m> and sketch <m>\vrt</m> with the unit tangent and normal vectors at <m>t=-1,0</m> and 1.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           In <xref ref="ex_tannorm2"/>, we found
@@ -684,7 +684,7 @@
           Find <m>a_\text{T}</m> and <m>a_\text{N}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The previous examples give <m>\vat = \la -3\cos(t) ,-3\sin(t) ,0\ra</m> and
@@ -728,7 +728,7 @@
           Find <m>a_\text{T}</m> and <m>a_\text{N}</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The previous examples give <m>\vat = \la 2,2\ra</m> and

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -43,10 +43,7 @@
           <m>\unittangent(0)</m> and <m>\unittangent(1)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="aGEMbQrBpPI" xml:id="vid-vvf-tannorm-tangent-eg1" label="vid-vvf-tannorm-tangent-eg1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We apply <xref ref="def_unit_tangent"/> to find <m>\unittangent(t)</m>.
@@ -134,6 +131,10 @@
           <m>\unittangent(1)</m> to verify it has length 1.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="aGEMbQrBpPI" xml:id="vid-vvf-tannorm-tangent-eg1" label="vid-vvf-tannorm-tangent-eg1" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -152,10 +153,7 @@
           <m>\unittangent(0)</m> and <m>\unittangent(1)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="zdfMTWdXzJs" xml:id="vid-vvf-tannorm-tangent-eg2" label="vid-vvf-tannorm-tangent-eg2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We find <m>\vrp(t) = \la 2t-1,2t+1\ra</m>, and
@@ -208,6 +206,10 @@
           </image>
           <!-- figures/fig_tannorm2.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="zdfMTWdXzJs" xml:id="vid-vvf-tannorm-tangent-eg2" label="vid-vvf-tannorm-tangent-eg2" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -322,10 +324,7 @@
           <m>\unitnormal(\pi/2)</m> with initial points at <m>\vec r(\pi/2)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="cZkvyF0t5P4" xml:id="vid-vvf-tannorm-normal-eg1" label="vid-vvf-tannorm-normal-eg1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           In <xref ref="ex_tannorm1"/>,
@@ -405,6 +404,10 @@
           <!-- figures/figtannorm3_3D.asy END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="cZkvyF0t5P4" xml:id="vid-vvf-tannorm-normal-eg1" label="vid-vvf-tannorm-normal-eg1" component="video"/>
+      </solution>
     </example>
 
     <aside>
@@ -435,10 +438,7 @@
           Find <m>\unitnormal(t)</m> and sketch <m>\vrt</m> with the unit tangent and normal vectors at <m>t=-1,0</m> and 1.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="VExazWvgGlQ" xml:id="vid-vvf-tannorm-normal-eg2" label="vid-vvf-tannorm-normal-eg2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           In <xref ref="ex_tannorm2"/>, we found
@@ -515,6 +515,10 @@
           </image>
           <!-- figures/fig_tannorm4.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="VExazWvgGlQ" xml:id="vid-vvf-tannorm-normal-eg2" label="vid-vvf-tannorm-normal-eg2" component="video"/>
       </solution>
     </example>
 
@@ -680,10 +684,7 @@
           Find <m>a_\text{T}</m> and <m>a_\text{N}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="qA776vEHYM0" xml:id="vid-vvf-tannorm-accel-eg1" label="vid-vvf-tannorm-accel-eg1" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The previous examples give <m>\vat = \la -3\cos(t) ,-3\sin(t) ,0\ra</m> and
@@ -712,6 +713,10 @@
           and hence all acceleration comes in the form of direction change.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="qA776vEHYM0" xml:id="vid-vvf-tannorm-accel-eg1" label="vid-vvf-tannorm-accel-eg1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_tannorm6">
@@ -723,10 +728,7 @@
           Find <m>a_\text{T}</m> and <m>a_\text{N}</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="8LTqjQPvh-A" xml:id="vid-vvf-tannorm-accel-eg2" label="vid-vvf-tannorm-accel-eg2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The previous examples give <m>\vat = \la 2,2\ra</m> and
@@ -792,6 +794,10 @@
           where <m>a_\text{T} = 0</m> and <m>a_\text{N} = 4/\sqrt{2}\approx 2.82</m>.
           Here the particle's speed is not changing and all acceleration is in the form of direction change.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="8LTqjQPvh-A" xml:id="vid-vvf-tannorm-accel-eg2" label="vid-vvf-tannorm-accel-eg2" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -459,10 +459,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="ENf-Z2pLrJg" xml:id="vid_deriv_apps_taylor_poly_ex_1" label="vid_deriv_apps_taylor_poly_ex_1" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -572,6 +569,10 @@
       <!-- figures/fig_taypoly1b.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="ENf-Z2pLrJg" xml:id="vid_deriv_apps_taylor_poly_ex_1" label="vid_deriv_apps_taylor_poly_ex_1" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_taypoly2">
@@ -599,10 +600,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="6BeNQe0hl3k" xml:id="vid_deriv_apps_taylor_poly_ex_2" label="vid_deriv_apps_taylor_poly_ex_2" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -803,6 +801,10 @@
           </figure>
         </sidebyside>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="6BeNQe0hl3k" xml:id="vid_deriv_apps_taylor_poly_ex_2" label="vid_deriv_apps_taylor_poly_ex_2" component="video"/>
+      </solution>
     </example>
 
     <aside>
@@ -981,10 +983,7 @@
           as calculated in <xref ref="ex_taypoly2"/>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="TBV4-X7HoHk" xml:id="vid_deriv_apps_taylor_poly_err_est_ex" label="vid_deriv_apps_taylor_poly_err_est_ex" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1061,6 +1060,10 @@
           </ol>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="TBV4-X7HoHk" xml:id="vid_deriv_apps_taylor_poly_err_est_ex" label="vid_deriv_apps_taylor_poly_err_est_ex" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -1079,10 +1082,7 @@
           What is <m>p_n(2)</m>?
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="zg1W9miUCB4" xml:id="vid_deriv_apps_taylor_poly_ex_4" label="vid_deriv_apps_taylor_poly_ex_4" component="video"/>
-      </solution>
+      
       <solution>
 
         <p>
@@ -1231,35 +1231,39 @@
             </description>
             <latex-image>
 
-          \begin{tikzpicture}
+              \begin{tikzpicture}
 
-          \begin{axis}[
-          axis on top,
-          xtick={-5,-4,-3,-2,-1,1,2,3,4,5},
-          ymin=-1.5,ymax=1.5,
-          xmin=-5.5,xmax=5.5
-          ]
+              \begin{axis}[
+              axis on top,
+              xtick={-5,-4,-3,-2,-1,1,2,3,4,5},
+              ymin=-1.5,ymax=1.5,
+              xmin=-5.5,xmax=5.5
+              ]
 
-          \addplot+[domain=-5:5,samples=100] {cos(deg(x))} node[pos=0.6, right] { $y=cos(x)$};
-          \addplot+[smooth] coordinates {(-5.,2.528)(-4.8,1.6)(-4.6,0.8894)(-4.4,0.343)(-4.2,-0.0768)(-4.,-0.
-          3968)(-3.8,-0.6355)(-3.6,-0.8052)(-3.4,-0.9146)(-3.2,-0.9695)(-3.,-0.
-          9748)(-2.8,-0.9345)(-2.6,-0.8532)(-2.4,-0.7357)(-2.2,-0.5878)(-2.,-0.
-          4159)(-1.8,-0.2271)(-1.6,-0.02917)(-1.4,0.17)(-1.2,0.3624)(-1.,0.5403)
-          (-0.8,0.6967)(-0.6,0.8253)(-0.4,0.9211)(-0.2,0.9801)(0,1.)(0.2,0.9801)
-          (0.4,0.9211)(0.6,0.8253)(0.8,0.6967)(1.,0.5403)(1.2,0.3624)(1.4,0.17)(
-          1.6,-0.02917)(1.8,-0.2271)(2.,-0.4159)(2.2,-0.5878)(2.4,-0.7357)(2.6,-
-          0.8532)(2.8,-0.9345)(3.,-0.9748)(3.2,-0.9695)(3.4,-0.9146)(3.6,-0.
-          8052)(3.8,-0.6355)(4.,-0.3968)(4.2,-0.0768)(4.4,0.343)(4.6,0.8894)(4.
-          8,1.6)(5.,2.528)}  node[pos=0.1,right] { $y=p_8(x)$} ;
+              \addplot+[domain=-5:5,samples=100] {cos(deg(x))} node[pos=0.6, right] { $y=cos(x)$};
+              \addplot+[smooth] coordinates {(-5.,2.528)(-4.8,1.6)(-4.6,0.8894)(-4.4,0.343)(-4.2,-0.0768)(-4.,-0.
+              3968)(-3.8,-0.6355)(-3.6,-0.8052)(-3.4,-0.9146)(-3.2,-0.9695)(-3.,-0.
+              9748)(-2.8,-0.9345)(-2.6,-0.8532)(-2.4,-0.7357)(-2.2,-0.5878)(-2.,-0.
+              4159)(-1.8,-0.2271)(-1.6,-0.02917)(-1.4,0.17)(-1.2,0.3624)(-1.,0.5403)
+              (-0.8,0.6967)(-0.6,0.8253)(-0.4,0.9211)(-0.2,0.9801)(0,1.)(0.2,0.9801)
+              (0.4,0.9211)(0.6,0.8253)(0.8,0.6967)(1.,0.5403)(1.2,0.3624)(1.4,0.17)(
+              1.6,-0.02917)(1.8,-0.2271)(2.,-0.4159)(2.2,-0.5878)(2.4,-0.7357)(2.6,-
+              0.8532)(2.8,-0.9345)(3.,-0.9748)(3.2,-0.9695)(3.4,-0.9146)(3.6,-0.
+              8052)(3.8,-0.6355)(4.,-0.3968)(4.2,-0.0768)(4.4,0.343)(4.6,0.8894)(4.
+              8,1.6)(5.,2.528)}  node[pos=0.1,right] { $y=p_8(x)$} ;
 
-          \end{axis}
+              \end{axis}
 
-          \end{tikzpicture}
+              \end{tikzpicture}
 
             </latex-image>
           </image>
           <!-- figures/fig_taypoly4.tex END -->
         </figure>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="zg1W9miUCB4" xml:id="vid_deriv_apps_taylor_poly_ex_4" label="vid_deriv_apps_taylor_poly_ex_4" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -209,7 +209,7 @@
             In particular, the point <m>(0,f(0))</m> appears to be a local minimum,
             and there is a corresponding minimum in the graphs of both <m>p_2(x)</m> and <m>p_4(x)</m>.
             But the graph of <m>f(x)</m> also appears to have a local maximum near <m>x=1</m>.
-            Near <m>x=1</m>, the graph of <m>p_2(x)</m> separates from that of <m>f(x)</m>: 
+            Near <m>x=1</m>, the graph of <m>p_2(x)</m> separates from that of <m>f(x)</m>:
             the first continues to increase, while the second begins to decrease.
             Near <m>x=1</m>, <m>p_2(x)</m> is no longer a good approximation to <m>f(x)</m>.
           </p>
@@ -459,7 +459,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -600,7 +600,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -983,7 +983,7 @@
           as calculated in <xref ref="ex_taypoly2"/>.
         </p>
       </statement>
-      
+
       <solution>
 
         <p>
@@ -1082,7 +1082,7 @@
           What is <m>p_n(2)</m>?
         </p>
       </statement>
-      
+
       <solution>
 
         <p>

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -85,7 +85,7 @@
         Find the Maclaurin series of <m>f(x)=\cos(x)</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         In <xref ref="ex_taypoly4"/>
@@ -210,7 +210,7 @@
         Find the Taylor series of <m>f(x) = \ln(x)</m> centered at <m>x=1</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <xref ref="fig_ts2"/>
@@ -472,7 +472,7 @@
         Find the Maclaurin series of <m>f(x) = (1+x)^k</m>, <m>k\neq 0</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         When <m>k</m> is a positive integer,
@@ -725,7 +725,7 @@
         and <xref ref="thm_series_alg"/>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <xref ref="idea_common_taylor"/> informs us that
@@ -776,7 +776,7 @@
         to create series for <m>y=\sin(x^2)</m> and <m>y=x^3/(3+x^4)</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         Given that
@@ -972,7 +972,7 @@
         Use the Taylor series of <m>e^{-x^2}</m> to evaluate <m>\ds \int_0^1e^{-x^2}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We learned, when studying Numerical Integration,
@@ -1038,7 +1038,7 @@
         and use the theory of Taylor series to recognize the solution in terms of an elementary function.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We found the first 5 terms of the power series solution to this differential equation in <xref ref="ex_ps5"/>

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -85,10 +85,7 @@
         Find the Maclaurin series of <m>f(x)=\cos(x)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="97x6p1616z0" xml:id="vid-seqseries-taylorseries-maclaurin-cos" label="vid-seqseries-taylorseries-maclaurin-cos" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         In <xref ref="ex_taypoly4"/>
@@ -193,6 +190,10 @@
         <em>equal</em> to this power series.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="97x6p1616z0" xml:id="vid-seqseries-taylorseries-maclaurin-cos" label="vid-seqseries-taylorseries-maclaurin-cos" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -209,10 +210,7 @@
         Find the Taylor series of <m>f(x) = \ln(x)</m> centered at <m>x=1</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="Bdk4lGCkz7o" xml:id="vid-seqseries-taylorseries-natural-log" label="vid-seqseries-taylorseries-natural-log" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <xref ref="fig_ts2"/>
@@ -332,6 +330,10 @@
         and have determined the series converges on <m>(0,2]</m>.
         We cannot (yet) say that <m>\ln x</m> is equal to this Taylor series on <m>(0,2]</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="Bdk4lGCkz7o" xml:id="vid-seqseries-taylorseries-natural-log" label="vid-seqseries-taylorseries-natural-log" component="video"/>
     </solution>
   </example>
 
@@ -470,10 +472,7 @@
         Find the Maclaurin series of <m>f(x) = (1+x)^k</m>, <m>k\neq 0</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="uQouiDtMuDY" xml:id="vid-seqseries-taylorseries-binomial" label="vid-seqseries-taylorseries-binomial" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         When <m>k</m> is a positive integer,
@@ -550,6 +549,10 @@
         When <m>-1\lt k\lt 0</m>, the interval of convergence is <m>[-1,1)</m>.
         If <m>k\leq -1</m>, the interval of convergence is <m>(-1,1)</m>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="uQouiDtMuDY" xml:id="vid-seqseries-taylorseries-binomial" label="vid-seqseries-taylorseries-binomial" component="video"/>
     </solution>
   </example>
 
@@ -722,10 +725,7 @@
         and <xref ref="thm_series_alg"/>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="rUBF6BC201g" xml:id="vid-seqseries-taylorseries-product" label="vid-seqseries-taylorseries-product" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <xref ref="idea_common_taylor"/> informs us that
@@ -762,6 +762,10 @@
         so does the series expansion for <m>e^x\cos(x)</m>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="rUBF6BC201g" xml:id="vid-seqseries-taylorseries-product" label="vid-seqseries-taylorseries-product" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_ts6">
@@ -772,10 +776,7 @@
         to create series for <m>y=\sin(x^2)</m> and <m>y=x^3/(3+x^4)</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="j3eHOO9taNQ" xml:id="vid-seqseries-taylorseries-composition" label="vid-seqseries-taylorseries-composition" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         Given that
@@ -813,6 +814,10 @@
           \frac{x^3}{3+x^4} = x^3\sum_{n=0}^\infty \frac{(-1^n)x^{4n}}{3^n} = \sum_{n=0}^\infty \frac{(-1)^nx^{4n+3}}{3^n}
         </me>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="j3eHOO9taNQ" xml:id="vid-seqseries-taylorseries-composition" label="vid-seqseries-taylorseries-composition" component="video"/>
     </solution>
   </example>
 
@@ -967,10 +972,7 @@
         Use the Taylor series of <m>e^{-x^2}</m> to evaluate <m>\ds \int_0^1e^{-x^2}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="WhpEci26gUA" xml:id="vid-seqseries-taylorseries-integration" label="vid-seqseries-taylorseries-integration" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We learned, when studying Numerical Integration,
@@ -1022,6 +1024,10 @@
         This is arguably much less work than using Simpson's Rule to approximate the value of the integral.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="WhpEci26gUA" xml:id="vid-seqseries-taylorseries-integration" label="vid-seqseries-taylorseries-integration" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_ts8">
@@ -1032,10 +1038,7 @@
         and use the theory of Taylor series to recognize the solution in terms of an elementary function.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="ojjEGO5H8qQ" xml:id="vid-seqseries-taylorseries-ivp" label="vid-seqseries-taylorseries-ivp" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We found the first 5 terms of the power series solution to this differential equation in <xref ref="ex_ps5"/>
@@ -1065,6 +1068,10 @@
           e^x = \infser[0] \frac{x^n}{n!} \qquad \Rightarrow \qquad e^{2x} = \infser[0] \frac{(2x)^n}{n!}
         </me>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="ojjEGO5H8qQ" xml:id="vid-seqseries-taylorseries-ivp" label="vid-seqseries-taylorseries-ivp" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_trig_sub.ptx
+++ b/ptx/sec_trig_sub.ptx
@@ -48,10 +48,7 @@
         Evaluate <m>\ds \int_{-3}^3\sqrt{9-x^2}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="5CKWeQvnGAU" xml:id="vid-int-trigsub-ex-def-sine" label="vid-int-trigsub-ex-def-sine" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We begin by noting that <m>9\left(\sin^2(\theta) + \cos^2(\theta)\right) = 9</m>,
@@ -86,6 +83,10 @@
       <p>
         This matches our answer from before.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="5CKWeQvnGAU" xml:id="vid-int-trigsub-ex-def-sine" label="vid-int-trigsub-ex-def-sine" component="video"/>
     </solution>
   </example>
 
@@ -285,10 +286,7 @@
         Evaluate <m>\ds \int \frac{1}{\sqrt{5+x^2}}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="2a9Oks-FCg0" xml:id="vid-int-trigsub-ex-tan1" label="vid-int-trigsub-ex-tan1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         Using <xref ref="idea_trigsubb" text="local">Item</xref> in <xref ref="idea_trigsub"/>,
@@ -341,6 +339,10 @@
         we will learn another way of approaching this problem.)
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="2a9Oks-FCg0" xml:id="vid-int-trigsub-ex-tan1" label="vid-int-trigsub-ex-tan1" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_trigsub2">
@@ -350,10 +352,7 @@
         Evaluate <m>\ds \int \sqrt{4x^2-1}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="0oCjVzIa_t8" xml:id="vid-int-trigsub-ex-sec1" label="vid-int-trigsub-ex-sec1" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We start by rewriting the integrand so that it looks like
@@ -427,6 +426,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="0oCjVzIa_t8" xml:id="vid-int-trigsub-ex-sec1" label="vid-int-trigsub-ex-sec1" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_trigsub4">
@@ -436,10 +439,7 @@
         Evaluate <m>\ds \int \frac{\sqrt{4-x^2}}{x^2}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="E37-2LvYSsg" xml:id="vid-int-trigsub-ex-sin2" label="vid-int-trigsub-ex-sin2" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We use <xref ref="idea_trigsuba" text="local">Part</xref> of <xref ref="idea_trigsub"/> with <m>a=2</m>,
@@ -463,6 +463,10 @@
           \int \frac{\sqrt{4-x^2}}{x^2}\, dx = -\frac{\sqrt{4-x^2}}x-\sin^{-1}\left(\frac x2\right) + C
         </me>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="E37-2LvYSsg" xml:id="vid-int-trigsub-ex-sin2" label="vid-int-trigsub-ex-sin2" component="video"/>
     </solution>
   </example>
 
@@ -518,10 +522,7 @@
         Evaluate <m>\ds\int\frac1{(x^2+6x+10)^2}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="5JAXeV1-vCo" xml:id="vid-int-trigsub-ex-complete-square" label="vid-int-trigsub-ex-complete-square" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We start by completing the square,
@@ -565,6 +566,10 @@
         </me>.
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="5JAXeV1-vCo" xml:id="vid-int-trigsub-ex-complete-square" label="vid-int-trigsub-ex-complete-square" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -586,10 +591,7 @@
         Evaluate <m>\ds\int_0^5\frac{x^2}{\sqrt{x^2+25}}\, dx</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="Pz56QfleHX4" xml:id="vid-int-trigsub-ex-tan-def" label="vid-int-trigsub-ex-tan-def" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         Using <xref ref="idea_trigsubb" text="local">Part</xref> of <xref ref="idea_trigsub"/>,
@@ -631,6 +633,10 @@
           <mrow>\amp \approx 6.661</mrow>
         </md>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="Pz56QfleHX4" xml:id="vid-int-trigsub-ex-tan-def" label="vid-int-trigsub-ex-tan-def" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_trig_sub.ptx
+++ b/ptx/sec_trig_sub.ptx
@@ -48,7 +48,7 @@
         Evaluate <m>\ds \int_{-3}^3\sqrt{9-x^2}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We begin by noting that <m>9\left(\sin^2(\theta) + \cos^2(\theta)\right) = 9</m>,
@@ -127,11 +127,11 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The diagram is of a right angled triangle. The perpendicular is marked <m>x</m> 
+                    The diagram is of a right angled triangle. The perpendicular is marked <m>x</m>
                     the base as <m>\sqrt{a^2 -x^2}</m>. The hypotenuse is marked <m>a</m>. The angle
                     opposite to the perpendicular is marked as <m>\theta</m>.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
 
                   \begin{tikzpicture}
@@ -170,11 +170,11 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The diagram is of a right angled triangle. The perpendicular is marked <m>x</m> 
-                    the base as <m>a</m>. The hypotenuse is marked <m>\sqrt{x^2+a^2}</m>. The angle 
+                    The diagram is of a right angled triangle. The perpendicular is marked <m>x</m>
+                    the base as <m>a</m>. The hypotenuse is marked <m>\sqrt{x^2+a^2}</m>. The angle
                     opposite to the perpendicular is marked as <m>\theta</m>.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
 
                   \begin{tikzpicture}
@@ -217,11 +217,11 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The diagram is of a right angled triangle. The perpendicular is marked <m>\sqrt{x^2-a^2}</m> 
-                    the base as <m>a</m>. The hypotenuse is marked <m>x</m>. The angle opposite to the perpendicular 
+                    The diagram is of a right angled triangle. The perpendicular is marked <m>\sqrt{x^2-a^2}</m>
+                    the base as <m>a</m>. The hypotenuse is marked <m>x</m>. The angle opposite to the perpendicular
                     is marked as <m>\theta</m>.
                   </p>
-                </description>  
+                </description>
                 <latex-image>
 
                   \begin{tikzpicture}
@@ -286,7 +286,7 @@
         Evaluate <m>\ds \int \frac{1}{\sqrt{5+x^2}}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         Using <xref ref="idea_trigsubb" text="local">Item</xref> in <xref ref="idea_trigsub"/>,
@@ -352,7 +352,7 @@
         Evaluate <m>\ds \int \sqrt{4x^2-1}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We start by rewriting the integrand so that it looks like
@@ -439,7 +439,7 @@
         Evaluate <m>\ds \int \frac{\sqrt{4-x^2}}{x^2}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We use <xref ref="idea_trigsuba" text="local">Part</xref> of <xref ref="idea_trigsub"/> with <m>a=2</m>,
@@ -522,7 +522,7 @@
         Evaluate <m>\ds\int\frac1{(x^2+6x+10)^2}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We start by completing the square,
@@ -591,7 +591,7 @@
         Evaluate <m>\ds\int_0^5\frac{x^2}{\sqrt{x^2+25}}\, dx</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         Using <xref ref="idea_trigsubb" text="local">Part</xref> of <xref ref="idea_trigsub"/>,
@@ -727,7 +727,7 @@
             Context()->variables->add(theta=>['Real',TeX=>'\theta']);
             # Redefine tan() so the following equtaion is not an identity
             package my::Function::numeric;
-            our @ISA = ('Parser::Function::numeric');      
+            our @ISA = ('Parser::Function::numeric');
             sub tan {
               shift; my $x = shift;
               return CORE::sin($x+2)/CORE::cos($x+2);

--- a/ptx/sec_trigint.ptx
+++ b/ptx/sec_trigint.ptx
@@ -36,10 +36,7 @@
           Evaluate <m>\ds\int\sin^3(x) \cos(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="soXjOeFRrsk" xml:id="vid-int-trig-ex-sin3cos" label="vid-int-trig-ex-sin3cos" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We have used substitution on problems similar to this problem in
@@ -84,6 +81,10 @@
           </md>,
           so the difference between the two answers is the constant <m>\frac14</m> .
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="soXjOeFRrsk" xml:id="vid-int-trig-ex-sin3cos" label="vid-int-trig-ex-sin3cos" component="video"/>
       </solution>
     </example>
 
@@ -159,10 +160,7 @@
           Evaluate <m>\ds\int\sin^5(x) \cos^8(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="CAV4gSbw1GU" xml:id="vid-int-trig-ex-sin5cos8" label="vid-int-trig-ex-sin5cos8" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The power of the sine term is odd,
@@ -192,6 +190,10 @@
             <mrow>\amp =-\frac19\cos^9(x) + \frac2{11}\cos^{11}(x) - \frac1{13}\cos^{13}(x) + C</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="CAV4gSbw1GU" xml:id="vid-int-trig-ex-sin5cos8" label="vid-int-trig-ex-sin5cos8" component="video"/>
       </solution>
     </example>
 
@@ -335,10 +337,7 @@
           Evaluate <m>\ds\int\cos^4(x) \sin^2(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="EXODR17otIw" xml:id="vid-int-trig-ex-cos4sin2" label="vid-int-trig-ex-cos4sin2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The powers of sine and cosine are both even,
@@ -395,6 +394,10 @@
           </md>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="EXODR17otIw" xml:id="vid-int-trig-ex-cos4sin2" label="vid-int-trig-ex-cos4sin2" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -426,10 +429,7 @@
           Evaluate <m>\ds\int\sin(5x)\cos(2x)\, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="KbW-xwlTuyI" xml:id="vid-int-trig-ex-sin5xcos2x" label="vid-int-trig-ex-sin5xcos2x" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The application of the formula and subsequent integration are straightforward:
@@ -439,6 +439,10 @@
             <mrow>\amp = -\frac16\cos(3x) - \frac1{14}\cos(7x) + C</mrow>
           </md>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="KbW-xwlTuyI" xml:id="vid-int-trig-ex-sin5xcos2x" label="vid-int-trig-ex-sin5xcos2x" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -581,10 +585,7 @@
           Evaluate <m>\ds\int \tan^2(x) \sec^6(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="yYbn6R20qTk" xml:id="vid-int-trig-ex-tan2sec6" label="vid-int-trig-ex-tan2sec6" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Since the power of secant is even,
@@ -600,6 +601,10 @@
             <mrow>\amp =\frac13\tan^3(x) +\frac25\tan^5(x) +\frac17\tan^7(x) +C</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="yYbn6R20qTk" xml:id="vid-int-trig-ex-tan2sec6" label="vid-int-trig-ex-tan2sec6" component="video"/>
       </solution>
     </example>
 
@@ -621,10 +626,7 @@
           Evaluate <m>\ds\int \sec^3(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="mPuR46ztxZQ" xml:id="vid-int-trig-ex-sec3" label="vid-int-trig-ex-sec3" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We apply <xref ref="idea_trig_int_2c" text="local"> Rule</xref>
@@ -675,6 +677,10 @@
           </md>
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="mPuR46ztxZQ" xml:id="vid-int-trig-ex-sec3" label="vid-int-trig-ex-sec3" component="video"/>
+      </solution>
     </example>
 
     <p xml:id="vidint-int-trig-ex-secant-power-reduction" component="video">
@@ -705,10 +711,7 @@
           Evaluate <m>\ds\int\tan^6(x) \, dx</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="MUDKKDz3_C8" xml:id="vid-int-trig-ex-tan6" label="vid-int-trig-ex-tan6" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We employ <xref ref="idea_trig_int_2c" text="local"> Rule</xref> of
@@ -728,6 +731,10 @@
             <mrow>\int \tan^6(x)\, dx\amp =	 \frac15\tan^5(x) -\frac13\tan^3(x) +\tan(x) - x+C</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="MUDKKDz3_C8" xml:id="vid-int-trig-ex-tan6" label="vid-int-trig-ex-tan6" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_trigint.ptx
+++ b/ptx/sec_trigint.ptx
@@ -36,7 +36,7 @@
           Evaluate <m>\ds\int\sin^3(x) \cos(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We have used substitution on problems similar to this problem in
@@ -160,7 +160,7 @@
           Evaluate <m>\ds\int\sin^5(x) \cos^8(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The power of the sine term is odd,
@@ -285,8 +285,8 @@
         </shortdescription>
         <description>
           <p>
-            The <m>y</m> axis is drawn from <m>-0.002</m> and <m>0.004</m> and the <m>x</m> axis 
-            is drawn from <m>0</m> to <m>3</m>. The graph has two functions drawn. Both of them 
+            The <m>y</m> axis is drawn from <m>-0.002</m> and <m>0.004</m> and the <m>x</m> axis
+            is drawn from <m>0</m> to <m>3</m>. The graph has two functions drawn. Both of them
             are plateau shaped.
           </p>
           <p>
@@ -296,10 +296,10 @@
             sharply till <m>x=2.75</m> then it merged with the <m>x</m> axis.
           </p>
           <p>
-            The second function <m>f(x)</m> is the same as the first but the line on which it is placed 
+            The second function <m>f(x)</m> is the same as the first but the line on which it is placed
             is <m>x=0.0025</m> instead of <m>x=0</m>.
           </p>
-        </description>          
+        </description>
         <latex-image>
 
         \begin{tikzpicture}
@@ -337,7 +337,7 @@
           Evaluate <m>\ds\int\cos^4(x) \sin^2(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The powers of sine and cosine are both even,
@@ -429,7 +429,7 @@
           Evaluate <m>\ds\int\sin(5x)\cos(2x)\, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The application of the formula and subsequent integration are straightforward:
@@ -585,7 +585,7 @@
           Evaluate <m>\ds\int \tan^2(x) \sec^6(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Since the power of secant is even,
@@ -626,7 +626,7 @@
           Evaluate <m>\ds\int \sec^3(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We apply <xref ref="idea_trig_int_2c" text="local"> Rule</xref>
@@ -711,7 +711,7 @@
           Evaluate <m>\ds\int\tan^6(x) \, dx</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We employ <xref ref="idea_trig_int_2c" text="local"> Rule</xref> of
@@ -725,7 +725,7 @@
             <mrow>\amp =	\frac15\tan^5(x) -\int\tan^2(x) \tan^2(x) \, dx</mrow>
             <mrow>\amp =	\frac15\tan^5(x) -\int\tan^2(x) \big(\sec^2(x) -1\big)\, dx</mrow>
             <mrow>\amp = \frac15\tan^5(x) -\underbrace{\int\tan^2(x) \sec^2(x) \, dx}_{a} + \underbrace{\int\tan^2(x) \, dx}_b</mrow>
-            <intertext>Again, use substitution (<m>u=\tan(x)</m>) for the first integral (a) and 
+            <intertext>Again, use substitution (<m>u=\tan(x)</m>) for the first integral (a) and
               <xref ref="idea_trig_int_2d" text="local"> Rule</xref> for the second (b).</intertext>
             <mrow>\amp = \frac15\tan^5(x) -\frac13\tan^3(x) +\int\big(\sec^2(x) -1\big)\, dx</mrow>
             <mrow>\int \tan^6(x)\, dx\amp =	 \frac15\tan^5(x) -\frac13\tan^3(x) +\tan(x) - x+C</mrow>

--- a/ptx/sec_triple_int.ptx
+++ b/ptx/sec_triple_int.ptx
@@ -3140,7 +3140,7 @@
             Two functions <m>f_1(x,y)</m> and
             <m>f_2(x,y)</m> and a region <m>R</m> in the <m>x</m>,
             <m>y</m> plane are given.
-            Set up and evaluate the double integral that finds the volume 
+            Set up and evaluate the double integral that finds the volume
             between the surfaces given by the graphs of these two functions over <m>R</m>.
           </p>
         </introduction>

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -264,10 +264,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="w1MzWJzoyGg" xml:id="vid-vectors-intro-sketch" label="vid-vectors-intro-sketch" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -425,6 +422,10 @@
         </ol>
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="w1MzWJzoyGg" xml:id="vid-vectors-intro-sketch" label="vid-vectors-intro-sketch" component="video"/>
+    </solution>
   </example>
 
   <p>
@@ -525,10 +526,7 @@
         <m>\vec u+\vec v</m> all with initial point at the origin.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="3MSwQJq_3s0" xml:id="vid-vectors-intro-addition" label="vid-vectors-intro-addition" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         We first compute <m>\vec u +\vec v</m>.
@@ -581,6 +579,10 @@
       <p>
         These are all sketched in <xref ref="fig_vect2"/>.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="3MSwQJq_3s0" xml:id="vid-vectors-intro-addition" label="vid-vectors-intro-addition" component="video"/>
     </solution>
   </example>
 
@@ -704,10 +706,7 @@
         Compute and sketch <m>\vec u-\vec v</m>.
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="a_qRwTkQXYQ" xml:id="vid-vectors-intro-subtraction" label="vid-vectors-intro-subtraction" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         The computation of <m>\vec u-\vec v</m> is straightforward,
@@ -775,6 +774,10 @@
         (when their initial points are the same).
       </p>
     </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="a_qRwTkQXYQ" xml:id="vid-vectors-intro-subtraction" label="vid-vectors-intro-subtraction" component="video"/>
+    </solution>
   </example>
 
   <example xml:id="ex_vect3">
@@ -796,10 +799,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="-zvqs7hveXc" xml:id="vid-vectors-intro-scalarmult" label="vid-vectors-intro-scalarmult" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -873,6 +873,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="-zvqs7hveXc" xml:id="vid-vectors-intro-scalarmult" label="vid-vectors-intro-scalarmult" component="video"/>
     </solution>
   </example>
 
@@ -1054,10 +1058,7 @@
         </ol>
       </p>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="B9OV0Dja6IY" xml:id="vid-vectors-intro-unitvec-eg" label="vid-vectors-intro-unitvec-eg" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         <ol>
@@ -1131,6 +1132,10 @@
           </li>
         </ol>
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="B9OV0Dja6IY" xml:id="vid-vectors-intro-unitvec-eg" label="vid-vectors-intro-unitvec-eg" component="video"/>
     </solution>
   </example>
 
@@ -1329,10 +1334,7 @@
         <!-- figures/fig_vect6.tex END -->
       </figure>
     </statement>
-    <solution component="video">
-      <title>Video solution</title>
-      <video width="98%" youtube="XxSQSU4Nvig" xml:id="vid-vectors-intro-weightchain" label="vid-vectors-intro-weightchain" component="video"/>
-    </solution>
+    
     <solution>
       <p>
         Knowing that gravity is pulling the 50lb weight straight down,
@@ -1438,6 +1440,10 @@
         they also pull against each other,
         creating an <q>additional</q> horizontal force while holding the weight in place.
       </p>
+    </solution>
+    <solution component="video">
+      <title>Video solution</title>
+      <video width="98%" youtube="XxSQSU4Nvig" xml:id="vid-vectors-intro-weightchain" label="vid-vectors-intro-weightchain" component="video"/>
     </solution>
   </example>
 

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -85,11 +85,11 @@
       </shortdescription>
       <description>
         <p>
-          The <m>x</m> and <m>y</m> axes are drawn from <m>-4</m> to <m>4</m>. There are four vectors drawn. 
-          In the first quadrant is the first vector drawn from point <m>(0,0)</m> to <m>(3,1)</m>. The second 
-          vector is drawn in the second quadrant from point <m>(-4,1)</m> to point <m>(-1,2)</m>. In the fourth 
-          quadrant the vector is drawn from <m>(2, -4)</m> to <m>(5, -3)</m>. The last vector is drawn from 
-          <m>(-2, -3)</m> to <m>(1, -2)</m> and it crosses the third . 
+          The <m>x</m> and <m>y</m> axes are drawn from <m>-4</m> to <m>4</m>. There are four vectors drawn.
+          In the first quadrant is the first vector drawn from point <m>(0,0)</m> to <m>(3,1)</m>. The second
+          vector is drawn in the second quadrant from point <m>(-4,1)</m> to point <m>(-1,2)</m>. In the fourth
+          quadrant the vector is drawn from <m>(2, -4)</m> to <m>(5, -3)</m>. The last vector is drawn from
+          <m>(-2, -3)</m> to <m>(1, -2)</m> and it crosses the third .
         </p>
       </description>
       <latex-image>
@@ -135,9 +135,9 @@
       </shortdescription>
       <description>
         <p>
-          The <m>x</m> and <m>y</m> axes are drawn from <m>-4</m> to <m>4</m>. There are two vectors 
-          <m>PQ</m> and <m>RS</m>. The vector <m>PQ</m> is drawn in the first quadrant from point 
-          <m>P=(1,0)</m> and <m>Q=(3,1)</m>. The second vector is in the second quadrant from point 
+          The <m>x</m> and <m>y</m> axes are drawn from <m>-4</m> to <m>4</m>. There are two vectors
+          <m>PQ</m> and <m>RS</m>. The vector <m>PQ</m> is drawn in the first quadrant from point
+          <m>P=(1,0)</m> and <m>Q=(3,1)</m>. The second vector is in the second quadrant from point
           <m>R=(-3, 1)</m> to <m>S=(-1,2)</m>.
         </p>
       </description>
@@ -264,7 +264,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -291,9 +291,9 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m> and <m>y</m> axes are drawn from <m>-4</m> to <m>4</m>. Two vectors are drawn. 
-                        The vector <m>PP’</m> is in the first quadrant it is downward facing, it starts from 
-                        <m>P=(3, 2)</m> and ends at <m>P'=(5, 1)</m> . The second vector <m>RS</m> from <m>(-3, -2)</m> 
+                        The <m>x</m> and <m>y</m> axes are drawn from <m>-4</m> to <m>4</m>. Two vectors are drawn.
+                        The vector <m>PP’</m> is in the first quadrant it is downward facing, it starts from
+                        <m>P=(3, 2)</m> and ends at <m>P'=(5, 1)</m> . The second vector <m>RS</m> from <m>(-3, -2)</m>
                         to <m>(-1, 2)</m>. This vector lies midway between the second and the third quadrant.
                       </p>
                     </description>
@@ -330,10 +330,10 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m> and <m>y</m> axes are drawn from <m>0</m> to <m>2</m>. The <m>z</m> axis is drawn 
-                        from <m>0</m> to <m>4</m>. The points <m>Q = (1, 1, 1)</m> and <m>Q'= (3, 0, 4)</m> along with 
+                        The <m>x</m> and <m>y</m> axes are drawn from <m>0</m> to <m>2</m>. The <m>z</m> axis is drawn
+                        from <m>0</m> to <m>4</m>. The points <m>Q = (1, 1, 1)</m> and <m>Q'= (3, 0, 4)</m> along with
                         the vector are drawn in space.
-                        A dashed cube is drawn with <m>Q</m> at the vertex furthest away from the origin. 
+                        A dashed cube is drawn with <m>Q</m> at the vertex furthest away from the origin.
                       </p>
                     </description>
                     <asymptote>
@@ -526,7 +526,7 @@
         <m>\vec u+\vec v</m> all with initial point at the origin.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         We first compute <m>\vec u +\vec v</m>.
@@ -545,12 +545,12 @@
           </shortdescription>
           <description>
             <p>
-              The <m>x</m> and y axes are drawn from <m>0</m> to <m>4</m>. Two vectors <m>\vec u</m> and <m>\vec v</m> 
-              are shown along with the vector addition of the two. The <m>\vec u</m> vector is drawn from point 
-              <m>(0,0)</m> to <m>(1,3)</m>. The <m>\vec v</m> vector is drawn from origin to <m>(2,1)</m>. The vector 
-              <m>\vec u</m> is longer than the <m>\vec v</m> vector. The <m>\vec u + \vec v</m> vector is drawn from 
+              The <m>x</m> and y axes are drawn from <m>0</m> to <m>4</m>. Two vectors <m>\vec u</m> and <m>\vec v</m>
+              are shown along with the vector addition of the two. The <m>\vec u</m> vector is drawn from point
+              <m>(0,0)</m> to <m>(1,3)</m>. The <m>\vec v</m> vector is drawn from origin to <m>(2,1)</m>. The vector
+              <m>\vec u</m> is longer than the <m>\vec v</m> vector. The <m>\vec u + \vec v</m> vector is drawn from
               the origin to <m>(3, 4)</m>.
-              The <m>\vec u + \vec v</m> vector is the longest and is in between the two vectors. 
+              The <m>\vec u + \vec v</m> vector is the longest and is in between the two vectors.
             </p>
           </description>
           <latex-image>
@@ -627,17 +627,17 @@
       </shortdescription>
       <description>
         <p>
-          The <m>x</m> and <m>y</m> axes are drawn from <m>0</m> to <m>4</m>. Two vectors <m>\vec u</m> and 
-          <m>\vec v</m> are shown along with the vector addition of the two. The <m>\vec u</m> vector is drawn 
-          from point <m>(0,0)</m> to <m>(1,3)</m>.  The <m>\vec v</m> vector is drawn from origin to <m>(2,1)</m>. 
+          The <m>x</m> and <m>y</m> axes are drawn from <m>0</m> to <m>4</m>. Two vectors <m>\vec u</m> and
+          <m>\vec v</m> are shown along with the vector addition of the two. The <m>\vec u</m> vector is drawn
+          from point <m>(0,0)</m> to <m>(1,3)</m>.  The <m>\vec v</m> vector is drawn from origin to <m>(2,1)</m>.
         </p>
         <p>
-          The <m>\vec v</m> vector is translated to start from the point <m>(1, 3)</m> to <m>(3, 4)</m> and it 
-          forms a triangle with <m>\vec u</m> and <m>u+v</m>. The <m>\vec u</m> vector is translated to start 
-          from point <m>(2, 1)</m> to point <m>(3, 4)</m>. The vector <m>\vec u</m> is longer than the <m>\vec v</m> 
-          vector and it forms a triangle with <m>\vec u</m> and <m>u+v</m>. The <m>\vec u + \vec v</m> vector is drawn 
+          The <m>\vec v</m> vector is translated to start from the point <m>(1, 3)</m> to <m>(3, 4)</m> and it
+          forms a triangle with <m>\vec u</m> and <m>u+v</m>. The <m>\vec u</m> vector is translated to start
+          from point <m>(2, 1)</m> to point <m>(3, 4)</m>. The vector <m>\vec u</m> is longer than the <m>\vec v</m>
+          vector and it forms a triangle with <m>\vec u</m> and <m>u+v</m>. The <m>\vec u + \vec v</m> vector is drawn
           from the origin to <m>(3, 4)</m>.
-          The <m>\vec u + \vec v</m> vector is the longest and is in between the two vectors. 
+          The <m>\vec u + \vec v</m> vector is the longest and is in between the two vectors.
         </p>
       </description>
       <latex-image>
@@ -706,7 +706,7 @@
         Compute and sketch <m>\vec u-\vec v</m>.
       </p>
     </statement>
-    
+
     <solution>
       <p>
         The computation of <m>\vec u-\vec v</m> is straightforward,
@@ -728,15 +728,15 @@
           </shortdescription>
           <description>
             <p>
-            The <m>x</m> axis is drawn from <m>0</m> to <m>4</m> and the <m>y</m> axis is drawn from <m>-1</m> to 
-            <m>3</m>. The <m>\vec u</m> vector is drawn from origin to point <m>(1, 2)</m>. The <m>\vec v</m> vector 
-            is drawn from the origin to <m>(2,1)</m>. The vector <m>\vec u - \vec v</m> is drawn from origin to 
-            <m>(2, -1)</m> and it lies in the fourth quadrant. 
+            The <m>x</m> axis is drawn from <m>0</m> to <m>4</m> and the <m>y</m> axis is drawn from <m>-1</m> to
+            <m>3</m>. The <m>\vec u</m> vector is drawn from origin to point <m>(1, 2)</m>. The <m>\vec v</m> vector
+            is drawn from the origin to <m>(2,1)</m>. The vector <m>\vec u - \vec v</m> is drawn from origin to
+            <m>(2, -1)</m> and it lies in the fourth quadrant.
             </p>
             <p>
-              The <m>\vec u - \vec v</m> vector is translated to start from point <m>(1, 2)</m> and ends at point 
-              <m>(3, 1)</m>. The <m>\vec v</m> vector is also translated but in the opposite direction and it starts 
-              from <m>(3, 1)</m> and ends at point <m>(2, -1)</m>.  
+              The <m>\vec u - \vec v</m> vector is translated to start from point <m>(1, 2)</m> and ends at point
+              <m>(3, 1)</m>. The <m>\vec v</m> vector is also translated but in the opposite direction and it starts
+              from <m>(3, 1)</m> and ends at point <m>(2, -1)</m>.
             </p>
           </description>
           <latex-image>
@@ -799,7 +799,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -821,9 +821,9 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> axis is drawn from <m>0</m> to <m>4</m> and the <m>y</m> axis is drawn from <m>-1</m> 
-                    to <m>3</m>. The <m>\vec v</m> vector is drawn from origin to point <m>(2,1)</m>, another vector 
-                    <m>2\vec v</m> is also drawn from origin to point <m>(4, 2)</m>. The two vectors have the same 
+                    The <m>x</m> axis is drawn from <m>0</m> to <m>4</m> and the <m>y</m> axis is drawn from <m>-1</m>
+                    to <m>3</m>. The <m>\vec v</m> vector is drawn from origin to point <m>(2,1)</m>, another vector
+                    <m>2\vec v</m> is also drawn from origin to point <m>(4, 2)</m>. The two vectors have the same
                     direction.
                   </p>
                 </description>
@@ -1058,7 +1058,7 @@
         </ol>
       </p>
     </statement>
-    
+
     <solution>
       <p>
         <ol>
@@ -1099,9 +1099,9 @@
                 </shortdescription>
                 <description>
                   <p>
-                    The <m>x</m> axis is drawn from <m>0</m> to <m>5</m> and the <m>y</m> axis is drawn from <m>0</m> 
-                    to <m>3</m>. The <m>\vec u</m> vector is drawn from origin to point <m>(1, 0.4)</m>, another vector 
-                    <m>\vec v</m> is also drawn from origin to point <m>(3, 1)</m>. The third vector <m>5\vec u</m> is 
+                    The <m>x</m> axis is drawn from <m>0</m> to <m>5</m> and the <m>y</m> axis is drawn from <m>0</m>
+                    to <m>3</m>. The <m>\vec u</m> vector is drawn from origin to point <m>(1, 0.4)</m>, another vector
+                    <m>\vec v</m> is also drawn from origin to point <m>(3, 1)</m>. The third vector <m>5\vec u</m> is
                     also drawn from the origin to point <m>(5, 1.5)</m>. The three vectors have the same direction.
                   </p>
                 </description>
@@ -1304,8 +1304,8 @@
           </shortdescription>
           <description>
             <p>
-              Image is of a weight of <m>50</m> pounds suspended by two chains. The chain on the left forms an angle 
-              of <m>30</m> degrees with the vertical and the chain on the left forms a degree of <m>45</m> with the 
+              Image is of a weight of <m>50</m> pounds suspended by two chains. The chain on the left forms an angle
+              of <m>30</m> degrees with the vertical and the chain on the left forms a degree of <m>45</m> with the
               vertical.
             </p>
           </description>
@@ -1334,7 +1334,7 @@
         <!-- figures/fig_vect6.tex END -->
       </figure>
     </statement>
-    
+
     <solution>
       <p>
         Knowing that gravity is pulling the 50lb weight straight down,
@@ -1382,7 +1382,7 @@
           </shortdescription>
           <description>
             <p>
-              Image shows the force vectors from the exercise. The vector <m>\vec F_2</m> is at an angle <m>45</m> 
+              Image shows the force vectors from the exercise. The vector <m>\vec F_2</m> is at an angle <m>45</m>
               from the horizontal and the vector <m>\vec F_1</m> forms an angle of <m>120</m> from the horizontal.
               A third vector representing the downward pull by gravity marked as <m>\vec F</m>.
             </p>
@@ -1555,8 +1555,8 @@
           </shortdescription>
           <description>
             <p>
-              Image shows a weight of <m>25</m> pounds being suspended by a chain. The chain forms an angle of 
-              <m>\theta</m> with the vertical, and an angle <m>\varphi</m> with the horizontal. The wind is pushing 
+              Image shows a weight of <m>25</m> pounds being suspended by a chain. The chain forms an angle of
+              <m>\theta</m> with the vertical, and an angle <m>\varphi</m> with the horizontal. The wind is pushing
               the weight to the right with force <m>\vec F_w</m>. The chain is of length <m>2</m> feet.
             </p>
           </description>
@@ -1809,7 +1809,7 @@
               <task label="ex-vector-between-points-1a">
                 <statement>
                   <p>
-                    in component form. 
+                    in component form.
                   </p>
 
                   <p>
@@ -2096,10 +2096,10 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m> and <m>y</m> axes are uncalibrated. Two vectors <m>\vec u</m> and <m>\vec v</m> 
-                        are shown, both starting at the origin and facing away. The vector <m>\vec u</m> is in the 
-                        first quadrant, and is bent close to the positive <m>x</m> axis, the <m>\vec v</m> vector is 
-                        in the third quadrant and is bent close to the negative <m>y</m> axis. The vector <m>\vec v</m> 
+                        The <m>x</m> and <m>y</m> axes are uncalibrated. Two vectors <m>\vec u</m> and <m>\vec v</m>
+                        are shown, both starting at the origin and facing away. The vector <m>\vec u</m> is in the
+                        first quadrant, and is bent close to the positive <m>x</m> axis, the <m>\vec v</m> vector is
+                        in the third quadrant and is bent close to the negative <m>y</m> axis. The vector <m>\vec v</m>
                         appears to be slightly longer than <m>\vec u</m> .
                       </p>
                     </description>
@@ -2180,9 +2180,9 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m> and <m>y</m> axes are uncalibrated. Two vectors <m>\vec u</m> and <m>\vec v</m> are shown, 
-                        both start at the origin and are facing away from each other. The <m>\vec u</m> vector is in the first 
-                        quadrant while the <m>\vec v</m> is in the third quadrant, the <m>\vec v</m> vector appears to be <m>1 / 4</m>  
+                        The <m>x</m> and <m>y</m> axes are uncalibrated. Two vectors <m>\vec u</m> and <m>\vec v</m> are shown,
+                        both start at the origin and are facing away from each other. The <m>\vec u</m> vector is in the first
+                        quadrant while the <m>\vec v</m> is in the third quadrant, the <m>\vec v</m> vector appears to be <m>1 / 4</m>
                         th <m>\vec u</m> .
                       </p>
                     </description>
@@ -2266,9 +2266,9 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. Two vectors <m>\vec u</m> and 
-                        <m>\vec v</m> are shown, both start at the origin and face away from each other. The vector 
-                        <m>\vec u</m> is longer and appears to be in the <m>zy</m> plane, and the vector <m>\vec v</m> 
+                        The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. Two vectors <m>\vec u</m> and
+                        <m>\vec v</m> are shown, both start at the origin and face away from each other. The vector
+                        <m>\vec u</m> is longer and appears to be in the <m>zy</m> plane, and the vector <m>\vec v</m>
                         is shorter and appears to be in the <m>xz</m> plane.
                       </p>
                     </description>
@@ -2369,11 +2369,11 @@
                     </shortdescription>
                     <description>
                       <p>
-                        The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. Two vectors <m>\vec u</m> and 
-                        <m>\vec v</m> are shown, both start at the origin. The <m>\vec u</m> vector is along the 
-                        positive <m>z</m> axis and the <m>\vec v</m> vector is along the positive <m>y</m> axis. 
+                        The <m>x</m>, <m>y</m> and <m>z</m> axes are uncalibrated. Two vectors <m>\vec u</m> and
+                        <m>\vec v</m> are shown, both start at the origin. The <m>\vec u</m> vector is along the
+                        positive <m>z</m> axis and the <m>\vec v</m> vector is along the positive <m>y</m> axis.
                       </p>
-                    </description>                      
+                    </description>
                     <latex-image>
 
                     \begin{tikzpicture}[&gt;=stealth]
@@ -2799,8 +2799,8 @@
               </shortdescription>
               <description>
                 <p>
-                  Image is of a weight of <m>100</m> pounds suspended by two chains. The chain on the left forms an 
-                  angle of <m>\varphi</m> degrees with the vertical and the chain on the right forms a degree of 
+                  Image is of a weight of <m>100</m> pounds suspended by two chains. The chain on the left forms an
+                  angle of <m>\varphi</m> degrees with the vertical and the chain on the right forms a degree of
                   <m>\theta</m> with the vertical.
                 </p>
               </description>
@@ -2920,8 +2920,8 @@
               </shortdescription>
               <description>
                 <p>
-                  Image shows a weight of <m>p</m> pounds being suspended by a chain. The chain forms an angle of 
-                  <m>\theta</m> with the vertical. The wind is pushing the weight to the right with force <m>\vec F_w</m>. 
+                  Image shows a weight of <m>p</m> pounds being suspended by a chain. The chain forms an angle of
+                  <m>\theta</m> with the vertical. The wind is pushing the weight to the right with force <m>\vec F_w</m>.
                   The chain is of length <m>\ell</m> feet.
                 </p>
               </description>

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -62,7 +62,7 @@
         <!-- START figures/fig_vvfintro1a.tex -->
           <image xml:id="img_vvfintro1a">
             <description>
-              Graph of the vector <m>\vec r(-2) =\la 4,1\ra</m>. 
+              Graph of the vector <m>\vec r(-2) =\la 4,1\ra</m>.
               This vector starts at the origin and ends at the point <m>(4,1)</m>.
             </description>
             <shortdescription>Graph of a vector whose terminal point corresponds to a point on the curve.</shortdescription>
@@ -93,11 +93,11 @@
         <!-- START figures/fig_vvfintro1.tex -->
           <image xml:id="img_vvfintro1b">
             <description>
-              The image contains the plot of the vector valued function <m>\vec r(t) = \la t^2,t^2+t-1\ra</m>. 
-              The image also contains the graph of the vector <m>\vec r(-2) =\la 4,1\ra</m>, which ends at a point on the function <m>\vec r(t)</m>. 
+              The image contains the plot of the vector valued function <m>\vec r(t) = \la t^2,t^2+t-1\ra</m>.
+              The image also contains the graph of the vector <m>\vec r(-2) =\la 4,1\ra</m>, which ends at a point on the function <m>\vec r(t)</m>.
               The function <m>\vec r(t)</m> resembles a parabola which has been rotated about <m>45</m> degrees clockwise.
               The function is plotted for <m>t</m> approximately between <m>-2.5</m> and <m>1.5</m>.
-              The function begins near the point <m>(5,2)</m> and then slopes down crossing the <m>x</m>-axis at approximately <m>x=2.5</m>. 
+              The function begins near the point <m>(5,2)</m> and then slopes down crossing the <m>x</m>-axis at approximately <m>x=2.5</m>.
               The slanted parabola then curves upwards around the point <m>(0,-1)</m>, from which point it begins increasing in both <m>x</m> and <m>y</m> as <m>t</m> increases.
             </description>
             <shortdescription>Graph of the vector and vector valued function from the example.</shortdescription>
@@ -147,7 +147,7 @@
           Sketch <m>\vec r(-1)</m> and <m>\vec r(2)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We start by making a table of <m>t</m>,
@@ -208,9 +208,9 @@
               <image xml:id="img_vvf1b">
                 <description>
                   The image contains the plot of the vector valued function <m>\vec r(t) = \la t^3-t, \frac{1}{t^2+1}\ra</m> for <m>-2\leq t\leq 2</m>.
-                  The image also contains the vectors <m>\vec r(-1) =\la 0,\frac12 \ra</m> and <m>\vec r(2) =\la 6,\frac15 \ra</m>, which both end at a point on the function <m>\vec r(t)</m>. 
-                  The function <m>\vec r(t)</m> begins at the point <m>(-6,\frac15)</m> corresponding to the lower bound of <m>t=-2</m>, from which it slowly slopes upwards until crossing the <m>y</m>-axis at <m>y=\frac12</m>. 
-                  From here, the function slopes upwards and slightly outwards away from the <m>y</m>-axis until curving back and crossing the <m>y</m>-axis once again at <m>y=1</m>. 
+                  The image also contains the vectors <m>\vec r(-1) =\la 0,\frac12 \ra</m> and <m>\vec r(2) =\la 6,\frac15 \ra</m>, which both end at a point on the function <m>\vec r(t)</m>.
+                  The function <m>\vec r(t)</m> begins at the point <m>(-6,\frac15)</m> corresponding to the lower bound of <m>t=-2</m>, from which it slowly slopes upwards until crossing the <m>y</m>-axis at <m>y=\frac12</m>.
+                  From here, the function slopes upwards and slightly outwards away from the <m>y</m>-axis until curving back and crossing the <m>y</m>-axis once again at <m>y=1</m>.
                   The function then slopes downwards and slightly away from the <m>y</m>-axis until curving back and crossing the <m>y</m>-axis again at <m>y=\frac12</m>, completing a loop.
                   After crossing the <m>y</m>-axis, the function continues slowly sloping downwards until reaching the point <m>(6,\frac15)</m> which corresponds to the upper bound of <m>t=2</m>.
                   The function is also symmetric about the <m>y</m>-axis.
@@ -260,7 +260,7 @@
           Graph <m>\vec r(t) = \la \cos(t) ,\sin(t) ,t\ra</m> for <m>0\leq t\leq 4\pi</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We can again plot points,
@@ -281,8 +281,8 @@
           <!-- START figures/figvvf2_3D.asy -->
           <image xml:id="img_vvf2" width="47%">
             <description>
-              The image contains the plot of the vector valued function <m>\vec r(t) = \la \cos(t) ,\sin(t) ,t\ra</m> for <m>0\leq t\leq 4\pi</m>. 
-              The image also contains the vector <m>\vec r(7\pi/4)\approx (0.707,-0.707,5.498)</m>, which corresponds to a point on the function <m>\vec r(t)</m>. 
+              The image contains the plot of the vector valued function <m>\vec r(t) = \la \cos(t) ,\sin(t) ,t\ra</m> for <m>0\leq t\leq 4\pi</m>.
+              The image also contains the vector <m>\vec r(7\pi/4)\approx (0.707,-0.707,5.498)</m>, which corresponds to a point on the function <m>\vec r(t)</m>.
               The function <m>\vec r(t)</m> begins at the point <m>(1,0,0)</m> corresponding to the lower bound of <m>t=0</m>.
               Ignoring the <m>z</m> coordinate of the vector valued function, the curve is simply a circle centered at the origin in the <m>xy</m> plane.
               The addition of the <m>z</m> coordinate given by <m>t</m> then makes this curve linearly increase at <m>t</m> increases.
@@ -395,7 +395,7 @@
           <m>\vec r(t)</m> and <m>5\vec r(t)</m> on <m>-10\leq t\leq10</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We can graph <m>\vec r_1</m> and
@@ -436,8 +436,8 @@
               <image xml:id="img_vvf3a">
                 <description>
                   The image contains the plot of the vector valued functions <m>\vec r_1(t) = \la 0.2t,0.3t \ra</m>, <m>\vec r_2(t) = \la \cos(t) ,\sin(t) \ra</m> on <m>-10\leq t\leq10</m>.
-                  The function <m>\vec r_1(t) = \la 0.2t,0.3t \ra</m> is a line which begins at the point <m>(-2,-3)</m> corresponding to <m>t=-10</m> and ends when <m>t=10</m> at the point <m>(2,3)</m>. 
-                  The second function <m>\vec r_2(t) = \la \cos(t) ,\sin(t) \ra</m> looks like a circle of radius <m>1</m>, but as <m>-10\leq t\leq10</m> the function completes <m>\frac{20}{2\pi}</m> full circular rotations, which cannot be seen in the graph. 
+                  The function <m>\vec r_1(t) = \la 0.2t,0.3t \ra</m> is a line which begins at the point <m>(-2,-3)</m> corresponding to <m>t=-10</m> and ends when <m>t=10</m> at the point <m>(2,3)</m>.
+                  The second function <m>\vec r_2(t) = \la \cos(t) ,\sin(t) \ra</m> looks like a circle of radius <m>1</m>, but as <m>-10\leq t\leq10</m> the function completes <m>\frac{20}{2\pi}</m> full circular rotations, which cannot be seen in the graph.
                 </description>
                 <shortdescription>Graph of the two vector valued functions prior to adding them together.</shortdescription>
                 <latex-image>
@@ -466,7 +466,7 @@
             <!-- START figures/fig_vvf3a.tex -->
               <image xml:id="img_vvf3b">
                 <description>
-                  The image contains the plot of the vector valued function <m>\vec r(t) = \vec r_1(t)+\vec r_2(t)</m>. 
+                  The image contains the plot of the vector valued function <m>\vec r(t) = \vec r_1(t)+\vec r_2(t)</m>.
                   The function is given by <m>\vec r(t) = \la\,\cos(t) + 0.2t,\sin(t) +0.3t\,\ra</m> on <m>-10\leq t\leq10</m>.
                   The function begins in the third quadrant, near the point <m>(-3,-2)</m>.
                   Near this point, the function is concave up, starting with a downward slope and later beginning to slope upwards.
@@ -500,7 +500,7 @@
             <!-- START figures/fig_vvf3b.tex -->
               <image xml:id="img_vvf3c">
                 <description>
-                  The image contains the plot of the vector valued function <m>5\vec r(t) = 5\vec r_1(t)+5\vec r_2(t)</m>. 
+                  The image contains the plot of the vector valued function <m>5\vec r(t) = 5\vec r_1(t)+5\vec r_2(t)</m>.
                   The function is now given by <m>\vec r(t) = \la\,5\cos(t) + t,5\sin(t) +1.5t\,\ra</m> on <m>-10\leq t\leq10</m>.
                   Compared to the unscaled function <m>\vec r(t)</m>, the function <m>5\vec r(t)</m> is exactly 5 times larger than the original function.
                   The function begins in the third quadrant, near the point <m>(-15,-10)</m>.
@@ -541,7 +541,7 @@
           which is graphed in <xref ref="fig_vvf3c"/> along with <m>\vec r(t)</m>.
           The new function is <q>5 times bigger</q> than <m>\vec r(t)</m>.
           Note how the graph of <m>5\vec r(t)</m> in <xref ref="fig_vvf3c"/> looks identical to the graph of <m>\vec r(t)</m> in <xref ref="fig_vvf3b"/>.
-          This is due to the fact that the <m>x</m> and <m>y</m> bounds of the plot in 
+          This is due to the fact that the <m>x</m> and <m>y</m> bounds of the plot in
           <xref ref="fig_vvf3c"/> are exactly 5 times larger than the bounds in <xref ref="fig_vvf3b"/>.
         </p>
       </solution>
@@ -567,7 +567,7 @@
           <caption>Tracing a cycloid</caption>
           <image xml:id="img_vvf4a" width="95%">
             <description>
-              The image shows the cycloid which comes from tracking a point <m>p</m> on a rolling circle of radius <m>1</m> on a flat surface. 
+              The image shows the cycloid which comes from tracking a point <m>p</m> on a rolling circle of radius <m>1</m> on a flat surface.
               The point <m>p</m> is initially at the top of the circle of radius <m>1</m>.
               Once the circle rolls, the point <m>p</m> is tracked to create a graph of a cycloid.
               The graph coming from tracking the point <m>p</m> first begins to decrease, until the point <m>p</m> is at the bottom of the circle, at which point the point <m>p</m> touches the surface the ball is rolling on.
@@ -599,7 +599,7 @@
         </figure>
         <!-- figures/fig_vvf4.tex END -->
       </statement>
-      
+
       <solution>
         <p>
           This problem is not very difficult if we approach it in a clever way.
@@ -641,7 +641,7 @@
           <!-- START figures/fig_vvf4a.tex -->
           <image xml:id="img_vvf4b" width="47%">
             <description>
-              The graph shows the function <m>\vec r(t) = \vec p(t) + \vec c(t) = \la \cos(t) + t,-\sin(t) +1\ra</m>, which is the graph of a cycloid which comes from tracking a point <m>p</m> on a rolling a circle of radius <m>1</m> on a flat surface. 
+              The graph shows the function <m>\vec r(t) = \vec p(t) + \vec c(t) = \la \cos(t) + t,-\sin(t) +1\ra</m>, which is the graph of a cycloid which comes from tracking a point <m>p</m> on a rolling a circle of radius <m>1</m> on a flat surface.
               The curve begins near the point <m>(0,2)</m>, after which it begins to decrease until it reaches its lowest point near the point <m>(2,0)</m>.
               After this point, the curve begins increasing, until it reaches its highest point when <m>p</m> is at the top of the circle, after which it decreases until reaching another minimum near the point <m>(8,0)</m>.
               The curve continues in the same fashion, reaching another minimum near the point <m>(14,0)</m>, after which it continues for a slight duration in the same fashion as before.
@@ -726,7 +726,7 @@
           and find the displacement of <m>\vec r(t)</m> on this interval.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           The function <m>\vec r(t)</m> traces out the unit circle,
@@ -742,7 +742,7 @@
           <!-- START figures/fig_vvf5.tex -->
           <image xml:id="img_vvf5" width="47%">
             <description>
-              Graph of the function <m>\vec r(t) = \la \cos(\frac{\pi}{2}t),\sin(\frac{\pi}2 t)\ra</m> on <m>-1\leq t\leq 1</m>. 
+              Graph of the function <m>\vec r(t) = \la \cos(\frac{\pi}{2}t),\sin(\frac{\pi}2 t)\ra</m> on <m>-1\leq t\leq 1</m>.
               The function <m>\vec r(t) </m> is the right half of the unit circle, beginning at the point <m>(0,-1)</m>, crossing the <m>x</m>-axis at the point <m>(1,0)</m>, and ending at the point <m>(0,-1)</m>.
               The graph also contains the displacement vector, which begins at the start of the curve at the point <m>(0,-1)</m> and heads directly upwards until reaching the endpoint of the curve at the point <m>(0,1)</m>.
             </description>
@@ -822,7 +822,7 @@
           <m>\vec r(t)</m> on <m>[-1,1]</m> and on <m>[-1,5]</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We computed in <xref ref="ex_vvf5"/>
@@ -970,7 +970,7 @@
                   <!-- START figures/fig_11_01_ex_03.tex -->
                   <image xml:id="img_11_01_ex_03X">
                     <description>
-                      Graph of the function <m>\vec r(t) = \la t^2,t^2-1\ra</m> for <m>-2\leq t\leq 2</m>. 
+                      Graph of the function <m>\vec r(t) = \la t^2,t^2-1\ra</m> for <m>-2\leq t\leq 2</m>.
                       The graph of the function <m>\vec r(t) </m> is a line which begins at the point <m>(0,-1)</m> and ends at the point <m>(4,3)</m>.
                       The function begins at the point <m>(4,3)</m> when <m>t=-2</m>, linearly decreases until the point <m>(0,-1)</m> and once again follows the same linear path until ending at the point <m>(4,3)</m>.
                     </description>
@@ -1013,7 +1013,7 @@
                   <!-- START figures/fig_11_01_ex_04.tex -->
                   <image xml:id="img_11_01_ex_04X">
                     <description>
-                      Graph of the function <m>\vec r(t) = \la t^2,t^3\ra</m>, for <m>-2\leq t\leq 2</m>. 
+                      Graph of the function <m>\vec r(t) = \la t^2,t^3\ra</m>, for <m>-2\leq t\leq 2</m>.
                       The graph of the function <m>\vec r(t) </m> begins at the point <m>(4,-8)</m>, and upwards and to the left in a concave down fashion until reaching the origin.
                       After reaching the origin, the function is concave and ends when it reaches the point <m>(4,8)</m>.
                       The function is also symmetric about the <m>x</m>-axis, meaning that the upper and lower half of the curves are mirror images of each other.
@@ -1111,7 +1111,7 @@
                       The function continues to decrease, crossing the <m>x</m>axis at <m>x=1</m>.
                       After this, the function continues to decrease until reaching a minimum near the point <m>(0.25,-1)</m>, after which it curves upwards until it reaches the origin.
                       The function now increases upwards and to the right until reaching a maximum near point <m>(0.25,1)</m>.
-                      After this point, the curve decreases, crossing the <m>x</m>-axis once again at <m>x=1</m>. 
+                      After this point, the curve decreases, crossing the <m>x</m>-axis once again at <m>x=1</m>.
                       The function now continues decreasing until it reaches a minimum near the point <m>(2.25,-1)</m> after which it begins to increase, until ending at its starting point of <m>(\frac{(2\pi)^2}{10},0)</m>.
                       The function is also symmetric about the <m>x</m>-axis.
                     </description>
@@ -1160,7 +1160,7 @@
                       The function continues to decrease, crossing the <m>x</m>axis at <m>x=1</m>.
                       After this, the function continues to decrease until reaching a minimum near the point <m>(0.25,-1)</m>, after which it curves upwards until it reaches the origin.
                       The function now increases upwards and to the right until reaching a maximum near point <m>(0.25,1)</m>.
-                      After this point, the curve decreases, crossing the <m>x</m>-axis once again at <m>x=1</m>. 
+                      After this point, the curve decreases, crossing the <m>x</m>-axis once again at <m>x=1</m>.
                       The function now continues decreasing until it reaches a minimum near the point <m>(2.25,-1)</m> after which it begins to increase, until ending at its starting point of <m>(\frac{(2\pi)^2}{10},0)</m>.
                       The function is also symmetric about the <m>x</m>-axis.
                     </description>
@@ -1206,8 +1206,8 @@
                     <description>
                       Graph of the function <m>\vec r(t) = \la 3\sin(\pi t),2\cos(\pi t)\ra</m>, on <m>[0,2]</m>.
                       The graph of the function <m>\vec r(t) </m> is an oval having a horizontal width of <m>6</m> and a height of <m>4</m> centered at the origin.
-                      The rightmost point of the oval is the point <m>(3,0)</m>. 
-                      The leftmost point of the oval is the point <m>(-3,0)</m>. 
+                      The rightmost point of the oval is the point <m>(3,0)</m>.
+                      The leftmost point of the oval is the point <m>(-3,0)</m>.
                       The highest point of the oval is the point <m>(0,2)</m>, while the lowest is the point <m>(0,-2)</m>.
                     </description>
                     <shortdescription>Graph of the vector valued function from the example.</shortdescription>
@@ -1254,10 +1254,10 @@
                       The graph of the function <m>\vec r(t) </m> resembles the symbol <m>\infty</m>.
                       The curve begins at the point <m>(3,0)</m> which corresponds to <m>t=0</m>.
                       The curve then begins going upwards and to the left, until it reaches a maximum near the point <m>(2,2)</m>.
-                      From here the curve begins going downwards and to the left, passing through the origin, until reaching a minimum near <m>(-2,-2)</m>. 
+                      From here the curve begins going downwards and to the left, passing through the origin, until reaching a minimum near <m>(-2,-2)</m>.
                       The curve then begins going upwards to the left, passing through the point <m>(-3,0)</m>, after which it begins going to the right.
                       The curve reaches a maximum near the point <m>(-2,2)</m>, after which it begins decreasing and going to the right, once again crossing the origin.
-                      Finally, the curve reaches another minimum near the point <m>(2,-2)</m>, after which it begins going upwards to the right, until reaching its starting point given by <m>(3,0)</m>. 
+                      Finally, the curve reaches another minimum near the point <m>(2,-2)</m>, after which it begins going upwards to the right, until reaching its starting point given by <m>(3,0)</m>.
                       The curve is symmetric about both the <m>x</m> and <m>y</m> axes.
                     </description>
                     <shortdescription>Graph of the vector valued function from the example.</shortdescription>
@@ -1301,11 +1301,11 @@
                   <image xml:id="img_11_01_ex_10X">
                     <description>
                       Graph of the function <m>\vec r(t) = \la 2\sec(t) ,\tan(t) \ra</m>, on <m>[-\pi,\pi]</m>.
-                      The graph of the function is symmetric about both the <m>x</m> and <m>y</m> axes. 
+                      The graph of the function is symmetric about both the <m>x</m> and <m>y</m> axes.
                       The curve crosses the <m>x</m>-axis at the point <m>x=2</m> corresponding to <m>t=\pi</m>.
-                      After this point the upper part of the curve goes upwards and to the right in a mostly linear fashion. 
+                      After this point the upper part of the curve goes upwards and to the right in a mostly linear fashion.
                       Since the curve is symmetric about the <m>y</m>-axis, the lower part of the curve is the mirrored version of the upper part, meaning that it goes downwards and to the left.
-                      As the curve is symmetric about the <m>x</m>-axis, the left side of the curve is the mirrored version of the right part, meaning that it crosses the <m>x</m>-axis at <m>x=-2</m>. 
+                      As the curve is symmetric about the <m>x</m>-axis, the left side of the curve is the mirrored version of the right part, meaning that it crosses the <m>x</m>-axis at <m>x=-2</m>.
                       From this point, the upper part of the left side of the curve goes upwards and to the left, while the lower part goes downwards and to the left.
                     </description>
                     <shortdescription>Graph of the vector valued function from the example.</shortdescription>
@@ -1360,7 +1360,7 @@
                   <image xml:id="img_11_01_ex_11X">
                     <description>
                       Graph of the function <m>\vec r(t) = \la 2\cos(t) , t, 2\sin(t) \ra</m>, on <m>[0,2\pi]</m>.
-                      The graph of the function is a circular spiral centered about the <m>y</m>-axis. 
+                      The graph of the function is a circular spiral centered about the <m>y</m>-axis.
                       Ignoring the <m>y</m>-axis, the curve is simply a singular circle of radius <m>2</m> in the <m>xz</m>-plane.
                       Incorporating the <m>y</m> coordinate then creates the linearly increasing spiral, which begins at the point <m>(2,0,0)</m>, completes precisely one full revolution and ends at the point <m>(2,2\pi,0)</m>.
                     </description>
@@ -1412,7 +1412,7 @@
                   <image xml:id="img_11_01_ex_12X">
                     <description>
                       Graph of the function <m>\vec r(t) = \la 3\cos(t) , \sin(t) , t/\pi\ra</m> on <m>[0,2\pi]</m>.
-                      The graph of the function is an oval-shaped spiral centered about the <m>z</m>-axis. 
+                      The graph of the function is an oval-shaped spiral centered about the <m>z</m>-axis.
                       Ignoring the <m>z</m>-axis, the curve is simply an oval having a horizontal width of <m>6</m> and a height of <m>2</m> in the <m>xy</m>-plane.
                       Incorporating the <m>z</m> coordinate then creates the linearly increasing oval spiral, which begins at the point <m>(3,0,0)</m>, completes precisely one full revolution and ends at the point <m>(3,0,2)</m>.
                     </description>
@@ -1463,7 +1463,7 @@
                   <image xml:id="img_11_01_ex_13X">
                     <description>
                       Graph of the function <m>\vec r(t) = \la \cos(t) , \sin(t) ,\sin(t) \ra</m> on <m>[0,2\pi]</m>.
-                      The graph of the function is an oval lying in the plane coming from rotating the <m>xy</m> plane <m>45</m> degrees towards the <m>z</m>-axis. 
+                      The graph of the function is an oval lying in the plane coming from rotating the <m>xy</m> plane <m>45</m> degrees towards the <m>z</m>-axis.
                       The oval lying in this plane has a horizontal width of <m>\sqrt{2}</m> and a height of <m>1</m>.
                       Ignoring the <m>z</m> coordinate, the curve is a unit circle in the <m>xy</m> plane.
                       Similarly ignoring the <m>y</m> coordinate, the curve is a unit circle in the <m>xz</m> plane.
@@ -1517,14 +1517,14 @@
                   <image xml:id="img_11_01_ex_14X">
                     <description>
                       Graph of the function <m>\vec r(t) = \la \cos(t) , \sin(t) ,\sin(2t)\ra</m> on <m>[0,2\pi]</m>.
-                      The graph of the function resembles a saddle centered at the origin whose height is defined by the <m>z</m>-axis. 
+                      The graph of the function resembles a saddle centered at the origin whose height is defined by the <m>z</m>-axis.
                       The two sides of the saddle that taper off fall into negative <m>z</m> and lie in the second and third quadrants in the <m>xy</m> plane.
                       Ignoring the <m>z</m> coordinate, the curve is a unit circle in the <m>xy</m> plane.
                       Ignoring the <m>x</m> or <m>y</m> coordinates individually, the curve looks like the <m>\infty</m> symbol in the <m>yz</m> and the <m>xz</m> planes, respectively.
                       We now describe the <m>z</m> coordinate with respect to travelling along the unit circle in the <m>xy</m> plane.
                       Starting at <m>t=</m>, the function begins at the point <m>(1,0,0)</m>.
                       As <m>t</m> increases and we travel along the unit circle in the <m>x</m> and <m>y</m> coordinates, <m>z</m> increases until we get to <m>t=\frac{\pi}{2}</m> at which <m>z=1</m>.
-                      Then, continuing along the unit circle, <m>z</m> decreases until it reaches a minimum of <m>z=-1</m> when <m>t=\frac{3\pi}{4}</m>. 
+                      Then, continuing along the unit circle, <m>z</m> decreases until it reaches a minimum of <m>z=-1</m> when <m>t=\frac{3\pi}{4}</m>.
                       Continuing along the circle, <m>z</m> begins to increase once again, reaching one more maximum of <m>z=1</m> when <m>t=\frac{5\pi}{4}</m>.
                       Finally, <m>z</m> begins to decrease, reaching its last minimum of <m>z=1</m> when <m>t=\frac{7\pi}{4}</m>, after which <m>z</m> increases, and the curve ends where it began, at the point <m>(1,0,0)</m>.
                     </description>

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -147,10 +147,7 @@
           Sketch <m>\vec r(-1)</m> and <m>\vec r(2)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="wXzQo0ce3Us" xml:id="vid-vvf-vvfintro-graph" label="vid-vvf-vvfintro-graph" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We start by making a table of <m>t</m>,
@@ -250,6 +247,10 @@
           </sidebyside>
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="wXzQo0ce3Us" xml:id="vid-vvf-vvfintro-graph" label="vid-vvf-vvfintro-graph" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_vvf2">
@@ -259,10 +260,7 @@
           Graph <m>\vec r(t) = \la \cos(t) ,\sin(t) ,t\ra</m> for <m>0\leq t\leq 4\pi</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="N1qqqHWR6yw" xml:id="vid-vvf-vvfintro-graph3d" label="vid-vvf-vvfintro-graph3d" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We can again plot points,
@@ -333,6 +331,10 @@
           <!-- figures/figvvf2_3D.asy END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="N1qqqHWR6yw" xml:id="vid-vvf-vvfintro-graph3d" label="vid-vvf-vvfintro-graph3d" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -393,10 +395,7 @@
           <m>\vec r(t)</m> and <m>5\vec r(t)</m> on <m>-10\leq t\leq10</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="6A3op7KYppw" xml:id="vid-vvf-vvfintro-algebra-eg" label="vid-vvf-vvfintro-algebra-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We can graph <m>\vec r_1</m> and
@@ -546,6 +545,10 @@
           <xref ref="fig_vvf3c"/> are exactly 5 times larger than the bounds in <xref ref="fig_vvf3b"/>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="6A3op7KYppw" xml:id="vid-vvf-vvfintro-algebra-eg" label="vid-vvf-vvfintro-algebra-eg" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_vvf4">
@@ -596,10 +599,7 @@
         </figure>
         <!-- figures/fig_vvf4.tex END -->
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="BH9FZMTdgQw" xml:id="vid-vvf-vvfintro-cycloid" label="vid-vvf-vvfintro-cycloid" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           This problem is not very difficult if we approach it in a clever way.
@@ -667,6 +667,10 @@
           <!-- figures/fig_vvf4a.tex END -->
         </figure>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="BH9FZMTdgQw" xml:id="vid-vvf-vvfintro-cycloid" label="vid-vvf-vvfintro-cycloid" component="video"/>
+      </solution>
     </example>
   </subsection>
 
@@ -722,10 +726,7 @@
           and find the displacement of <m>\vec r(t)</m> on this interval.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="eGsIv3hYlak" xml:id="vid-vvf-vvfintro-displacement-eg" label="vid-vvf-vvfintro-displacement-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           The function <m>\vec r(t)</m> traces out the unit circle,
@@ -774,6 +775,10 @@
           along with the displacement vector <m>\vec d</m> on this interval.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="eGsIv3hYlak" xml:id="vid-vvf-vvfintro-displacement-eg" label="vid-vvf-vvfintro-displacement-eg" component="video"/>
+      </solution>
     </example>
 
     <p>
@@ -817,10 +822,7 @@
           <m>\vec r(t)</m> on <m>[-1,1]</m> and on <m>[-1,5]</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="REA-v1g68bo" xml:id="vid-vvf-vvfintro-average" label="vid-vvf-vvfintro-average" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We computed in <xref ref="ex_vvf5"/>
@@ -854,6 +856,10 @@
           to arrive at the same place,
           this average rate of change on <m>[-1,5]</m> is <m>1/3</m> the average rate of change on <m>[-1,1]</m>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="REA-v1g68bo" xml:id="vid-vvf-vvfintro-average" label="vid-vvf-vvfintro-average" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -109,7 +109,7 @@
           Find <m>\lim\limits_{t\to 0}\vec r(t)</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We apply the theorem and compute limits component-wise.
@@ -231,7 +231,7 @@
               The function <m>\vec r</m> is a small part of a concave down circular arc.
               The graph includes the vectors <m>\vec r (t_0)</m> and <m>\vec r (t_1)</m>, which begin from the origin and end at the corresponding point of the function <m>\vec r </m>.
               The graph also includes the vector <m>\vec r (t_1) - \vec r (t_0)</m>, which begins where <m>\vec r (t_0)</m> ends, and then terminates at the same termination point as <m>\vec r (t_1)</m>.
-              The three vectors <m>\vec r (t_0)</m>, <m>\vec r (t_1)</m> and <m>\vec r (t_1) - \vec r (t_0)</m> for a triangle, where following the path of  <m>\vec r (t_0)</m> and <m>\vec r (t_1) - \vec r (t_0)</m> takes you to the same point as  <m>\vec r (t_1)</m>. 
+              The three vectors <m>\vec r (t_0)</m>, <m>\vec r (t_1)</m> and <m>\vec r (t_1) - \vec r (t_0)</m> for a triangle, where following the path of  <m>\vec r (t_0)</m> and <m>\vec r (t_1) - \vec r (t_0)</m> takes you to the same point as  <m>\vec r (t_1)</m>.
               The vector  <m>\vec r (t_0)</m> terminates on the left side of the circular arc, while <m>\vec r (t_1)</m> terminates further on the right side of the circular arc of given by the function <m>\vec r</m>.
             </description>
             <shortdescription>Illustration of a vector-valued function on a given interval.</shortdescription>
@@ -423,7 +423,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -463,7 +463,7 @@
                       <description>
                         Graph of the vector-valued function <m>\vec r(t) = \la t^2,t\ra</m>.
                         The graph of the function <m>\vec r(t) </m> is simply the graph of the parabola <m>y=x^2</m>, but instead of opening towards the positive <m>y</m>-axis, the function <m>\vec r(t) </m> opens towards the positive <m>x</m>-axis.
-                        The function <m>\vec r(t) </m> is plotted on the interval <m>[-2,2]</m>, where <m>\vec r(-2)= \la 4,-2\ra</m> and <m>\vec r(2)= \la 4,2\ra</m>. 
+                        The function <m>\vec r(t) </m> is plotted on the interval <m>[-2,2]</m>, where <m>\vec r(-2)= \la 4,-2\ra</m> and <m>\vec r(2)= \la 4,2\ra</m>.
                         The graph also includes the derivative function <m> \vrp(t) = \la 2t, 1\ra </m> which takes the path of the horizontal line <m>y=1</m> going from left to right in the standard coordinate axes.
                       </description>
                       <shortdescription>Graph of the vector-valued function from the example and its derivative.</shortdescription>
@@ -501,7 +501,7 @@
                       <description>
                         Graph of the vector-valued function <m>\vec r(t) = \la t^2,t\ra</m> described in the previous image.
                         The graph also includes two copies of the vector <m>\vrp(1) = \la 2,1\ra</m>.
-                        The first copy of the vector <m>\vrp(1) = \la 2,1\ra</m> begins at the origin, and ends at the point <m>(2,1)</m>, which is also a point on the derivative function <m> \vrp(t) = \la 2t, 1\ra </m> from the previous image. 
+                        The first copy of the vector <m>\vrp(1) = \la 2,1\ra</m> begins at the origin, and ends at the point <m>(2,1)</m>, which is also a point on the derivative function <m> \vrp(t) = \la 2t, 1\ra </m> from the previous image.
                         The second copy of the vector <m>\vrp(1) = \la 2,1\ra</m> begins at the point <m>(1,1)</m>, which corresponds to the termination point of <m>\vec r(1) = \la 1,1 \ra</m>.
                         The second copy of the vector <m>\vrp(1) = \la 2,1\ra</m> is tangent to the function <m>\vec r(t) = \la t^2,t\ra</m> at the point <m>(1,1)</m> corresponding to when <m>t=1</m> in the function <m> \vec r(t)</m>.
                       </description>
@@ -570,7 +570,7 @@
               Looking at the graph from above the <m>z</m>-axis, the function resembles a unit circle in the <m>xy</m>-plane.
               Adding the <m>z</m> coordinate then creates the linearly increasing spiral.
               The graph also includes two copies of the vector <m>\vrp(\pi/2) = \la -1,0,1\ra</m>
-              The first copy of the vector <m>\vrp(\pi/2) = \la -1,0,1\ra</m> begins at the origin, and ends at the point <m>(-1,0,1)</m>. 
+              The first copy of the vector <m>\vrp(\pi/2) = \la -1,0,1\ra</m> begins at the origin, and ends at the point <m>(-1,0,1)</m>.
               The second copy of the vector <m>\vrp(\pi/2) = \la -1,0,1\ra</m> begins at the point <m>(0,1,\pi/2)</m>, which corresponds to the termination point of <m>\vec r(\pi/2)</m>.
               The second copy of the vector <m>\vrp(\pi/2) = \la -1,0,1\ra</m> is also tangent to the function <m>\vec r(t) </m> at the point <m>(0,1,\pi/2)</m> corresponding to when <m>t=\pi/2</m> in the function <m> \vec r(t)</m>.
             </description>
@@ -682,7 +682,7 @@
           Find the vector equation of the line tangent to the graph of <m>\vec r</m> at <m>t=-1</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           To find the equation of a line,
@@ -710,7 +710,7 @@
               The function begins at the point <m>(-1.5,2.25,-3.375)</m>, from which it begins to increase linearly in the <m>x</m> and <m>z</m> coordinates, and decrease in the <m>y</m> coordinate.
               The function then curves towards the origin.
               After passing through the origin, the function begins to increase in all <m>x</m>,<m>y</m> and <m>z</m> coordinates until it reaches the point <m>(1.5,2.25,3.375)</m>, at which it ends.
-              The graph also contains the line <m>\ell(t) = \la -1,1,-1\ra + t\la 1,-2,3\ra</m>, which is the tangent line to the function at <m>\vec r(-1)</m>, which is the point <m>(-1,1,-1)</m>. 
+              The graph also contains the line <m>\ell(t) = \la -1,1,-1\ra + t\la 1,-2,3\ra</m>, which is the tangent line to the function at <m>\vec r(-1)</m>, which is the point <m>(-1,1,-1)</m>.
               The line can be described as the line which passes through the point <m>(-1,1,-1)</m>, moving in the direction of the vector <m>\la 1,-2,3\ra</m>.
               Additionally, the line is defined for all <m>t</m>, so it also moves in the opposite direction of the vector <m>\la 1,-2,3\ra</m>, or in other words in the direction of <m>\la -1,2,-3\ra</m> from the point <m>(-1,1,-1)</m>.
             </description>
@@ -775,7 +775,7 @@
           <m>\vec r(t) = \la t^3,t^2\ra</m> at <m>t=-1</m> and <m>t=0</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We find that <m>\vrp(t) = \la 3t^2,2t\ra</m>.
@@ -967,7 +967,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -991,10 +991,10 @@
                   <description>
                     Graph of the vector-valued function <m>\vec r(t) = \la t,t^2 -1\ra</m> on <m>[-2,2]</m>.
                     The function looks like the parabola <m>y=x^2 -1</m>, which takes the path going towards positive <m>x</m>.
-                    The function begins at the point <m>(-2,3)</m>, decreases until reaching the point <m>(0,-1)</m>, and then increases until ending at the point <m>(2,3)</m>. 
+                    The function begins at the point <m>(-2,3)</m>, decreases until reaching the point <m>(0,-1)</m>, and then increases until ending at the point <m>(2,3)</m>.
                     The graph also contains the function <m>\vec u(t)</m> which is the unit vector that points in the direction of <m>\vec r(t)</m>.
                     The function <m>\vec u(t)</m> looks like the unit circle which is missing a piece of the top.
-                    The circular arc from the graph of <m>\vec u(t)</m> begins at the point where the vector <m>\vec r(-2)=\la -2,3\ra </m> crosses the unit circle. 
+                    The circular arc from the graph of <m>\vec u(t)</m> begins at the point where the vector <m>\vec r(-2)=\la -2,3\ra </m> crosses the unit circle.
                     The circular arc then goes counterclockwise following the path of the unit circle, until ending at the point where the vector<m>\vec r(2)=\la 2,3\ra </m> crosses the unit circle.
                   </description>
                   <shortdescription>Graph of the vector-valued function with the unit vector function which points in the direction of the function.</shortdescription>
@@ -1066,13 +1066,13 @@
                 <image xml:id="img_vvfderiv2b" width="47%">
                   <description>
                     Graph of the function <m>\vec u(t)</m> which is the unit vector that points in the direction of <m>\vec r(t)</m>.
-                    The graph also contains three unit vectors, <m>\vec u\,'(-2)</m>, <m>\vec u\,'(-1)</m> and <m>\vec u\,'(0)</m>. 
+                    The graph also contains three unit vectors, <m>\vec u\,'(-2)</m>, <m>\vec u\,'(-1)</m> and <m>\vec u\,'(0)</m>.
                     The vector <m>\vec u\,'(-2)\approx \la -0.320,-0.213\ra</m> begins at the starting point of the function <m>\vec u(t)</m> and points in the direction tangent to the circular arc at <m>t=-2</m>.
                     The vector <m>\vec u\,'(-1)= \la 0,-2\ra</m> begins at the point <m>(-1,0)</m> corresponding to the termination point of <m>\vec u(-1)</m>
                     From here, the vector points straight down, as it is tangent to the leftmost point of the circular arc.
-                    The vector <m>\vec u\,'(0)= \la 1,0\ra</m> begins at the point <m>(0,-1)</m> corresponding to the termination point of <m>\vec u(0)</m>. 
+                    The vector <m>\vec u\,'(0)= \la 1,0\ra</m> begins at the point <m>(0,-1)</m> corresponding to the termination point of <m>\vec u(0)</m>.
                     From here the vector points to the right, as it is tangent to the bottom point of the circular arc.
-                    If the vectors <m>\vec u\,'(-2)</m>, <m>\vec u\,'(-1)</m> and <m>\vec u\,'(0)</m> were extended to lines, all three lines would be tangent to a point on the nearly complete unit circle given by <m>\vec u(t)</m>. 
+                    If the vectors <m>\vec u\,'(-2)</m>, <m>\vec u\,'(-1)</m> and <m>\vec u\,'(0)</m> were extended to lines, all three lines would be tangent to a point on the nearly complete unit circle given by <m>\vec u(t)</m>.
                   </description>
                   <shortdescription>Graph of the circular unit vector function along with three derivative vectors of the function.</shortdescription>
                   <latex-image>
@@ -1274,7 +1274,7 @@
           Evaluate <m>\ds \int_0^1 \vec r(t) \,dt</m>.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           We follow <xref ref="thm_vvf_integration"/>.
@@ -1317,7 +1317,7 @@
           </ul>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           Knowing <m>\vrp'(t) = \la 2,\cos(t) , 12t\ra</m>,
@@ -1831,7 +1831,7 @@
                     <description>
                       Graph of the function <m>\vec r(t) = \la t^2-2t+2,t^3-3t^2+2t\ra</m>.
                       The function <m>\vec r(t) </m> begins in the fourth quadrant, and begins heading upwards and to the left towards the point <m>(2,0)</m>.
-                      After crossing this point, the curve loops up into the first quadrant and back down until it reaches the point <m>(1,0)</m>. 
+                      After crossing this point, the curve loops up into the first quadrant and back down until it reaches the point <m>(1,0)</m>.
                       From this point, the curve loops down into the fourth quadrant and back up until it once again reaches the point <m>(2,0)</m>, from which it begins increasing in both <m>x</m> and <m>y</m> coordinates in the first quadrant.
                       The graph of the function is also symmetric about the <m>y</m>-axis.
                       The graph also contains <m>\vrp(1)</m> beginning at the point <m>(1,0)</m> corresponding to the termination point of <m>\vec r(1)</m>.
@@ -1881,7 +1881,7 @@
                     <description>
                       Graph of the function <m>\vec r(t) = \la t^2+1,t^3-t\ra</m>.
                       The function <m>\vec r(t) </m> begins in the fourth quadrant, and begins heading upwards and to the left towards the point <m>(2,0)</m>.
-                      After crossing this point, the curve loops up into the first quadrant and back down until it reaches the point <m>(1,0)</m>. 
+                      After crossing this point, the curve loops up into the first quadrant and back down until it reaches the point <m>(1,0)</m>.
                       From this point, the curve loops down into the fourth quadrant and back up until it once again reaches the point <m>(2,0)</m>, from which it begins increasing in both <m>x</m> and <m>y</m> coordinates in the first quadrant.
                       The graph of the function is also symmetric about the <m>y</m>-axis.
                       The graph also contains <m>\vrp(1)</m> beginning at the point <m>(2,0)</m> corresponding to the termination point of <m>\vec r(1)</m>.
@@ -1931,7 +1931,7 @@
                     <description>
                       Graph of the function <m>\vec r(t) = \la t^2-4t+5,t^3-6t^2+11t-6\ra</m>.
                       The function <m>\vec r(t) </m> begins in the fourth quadrant, and begins heading upwards and to the left towards the point <m>(2,0)</m>.
-                      After crossing this point, the curve loops up into the first quadrant and back down until it reaches the point <m>(1,0)</m>. 
+                      After crossing this point, the curve loops up into the first quadrant and back down until it reaches the point <m>(1,0)</m>.
                       From this point, the curve loops down into the fourth quadrant and back up until it once again reaches the point <m>(2,0)</m>, from which it begins increasing in both <m>x</m> and <m>y</m> coordinates in the first quadrant.
                       The graph of the function is also symmetric about the <m>y</m>-axis.
                       The graph also contains <m>\vrp(1)</m> beginning at the point <m>(2,0)</m> corresponding to the termination point of <m>\vec r(1)</m>.

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -109,10 +109,7 @@
           Find <m>\lim\limits_{t\to 0}\vec r(t)</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="FCFNyv2V8yk" xml:id="vid-vvf-calc-limit-eg" label="vid-vvf-calc-limit-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We apply the theorem and compute limits component-wise.
@@ -121,6 +118,10 @@
             <mrow>\amp = \la 1,3,1\ra</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="FCFNyv2V8yk" xml:id="vid-vvf-calc-limit-eg" label="vid-vvf-calc-limit-eg" component="video"/>
       </solution>
     </example>
   </subsection>
@@ -422,10 +423,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="vcTn9uy2Fi8" xml:id="vid-vvf-calc-deriv-eg" label="vid-vvf-calc-deriv-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -537,6 +535,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="vcTn9uy2Fi8" xml:id="vid-vvf-calc-deriv-eg" label="vid-vvf-calc-deriv-eg" component="video"/>
       </solution>
     </example>
 
@@ -680,10 +682,7 @@
           Find the vector equation of the line tangent to the graph of <m>\vec r</m> at <m>t=-1</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="mG-r7_uCzSk" xml:id="vid-vvf-calc-tangent-eg" label="vid-vvf-calc-tangent-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           To find the equation of a line,
@@ -762,6 +761,10 @@
           This line and <m>\vec r(t)</m> are sketched in <xref ref="fig_vvfderiv1"/>.
         </p>
       </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="mG-r7_uCzSk" xml:id="vid-vvf-calc-tangent-eg" label="vid-vvf-calc-tangent-eg" component="video"/>
+      </solution>
     </example>
 
     <example xml:id="ex_vvfderiv3">
@@ -772,10 +775,7 @@
           <m>\vec r(t) = \la t^3,t^2\ra</m> at <m>t=-1</m> and <m>t=0</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="czvJ5AtLpa4" xml:id="vid-vvf-calc-tangent-eg2" label="vid-vvf-calc-tangent-eg2" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We find that <m>\vrp(t) = \la 3t^2,2t\ra</m>.
@@ -839,6 +839,10 @@
           We cannot apply <xref ref="def_vector_tangent"/>,
           hence cannot find the equation of the tangent line.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="czvJ5AtLpa4" xml:id="vid-vvf-calc-tangent-eg2" label="vid-vvf-calc-tangent-eg2" component="video"/>
       </solution>
     </example>
 
@@ -963,10 +967,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="sD1mgVOWQFo" xml:id="vid-vvf-calc-deriv-prop-eg" label="vid-vvf-calc-deriv-prop-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1110,6 +1111,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="sD1mgVOWQFo" xml:id="vid-vvf-calc-deriv-prop-eg" label="vid-vvf-calc-deriv-prop-eg" component="video"/>
       </solution>
     </example>
 
@@ -1269,10 +1274,7 @@
           Evaluate <m>\ds \int_0^1 \vec r(t) \,dt</m>.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="57pkOzkF7TE" xml:id="vid-vvf-calc-integration-eg" label="vid-vvf-calc-integration-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           We follow <xref ref="thm_vvf_integration"/>.
@@ -1284,6 +1286,10 @@
             <mrow>\amp \approx \la 3.19,0.460\ra</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="57pkOzkF7TE" xml:id="vid-vvf-calc-integration-eg" label="vid-vvf-calc-integration-eg" component="video"/>
       </solution>
     </example>
 
@@ -1311,10 +1317,7 @@
           </ul>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="0-1B6C9jj9k" xml:id="vid-vvf-calc-ivp-eg" label="vid-vvf-calc-ivp-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           Knowing <m>\vrp'(t) = \la 2,\cos(t) , 12t\ra</m>,
@@ -1364,6 +1367,10 @@
             <mrow> \amp = \la t^2+5t-7,-\cos(t) +3t,2t^3+2\ra</mrow>
           </md>.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="0-1B6C9jj9k" xml:id="vid-vvf-calc-ivp-eg" label="vid-vvf-calc-ivp-eg" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -5,7 +5,7 @@
     <p>
       A common use of vector-valued functions is to describe the motion of an object in the plane or in space.
       A <em>position function</em>
-      <m>\vec r(t)</m> gives the position of an object at <em>time</em> <m>t</m>. More formally, let <m>O = \vec 0 </m> (either in the plane or in space) and suppose an object is at point <m>P_c</m> at time <m>t=t_c</m>. Then <m>\vec r\big(t_c\big) = \overrightarrow{OP_c}</m>; that is, the vector <m>\vec r\big(t_c\big)</m> <q>points</q> to the location of the object at a given time. 
+      <m>\vec r(t)</m> gives the position of an object at <em>time</em> <m>t</m>. More formally, let <m>O = \vec 0 </m> (either in the plane or in space) and suppose an object is at point <m>P_c</m> at time <m>t=t_c</m>. Then <m>\vec r\big(t_c\big) = \overrightarrow{OP_c}</m>; that is, the vector <m>\vec r\big(t_c\big)</m> <q>points</q> to the location of the object at a given time.
       This section explores how derivatives and integrals are used to study the motion described by such a function.
     </p>
 
@@ -88,7 +88,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -490,7 +490,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>
@@ -836,7 +836,7 @@
           assuming the bb is fired at the advertised rate of <quantity><mag>350</mag><unit base="foot"/><per base="second"/></quantity> and ignoring air resistance.
         </p>
       </statement>
-      
+
       <solution>
         <p>
           A direct application of <xref ref="idea_projectile"/> gives
@@ -1045,7 +1045,7 @@
           </ol>
         </p>
       </statement>
-      
+
       <solution>
         <p>
           <ol>

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -88,10 +88,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="qpQidOR7TQQ" xml:id="vid-vvf-motion-example-velacc" label="vid-vvf-motion-example-velacc" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -241,6 +238,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="qpQidOR7TQQ" xml:id="vid-vvf-motion-example-velacc" label="vid-vvf-motion-example-velacc" component="video"/>
       </solution>
     </example>
 
@@ -489,10 +490,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="qrNYh5hmyLE" xml:id="vid-vvf-motion-example-ball" label="vid-vvf-motion-example-ball" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -652,6 +650,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="qrNYh5hmyLE" xml:id="vid-vvf-motion-example-ball" label="vid-vvf-motion-example-ball" component="video"/>
       </solution>
     </example>
 
@@ -834,10 +836,7 @@
           assuming the bb is fired at the advertised rate of <quantity><mag>350</mag><unit base="foot"/><per base="second"/></quantity> and ignoring air resistance.
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="9_Ev_uu0Y74" xml:id="vid-vvf-motion-projectile-eg" label="vid-vvf-motion-projectile-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           A direct application of <xref ref="idea_projectile"/> gives
@@ -866,6 +865,10 @@
           we find the <m>x</m>-component of our position function is <m>346.67(2.03) = 703.74\,\text{ft}</m>.
           The bb lands about 704 feet away.
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="9_Ev_uu0Y74" xml:id="vid-vvf-motion-projectile-eg" label="vid-vvf-motion-projectile-eg" component="video"/>
       </solution>
     </example>
 
@@ -1042,10 +1045,7 @@
           </ol>
         </p>
       </statement>
-      <solution component="video">
-        <title>Video solution</title>
-        <video width="98%" youtube="vLSocZ7XLQM" xml:id="vid-vvf-motion-distance-eg" label="vid-vvf-motion-distance-eg" component="video"/>
-      </solution>
+      
       <solution>
         <p>
           <ol>
@@ -1138,6 +1138,10 @@
             </li>
           </ol>
         </p>
+      </solution>
+      <solution component="video">
+        <title>Video solution</title>
+        <video width="98%" youtube="vLSocZ7XLQM" xml:id="vid-vvf-motion-distance-eg" label="vid-vvf-motion-distance-eg" component="video"/>
       </solution>
     </example>
 

--- a/ptx/sec_work.ptx
+++ b/ptx/sec_work.ptx
@@ -534,7 +534,7 @@
               Image of a cylindrical storage tank with a radius of <quantity><mag>10</mag><unit base="foot"/></quantity> and a height of 30ft.
               On the left side of the storage tank the <m>y</m>-axis is shown with measurements of <m>y=0</m> at the base of the tank, <m>y=30</m> and the top of the tank, and <m>y=35</m> 5 feet above the tank.
               The image also contains the <m>i</m>th subinterval of <m>y</m>, which corresponds to the shaded region between <m>y_{i-1}</m> and <m>y_i</m> on the <m>y</m>-axis.
-              The height of this subinterval of <m>y</m> given by <m>y_{i}-y_{i-1}</m> is also labeled <m>\Delta y_i</m>. 
+              The height of this subinterval of <m>y</m> given by <m>y_{i}-y_{i-1}</m> is also labeled <m>\Delta y_i</m>.
               Additionally, the distance from the top of this subinterval, occuring at <m>y_{i}</m> and the point <m>5</m> feet above the tank is given on the <m>y</m>-axis as <m>35-y_i</m>.
             </description>
             <shortdescription>Illustration of a cylindrical water tank with measurements used to compute the work required to empty it.</shortdescription>
@@ -650,7 +650,7 @@
           Image of the same cylindrical storage tank with a radius of <quantity><mag>10</mag><unit base="foot"/></quantity> and a height of <quantity><mag>30</mag><unit base="foot"/></quantity>.
           On the left side of the storage tank the <m>y</m>-axis is shown with measurements of <m>y=0</m> at the base of the tank, <m>y=30</m> and the top of the tank, and <m>y=35</m> 5 feet above the tank.
           Now instead of containing the <m>i</m>th subinterval of <m>y</m>, the image contains an arbitrarily chosen point <m>y</m> which is contained in the tank.
-          At this point <m>y</m>, the volume is given as <m>V(y)=100\pi dy</m>, where <m>d</m> is the arbitrarily short distance between the top and bottom of the thin slice of water in the tank at the point <m>y</m>. 
+          At this point <m>y</m>, the volume is given as <m>V(y)=100\pi dy</m>, where <m>d</m> is the arbitrarily short distance between the top and bottom of the thin slice of water in the tank at the point <m>y</m>.
           Additionally, the distance from the arbitrary point <m>y</m> and the point <m>5</m> feet above the tank is given on the <m>y</m>-axis as <m>35-y</m>.
         </description>
         <shortdescription>Illustration of a cylindrical water tank with simplified measurements used to compute the work required to empty it.</shortdescription>
@@ -726,7 +726,7 @@
               This means as we move further below ground level, the area of the circular cross-section of the conical storage tank decreases.
               On the left side of the storage tank the <m>y</m>-axis is shown with measurements of <m>y=3</m> which is 3 feet above the tank, <m>y=0</m> which is the top of the tank, and <m>y=-10</m> which is the tip of the cone, 10 feet below ground level.
               The image contains an arbitrarily chosen point <m>y</m> between <m>y=-10</m> and <m>y=0</m> which is contained in the tank.
-              At this point <m>y</m>, the volume is given as <m>V(y)=\pi (\frac{y}{5} + 2)^2 dy</m>, where <m>d</m> is the arbitrarily short distance between the top and bottom of the thin slice of water in the tank at the point <m>y</m>. 
+              At this point <m>y</m>, the volume is given as <m>V(y)=\pi (\frac{y}{5} + 2)^2 dy</m>, where <m>d</m> is the arbitrarily short distance between the top and bottom of the thin slice of water in the tank at the point <m>y</m>.
               Additionally, the distance from the arbitrary point <m>y</m> and the point <m>3</m> feet above the tank is given on the <m>y</m>-axis as <m>3-y</m>.
             </description>
             <shortdescription>Illustration of a conical water tank with measurements used to compute the work required to empty it.</shortdescription>
@@ -806,12 +806,12 @@
             <description>
               Image of the swimming pool described in the example.
               The pool is <quantity><mag>25</mag><unit base="foot"/></quantity> long.
-              On the leftmost side of the image is the deep end of the pool, which is 
+              On the leftmost side of the image is the deep end of the pool, which is
               <quantity><mag>10</mag><unit base="foot"/></quantity> long having a depth of <quantity><mag>6</mag><unit base="foot"/></quantity>.
-              After the <quantity><mag>10</mag><unit base="foot"/></quantity> mark, 
-              the bottom of the pool slopes up until it rises to a depth of <quantity><mag>3</mag><unit base="foot"/></quantity> 
+              After the <quantity><mag>10</mag><unit base="foot"/></quantity> mark,
+              the bottom of the pool slopes up until it rises to a depth of <quantity><mag>3</mag><unit base="foot"/></quantity>
               a distance of <quantity><mag>5</mag><unit base="foot"/></quantity> away in the <m>x</m> dimension.
-              The shallow end of the pool has a depth of <quantity><mag>3</mag><unit base="foot"/></quantity> 
+              The shallow end of the pool has a depth of <quantity><mag>3</mag><unit base="foot"/></quantity>
               and length of <quantity><mag>10</mag><unit base="foot"/></quantity>.
               The end of the shallow end marks the end of the pool.
             </description>
@@ -843,7 +843,7 @@
           <image xml:id="img_pump3a" width="47%">
             <description>
               Image of the same swimming pool described in the example.
-              The image now contains the two coordinate axes <m>x</m> and <m>y</m>. 
+              The image now contains the two coordinate axes <m>x</m> and <m>y</m>.
               On the <m>y</m> axis are five markings.
               The label <m>y=0</m> marks the bottom of the deep end of the pool, the label <m>y=3</m> marks the bottom of the shallow end of the pool.
               The label <m>y=6</m> marks the top of the water in the pool, and the label <m>y=8</m> marks a point <quantity><mag>2</mag><unit base="foot"/></quantity> above the top of the water.
@@ -1161,9 +1161,9 @@
       <exercise label="ex-work-5">
         <introduction>
           <p>
-            A crane lifts a <quantity><mag>2000</mag><unit base="pound"/></quantity>  
-            load vertically <quantity><mag>30</mag><unit base="foot"/></quantity> 
-            with a <quantity><mag>1</mag><unit base="inch"/></quantity>  cable weighing 
+            A crane lifts a <quantity><mag>2000</mag><unit base="pound"/></quantity>
+            load vertically <quantity><mag>30</mag><unit base="foot"/></quantity>
+            with a <quantity><mag>1</mag><unit base="inch"/></quantity>  cable weighing
             <quantity><mag>1.68</mag><unit base="pound"/><per base="foot"/></quantity>.
           </p>
         </introduction>
@@ -1527,7 +1527,7 @@
         <task label="ex-work-20b">
           <statement>
             <p>
-              Find the work performed in pumping the top 
+              Find the work performed in pumping the top
               <quantity><mag>2.5</mag><unit base="meter"/></quantity> of water to the top of the tank.
             </p>
           </statement>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # <!-- Managed automatically by PreTeXt authoring tools -->
-pretext == 2.3.9
+pretext == 2.4.0


### PR DESCRIPTION
When I put the video solutions into their own solution knowl, they ended up as the first solution, because I could do this with an easy find+replace (and some regex).

But video solutions should not come first. I finally did the manual work required to put the video solutions after the text solutions, so that the text solution comes first.

So in HTML, instead of seeing:
> Solution 1 (Video Solution)
> Solution 2

we will see

> Solution 1
> Solution 2 (Video Solution)

This will affect placement of QR codes in the margin for PDF that includes video links, but I suppose that's my problem.

I also cleaned up some trailing whitespace.