### PR TITLE
Add image descriptions for vectors chapter

### DIFF
--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -129,7 +129,25 @@
     </p>
 
     <image width="47%">
-      <description/>
+      <shortdescription>Schematic diagram for computing the cross product by multiplying along diagonal arrows.</shortdescription>
+      <description>
+        <p>
+          The image illustrates how to use the array given above, with the two repeated columns,
+          to compute the cross product.
+          From the top row, diagonal arrows are drawn down and to the right,
+          starting in the first three columns from <m>\vec i</m>, <m>\vec j</m>, and <m>vec k</m>.
+          Diagonal arrows are also drawn down and to the left,
+          starting in the last three columns from <m>\vec k</m>, <m>\vec i</m>, and <m>\vec j</m>.
+          (Recall that the last two columns are copies of the first two.)
+        </p>
+
+        <p>
+          The cross product is computed by multiplying along each arrow.
+          The quantities obtained from the right-pointing arrows are added,
+          while the quantities obtained from the left-pointing arrows are subtracted.
+          The result of the product along each arrow is indicated at the tip of that arrow.
+        </p>
+      </description>
       <latex-image label="img_intro3">
 
         \begin{tikzpicture}[&gt;=stealth]
@@ -477,7 +495,21 @@
 
         <!-- START figures/figcrossp_rhr_3D.asy -->
         <image width="47%">
-          <description/>
+          <shortdescription>Three-dimensional image illustrating the right-hand rule for the direction of the cross product.</shortdescription>
+          <description>
+            <p>
+              On a three-dimensional coordinate system, with <m>x</m>, <m>y</m>, and <m>z</m> axes,
+              vectors <m>\vec u</m> and <m>\vec v</m> are plotted with their tails at the origin.
+              The plane passing through the origin that contains these two vectors is also plotted,
+              along with a normal vector to the plane.
+            </p>
+
+            <p>
+              The normal vector is upward-pointing, and is equal to the cross product <m>\vec{u}\times\vec{v}</m>.
+              When the plane is viewed from the side on which the normal vector is placed,
+              the position of the vector <m>\vec v</m> corresponds to a counter-clockwise rotation from the position of <m>\vec u</m>.
+            </p>
+          </description>
           <asymptote label="img_crossp_rhr">
 
 
@@ -567,7 +599,17 @@
             <caption/>
             <!-- START figures/fig_crossp_parallelogram1.tex -->
             <image>
-              <description/>
+              <shortdescription>A parallelogram with base b and height h labeled.</shortdescription>
+              <description>
+                <p>
+                  A parallelogram with a horizontal base is shown.
+                  The base is labeled with the quantity <m>b</m>.
+                  A dashed line is drawn from the top-left vertex of the parallelogram to the base;
+                  this line is perpendicular to the base, 
+                  and its length is equal to the height of the parallelogram,
+                  which is labeled <m>h</m>.
+                </p>
+              </description>
               <latex-image label="img_crossp_parallelograma">
 
               \begin{tikzpicture}
@@ -587,7 +629,18 @@
             <caption/>
             <!-- START figures/fig_crossp_parallelogram2.tex -->
             <image>
-              <description/>
+              <shortdescription>Another parallelogram, with two adjacent sides labeled as vectors.</shortdescription>
+              <description>
+                <p>
+                  The parallelogram is the same one as <xref ref="fig_crossp_parallelograma"/>,
+                  but with different labeling.
+                  This time, the two sides adjacent to the bottom-right vertex are labeled with vectors.
+                  The bottom of the parallelogram is labeled with a vector <m>\vec v</m>,
+                  and the left side is labeled with a vector <m>\vec u</m>.
+                  The angle between these vectors is labeled <m>\theta</m>.
+                  The same altitude of the parellelogram is drawn as a dashed line with height <m>h</m>.
+                </p>
+              </description>
               <latex-image label="img_crossp_parallelogramb">
 
               \begin{tikzpicture}[&gt;=stealth]
@@ -657,7 +710,21 @@
                       <caption/>
                     <!-- START figures/fig_crossp4b.tex -->
                     <image>
-                      <description/>
+                      <shortdescription>A parallelogram in the plane, spanned by vectors u and v.</shortdescription>
+                      <description>
+                        <p>
+                          The first quadrant in <m>\R^2</m> is shown.
+                          Two vectors a drawn with their tails at the origin.
+                          The vector <m>\vec u</m> ends at the point <m>(2,1)</m>,
+                          while the vector <m>\vec v</m> ends at the point <m>(1,3)</m>.
+                        </p>
+
+                        <p>
+                          These vectors make up two of the four sides of the parallelogram.
+                          The side from <m>(1,3)</m> to <m>(3,4)</m> is parallel to <m>\vec u</m>,
+                          and the side from <m>(2,1)</m> to <m>(3,4)</m> is parallel to <m>\vec v</m>.
+                        </p>
+                      </description>
                       <latex-image label="img_crossp4a">
 
                         \begin{tikzpicture}[&gt;=stealth]
@@ -689,7 +756,14 @@
 
                     <!-- START figures/figcrossp4a_3D.asy -->
                       <image>
-                        <description/>
+                        <shortdescription>A three-dimensional image of a parallelogram in space, with vertices A, B, C, and D.</shortdescription>
+                        <description>
+                          <p>
+                            A three-dimensional coordinate system is shown, with <m>x</m>, <m>y</m>, and <m>z</m> axes.
+                            A parallelogram is shown in space relative to these axes,
+                            with vertices labeled <m>A</m>, <m>B</m>, <m>C</m>, and <m>D</m>.
+                          </p>
+                        </description>
                         <asymptote label="img_crossp4b_3D">
 
 
@@ -780,7 +854,14 @@
             <caption>Finding the area of a triangle in <xref ref="ex_crossp5"/></caption>
             <!-- START figures/fig_crossp5.tex -->
             <image width="47%">
-              <description/>
+              <shortdescription>A triangle in the plane, with vertices A(1,2), B(2,3), and C(3,1).</shortdescription>
+              <description>
+                <p>
+                  The triangle for this problem is sketched in the first quadrant of the plane.
+                  The vertices are labeled, with <m>A</m> at <m>(1,2)</m>, 
+                  <m>B</m> at <m>(2,3)</m>, and <m>C</m> at <m>(3,1)</m>.
+                </p>
+              </description>
               <latex-image label="img_crossp5">
 
               \begin{tikzpicture}
@@ -863,7 +944,17 @@
 
         <!-- START figures/figcrosspparallelpiped_3D.asy -->
         <image width="47%">
-          <description/>
+          <shortdescription>A parellelepiped in three dimensions. It is the box-like object spanned by three vectors.</shortdescription>
+          <description>
+            <p>
+              Three vectors <m>\vec u</m>, <m>\vec v</m>, and <m>\vec w</m> are plotted in three dimensions.
+              These vectors make up three edges of a three-dimensional solid known as a parallelepiped.
+              Each side of the parallelepiped is a parallelogram, and opposite sides are equal parallelograms lying in parallel planes.
+              One pair of opposite sides comes from the parallelogram spanned by <m>\vec u</m> and <m>\vec v</m>,
+              another from the parallelogram spanned by <m>\vec v</m> and <m>\vec w</m>,
+              and the last pair from the parallelogram spanned by <m>\vec u</m> and <m>\vec w</m>.
+            </p>
+          </description>
           <asymptote label="img_crossp_parallelepiped">
 
 
@@ -994,7 +1085,20 @@
 
             <!-- START figures/figcrossp6_3D.asy -->
             <image width="47%">
-              <description/>
+              <shortdescription>The parallelepiped whose volume is computed in this example.</shortdescription>
+              <description>
+                <p>
+                  A parallelpiped is plotted against a three-dimensional coordinate system,
+                  with <m>x</m>, <m>y</m>, and <m>z</m> axes.
+                  Vectors <m>\vec{u}, \vec{v}, \vec{w}</m> are plotted with their tails at the origin,
+                  although the vector <m>\vec{v}</m> is not visible in the default view of the parallelepiped.
+                  (It can be seen once the image is rotated.)
+                </p>
+
+                <p>
+                  These vectors make up the three edges of the parallelepiped that are adjacent to the origin.
+                </p>
+              </description>
               <asymptote label="img_crossp6">
 
 
@@ -1116,7 +1220,28 @@
             <caption>Showing a force being applied to a lever in <xref ref="ex_crossp7"/></caption>
             <!-- START figures/fig_crossp7.tex -->
             <image width="47%">
-              <description/>
+              <shortdescription>Two adjacent images, each showing a pair of vectors, one of which represents a lever, and the other, a force.</shortdescription>
+              <description>
+                <p>
+                  Two images are shown side-by-side.
+                  Both images show a pair of vectors, one of which is labeled <m>\vec l</m> (the lever),
+                  and the other, which is labeled <m>\vec F</m> (the force).
+                </p>
+
+                <p>
+                  In each image, the vector <m>\vec l</m> has its tail at a pivot point.
+                  A circular arrow is drawn around this point to show the direction of rotation of the lever about the pivot.
+                  The direction is clockwise in each image.
+                </p>
+
+                <p>
+                  The force vector <m>\vec F</m> is drawn with its tip at the tip of the vector <m>\vec l</m>.
+                  In both images, the vector <m>\vec l</m> points up and to the right,
+                  and the vector <m>\vec F</m> points down and to the right.
+                  The difference is that in the first image, the vectors meet at a <m>90^\circ</m> angle,
+                  while in the second image, the angle is <m>60^\circ</m>.
+                </p>
+              </description>
               <latex-image label="img_crossp7">
 
               \begin{tikzpicture}[&gt;=stealth]

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -617,15 +617,15 @@
               the vertical line starts at <m>(0, 1)</m> and ends at <m>(0, -1)</m>.
             </p>
             <p>
-              The right Triangle is made up of the points <m>(0, 0)</m>, 
+              The right triangle is made up of the points <m>(0, 0)</m>, 
               <m>(1, \tan(\theta))</m>, and <m>(1, 0)</m>. The acute Triangle is made
               of the points <m>(0, 0)</m>, <m>(\cos(\theta), \sin(\theta))</m>, and
               <m>(1, 0)</m>. The angle at point <m>(0, 0)</m> is labeled as <m>\theta</m>
             </p>
           </description>
           <shortdescription>
-            Illustration of a unit Circle, with a right and acute Triangle in 
-            quadrant one.
+            Illustration of a unit circle, with a right and acute triangle in 
+            the first quadrant.
           </shortdescription>
           <latex-image>
             \begin{tikzpicture}
@@ -688,7 +688,7 @@
                 </p>
               </description>
               <shortdescription>
-                right triangle housing an acute triangle and sector of a circle.
+                Right triangle housing an acute triangle and sector of a circle.
               </shortdescription>
               <latex-image>
                 \begin{tikzpicture}[x=100pt,y=100pt]

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -39,16 +39,16 @@
           <description>
             <p>
               Graph of <m>\sin(x)/x</m> showing the domain and range of  
-              <m>-7</m>to <m>7</m> and <m>0</m> to 
-              <m>1</m> respectively. <m>x</m> intercepts are at 
-              <m>x=--2\pi, -\pi, \pi. 2\pi</m> and a <m>y</m> intercept is at <m>y = 1</m>. 
+              <m>-7</m> to <m>7</m> and <m>0</m> to 
+              <m>1</m> respectively. The <m>x</m> intercepts are at 
+              <m>x=-2\pi, -\pi, \pi</m>, and <m>2\pi</m>, and a <m>y</m> intercept is at <m>y = 1</m>. 
               The function has a downward curve for <m>-\pi \lt x \lt \pi</m> and an 
               upward curve for <m>-2\pi \gt x \lt -\pi</m>, and 
               <m>\pi \gt x \lt 2\pi</m>. The graph is undefined for <m>x = 0</m>.
             </p>
           </description>
           <shortdescription>
-            Graph of sinx/x, shows values for the domain -7 &lt;=x &lt;=7,
+            Graph of sin(x)/x, shows values for the domain -7 &lt;=x &lt;=7,
             undefined at x = 0. 
           </shortdescription>
           <latex-image>
@@ -77,13 +77,13 @@
             <p>
               Graph of <m>\sin(x)/x</m> zoomed in on values where <m>x</m> is near <m>1</m>. The 
               domain of the graph is <m>0.5</m> to <m>1.5</m>. 
-              The line has only a slight downward curve. It shows that for <m>x = 1</m>, 
+              The graph has only a slight downward curve. It shows that for <m>x = 1</m>, 
               <m>\sin(x)/x</m> is approx. <m>0.84</m>
             </p>
           </description>
           <shortdescription> 
-            Graph of sinx / x zoomed in on values where x is near 1. Shows that for x = 1, 
-            sinx/x is approx. 0.84.
+            Graph of sin(x)/x zoomed in on values where x is near 1. Shows that for x = 1, 
+            sin(x)/x is approx. 0.84.
           </shortdescription>
           <latex-image>
             \begin{tikzpicture}
@@ -144,8 +144,8 @@
           </p>
         </description>
         <shortdescription> 
-          Graph of sinx/x zoomed in on values where x is near 0. Shows that when x = 0 
-          sinx/x is undefined.
+          Graph of sin(x)/x zoomed in on values where x is near 0. Shows that when x = 0 
+          sin(x)/x is undefined.
         </shortdescription>
         <latex-image>
           \begin{tikzpicture}[

--- a/ptx/sec_lines.ptx
+++ b/ptx/sec_lines.ptx
@@ -51,7 +51,17 @@
 
       <!-- START figures/figlines_intro_3D.asy -->
       <image width="47%">
-        <description/>
+        <shortdescription>In three dimensions, vectors p (position), d (direction), and p+d are plotted. A line passes through the tips of p and p+d.</shortdescription>
+        <description>
+          <p>
+            In a three-dimensional coordinate system, vectors <m>\vec d</m> and <m>\vec p</m> are plotted with their tails at the origin,
+            along with their sum, <m>\vec{p}+\vec{d}</m>.
+            The vector <m>\vec{p}</m> is the position vector for a line, which is also shown.
+            The line passes through the tips of <m>\vec{p}</m> and <m>\vec{p}+\vec{d}</m>,
+            since the difference <m>(\vec{p}+\vec{d})-\vec{p}=\vec d</m> is the direction vector of the line.
+            Also plotted is the vector <m>\vec{p}-2\vec{d}</m>, which points to another point on the line.
+          </p>
+        </description>
         <asymptote label="img_lines_intro">
 
 
@@ -117,7 +127,26 @@
     <figure xml:id="fig_lines_eq">
       <caption>Understanding the vector equation of a line</caption>
       <image width="47%">
-        <description/>
+        <shortdescription>A text description, comparing the elements the equations of a line in the plane, and in space.</shortdescription>
+        <description>
+          <p>
+            On the left is the equation <m>y=mx+b</m> for a line in the plane with slope <m>m</m> and <m>y</m> intercept <m>b</m>.
+            On the right is the equation <m>\vec{\ell}(t) = \vec p + t\vec d</m> for a line in space
+            through the point <m>\vec p</m> with direction vector <m>\vec d</m>.
+          </p>
+
+          <p>
+            Above the two equations is the text <q>Starting Point</q>.
+            From this text are two arrows, pointing to the value <m>b</m> in the plane equation, and the value <m>\vec p</m> in the space equation.
+            Also above the equations is the text <q>Direction</q>.
+            From this text, two arrows point to the value <m>m</m> in the plane equation, and the value <m>\vec d</m> in the space equation.
+          </p>
+
+          <p>
+            Below the two equations is the text <q>How Far To Go In That Direction</q>.
+            Arrows point from this text to the value <m>x</m> in the plane equation, and the value <m>t</m> in the space equation.
+          </p>
+        </description>
         <latex-image label="img_lines_intro_3D">
 
         \begin{tikzpicture}[&gt;=stealth]
@@ -292,7 +321,16 @@
 
           <!-- START figures/figlines1_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>A line in space with direction vector d passes through a point P.</shortdescription>
+            <description>
+              <p>
+                A set three-dimensional coordinate axes is shown.
+                A vector <m>\vec d</m> is plotted with its tail at the origin of this coordinate system;
+                it is the direction vector for a line. The line is also plotted,
+                and is shown passing through a point <m>P</m>.
+                An additional point <m>Q</m> is in the image, but it is not on the line.
+              </p>
+            </description>
             <asymptote label="img_lines1">
 
 
@@ -404,7 +442,15 @@
 
           <!-- START figures/figlines6_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>A line in space passes through points P and Q. The vector PQ between these points is also shown.</shortdescription>
+            <description>
+              <p>
+                Two points <m>P</m> and <m>Q</m> are plotted in space, against a set of three-dimensional coordinate axes.
+                The vector <m>\overrightarrow{PQ}</m> is plotted as an arrow pointing from <m>P</m> to <m>Q</m>.
+                The line passing through <m>P</m> and <m>Q</m> is also plotted;
+                between <m>P</m> and <m>Q</m>, it overlaps with the vector <m>\overrightarrow{PQ}</m>.
+              </p>
+            </description>
             <asymptote label="img_lines6">
 
 
@@ -556,7 +602,23 @@
 
           <!-- START figures/figlines2_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>A three dimensional plot of two lines in space. The lines are not parallel, and they do not intersect.</shortdescription>
+            <description>
+              <p>
+                A set of three-dimensional coordinate axes are shown,
+                with labels <m>x</m>, <m>y</m>, and <m>z</m>, as usual.
+                Two points <m>P_1</m> and <m>P_2</m> are plotted.
+                The point <m>P_1</m> is in the <m>xy</m> plane,
+                while the point <m>P_2</m> is higher up, near the top of the figure.
+              </p>
+
+              <p>
+                Through each of the two points, a line is drawn.
+                The line through <m>P_1</m> has a direction vector <m>\vec{d}_1</m> 
+                that points in a different direction from that of the direction vector <m>\vec{d}_2</m> of the line through <m>P_2</m>,
+                so the lines are not parallel. It also appears from the figure that the lines do not intersect.
+              </p>
+            </description>
             <asymptote label="img_lines2">
 
 
@@ -736,7 +798,21 @@
 
           <!-- START figures/figlines3_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>A plot in space of a single line through two points, with two parallel direction vectors shown next to it.</shortdescription>
+            <description>
+              <p>
+                Two points <m>P_1</m> and <m>P_2</m> are plotted in a three-dimensional coordinate system.
+                A line is shown passing through these two points.
+                Next to the line, two vectors are plotted.
+                The vector <m>\vec{d}_1</m> points downward, in the direction of the line.
+                The vector <m>\vec{d}_2</m> points in the opposite direction, and is twice as long.
+              </p>
+
+              <p>
+                The diagram shows that the line through <m>P_1</m> in the direction of <m>\vec{d}_1</m>
+                is in fact the same as the line through <m>P_2</m> in the direction of <m>\vec{d}_2</m>.
+              </p>
+            </description>
             <asymptote label="img_lines3">
 
 
@@ -820,7 +896,19 @@
       <caption>Establishing the distance from a point to a line</caption>
       <!-- START figures/fig_lines_dist1.tex -->
       <image width="33%">
-        <description/>
+        <shortdescription>A line through a point P, with direction d. Near the line is a point Q, whose distance to the line is shown as the height h of a triangle.</shortdescription>
+        <description>
+          <p>          
+            A generic line is shown, without coordinates.
+            On the line is a point <m>P</m> and a direction vector <m>\vec{d}</m>.
+            Near the line is a point <m>Q</m>.
+            The vector <m>\overrightarrow{PQ}</m> points from the point <m>P</m> on the line to the point <m>Q</m> off the line.
+            This vector forms the hypotenuse of a right-angled triangle whose base is part of the line,
+            and whose height, <m>h</m>, is shown as a dashed line segment from <m>Q</m> to the line.
+            The angle <m>\theta</m> between <m>\vec d</m> and <m>\overrightarrow{PQ}</m> is also shown.
+            The height <m>h</m> is the perpendicular distance from <m>Q</m> to the line.
+          </p>
+        </description>
         <latex-image label="img_lines_dist1">
 
         \begin{tikzpicture}[&gt;=stealth]
@@ -881,7 +969,21 @@
 
       <!-- START figures/figlines_dist2_3D.asy -->
       <image width="47%">
-        <description/>
+        <shortdescription>Two skew lines in space are plotted with respective points and direction vectors. The distance h between them is indicated.</shortdescription>
+        <description>
+          <p>
+            Two lines in space are shown, without a coordinate system.
+            The lines pass, respectively, through points <m>P_1</m> and <m>P_2</m>,
+            and have respective direction vectors <m>\vec{d}_1</m> and <m>\vec{d}_2</m>.
+          </p>
+
+          <p>
+            The vector <m>\overrightarrow{P_1P_2}</m> is shown pointing from the first line to the second.
+            Also shown is the cross product <m>\vec{c}=\vec{d}_1\times\vec{d}_2</m>;
+            this vector is perpendicular to both lines. 
+            The distance <m>h</m> between the lines is shown as a segment parallel to <m>\vec c</m>.
+          </p>
+        </description>
         <asymptote label="img_lines_dist2">
 
 

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -15,7 +15,14 @@
 
       <!-- START figures/figplanes_intro_3D.asy -->
       <image width="47%">
-        <description/>
+        <shortdescription>A nail sticks into a flat, rectangular sheet of cardboard.</shortdescription>
+        <description>
+          <p>
+            A flat, rectangular surface represents a sheet of cardboard.
+            The image of a nail is drawn sticking into the sheet, at a point <m>P</m>, which is marked.
+            The nail is standing upright, in a position perpendicular to the sheet of cardboard.
+          </p>
+        </description>
         <asymptote label="img_planes_intro">
 
 
@@ -206,7 +213,17 @@
 
           <!-- START figures/figplanes1_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>Three points P, Q, and R are plotted in space, along with the plane containing them.</shortdescription>
+            <description>
+              <p>
+                In a three-dimensional coordinate system, three points <m>P</m>, <m>Q</m>, and <m>R</m> are plotted.
+                Three vectors are drawn with their tails at <m>P</m>:
+                <m>\overrightarrow{PQ}</m>, <m>\overrightarrow{PR}</m>, and the cross product <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m>.
+                The plane containing <m>P</m>, <m>Q</m>, and <m>R</m> is also shown.
+                The vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> are parallel to the plane,
+                while their cross product is perpendicular to the plane.
+              </p>
+            </description>
             <asymptote label="img_planes1">
 
 
@@ -362,7 +379,14 @@
 
           <!-- START figures/figplanes2_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>In three dimensions, two lines are plotted, intersecting at a point P, along with the plane containing both lines.</shortdescription>
+            <description>
+              <p>
+                Three-dimensional coordinate axes are shown, with the points <m>(5,0,0)</m>, <m>(0,5,0)</m>, and <m>(0,0,-5)</m> indicated for scale.
+                A point <m>P</m> is plotted in space. Two lines <m>\ell_1</m> and <m>\ell_2</m> are shown intersecting at this point.
+                The plane containing both lines is also plotted, along with a normal vector, located with its tail at <m>P</m>.
+              </p>
+            </description>
             <asymptote label="img_planes2">
 
 
@@ -448,7 +472,14 @@
 
           <!-- START figures/figplanes3_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>A plane is plotted in a three-dimensional coordinate system, along with a line passing through it at a point P.</shortdescription>
+            <description>
+              <p>
+                A plane is plotted against a set of three-dimensional coordinate axes.
+                A line passes through the plane, intersecting it at a point <m>P</m>.
+                The line is perpendicular to the plane.
+              </p>
+            </description>
             <asymptote label="img_planes3">
 
 
@@ -582,7 +613,14 @@
 
           <!-- START figures/figplanes4_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>Two planes are shown intersecting along a common line.</shortdescription>
+            <description>
+              <p>
+                Two planes are plotted in a three-dimensional coordinate system.
+                The planes intersect along a line, which is also plotted,
+                along with a point <m>P</m> that lies on the line, as well as on both planes.
+              </p>
+            </description>
             <asymptote label="img_planes4">
 
 
@@ -703,7 +741,15 @@
 
           <!-- START figures/figplanes5_3D.asy -->
           <image width="47%">
-            <description/>
+            <shortdescription>A line in three dimensions passes through a plane, intersecting it at a point.</shortdescription>
+            <description>
+              <p>
+                A plane is plotted against a three-dimensional coordinate system.
+                A line, labeled <m>\ell(t)</m>, is also plotted.
+                The line appears to be almost, but not quite, parallel to the plane.
+                It passes through the plane, intersecting it at a point that is plotted, but not labeled.
+              </p>
+            </description>
             <asymptote label="img_planes5">
 
 
@@ -796,7 +842,15 @@
 
       <!-- START figures/figplanes_dist_3D.asy -->
       <image width="47%">
-        <description/>
+        <shortdescription>A plane, on which a point P and normal vector n are marked, along with a point Q not on the plane, and its distance from the plane.</shortdescription>
+        <description>
+          <p>
+            A generic plane is shown, along with a point <m>P</m> on the plane.
+            The normal vector <m>\vec n</m> is plotted with its tail at <m>P</m>.
+            A point <m>Q</m> is shown above the plane, and the vector <m>\overrightarrow{PQ}</m> from <m>P</m> to <m>Q</m> is drawn.
+            A perpendicular is drawn from the point <m>Q</m> to the plane, and labeled with the distance <m>h</m>.
+          </p>
+        </description>
         <asymptote label="img_planes_dist">
 
 

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -62,13 +62,14 @@
       <!-- START figures/figcartcoord1_3D.asy -->
       <image xml:id="img_cartcoord1" width="47%">
         <shortdescription>
-          Plot of point P= (2, 1,3) in space.
+          Plot of point P = (2, 1, 3) in space.
         </shortdescription>
         <description>
           <p>
             The <m>x</m> and <m>y</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>z</m>
              axis is drawn from <m>-1</m> to <m>3</m>. The point <m>P= (2,1,3)</m> is drawn in space. 
-             A dashed cuboid is drawn with the point <m>P</m> on the corner away from the axes.
+             A dashed cuboid is drawn with one vertex at the origin, three of its edges along the coordinate axes, 
+             and the point <m>P</m> on the corner opposite the origin.
           </p>
         </description>
       <asymptote>
@@ -150,13 +151,14 @@
       <!-- START figures/figcartcoord2_3D.asy -->
       <image xml:id="img_cartcoord2" width="47%">
         <shortdescription>
-          Plot of point P= (2,1,3) in space with perspective used in the text.
+          Plot of point P = (2,1,3) in space with perspective used in the text.
         </shortdescription>
         <description>
           <p>
             The <m>x</m> and <m>y</m> axes are drawn from <m>-2</m> to <m>2</m> and the <m>z</m> 
             axis is drawn from <m>-1</m> to <m>3</m>. The point <m>P= (2,1,3)</m> is drawn in space. 
-            A dashed cuboid is drawn with the point <m>P</m> on the corner away from the axes. 
+            A dashed cuboid is drawn with one vertex at the origin, three of its edges along the coordinate axes,
+            and the point <m>P</m> on the corner opposite the origin.
             The <m>z</m> axis is shown as the vertical line.
           </p>
         </description>
@@ -270,7 +272,7 @@
           <!-- START figures/figspace1_3D.asy -->
           <image xml:id="img_space1" width="47%">
             <shortdescription>
-              Plotting point P =(1, 4, -1) and point Q= (2, 1, 1).
+              Plotting point P = (1, 4, -1) and point Q = (2, 1, 1).
             </shortdescription>
             <description>
               <p>

--- a/ptx/sec_vector_intro.ptx
+++ b/ptx/sec_vector_intro.ptx
@@ -1869,11 +1869,11 @@
                   <p>
                     using the standard unit vectors.
                   </p>
-                </statement>
 
-                <p>
-                  <var name="$stan" width="10"/>
-                </p>
+                  <p>
+                    <var name="$stan" width="10"/>
+                  </p>
+                </statement>
               </task>
           </webwork>
         </exercise>

--- a/publication/publication-accelerated.ptx
+++ b/publication/publication-accelerated.ptx
@@ -24,7 +24,7 @@
         <knowl example="no"/>
         <asymptote links="yes"/>
         <webwork divisional="dynamic"/>
-        <css toc="crc" banner="crc" navbar="crc" shell="crc"/>
+        <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     <!-- PDF-Specific Options -->
     <latex print="no" sides="one">

--- a/publication/publication-runestone.ptx
+++ b/publication/publication-runestone.ptx
@@ -25,7 +25,7 @@
         <knowl example="no"/>
         <asymptote links="yes"/>
         <webwork divisional="dynamic"/>
-        <css toc="crc" banner="crc" navbar="crc" shell="crc"/>
+        <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     
 </publication>

--- a/publication/publication-standard.ptx
+++ b/publication/publication-standard.ptx
@@ -24,7 +24,7 @@
         <knowl example="no"/>
         <asymptote links="yes"/>
         <webwork divisional="dynamic"/>
-        <css toc="crc" banner="crc" navbar="crc" shell="crc"/>
+        <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     <!-- PDF-Specific Options -->
     <latex print="no" sides="one">

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -24,7 +24,7 @@
         <knowl example="no"/>
         <asymptote links="yes"/>
         <webwork divisional="dynamic"/>
-        <css toc="crc" banner="crc" navbar="crc" shell="crc"/>
+        <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     <!-- PDF-Specific Options -->
     <latex print="no" sides="one">


### PR DESCRIPTION
Adds descriptions for images in the vectors chapter.

There are also a few typo corrections.

The other change is to revert to the default layout, instead of the "CRC" option.
CRC looks a bit nicer, mostly because the text is centred on the webpage, but there is a bug: it causes the MathJax menus to misbehave, which could be an accessibility issue.