### PR TITLE
A few small fixes to previous PR

### DIFF
--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -284,8 +284,8 @@
         </p>
         <p>
           <ol marker="(a)">
-            <li><m>y = C \left ( 1 + \ln(x) \right )^2</m></li>
-            <li><m>y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m></li>
+            <li><m>y = C \left( 1 + \ln(x) \right)^2</m></li>
+            <li><m>y = \left( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right)^2</m></li>
             <li><m>y = C e^{-3x} + \sqrt{\sin(x)}</m></li>
           </ol>
         </p>
@@ -299,7 +299,7 @@
           <ol marker="(a)">
             <li>
               <p>
-                Testing the potential solution <m>y = C \left ( 1 + \ln(x) \right )^2</m>:
+                Testing the potential solution <m>y = C \left( 1 + \ln(x) \right)^2</m>:
               </p>
               <p>
                 Differentiating,
@@ -319,20 +319,20 @@
 
             <li>
               <p>
-                Testing the potential solution <m>\displaystyle y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m>:
+                Testing the potential solution <m>\displaystyle y = \left( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right)^2</m>:
               </p>
               <p>
                 Differentiating,
-                we have <m>\displaystyle \yp = 2\left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )\left ( \frac{1}{3} - \frac{C}{2x^{3/2}}\right )</m>.
+                we have <m>\displaystyle \yp = 2\left( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right)\left( \frac{1}{3} - \frac{C}{2x^{3/2}}\right)</m>.
                 Substituting into the differential equation,
                 <md>
-                  <mrow>\amp 2\left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )\left ( \frac{1}{3} - \frac{C}{2x^{3/2}}\right ) + \frac{1}{x}\left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2 - \left (\frac{1}{3}x + \frac{C}{\sqrt{x}}\right)</mrow>
-                  <mrow>\amp = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right ) \left ( \frac{2}{3} - \frac{C}{x^{3/2}} + \frac{1}{3} + \frac{C}{x^{3/2}} - 1 \right )</mrow>
+                  <mrow>\amp 2\left( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right)\left( \frac{1}{3} - \frac{C}{2x^{3/2}}\right) + \frac{1}{x}\left( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right)^2 - \left(\frac{1}{3}x + \frac{C}{\sqrt{x}}\right)</mrow>
+                  <mrow>\amp = \left( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right) \left( \frac{2}{3} - \frac{C}{x^{3/2}} + \frac{1}{3} + \frac{C}{x^{3/2}} - 1 \right)</mrow>
                   <mrow>\amp = 0. \text{ (Note how the second parenthetical grouping above reduces to 0.) }</mrow>
                 </md>
               </p>
               <p>
-                Thus <m>\displaystyle y = \left ( \frac{1}{3}x + \frac{C}{\sqrt{x}} \right )^2</m> <em>is</em>
+                Thus <m>\displaystyle y = \left(\frac{1}{3}x + \frac{C}{\sqrt{x}} \right)^2</m> <em>is</em>
                 a solution to the differential equation.
               </p>
             </li>

--- a/ptx/sec_Linear.ptx
+++ b/ptx/sec_Linear.ptx
@@ -182,7 +182,7 @@
       Let's call the integrating factor <m>\mu(x)</m>.
       We multiply both sides of the differential equation by <m>\mu(x)</m> to get
       <me>
-        \mu(x) \left ( \frac{dy}{dx} + p(x)y \right ) = \mu(x)q(x)
+        \mu(x) \left( \frac{dy}{dx} + p(x)y \right) = \mu(x)q(x)
       </me>.
     </p>
 
@@ -212,7 +212,7 @@
 
     <p>
       Equating
-      <m>\frac{d}{dx} \big ( \mu(x) y \big )</m> and <m>\mu(x) \left ( \frac{dy}{dx} + p(x)y \right )</m> gives
+      <m>\frac{d}{dx} \big ( \mu(x) y \big )</m> and <m>\mu(x) \left( \frac{dy}{dx} + p(x)y \right)</m> gives
       <me>
         \frac{d\mu}{dx}y + \mu(x)\frac{dy}{dx} = \mu(x) \frac{dy}{dx} + \mu(x)p(x)y
       </me>,
@@ -357,7 +357,7 @@
         <p>
           The left hand side of the differential equation condenses to yield
           <me>
-            \frac{d}{dx} \left ( e^{-\frac{1}{2}x^2}y\right ) = 0
+            \frac{d}{dx} \left( e^{-\frac{1}{2}x^2}y\right) = 0
           </me>.
         </p>
 
@@ -367,7 +367,7 @@
             The reality is that we choose <m>\mu(x)</m> so that we can get exactly this condensing behavior.
             It's not magic, it's math!
             If you're still skeptical,
-            try using the Product Rule and Implicit Differentiation to evaluate <m>\displaystyle \frac{d}{dx}\left (e^{-\frac{1}{2}x^2}y\right)</m>,
+            try using the Product Rule and Implicit Differentiation to evaluate <m>\displaystyle \frac{d}{dx}\left(e^{-\frac{1}{2}x^2}y\right)</m>,
             and verify that it becomes <m>e^{-\frac{1}{2}x^2}\left(\displaystyle \frac{dy}{dx} - xy\right)</m>.
           </p>
         </aside>
@@ -678,7 +678,7 @@
       (the object is dropped, not thrown from the plane),
       the velocities from <xref ref="ex_falling_object" text="global">Examples</xref>
       and <xref ref="ex_falling_object1" text="global"/>
-      are given by <m>v = gt</m> and <m>v = \displaystyle \frac{mg}{k}\left (1 - e^{-\frac{k}{m}t}\right )</m>,
+      are given by <m>v = gt</m> and <m>v = \displaystyle \frac{mg}{k}\left(1 - e^{-\frac{k}{m}t}\right)</m>,
       respectively.
       These two functions are shown in <xref ref="fig_20_03_falling_object"/>,
       with <m>g = 9.8, m=1</m>, and <m>k=1</m>.
@@ -897,7 +897,7 @@
           </statement>
           <answer>
             <p>
-              <m>y = \displaystyle x^2\left (\arctan x - \frac{\pi}{4}\right )</m>
+              <m>y = \displaystyle x^2\left(\arctan x - \frac{\pi}{4}\right)</m>
             </p>
           </answer>
         </exercise>

--- a/ptx/sec_Modeling.ptx
+++ b/ptx/sec_Modeling.ptx
@@ -949,7 +949,7 @@
           </statement>
           <answer>
             <p>
-              <m>y = \displaystyle 20 - \frac{10}{17}\left (4\cos(2t)- \sin(2t)\right) - \frac{300}{17}e^{-\frac{1}{2}t}</m> g
+              <m>y = \displaystyle 20 - \frac{10}{17}\left(4\cos(2t)- \sin(2t)\right) - \frac{300}{17}e^{-\frac{1}{2}t}</m> g
             </p>
           </answer>
         </exercise>

--- a/ptx/sec_Separable.ptx
+++ b/ptx/sec_Separable.ptx
@@ -463,7 +463,7 @@
           </statement>
           <answer>
             <p>
-              <m>\left \{ \displaystyle y = \frac{1 + Ce^{2x}}{1 - Ce^{2x}}, y = -1\right \}</m>
+              <m>\left\{ \displaystyle y = \frac{1 + Ce^{2x}}{1 - Ce^{2x}}, y = -1\right\}</m>
             </p>
           </answer>
         </exercise>
@@ -535,7 +535,7 @@
           </statement>
           <answer>
             <p>
-              <m>\left \{ \arcsin{2y} - \arctan(x^2+1) = C, y = \pm \displaystyle \frac{1}{2} \right \}</m>
+              <m>\left\{ \arcsin{2y} - \arctan(x^2+1) = C, y = \pm \displaystyle \frac{1}{2} \right\}</m>
             </p>
           </answer>
         </exercise>
@@ -547,7 +547,7 @@
           </statement>
           <answer>
             <p>
-              <m>\left \{ \displaystyle y = \frac{1}{C - \arctan x}, y = 0 \right \}</m>
+              <m>\left\{ \displaystyle y = \frac{1}{C - \arctan x}, y = 0 \right\}</m>
             </p>
           </answer>
         </exercise>
@@ -653,7 +653,7 @@
           </statement>
           <answer>
             <p>
-              <m>x = exp \displaystyle \left ( -\frac{\sqrt{1-y^2}}{y}\right )</m>
+              <m>x = exp \displaystyle \left( -\frac{\sqrt{1-y^2}}{y}\right)</m>
             </p>
           </answer>
         </exercise>

--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -307,7 +307,7 @@
       <xref ref="fig_taypolyintroc"/> shows <m>p_{13}(x)</m>;
       we can visually affirm that this polynomial approximates <m>f</m> very
       well on <m>[-2,3]</m>. 
-      <pagebreak-latex component="taypoly-early"/>
+      <pagebreak-latex component="taypoly-late"/>
       (The polynomial <m>p_{13}(x)</m> is not
       particularly <q>nice</q>. It is
       <md>
@@ -1101,7 +1101,7 @@
           A table of these values is given in <xref ref="fig_taypoly4a"/>.
         </p>
 
-        <figure xml:id="fig_taypoly4a" vshift="1.5" component="taypoly-late">
+        <figure xml:id="fig_taypoly4a" vshift="4" component="taypoly-late">
           <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></caption>
           <tabular>
             <row>
@@ -1147,7 +1147,7 @@
           </tabular>
         </figure>
 
-        <figure xml:id="fig_taypoly4a" vshift="3" component="taypoly-early">
+        <figure xml:id="fig_taypoly4a" vshift="0" component="taypoly-early">
           <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></caption>
           <tabular>
             <row>
@@ -1230,7 +1230,7 @@
           Note how well the two functions agree on about <m>(-\pi,\pi)</m>.
         </p>
 
-        <figure xml:id="fig_taypoly4b" vshift="-2" component="taypoly-late">
+        <figure xml:id="fig_taypoly4b" vshift="1" component="taypoly-late">
           <caption>A graph of <m>f(x)= \cos(x)</m> and its degree 8 Maclaurin
           polynomial</caption>
           <!-- START figures/fig_taypoly4.tex -->
@@ -1279,7 +1279,7 @@
           <!-- figures/fig_taypoly4.tex END -->
         </figure>
 
-        <figure xml:id="fig_taypoly4b" vshift="-0.5" component="taypoly-early">
+        <figure xml:id="fig_taypoly4b" vshift="-3" component="taypoly-early">
           <caption>A graph of <m>f(x)= \cos(x)</m> and its degree 8 Maclaurin
           polynomial</caption>
           <!-- START figures/fig_taypoly4.tex -->
@@ -1328,11 +1328,11 @@
           <!-- figures/fig_taypoly4.tex END -->
         </figure>
       </solution>
-      <solution component="video-late" vshift="4.5">
+      <solution component="video-late" vshift="7">
         <title>Video solution</title>
         <video width="98%" youtube="zg1W9miUCB4" xml:id="vid_deriv_apps_taylor_poly_ex_4" label="vid_deriv_apps_taylor_poly_ex_4" component="video"/>
       </solution>
-      <solution component="video-early" vshift="6">
+      <solution component="video-early" vshift="3">
         <title>Video solution</title>
         <video width="98%" youtube="zg1W9miUCB4" xml:id="vid_deriv_apps_taylor_poly_ex_4" label="vid_deriv_apps_taylor_poly_ex_4" component="video"/>
       </solution>
@@ -1375,7 +1375,7 @@
                 This is done in <xref ref="fig_taypoly5a"/>.
               </p>
 
-              <figure xml:id="fig_taypoly5a" vshift="-3" component="taypoly-late">
+              <figure xml:id="fig_taypoly5a" vshift="0" component="taypoly-late">
                 <caption>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></caption>
                 <tabular>
                   <row>
@@ -1401,7 +1401,7 @@
                 </tabular>
               </figure>
 
-              <figure xml:id="fig_taypoly5a" vshift="-1.5" component="taypoly-early">
+              <figure xml:id="fig_taypoly5a" vshift="-4.5" component="taypoly-early">
                 <caption>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></caption>
                 <tabular>
                   <row>

--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -344,12 +344,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 
 <xsl:template match="definition|theorem|insight|sidebyside|table">
   <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-    <xsl:text>&#xa;\noindent\hskip-</xsl:text>
+    <xsl:text>&#xa;\medskip&#xa;\noindent\hskip-</xsl:text>
     <xsl:value-of select="@hskip"/>
     <xsl:text>pt\begin{minipage}{</xsl:text>
     <xsl:value-of select="@minisize"/>
     <xsl:text>pt}&#xa;</xsl:text>
-    <xsl:text>\medskip&#xa;</xsl:text>
   </xsl:if>
   <xsl:if test="@hstretch">
     <xsl:text>&#xa;</xsl:text>
@@ -362,8 +361,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
     <xsl:text>}&#xa;</xsl:text>
   </xsl:if>
   <xsl:if test="@hskip">
-    <xsl:text>\medskip&#xa;</xsl:text>
-    <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
+    <xsl:text>\end{minipage}&#xa;\medskip&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>
 

--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -344,7 +344,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 
 <xsl:template match="definition|theorem|insight|sidebyside|table">
   <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-    <xsl:text>\noindent\hskip-</xsl:text>
+    <xsl:text>&#xa;\noindent\hskip-</xsl:text>
     <xsl:value-of select="@hskip"/>
     <xsl:text>pt\begin{minipage}{</xsl:text>
     <xsl:value-of select="@minisize"/>
@@ -363,7 +363,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   </xsl:if>
   <xsl:if test="@hskip">
     <xsl:text>\smallskip&#xa;</xsl:text>
-    <xsl:text>\end{minipage}&#xa;</xsl:text>
+    <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>
 

--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -349,7 +349,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
     <xsl:text>pt\begin{minipage}{</xsl:text>
     <xsl:value-of select="@minisize"/>
     <xsl:text>pt}&#xa;</xsl:text>
-    <xsl:text>\smallskip&#xa;</xsl:text>
+    <xsl:text>\medskip&#xa;</xsl:text>
   </xsl:if>
   <xsl:if test="@hstretch">
     <xsl:text>&#xa;</xsl:text>
@@ -362,7 +362,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
     <xsl:text>}&#xa;</xsl:text>
   </xsl:if>
   <xsl:if test="@hskip">
-    <xsl:text>\smallskip&#xa;</xsl:text>
+    <xsl:text>\medskip&#xa;</xsl:text>
     <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -344,12 +344,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 
 <xsl:template match="definition|theorem|insight|sidebyside|table">
   <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-      <xsl:text>&#xa;\noindent\hskip-</xsl:text>
+      <xsl:text>&#xa;\medskip&#xa;\noindent\hskip-</xsl:text>
       <xsl:value-of select="@hskip"/>
       <xsl:text>pt\begin{minipage}{</xsl:text>
       <xsl:value-of select="@minisize"/>
       <xsl:text>pt}&#xa;</xsl:text>
-      <xsl:text>\medskip&#xa;</xsl:text>
     </xsl:if>
   <xsl:if test="@hstretch">
     <xsl:text>&#xa;</xsl:text>
@@ -362,8 +361,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
     <xsl:text>}&#xa;</xsl:text>
   </xsl:if>
   <xsl:if test="@hskip">
-    <xsl:text>\medskip&#xa;</xsl:text>
-    <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
+    <xsl:text>\end{minipage}&#xa;\medskip&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>
 

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -349,7 +349,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
       <xsl:text>pt\begin{minipage}{</xsl:text>
       <xsl:value-of select="@minisize"/>
       <xsl:text>pt}&#xa;</xsl:text>
-      <xsl:text>\smallskip&#xa;</xsl:text>
+      <xsl:text>\medskip&#xa;</xsl:text>
     </xsl:if>
   <xsl:if test="@hstretch">
     <xsl:text>&#xa;</xsl:text>
@@ -362,7 +362,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
     <xsl:text>}&#xa;</xsl:text>
   </xsl:if>
   <xsl:if test="@hskip">
-    <xsl:text>\smallskip&#xa;</xsl:text>
+    <xsl:text>\medskip&#xa;</xsl:text>
     <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -344,7 +344,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 
 <xsl:template match="definition|theorem|insight|sidebyside|table">
   <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-      <xsl:text>\noindent\hskip-</xsl:text>
+      <xsl:text>&#xa;\noindent\hskip-</xsl:text>
       <xsl:value-of select="@hskip"/>
       <xsl:text>pt\begin{minipage}{</xsl:text>
       <xsl:value-of select="@minisize"/>
@@ -363,7 +363,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   </xsl:if>
   <xsl:if test="@hskip">
     <xsl:text>\smallskip&#xa;</xsl:text>
-    <xsl:text>\end{minipage}&#xa;</xsl:text>
+    <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
Fixing a couple of small items that I missed in the last pull request:

- I accidentally deleted a couple of necessary line breaks around minipages (with two-sided printing, there are some over-wide boxes that I need to shift over, or I'd vanquish the minipage altogether...)
- I also decided that we needed `\medskip`, not `\smallskip` around those minipages
- In the Taylor polynomial section, I mixed up the "early" and "late" components in a couple of places. (My versions are "early", since we do Taylor polynomials as part of Chapter 4.)
- I also noticed some places where there was a space between `\left` and `\right` and the delimiter. This doesn't seem to be a problem but I fixed it anyway since it seemed wrong.