### PR TITLE
(Possibly) last batch of changes from this PDF publishing run

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ APEX Calculus was originally [written in LaTeX](https://github.com/APEXCalculus/
 
 To build the book, use of the [PreTeXt CLI](https://github.com/PreTeXtBook/pretext-cli) is recommended.
 
+Note that the build time is quite long, and may exceed the time allowed using GitHub codespaces. 
+(If you're building on Windows, make sure your computer is not set to sleep after an hour!)
+
 Preparation for generating APEX Calculus from source:
 
 Software requirements:
 - a recent LaTeX distribution
-- [Sage](https://www.sagemath.org/)
 - Python (version 3.8 or later)
 - the PreTeXt CLI (do `pip install pretextbook`)
-- [pdf2svg](https://github.com/jalios/pdf2svg-windows)
-- ImageMagick
 
-Note that Asymptote compilation is done remotely by default, so Asymptote does not need to be installed locally.
+**Note**: ImageMagick may be needed, but can probably be avoided.
+Older versions of the PreTeXt CLI also require `pdf2svg` to build HTML, but soon this will not be required.
 
 Configuration:
 
@@ -37,13 +38,7 @@ The following variations are also available:
 - `pretext build latex-color-print`: in color, but two-sided layout for printing
 - `pretext build latex-color-print-novideo`: as above, but without QR codes for videos
 
-**Do not build PDF directly.** APEX Calculus places figures in the margins in PDF.
-Unfortunately, we do not currently have a mechanism for setting the vertical placement
-of margin figures in the PreTeXt source, so these have to be adjusted by hand.
-Look in the LaTeX source for occurrences of `\listmarginbox`, `\parmarginbox` and `\tcbmarginbox`.
-Each such environment ends with either `{0cm}` or `{-1cm}`.
-
-These values can be adjusted to ensure that items in the margins do not overlap.
-It is unfortunately a rather tedious process at the moment.
+**Do not build PDF directly.** Most of the PDF design is now automated,
+but you may need to adjust the placement of some figures, add page breaks, etc.
 
 At this time, EPUB generation is not fully supported.

--- a/ptx/sec_Graphical_Numerical.ptx
+++ b/ptx/sec_Graphical_Numerical.ptx
@@ -918,7 +918,7 @@
       and then uses the above idea to find approximate values for the solution <m>y</m> at later <m>x</m>-values.
       The algorithm is summarized in <xref ref="idea_Euler"/>.
     </p>
-    <insight xml:id="idea_Euler" hstretch="330" hskip="30" minisize="330">
+    <insight xml:id="idea_Euler" hstretch="330" hskip="30">
       <title>Euler's Method</title>
       <p>
         Consider the initial value problem
@@ -1864,7 +1864,7 @@
             </p>
           </statement>
           <answer>
-            <image>
+            <image width="47%">
               <shortdescription>
                 Graph showing slope field for the given differential equation.
               </shortdescription>
@@ -1917,7 +1917,7 @@
             </p>
           </statement>
           <answer>
-            <image>
+            <image width="47%">
               <shortdescription>
                 Graph showing slope field for the given differential equation.
               </shortdescription>
@@ -1972,7 +1972,7 @@
             </p>
           </statement>
           <answer>
-            <image>
+            <image width="47%">
               <shortdescription>
                 Graph showing slope field for the given differential equation.
               </shortdescription>
@@ -2020,7 +2020,7 @@
             </p>
           </statement>
           <answer>
-            <image>
+            <image width="47%">
               <shortdescription>
                 Graph showing slope field for the given differential equation.
               </shortdescription>
@@ -2183,7 +2183,7 @@
           </answer>
         </exercise>
       </exercisegroup>
-      <exercisegroup cols="2">
+      <exercisegroup>
         <introduction>
           <p>
             In the following exercises,

--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -365,7 +365,7 @@
       as we learn.
     </p>
 
-    <theorem xml:id="thm_indef_alg" hstretch="360" hskip="60" minisize="360">
+    <theorem xml:id="thm_indef_alg" hstretch="360" hskip="60">
       <title>Derivatives and Antiderivatives</title>
       <statement>
         <p>

--- a/ptx/sec_cross_product.ptx
+++ b/ptx/sec_cross_product.ptx
@@ -2101,7 +2101,7 @@
         </exercise>
 
       </exercisegroup>
-      <exercisegroup cols="2" xml:id="exset-cross-product-unit-ortho">
+      <exercisegroup xml:id="exset-cross-product-unit-ortho">
 
         <introduction>
           <p>

--- a/ptx/sec_cylindrical_spherical.ptx
+++ b/ptx/sec_cylindrical_spherical.ptx
@@ -789,7 +789,7 @@
       The following Key Idea gives conversions to/from our three spatial coordinate systems.
     </p>
 
-    <insight xml:id="idea_convert_coords" hstretch="330" hskip="60" minisize="330">
+    <insight xml:id="idea_convert_coords" hstretch="330" hskip="60">
       <title>Converting Between Rectangular, Cylindrical and Spherical Coordinates</title>
       <p>
         <ul>

--- a/ptx/sec_hessian.ptx
+++ b/ptx/sec_hessian.ptx
@@ -163,7 +163,7 @@
       You've probably already noticed a problem with talking about higher-order polynomials in several variables:
       the notation gets really messy, since there are so many more possible terms!
       For example, even a relatively simple case like a degree 3 polynomial in 3 variables looks like
-      <md hskip="60" minisize="360">
+      <md>
         <mrow> P(x,y,z) \amp = a+bx+cy+dz+ex^2+fxy+gxz+hy^2+kyz+lz^2</mrow>
         <mrow>\amp \quad\quad\quad\quad +mx^3+nx^2y+oxy^2+pxyz+qx^2z+rxz^2+sy^3+ty^2z+uyz^2+vz^3</mrow>
       </md>

--- a/ptx/sec_hyperbolic.ptx
+++ b/ptx/sec_hyperbolic.ptx
@@ -765,7 +765,7 @@
       <video youtube="znJxWgMJPw8" label="vid-hyperbolic-inverse-sinh"/>
     </figure>
 
-    <table xml:id="fig_hfinverse2" hskip="120" minisize="460">
+    <table xml:id="fig_hfinverse2" hstretch="400" hskip="125">
       <title>Domains and ranges of the hyperbolic and inverse hyperbolic functions</title>
 
       <tabular>

--- a/ptx/sec_polar.ptx
+++ b/ptx/sec_polar.ptx
@@ -1227,7 +1227,7 @@
       and to investigate with technology other types of polar functions.
     </p>
 
-    <figure xml:id="fig_polar_lines" hstretch="450" hskip="120" minisize="460">
+    <figure xml:id="fig_polar_lines" hstretch="450" hskip="120">
       <caption>Lines in polar coordinates</caption>
       <sidebyside valign="bottom" widths="23% 23% 23% 23%">
         <figure xml:id="fig_polar_lines1">
@@ -1350,7 +1350,7 @@
       </sidebyside>
     </figure>
 
-    <figure xml:id="fig_polar_circle_spiral" hstretch="450" hskip="120" minisize="460">
+    <figure xml:id="fig_polar_circle_spiral" hstretch="450" hskip="120">
       <caption>Circles and Spirals</caption>
       <sidebyside valign="bottom" widths="23% 23% 23% 23%">
         <figure xml:id="fig_polar_circle1">
@@ -1475,7 +1475,7 @@
       </sidebyside>
     </figure>
 
-    <figure xml:id="fig_polar_limacons" hstretch="450" hskip="120" minisize="460">
+    <figure xml:id="fig_polar_limacons" hstretch="450" hskip="120">
       <caption>Limaçons</caption>
       <sidebyside valign="bottom" widths="23% 23% 23% 23%">
         <figure xml:id="fig_polar_limacon1">
@@ -1625,7 +1625,9 @@
       Symmetric about <m>y</m>-axis: <m>r=a\pm b\sin(\theta)</m>; <m>a,b \gt 0</m>
     </p>
 
-    <figure xml:id="fig_polar_roses" hstretch="450" hskip="120" minisize="460">
+    <pagebreak-latex/>
+    
+    <figure xml:id="fig_polar_roses" hstretch="450">
       <caption>Rose curves</caption>
       <sidebyside valign="bottom" widths="23% 23% 23% 23%">
         <figure xml:id="fig_polar_rose1">

--- a/ptx/sec_space_coord.ptx
+++ b/ptx/sec_space_coord.ptx
@@ -146,7 +146,7 @@
           <idx><h>first octant</h></idx>
     </p>
 
-    <figure xml:id="fig_cartcoord2" vshift="3">
+    <figure xml:id="fig_cartcoord2" vshift="4">
       <caption>Plotting the point <m>P=(2,1,3)</m> in space with a perspective used in this text</caption>
       <!-- START figures/figcartcoord2_3D.asy -->
       <image width="47%">
@@ -237,7 +237,7 @@
       The above distance formula allows us to compute the length of this segment.
     </p>
 
-    <figure xml:id="vid-vectors-spacecoord-distance" component="video" vshift="3">
+    <figure xml:id="vid-vectors-spacecoord-distance" component="video" vshift="4.5">
       <caption>Video presentation of <xref ref="def_space_distance"/></caption>
       <video youtube="zNUbi5ahC0Y" label="vid-vectors-spacecoord-distance"/>
     </figure>
@@ -263,7 +263,7 @@
           </me>.
         </p>
 
-        <figure xml:id="fig_space1" vshift="-3">
+        <figure xml:id="fig_space1" vshift="-1">
           <caption>Plotting points <m>P</m> and <m>Q</m> in <xref ref="ex_space1"/></caption>
           <!-- START figures/figspace1_3D.asy -->
           <image width="47%">
@@ -334,7 +334,7 @@
           <!-- figures/figspace1_3D.asy END -->
         </figure>
       </solution>
-      <solution component="video" vshift="3">
+      <solution component="video" vshift="5">
         <title>Video solution</title>
         <video width="98%" youtube="EF-aTKoAQsU" xml:id="vid-vectors-spacecoord-linesegment" label="vid-vectors-spacecoord-linesegment" component="video"/>
       </solution>
@@ -1426,7 +1426,7 @@
       We now consider how to find the equation of the surface of such a solid.
     </p>
 
-    <figure xml:id="vid-vectors-spacecoord-surfrev-intro" component="video" vshift="0">
+    <figure xml:id="vid-vectors-spacecoord-surfrev-intro" component="video" vshift="-1">
       <caption>Video presentation of <xref ref="subsec-space-surface-revolution"/></caption>
       <video youtube="gxnpRE0b68U" label="vid-vectors-spacecoord-surfrev-intro"/>
     </figure>

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -581,7 +581,65 @@
     which is not particularly good.
   </p>
 
-  <insight xml:id="idea_common_taylor" hstretch="375">
+  <insight xml:id="idea_common_taylor" hstretch="375" component="taypoly-late">
+    <title>Important Taylor Series Expansions</title>
+    <tabular>
+      <row>
+        <cell><term>Function and Series</term></cell>
+        <cell><term>First Few Terms</term></cell>
+        <cell><term>Interval of</term></cell>
+      </row>
+      <row>
+        <cell/><cell/><cell><term>Convergence</term></cell>
+      </row>
+      <row>
+        <cell><m>\ds e^x = \infser[0] \frac{x^n}{n!}</m></cell>
+        <cell><m>\ds 1+ x+\frac{x^2}{2!} + \frac{x^3}{3!}+\cdots</m></cell>
+        <cell><m>(-\infty,\infty)</m></cell>
+      </row>
+      <row>
+        <cell><m>\ds \sin(x) = \infser[0] (-1)^n\frac{x^{2n+1}}{(2n+1)!}</m></cell>
+        <cell><m>\ds x-\frac{x^3}{3!}+\frac{x^5}{5!} - \frac{x^7}{7!}+\cdots</m></cell>
+        <cell><m>(-\infty,\infty)</m></cell>
+      </row>
+      <row>
+        <cell><m>\ds \cos(x) = \infser[0] (-1)^n\frac{x^{2n}}{(2n)!}</m></cell>
+        <cell><m>\ds 1-\frac{x^2}{2!}+\frac{x^4}{4!} - \frac{x^6}{6!} +\cdots</m></cell>
+        <cell><m>(-\infty,\infty)</m></cell>
+      </row>
+      <row>
+        <cell><m>\ds \ln(x) = \infser(-1)^{n+1}\frac{(x-1)^n}{n}</m></cell>
+        <cell><m>\ds (x-1)- \frac{(x-1)^2}{2} +\frac{(x-1)^3}{3}-\cdots</m></cell>
+        <cell><m>(0,2]</m></cell>
+      </row>
+      <row>
+        <cell><m>\ds \frac{1}{1-x} = \infser[0] x^n</m></cell>
+        <cell><m>\ds 1+x+x^2+x^3+\cdots</m></cell>
+        <cell><m>(-1,1)</m></cell>
+      </row>
+      <row>
+        <cell><m>\ds \tan^{-1}(x) = \infser[0] (-1)^n\frac{x^{2n+1}}{2n+1}</m></cell>
+        <cell><m>\ds x-\frac{x^3}{3}+\frac{x^5}{5}-\frac{x^7}{7}+\cdots</m></cell>
+        <cell><m>[-1,1]</m></cell>
+      </row>
+      <row>
+        <cell><m>\ds (1+x)^k=\infser[0] \binom{k}{n}x^n</m></cell>
+        <cell><m>\ds 1+kx+\frac{k(k-1)}{2!}x^2 + \cdots</m></cell>
+        <cell><m>(-1,1)</m></cell>
+      </row>
+    </tabular>
+
+    <p>
+      Note that for <m>(1+x)^k</m>, the interval of convergence may contain one or both endpoints,
+      depending on the value of <m>k</m>, and we are using the generalized binomial coefficients
+      <me>
+        \binom{k}{n} = \frac{k(k-1)\cdots (k-(n-1))}{n!}
+      </me>.
+          <idx><h>Taylor Series</h><h>common series</h></idx>
+    </p>
+  </insight>
+
+  <insight xml:id="idea_common_taylor" hstretch="375" hskip="87" component="taypoly-early">
     <title>Important Taylor Series Expansions</title>
     <tabular>
       <row>

--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -300,13 +300,6 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 
 <!-- move vshift figures to the margin -->
   <xsl:template match="figure">
-    <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-      <xsl:text>&#xa;\noindent\hskip-</xsl:text>
-      <xsl:value-of select="@hskip"/>
-      <xsl:text>pt\begin{minipage}{</xsl:text>
-      <xsl:value-of select="@minisize"/>
-      <xsl:text>pt}</xsl:text>
-    </xsl:if>
     <xsl:if test="@vshift">
       <xsl:text>&#xa;</xsl:text>
       <xsl:choose>
@@ -327,6 +320,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
         <xsl:value-of select="@hstretch"/>
       <xsl:text>pt}&#xa;</xsl:text>  
     </xsl:if>
+    <xsl:if test="(@hskip) and ($b-latex-two-sides)">
+    <xsl:text>\tcbset{enlarge left by=-</xsl:text>
+      <xsl:value-of select="@hskip"/>
+      <xsl:text>pt}&#xa;</xsl:text>  
+  </xsl:if>
     <xsl:apply-imports/>
     <xsl:if test="@vshift">
       <xsl:text>}{</xsl:text><xsl:value-of select="@vshift"/><xsl:text>cm}&#xa;</xsl:text>
@@ -335,33 +333,24 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
     <xsl:if test="@hstretch">
       <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@hskip">
-      <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
-    </xsl:if>
 </xsl:template>
 
 <!-- Adjust width of some tcolorboxes that aren't wide enough to fit their content -->
 
 <xsl:template match="definition|theorem|insight|sidebyside|table">
-  <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-    <xsl:text>&#xa;\medskip&#xa;\noindent\hskip-</xsl:text>
-    <xsl:value-of select="@hskip"/>
-    <xsl:text>pt\begin{minipage}{</xsl:text>
-    <xsl:value-of select="@minisize"/>
-    <xsl:text>pt}&#xa;</xsl:text>
-  </xsl:if>
   <xsl:if test="@hstretch">
-    <xsl:text>&#xa;</xsl:text>
     <xsl:text>{\tcbset{text width=</xsl:text>
       <xsl:value-of select="@hstretch"/>
     <xsl:text>pt}&#xa;</xsl:text>  
   </xsl:if>
+  <xsl:if test="(@hskip) and ($b-latex-two-sides)">
+    <xsl:text>\tcbset{enlarge left by=-</xsl:text>
+      <xsl:value-of select="@hskip"/>
+      <xsl:text>pt}&#xa;</xsl:text>  
+  </xsl:if>
   <xsl:apply-imports/>
   <xsl:if test="@hstretch">
     <xsl:text>}&#xa;</xsl:text>
-  </xsl:if>
-  <xsl:if test="@hskip">
-    <xsl:text>\end{minipage}&#xa;\medskip&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>
 
@@ -502,9 +491,9 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 </xsl:template>
 
 <!-- ensure exercises ignore subsection numbering -->
-<!-- shamelessly stolen from Oscar Levin -->
-<xsl:template match="book|article|part|chapter|appendix|section|subsection|subsubsection" mode="is-structured-division">
-    <xsl:if test="chapter|section|subsection|subsubsection">
+<!-- stolen from Oscar Levin and changed to fix headings -->
+<xsl:template match="appendix|section|subsection|subsubsection" mode="is-structured-division">
+    <xsl:if test="subsection|subsubsection">
         <xsl:text></xsl:text> <!-- removed "true", so now this should make all exercises think they are part of unstructured divisions -->
     </xsl:if>
 </xsl:template>

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -108,33 +108,7 @@
 <xsl:template match="exercises|appendix|solutions" mode="latex-division-heading">
     <!-- \newgeometry includes a \clearpage -->
     <xsl:apply-templates select="." mode="new-geometry"/>
-    <xsl:text>\begin{</xsl:text>
-    <xsl:apply-templates select="." mode="division-environment-name" />
-    <!-- possibly numberless -->
-    <xsl:apply-templates select="." mode="division-environment-name-suffix" />
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="title-full"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- subtitle here -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="title-short"/>
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- author here -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <!-- subtitle here -->
-    <xsl:text>}</xsl:text>
-    <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="." mode="unique-id" />
-    <xsl:text>}</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-imports/>
 </xsl:template>
 
 
@@ -152,11 +126,7 @@
 
 <!-- restore geometry for next section -->
 <xsl:template match="exercises|appendix|solutions" mode="latex-division-footing">
-    <xsl:text>\end{</xsl:text>
-    <xsl:apply-templates select="." mode="division-environment-name" />
-    <!-- possibly numberless -->
-    <xsl:apply-templates select="." mode="division-environment-name-suffix" />
-    <xsl:text>}&#xa;</xsl:text>
+    <xsl:apply-imports/>
       <!-- \restoregeometry includes a \clearpage -->
     <xsl:text>\restoregeometry&#xa;</xsl:text>
 </xsl:template>
@@ -300,13 +270,6 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 
 <!-- move vshift figures to the margin -->
 <xsl:template match="figure">
-  <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-      <xsl:text>&#xa;\noindent\hskip-</xsl:text>
-      <xsl:value-of select="@hskip"/>
-      <xsl:text>pt\begin{minipage}{</xsl:text>
-      <xsl:value-of select="@minisize"/>
-      <xsl:text>pt}</xsl:text>
-    </xsl:if>
     <xsl:if test="@vshift">
       <xsl:text>&#xa;</xsl:text>
       <xsl:choose>
@@ -327,41 +290,38 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
         <xsl:value-of select="@hstretch"/>
       <xsl:text>pt}&#xa;</xsl:text>  
     </xsl:if>
+    <xsl:if test="(@hskip) and ($b-latex-two-sides)">
+      <xsl:text>\tcbset{enlarge left by=-</xsl:text>
+        <xsl:value-of select="@hskip"/>
+        <xsl:text>pt}&#xa;</xsl:text>  
+    </xsl:if>
     <xsl:apply-imports/>
     <xsl:if test="@vshift">
       <xsl:text>}{</xsl:text><xsl:value-of select="@vshift"/><xsl:text>cm}&#xa;</xsl:text>
       <xsl:text>&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@hstretch">
-      <xsl:text>}&#xa;</xsl:text>
+      <xsl:text>}&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@hskip">
-    <xsl:text>\end{minipage}&#xa;&#xa;</xsl:text>
-  </xsl:if>
 </xsl:template>
 
 <!-- Adjust width of some tcolorboxes that aren't wide enough to fit their content -->
 
 <xsl:template match="definition|theorem|insight|sidebyside|table">
-  <xsl:if test="(@hskip) and ($b-latex-two-sides)">
-      <xsl:text>&#xa;\medskip&#xa;\noindent\hskip-</xsl:text>
-      <xsl:value-of select="@hskip"/>
-      <xsl:text>pt\begin{minipage}{</xsl:text>
-      <xsl:value-of select="@minisize"/>
-      <xsl:text>pt}&#xa;</xsl:text>
-    </xsl:if>
-  <xsl:if test="@hstretch">
+  <xsl:if test="(@hstretch)">
     <xsl:text>&#xa;</xsl:text>
     <xsl:text>{\tcbset{text width=</xsl:text>
       <xsl:value-of select="@hstretch"/>
     <xsl:text>pt}&#xa;</xsl:text>  
   </xsl:if>
+  <xsl:if test="(@hskip) and ($b-latex-two-sides)">
+    <xsl:text>\tcbset{enlarge left by=-</xsl:text>
+      <xsl:value-of select="@hskip"/>
+      <xsl:text>pt}&#xa;</xsl:text>  
+  </xsl:if>
   <xsl:apply-imports/>
   <xsl:if test="@hstretch">
     <xsl:text>}&#xa;</xsl:text>
-  </xsl:if>
-  <xsl:if test="@hskip">
-    <xsl:text>\end{minipage}&#xa;\medskip&#xa;</xsl:text>
   </xsl:if>
 </xsl:template>
 
@@ -503,10 +463,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 </xsl:template>
 
 <!-- ensure exercises ignore subsection numbering -->
-<!-- shamelessly stolen from Oscar Levin -->
-<xsl:template match="book|article|part|chapter|appendix|section|subsection|subsubsection" mode="is-structured-division">
-    <xsl:if test="chapter|section|subsection|subsubsection">
-        <xsl:text></xsl:text> <!-- removed "true", so now this should make all exercises think they are part of unstructured divisions -->
+<!-- stolen from Oscar Levin and changed to fix headings -->
+<xsl:template match="appendix|section|subsection|subsubsection" mode="is-structured-division">
+    <xsl:if test="subsection|subsubsection">
+        <xsl:text></xsl:text> 
+        <!-- removed "true", so now this should make all exercises think they are part of unstructured divisions -->
     </xsl:if>
 </xsl:template>
 

--- a/xsl/apex-latex-style.xsl
+++ b/xsl/apex-latex-style.xsl
@@ -456,9 +456,9 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
 </xsl:template>
 
 <!-- ensure exercises ignore subsection numbering -->
-<!-- shamelessly stolen from Oscar Levin -->
-<xsl:template match="book|article|part|chapter|appendix|section|subsection|subsubsection" mode="is-structured-division">
-    <xsl:if test="chapter|section|subsection|subsubsection">
+<!-- stolen from Oscar Levin and changed to fix headings -->
+<xsl:template match="appendix|section|subsection|subsubsection" mode="is-structured-division">
+    <xsl:if test="subsection|subsubsection">
         <xsl:text></xsl:text> <!-- removed "true", so now this should make all exercises think they are part of unstructured divisions -->
     </xsl:if>
 </xsl:template>


### PR DESCRIPTION
I changed the way some of the over-wide colorboxes (theorem, key idea, etc) get shifted when using two-sided printing.

The previous minipage solution had a few places that did weird things...

I've also updated the README with instructions that reflect the new steps for PDF production.