### PR TITLE
Add vertical skip after figures; change radio buttons to drop-down

### DIFF
--- a/ptx/sec_deriv_interpret.ptx
+++ b/ptx/sec_deriv_interpret.ptx
@@ -1147,6 +1147,9 @@
 
         <exercise label="ex-deriv-interpret-graph-1">
           <webwork xml:id="webwork-ex-deriv-interpret-graph-1">
+            <pg-macros>
+              <macro-file>parserPopUp.pl</macro-file>
+            </pg-macros>
             <pg-code>
               $h=non_zero_random(-2,2,1);
               $k=non_zero_random(-2,2,1);
@@ -1173,10 +1176,10 @@
               $fright=min($fright,4);
               $fpleft=max($fpleft,-4);
               $fpright=min($fpright,4);
-              $radio=RadioButtons([
-                math_ev3(f).' is the derivative of '.math_ev3(g).'.',
-                math_ev3(g).' is the derivative of '.math_ev3(f).'.'
-              ],0);
+              $radio=DropDown([
+                'f is the derivative of g.',
+                'g is the derivative of f.'
+              ],0,showInStatic=&gt;0);
             </pg-code>
             <statement>
               <image>
@@ -1222,6 +1225,9 @@
 
         <exercise label="ex-deriv-interpret-graph-2">
           <webwork xml:id="webwork-ex-deriv-interpret-graph-2">
+            <pg-macros>
+              <macro-file>parserPopUp.pl</macro-file>
+            </pg-macros>
             <pg-code>
               ($r,$s,$t)=num_sort((-3..3)[NchooseK(7,3)]);
               $a=non_zero_random(-1,1,0.05);
@@ -1239,10 +1245,10 @@
               $ymax=max(5,map{Round($_)+1}(@cv));
               $infl=($r+$s+$t)/3;
               $inflval=$fp-&gt;eval(x=&gt;$infl);
-              $radio=RadioButtons([
-                math_ev3(f).' is the derivative of '.math_ev3(g).'.',
-                math_ev3(g).' is the derivative of '.math_ev3(f).'.'
-              ],1);
+              $radio=DropDown([
+                'f is the derivative of g.',
+                'g is the derivative of f.'
+              ],1,showInStatic=&gt;0);
             </pg-code>
             <statement>
               <image>
@@ -1290,11 +1296,14 @@
 
         <exercise label="ex-deriv-interpret-graph-3">
           <webwork xml:id="webwork-ex-deriv-interpret-graph-3">
+            <pg-macros>
+              <macro-file>parserPopUp.pl</macro-file>
+            </pg-macros>
             <pg-code>
-              $radio=RadioButtons([
-                math_ev3(f).' is the derivative of '.math_ev3(g).'.',
-                math_ev3(g).' is the derivative of '.math_ev3(f).'.'
-              ],1);
+              $radio=DropDown([
+                'f is the derivative of g.',
+                'g is the derivative of f.'
+              ],1,showInStatic=&gt;0);
             </pg-code>
             <statement>
               <image>
@@ -1340,6 +1349,9 @@
 
         <exercise label="ex-deriv-interpret-graph-4">
           <webwork xml:id="webwork-ex-deriv-interpret-graph-4">
+            <pg-macros>
+              <macro-file>parserPopUp.pl</macro-file>
+            </pg-macros>
             <pg-code>
               $h=random(-2,2,1);
               $p=random(2,4,1);
@@ -1348,10 +1360,10 @@
               $fp=$f-&gt;D('x');
               $ymin=-max(int(pi/$p),1)-1;
               $ymax=max(int(pi/$p),1)+1;
-              $radio=RadioButtons([
-                math_ev3(f).' is the derivative of '.math_ev3(g).'.',
-                math_ev3(g).' is the derivative of '.math_ev3(f).'.'
-              ],1);
+              $radio=DropDown([
+                'f is the derivative of g.',
+                'g is the derivative of f.'
+              ],1,showInStatic=&gt;0);
             </pg-code>
             <statement>
               <image>

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -1813,13 +1813,16 @@
         <!-- Exercise 37: Compare errors in wall measurements from previous exercises -->
         <exercise label="ex-differentials-survey-4">
           <webwork xml:id="webwork-ex-differentials-survey-4">
+            <pg-macros>
+              <macro-file>parserPopUp.pl</macro-file>
+            </pg-macros>
             <pg-code>
-              $buttons = RadioButtons(
+              $buttons = DropDown(
                 [
                   'Right triangle at 25 feet',
                   'Right triangle at 100 feet',
                   'Isosceles triangle at 50 feet',
-                ],2);
+                ],2,showInStatic=&gt;0);
             </pg-code>
             <statement>
               <p>

--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -80,7 +80,7 @@
 </xsl:template>
 
 <xsl:template match="figure" mode="tcb-style">
-    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
+    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=\baselineskip</xsl:text>
 </xsl:template>
 
 <xsl:template match="example" mode="tcb-style">

--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -79,6 +79,10 @@
     <xsl:text>coltitle=black, fonttitle=\bfseries, attach title to upper, after title={\space},left=1pt,</xsl:text>
 </xsl:template>
 
+<xsl:template match="figure" mode="tcb-style">
+    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
+</xsl:template>
+
 <xsl:template match="example" mode="tcb-style">
     <xsl:text>blockspacingstyle, after title={\space}, before upper ={\setparstyle}, &#xa; </xsl:text>
     <xsl:text>fonttitle=\normalfont\bfseries, colback=white, colframe=black, colbacktitle=white, coltitle=black,

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -79,6 +79,10 @@
     <xsl:text>coltitle=black, fonttitle=\bfseries, attach title to upper, after title={\space},left=1pt,</xsl:text>
 </xsl:template>
 
+<xsl:template match="figure|listing" mode="tcb-style">
+    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
+</xsl:template>
+
 <xsl:template match="example" mode="tcb-style">
     <xsl:text>blockspacingstyle, after title={\space}, before upper ={\setparstyle}, &#xa; </xsl:text>
     <xsl:text>fonttitle=\normalfont\bfseries, colback=white, colframe=black, colbacktitle=white, coltitle=black,

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -80,7 +80,7 @@
 </xsl:template>
 
 <xsl:template match="figure" mode="tcb-style">
-    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
+    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=\baselineskip</xsl:text>
 </xsl:template>
 
 <xsl:template match="example" mode="tcb-style">

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -79,7 +79,7 @@
     <xsl:text>coltitle=black, fonttitle=\bfseries, attach title to upper, after title={\space},left=1pt,</xsl:text>
 </xsl:template>
 
-<xsl:template match="figure|listing" mode="tcb-style">
+<xsl:template match="figure" mode="tcb-style">
     <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
 </xsl:template>
 

--- a/xsl/apex-latex-style.xsl
+++ b/xsl/apex-latex-style.xsl
@@ -79,6 +79,10 @@
     <xsl:text>coltitle=black, fonttitle=\bfseries, attach title to upper, after title={\space},left=1pt,</xsl:text>
 </xsl:template>
 
+<xsl:template match="figure|listing" mode="tcb-style">
+    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
+</xsl:template>
+
 <xsl:template match="example" mode="tcb-style">
   <xsl:text>blockspacingstyle, after title={\space}, before upper ={\setparstyle},&#xa; </xsl:text>
     <xsl:text>fonttitle=\normalfont\bfseries, colback=white, colframe=black, colbacktitle=white, coltitle=black,

--- a/xsl/apex-latex-style.xsl
+++ b/xsl/apex-latex-style.xsl
@@ -80,7 +80,7 @@
 </xsl:template>
 
 <xsl:template match="figure" mode="tcb-style">
-    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
+    <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=\baselineskip</xsl:text>
 </xsl:template>
 
 <xsl:template match="example" mode="tcb-style">

--- a/xsl/apex-latex-style.xsl
+++ b/xsl/apex-latex-style.xsl
@@ -79,7 +79,7 @@
     <xsl:text>coltitle=black, fonttitle=\bfseries, attach title to upper, after title={\space},left=1pt,</xsl:text>
 </xsl:template>
 
-<xsl:template match="figure|listing" mode="tcb-style">
+<xsl:template match="figure" mode="tcb-style">
     <xsl:text>bwminimalstyle, middle=1ex, blockspacingstyle, fontlower=\blocktitlefont, after skip=12pt</xsl:text>
 </xsl:template>
 


### PR DESCRIPTION
This updates the XSL stylesheets to add a vertical skip after each figure.

Testing shows that the `after skip=\baselineskip` is being added for figure, and also for a couple of figure-related items but when I build, the only place where I see a difference is after a figure.

I also changed the radio buttons for the last 4 exercises of `sec-deriv-interpret` to use drop-down instead. Drop-down has a `showInStatic` option you can use to hide it in PDF, and in HTML before the problem is activated. The only compromise is that in the drop-down, f and g are not in math mode. I don't think that's a big deal.