### PR TITLE
Tweak size of margin figures to match inline

### DIFF
--- a/xsl/apex-latex-print-color.xsl
+++ b/xsl/apex-latex-print-color.xsl
@@ -240,11 +240,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   <xsl:choose>
     <xsl:when test="ancestor::figure/@vshift">
       <xsl:text>\begin{image}</xsl:text>
-      <xsl:text>{0</xsl:text>
+      <xsl:text>{0.02</xsl:text>
       <xsl:text>}</xsl:text>
-      <xsl:text>{1</xsl:text>
+      <xsl:text>{0.96</xsl:text>
       <xsl:text>}</xsl:text>
-      <xsl:text>{0</xsl:text>
+      <xsl:text>{0.02</xsl:text>
       <xsl:text>}{}%&#xa;</xsl:text>
       <xsl:apply-templates select="." mode="image-inclusion" />
       <xsl:text>\end{image}%&#xa;</xsl:text>
@@ -368,7 +368,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   </xsl:if>
 </xsl:template>
 
-<!-- fix this one damn display math that doesn't fit for 2 side printing -->
+<!-- fix this one darn display math that doesn't fit for 2 side printing -->
 <xsl:template match="md">
   <xsl:if test="(@hskip) and ($b-latex-two-sides)">
     <xsl:text>&#xa;&#xa;\noindent\hskip-</xsl:text>

--- a/xsl/apex-latex-print-style.xsl
+++ b/xsl/apex-latex-print-style.xsl
@@ -210,11 +210,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   <xsl:choose>
     <xsl:when test="ancestor::figure/@vshift">
       <xsl:text>\begin{image}</xsl:text>
-      <xsl:text>{0</xsl:text>
+      <xsl:text>{0.02</xsl:text>
       <xsl:text>}</xsl:text>
-      <xsl:text>{1</xsl:text>
+      <xsl:text>{0.96</xsl:text>
       <xsl:text>}</xsl:text>
-      <xsl:text>{0</xsl:text>
+      <xsl:text>{0.02</xsl:text>
       <xsl:text>}{}%&#xa;</xsl:text>
       <xsl:apply-templates select="." mode="image-inclusion" />
       <xsl:text>\end{image}%&#xa;</xsl:text>
@@ -339,7 +339,7 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   </xsl:if>
 </xsl:template>
 
-<!-- fix this one damn display math that doesn't fit for 2 side printing -->
+<!-- fix this one darn display math that doesn't fit for 2 side printing -->
 <xsl:template match="md">
   <xsl:if test="(@hskip) and ($b-latex-two-sides)">
     <xsl:text>&#xa;&#xa;\noindent\hskip-</xsl:text>

--- a/xsl/apex-latex-style.xsl
+++ b/xsl/apex-latex-style.xsl
@@ -228,11 +228,11 @@ https://tex.stackexchange.com/questions/605955/can-i-avoid-indentation-of-margin
   <xsl:choose>
     <xsl:when test="ancestor::figure/@vshift">
       <xsl:text>\begin{image}</xsl:text>
-      <xsl:text>{0</xsl:text>
+      <xsl:text>{0.02</xsl:text>
       <xsl:text>}</xsl:text>
-      <xsl:text>{1</xsl:text>
+      <xsl:text>{0.96</xsl:text>
       <xsl:text>}</xsl:text>
-      <xsl:text>{0</xsl:text>
+      <xsl:text>{0.02</xsl:text>
       <xsl:text>}{}%&#xa;</xsl:text>
       <xsl:apply-templates select="." mode="image-inclusion" />
       <xsl:text>\end{image}%&#xa;</xsl:text>


### PR DESCRIPTION
Related to an email discussion about fonts in images. Inline images are 47% of the text width, which works out to 144 pt. The marginparwidth is 150pt. Tweaking image width from 100% to 96% means margin images will be 144pt as well.