### PR TITLE
Update sec_antider.ptx

### DIFF
--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -374,7 +374,7 @@
         </p>
         <p>
           <md>
-            <mrow>\amp\lzoo{x}{cf(x)}=c\cdot\fp(x)\amp\amp\int c\cdot f(x)\,dx= c\cdot \int f(x)\,dx</mrow>
+            <mrow>\amp\lzoo{x}{cf(x)}=c\cdot\fp(x)\amp\amp\int c\cdot f(x)\,dx= c\cdot \int f(x)\,dx\quad(c\neq 0)</mrow>
             <mrow>\amp\lzoo{x}{f(x)\pm g(x)} =\fp(x)\pm g'(x)\amp\amp \int \big(f(x)\pm g(x)\big)\,dx =\int f(x)\,dx\pm \int g(x)\,dx</mrow>
             <mrow>\amp\lzoo{x}{C} = 0\amp\amp \int 0\,dx = C</mrow>
             <mrow>\amp\lzoo{x}{x} = 1\amp\amp \int 1\,dx = \int dx = x+C</mrow>


### PR DESCRIPTION
Possible correction to antidiff. property.

[Theorem 5.1.6](https://opentext.uleth.ca/apex-calculus/sec_antider.html#thm_indef_alg-2-2) states  \int c \cdot f(x) \, dx = c \cdot \int f(x) \, dx.
While this is identical to language in other texts, I got a suggestion that we should add "(c \neq 0)" as a condition.

The reason (which you can figure on your own) is that if c=0, integrating 0 leads to a +C, whereas integrating first then multiplying by 0 means you just get 0. 

I'm wondering what others think of this suggestion. I'm lean toward making the change. 
Yes, I think they have a point. 
I also think the expression "c \cdot \int f(x)\,dx" is also playing a bit loose with set notation, and this may be an unimportant nitpick. But if it gets students thinking about what's going on, it may create a bit of a learning moment.

Interested in any discussion before someone merges.