### PR TITLE
WeBWorK errors and typos

### DIFF
--- a/ptx/sec_antider.ptx
+++ b/ptx/sec_antider.ptx
@@ -1501,8 +1501,11 @@
               if($envir{problemSeed}==1){$fpp=7;$fp0=-1;$f0=10;};
               Context("Fraction");
               $a = Fraction($fpp,6);
-              $c = Fraction($f0 - $a - $fp0);
-              $F = Formula("$a x^3 + $fp0 x + $c");
+              $a2 = Fraction($fpp,2);
+              $a3 = Fraction($fpp,3);
+              $b = Fraction($fp0 - $a2);
+              $c = Fraction($f0 + $a3 - $fp0);
+              $F = Formula("$a x^3 + $b x + $c");
             </pg-code>
             <statement>
               <p>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1970,7 +1970,7 @@
               parser::Assignment-&gt;Allow;
               $f=Formula("$b x + $c")-&gt;reduce;
               $k=$f-&gt;eval(x=&gt;$a);
-              $t=$f;
+              $t=Formula("y=$f");
               $n=Formula("y=-1/$b(x-$a)+$k");
             </pg-code>
             <statement>


### PR DESCRIPTION
The last question in Section 2.3 (basic derivative rules) was coded incorrectly: all of the other problems in that section expect you to include the "y=" part of the equation for the tangent line. This ensures that the last question behaves the same way.

An easy fix, but I think it might be worthwhile to keep this pull request open until the end of the term, in case my students find other errors in the exercises.