### PR TITLE
Add chapter 1 peer instruction

### DIFF
--- a/ptx/docinfo.ptx
+++ b/ptx/docinfo.ptx
@@ -4,6 +4,7 @@
   <initialism>APEX</initialism>
   <rename element="inlineexercise">Exercise</rename>
   <rename element="task">Part</rename>
+  <rename element="reading-questions">Discussion Questions</rename>
 
   <document-id edition="5" component="proteus">APEXPROTEUS</document-id>
   <document-id edition="5" component="main">APEX</document-id>

--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -1328,6 +1328,229 @@
     Defining that term will require us to look again at what a limit is and what causes limits to not exist.
   </p>
 
+  <reading-questions component="peer">
+    <exercise label="peer-limit-analytic-1">
+      <statement>
+        <p>
+          Using properties of limits, the value of
+          <me>
+            \lim_{x\to -3}(4x^2-2x+3)
+          </me>
+          is:
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>-27</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>45</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>-39</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>33</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The limit cannot be evaluated using only limit properties.
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-analytic-2">
+      <statement>
+        <p>
+          Which of the following limits can <em>not</em> be evaluated using limit properties?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim_{x\to 2}\frac{x^2-4}{x+4}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>\lim_{x\to 1}\frac{x^2-3x+2}{x^2-1}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim_{x\to 0}(x+x^2+x^3+x^4)</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim_{x\to -1}\frac{2}{x^2+1}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              None of these.
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-analytic-3">
+      <introduction>
+        <p>
+          Consider the function <m>f(x) = \dfrac{x^2+4x+3}{x^2-1}</m>.
+        </p>
+      </introduction>
+
+      <task label="peer-limit-analytic-3a">
+        <statement>
+          <p>
+            A function <m>g(x)</m> such that <m>g(x)=f(x)</m>
+            for all <m>x\neq -1</m> is:
+          </p>
+        </statement>
+        <choice>
+          <statement>
+            <p>
+              <m>g(x) = \dfrac{x-3}{x-1}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>g(x) = \dfrac{4x+3}{-1}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>g(x) = \dfrac{x+3}{x+1}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>g(x) = \dfrac{x+3}{x-1}</m>
+            </p>
+          </statement>
+        </choice>
+      </task>
+      <task label="peer-limit-analytic-3b">
+        <statement>
+          <p>
+            The value of <m>\lim\limits_{x\to -1}f(x)</m> is:
+          </p>
+        </statement>
+        <choice>
+          <statement>
+            <p>
+              Undefined
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>-1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>-2</m>
+            </p>
+          </statement>
+        </choice>
+      </task>
+    </exercise>
+    
+    <exercise label="peer-limit-analytic-4">
+      <statement>
+        <p>
+          The limit <m>\lim\limits_{x\to 0}\dfrac{\sin(2x)}{x}</m> is a <m>0/0</m> limit.
+        </p>
+        <p>
+          Which of the following is a valid first step? 
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              Factor out the 2 to get <m>2\sin(x)</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Cancel the <m>x</m> in the numerator with the <m>x</m> in the denominator
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              Multiply numerator and denominator by 2
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Put your calculator in degrees mode
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+  </reading-questions>
   <exercises>
     <subexercises xml:id="TaC-limit-analytically">
       <title>Terms and Concepts</title>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1504,6 +1504,314 @@
   </paragraphs>
   <!--<p>In the next section we examine one more aspect of limits: limits that involve infinity.  </p>-->
 
+  <reading-questions component="peer">
+    <exercise label="peer-limit-continuity-1">
+      <statement>
+        <p>
+          Which of the following quantities is best modelled by a continuous function of time?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              The enrollment in this course.
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              The outdoor temperature
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The outdoor temperature, rounded to the nearest degree
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The balance in your bank account
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+    <exercise label="peer-limit-continuity-2">
+      <statement>
+        <p>
+          The graph of a function is shown below.
+          At what points is it not continuous?
+        </p>
+
+        <image width="47%">
+          <shortdescription>A graph of a piecewise-defined function with many different features and points of discontinuity.</shortdescription>
+          <latex-image label="peer-continuity-img1">
+            \begin{tikzpicture}
+              \begin{axis}[
+                  minor xtick={0,0.1,...,1},
+                  xmin=-4.5,
+                  xmax=6.5,
+                  ymin=-1.5,
+                  ymax=6.5
+                ]
+                \addplot[firstcurvestyle,domain=-4:-2.05] {0.5*(x+1)^2+0.5};
+                \addplot[firstcurvestyle,samples=50,domain=-1.95:-0.05] {(x+3)*cos(180*x)+1};
+                \addplot[firstcurvestyle,domain=0.05:1.9] {1/(x-2)+4.5};
+                \addplot[firstcurvestyle,domain=2.1:2.98] {(x+5)/(2*x-4)};
+                \addplot[firstcurvestyle,domain=3.02:6] {(x+5)/(2*x-4)};
+                \addplot[hollowdot] coordinates {(-2,2)};
+                \addplot[hollowdot] coordinates {(3,4)};
+                \addplot[soliddot] coordinates {(-2,1)};
+                \addplot[soliddot] coordinates {(-4,5)};
+                \addplot[soliddot] coordinates {(0,4)};
+                \addplot[soliddot] coordinates {(3,2)};
+                \addplot[soliddot] coordinates {(6,1.375)};
+                \addplot[asymptote] coordinates {(2,-1.5) (2,6.5)};
+              \end{axis}
+            \end{tikzpicture}
+           </latex-image>
+        </image>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              At <m>x=-2</m> only
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              At <m>x=-2</m> and <m>x=2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              At <m>x=-2</m>, <m>x=2</m>, and <m>x=3</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              At <m>x=-2</m>, <m>x=0</m>, <m>x=2</m>, and <m>x=3</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-continuity-3">
+      <statement>
+        <p>
+          Let <m>f(x) = \begin{cases}2x+x^2, \amp x\lt 1\\ 4-x, \amp x\geq 1\end{cases}</m>
+        </p>
+        <p>
+          Which of the following is true?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>f</m> is continuous at <m>0</m> and <m>1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>f</m> is continuous at <m>0</m>, but not at <m>1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>f</m> is continuous at <m>1</m>, but not at <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>f</m> is not continuous at either <m>0</m> or <m>1</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-continuity-4">
+      <statement>
+        <p>
+          <m>f</m> is not continuous at either <m>0</m> or <m>1</m>
+        </p>
+
+        <p>
+          For what value of <m>c</m> is <m>f</m> continuous at <m>2</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>5/2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>8/3</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\sqrt{2}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Not possible to solve for <m>c</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+    <exercise label="peer-limit-continuity-5">
+      <introduction>
+        <p>
+          Determine the type of discontinity each function has at the given point.
+        </p>
+      </introduction>
+      <task label="peer-limit-continuity-5a">
+        <statement>
+          <p>
+            <m>f(x) = \dfrac{\abs{x}}{x}</m>, at <m>x=0</m>
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                Removable
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                Jump
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                Infinite
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                No discontinuity
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+      <task label="peer-limit-continuity-5b">
+        <statement>
+          <p>
+            <m>f(x) = \dfrac{\sin(x)}{x}</m>, at <m>x=0</m>
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                Removable
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                Jump
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                Infinite
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                No discontinuity
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+      <task label="peer-limit-continuity-5c">
+        <statement>
+          <p>
+            <m>f(x) = \dfrac1x</m>, at <m>x=0</m>
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                Removable
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                Jump
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                Infinite
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                No discontinuity
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+    </exercise>
+  </reading-questions>
+
   <exercises>
     <subexercises xml:id="TaC-limit-continuity">
       <title>Terms and Concepts</title>

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1343,6 +1343,285 @@
     </figure>
   </subsection>
 
+  <reading-questions component="peer">
+    <exercise label="peer-limit-infinite-1">
+      <introduction>
+        <p>
+          Let <m>f(x) = \dfrac{(x+1)(x-4)}{(x+2)^2(x-2)}</m>.
+        </p>
+
+        <p>
+          Construct a sign diagram for <m>f(x)</m>,
+          and use it to answer the following questions.
+        </p>
+      </introduction>
+      <task label="peer-limit-infinite-1a">
+        <statement>
+          <p>
+            Which of the following is true at <m>x=2</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to 2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=\infty</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to 2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=\infty</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to 2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=-\infty</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to 2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=-\infty</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+      <task label="peer-limit-infinite-1b">
+        <statement>
+          <p>
+            Which of the following is true at <m>x=-2</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to -2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=\infty</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to -2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=\infty</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to -2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=-\infty</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                <m>\lim\limits_{x\to -2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=-\infty</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+    </exercise>
+    
+    <exercise label="peer-limit-infinite-2">
+      <statement>
+        <p>
+          For the function <m>f(x) = \dfrac{x^2-4}{x^3-5x^2+6x}</m>,
+          which of the following is true of the graph <m>y=f(x)</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              There is one vertical asymptote, at <m>x=0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              There are two vertical asymptotes, at <m>x=0</m> and <m>x=2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              There are two vertical asymptotes, at <m>x=2</m> and <m>x=-2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              There are two vertical asymptotes, at <m>x=0</m> and <m>x=3</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              There are three vertical asymptotes, at <m>x=0</m>, <m>x=2</m>, and <m>x=3</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-infinite-3">
+      <introduction>
+        <p>
+          Let <m>f(x) = \dfrac{3x^2-4x}{4-5x+8x^2}</m>.
+        </p>
+      </introduction>
+      <task label="peer-limit-infinite-3a">
+        <statement>
+          <p>
+            Which of the following is equal to <m>f(x)</m> when <m>x\neq 0</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                <m>\dfrac{3-4x}{4-5x+8}</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>\dfrac{3-4/x}{4-5x+8x^2}</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                <m>\dfrac{3-4/x}{8-5/x+4/x^2}</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+      <task label="peer-limit-infinite-3b">
+        <statement>
+          <p>
+            What is the value of <m>\lil\limits_{x\to\infty}f(x)</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                <m>3/8</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>3/4</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>0</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>\infty</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+    </exercise>
+
+    <exercise label="peer-limit-infinite-4">
+      <statement>
+        <p>
+          For the function <m>f(x)=\dfrac{x}{\sqrt{x^2+1}}</m>:
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to \infty}f(x)=1</m> and <m>\lim\limits_{x\to -\infty}f(x)=1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice corect="yes">
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to \infty}f(x)=1</m> and <m>\lim\limits_{x\to -\infty}f(x)=-1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to \infty}f(x)=0</m> and <m>\lim\limits_{x\to -\infty}f(x)=0</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-infinite-5">
+      <statement>
+        <p>
+          Which of the following is true of a function that is continuous on its domain?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              The graph of the function cannot cross either a vertical asymptote or a horizontal asymptote
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The graph of the function cannot cross a horizontal asymptote, but it can cross a vertical asymptote
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              The graph of the function cannot cross a vertical asymptote, but it can cross a horizontal asymptote
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The graph of the function can cross both a horizontal asymptote and a vertical asymptote
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+  </reading-questions>
+
   <exercises>
     <subexercises xml:id="TaC-limit-infinity">
       <title>

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -1524,6 +1524,213 @@
     </p>
   </paragraphs>
 
+  <reading-questions component="peer">
+    <exercise label="peer-limit-intro-1">
+      <introduction>
+        <p>
+          Suppose we have the following graph of a function <m>f</m>,
+          but we can't see what is happening under the square:
+        </p>
+
+        <image width="47%">
+          <shortdescription>A downward-facing parabola, with one portion blocked by a square.</shortdescription>
+          <latex-image label="peer-limit-intro-img1">
+            \begin{tikzpicture}
+              
+                  \begin{axis}[
+                      ymin=-1,
+                      ymax=3,
+                      xmin=-1,
+                      xmax=4.3,
+                      axis equal,
+                    ]
+                    \addplot+ [leftarrow,domain=-0.9:1.98]{-0.5*x^2+x+2};
+                    \addplot [firstcurvestyle,rightarrow,domain=2.02:3.5]{-0.5*x^2+x+2};
+                    \addplot[squaremark] coordinates{(2,2)};
+                    %\addplot[hollowdot] coordinates{(2,2.6)};
+                    %\addplot[hollowdot] coordinates{(2,0.4)};
+                  \end{axis}
+                
+            \end{tikzpicture}
+          </latex-image>
+        </image>
+      </introduction>
+      <task label="peer-limit-intro1a">
+        <statement>
+          <p>
+            If you had to guess, when <m>x</m> is close to 2,
+            you would say that <m>f(x)</m> is close to:
+          </p>
+        </statement>
+        <choices>
+          <choice correct="no">
+            <statement>
+              <p>
+                <m>0</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="no">
+            <statement>
+              <p>
+                <m>1</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                <m>2</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="no">
+            <statement>
+              <p>
+                <m>3</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+      <task label="peer-limit-intro1b">
+        <statement>
+          <p>
+            What can you say about <m>f(2)</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement correct="no">
+              <p>
+                <m>f(2)=2</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="no">
+            <statement>
+              <p>
+                <m>f(2)</m> is close to <m>2</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="no">
+            <statement>
+              <p>
+                <m>f(2) is undefined</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                Nothing
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+    </exercise>
+
+    <exercise label="peer-limit-intro-2">
+      <statement>
+        <p>
+          Referring to the graph below, what is the value of <m>\lim_{x\to 2}f(x)</m>?
+        </p>
+
+        <image width="47%">
+          <shortdescription>A piecewise defined graph with a break at x=2.</shortdescription>
+          <latex-image label="peer-limit-intro-img2">
+            \begin{tikzpicture}
+              \begin{axis}[
+                ymin=-.1,
+                ymax=3.5,
+                xmin=-0.1,
+                xmax=4.3,
+                axis equal,
+              ]
+              \addplot+ [leftarrow,domain=0:1.98]{-0.5*x^2+x+3};
+              \addplot [firstcurvestyle,rightarrow,domain=2.02:3.4]{0.5*x^2-x+1};
+              \addplot[soliddot] coordinates{(2,2)};
+              \addplot[hollowdot] coordinates{(2,3)};
+              \addplot[hollowdot] coordinates{(2,1)};
+              \end{axis}
+            \end{tikzpicture}
+          </latex-image>
+        </image>
+      </statement>
+      <choices>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>\lim_{x\to 2}f(x)=1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>\lim_{x\to 2}f(x)=2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>\lim_{x\to 2}f(x)=3</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              It doesn't exist
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-intro-3">
+      <statement>
+        <p>
+          Sometimes you can get an idea of a limit by trying test values.
+        </p>
+
+        <p>
+          Consider the function <m>f(x) = \sin\left(\dfrac{\pi}{x}\right)</m>.
+        </p>
+
+        <p>
+          Try plugging in <m>x=0.1, 0.01, 0.001</m>. What do you think is the value of <m>\lim\limits_{x\to 0}f(x)</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              It's definitely <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              I'm not so sure...
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+  </reading-questions>
+
   <exercises>
     <subexercises xml:id="TaC-limit-intro">
       <title>Terms and Concepts</title>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -871,6 +871,244 @@
     Such functions behave nicely as they are very predictable.
   </p>
 
+  <reading-questions component="peer">
+    <exercise label="peer-limit-oneside-1">
+      <introduction>
+        <p>
+          Consider the function <m>f(x) = \begin{cases}2-x, \amp x\lt -1\\ 1+x^2, \amp -1\leq x\lt 2\\ \sin(\pi x),\amp x\geq 2\end{cases}</m>.
+        </p>
+      </introduction>
+      <task label="peer-limit-oneside-1a">
+        <statement>
+          <p>
+            What is the value of <m>f(0)</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                <m>2</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>0</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>-1</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                <m>1</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+      <task label="peer-limit-oneside-1b">
+        <statement>
+          <p>
+            What is the value of <m>f(2)</m>?
+          </p>
+        </statement>
+        <choices>
+          <choice>
+            <statement>
+              <p>
+                <m>2</m>
+              </p>
+            </statement>
+          </choice>
+          <choice correct="yes">
+            <statement>
+              <p>
+                <m>0</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>5</m>
+              </p>
+            </statement>
+          </choice>
+          <choice>
+            <statement>
+              <p>
+                <m>1</m>
+              </p>
+            </statement>
+          </choice>
+        </choices>
+      </task>
+    </exercise>
+
+    <exercise label="peer-limit-oneside-2">
+      <statement>
+        <p>
+          You may have learned that the function <m>\abs{x}</m> measures <q>distance from 0</q>:
+        </p>
+
+        <p>
+          If <m>x\gt 0</m>, then <m>\abs{x}=x</m>. If <m>x\lt 0</m>, then <m>\abs{x}=-x</m>.
+        </p>
+
+        <p>
+          Which of the following functions is equivalent to <m>f(x)=\abs{x-2}</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>f(x) = \begin{cases}x-2, \amp x\geq 2\\ 2-x, \amp x\lt 2\end{cases}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>f(x) = \begin{cases}x-2, \amp x\geq 0\\ 2-x, \amp x\lt 0\end{cases}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>f(x) = \begin{cases}x, \amp x\geq 2\\ -x, \amp x\lt 2\end{cases}</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-oneside-2">
+      <statement>
+        <p>
+          For the graph below, at <m>x=2</m>:
+        </p>
+
+        <image width="47%">
+          <shortdescription>The graph of a piecewise-defined function.</shortdescription>
+          <latex-image label="peer-limit-oneside-img1">
+            \begin{tikzpicture}
+            \begin{axis}[
+                ymin=-.1,
+                ymax=3.5,
+                xmin=-0.1,
+                xmax=4.3,
+                axis equal
+              ]
+              \addplot+ [leftarrow,domain=0:1.98]{-0.5*x^2+x+3};
+              \addplot [firstcurvestyle,rightarrow,domain=2.02:3.4]{0.5*x^2-x+1};
+              %\addplot[soliddot] coordinates{(2,2)};
+              \addplot[soliddot] coordinates{(2,3)};
+              \addplot[hollowdot] coordinates{(2,1)};
+            \end{axis}
+            \end{tikzpicture}
+          </latex-image>
+        </image>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              The left-hand limit is 3 and the right-hand limit is 3.
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The left-hand limit is 1 and the right-hand limit is 3.
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              The left-hand limit is 3 and the right-hand limit is 1.
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The left-hand limit is 1 and the right-hand limit is 1.
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              The left-hand limit is 3 and the right-hand limit does not exist.
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-onside-4">
+      <statement>
+        <p>
+          Let <m>f(x) = \begin{cases}4-x^2,\amp x\lt 3\\ 2x-5,\amp x\geq 3\end{cases}</m>.
+        </p>
+
+        <p>
+          To compute the left-hand limit <m>\lim\limits_{x\to 3^-}f(x)</m>:
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              We plug in <m>x=2.99</m>, since that's a little less than 3.
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              We plug in <m>3.01</m>, since that's a little more than 3.
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              We set <m>f(x)=4-x^2</m>, since <m>x\lt 3</m>, and take the limit as <m>x\to 3</m>.
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              We set <m>f(x)=2x-5</m>, since <m>x\gt 3</m>, and take the limit as <m>x\to 3</m>.
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              We plug in <m>x=3</m>, since the limit is the same as <m>f(3)</m>.
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+  </reading-questions>
+
   <exercises>
     <subexercises xml:id="TaC-limit-onesided">
       <title>Terms and Concepts</title>


### PR DESCRIPTION
This adds some peer instruction problems for classroom use.

I've placed them in a "reading questions" division, and they do not appear in the book unless the `peer` component is included in the publication file.