### PR TITLE
Remove introduction and subsection

### DIFF
--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1,591 +1,589 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_basic_diff_rules" label="sec_basic_diff_rules">
   <title>Basic Differentiation Rules</title>
-  <introduction>
-    <p>
-      The derivative is a powerful tool but is admittedly awkward given its reliance on limits.
-      Fortunately, one thing mathematicians are good at is
-      <em>abstraction.</em> For instance,
-      instead of continually finding derivatives at a point,
-      we abstracted and found the derivative function.
-    </p>
+  <p>
+    The derivative is a powerful tool but is admittedly awkward given its reliance on limits.
+    Fortunately, one thing mathematicians are good at is
+    <em>abstraction.</em> For instance,
+    instead of continually finding derivatives at a point,
+    we abstracted and found the derivative function.
+  </p>
 
-    <p>
-      Let's practice abstraction on linear functions, <m>y=mx+b</m>.
-      What is <m>\yp</m>?
-      Without limits,
-      recognize that linear functions are characterized by being functions with a constant rate of change
-      (the slope).
-      The derivative, <m>\yp</m>, gives the instantaneous rate of change;
-      with a linear function, this is constant, <m>m</m>.
-      Thus <m>\yp=m</m>.
-    </p>
+  <p>
+    Let's practice abstraction on linear functions, <m>y=mx+b</m>.
+    What is <m>\yp</m>?
+    Without limits,
+    recognize that linear functions are characterized by being functions with a constant rate of change
+    (the slope).
+    The derivative, <m>\yp</m>, gives the instantaneous rate of change;
+    with a linear function, this is constant, <m>m</m>.
+    Thus <m>\yp=m</m>.
+  </p>
 
-    <p>
-      Let's abstract once more.
-      Let's find the derivative of the general quadratic function,
-      <m>f(x) = ax^2+bx+c</m>.
-      Using the definition of the derivative, we have:
-      <md>
-        <mrow>\fp(x) \amp = \lim_{h\to 0}\frac{a(x+h)^2+b(x+h)+c-(ax^2+bx+c)}{h}</mrow>
-        <mrow>\amp = \lim_{h\to 0}\frac{ax^2+2ahx+ah^2+bx+bh+c-ax^2-bx-c}{h}</mrow>
-        <mrow>\amp = \lim_{h\to 0} \frac{ah^2+2ahx+bh}{h}</mrow>
-        <mrow>\amp = \lim_{h\to 0} ah+2ax+b</mrow>
-        <mrow>\amp = 2ax+b</mrow>
-      </md>.
-    </p>
+  <p>
+    Let's abstract once more.
+    Let's find the derivative of the general quadratic function,
+    <m>f(x) = ax^2+bx+c</m>.
+    Using the definition of the derivative, we have:
+    <md>
+      <mrow>\fp(x) \amp = \lim_{h\to 0}\frac{a(x+h)^2+b(x+h)+c-(ax^2+bx+c)}{h}</mrow>
+      <mrow>\amp = \lim_{h\to 0}\frac{ax^2+2ahx+ah^2+bx+bh+c-ax^2-bx-c}{h}</mrow>
+      <mrow>\amp = \lim_{h\to 0} \frac{ah^2+2ahx+bh}{h}</mrow>
+      <mrow>\amp = \lim_{h\to 0} ah+2ax+b</mrow>
+      <mrow>\amp = 2ax+b</mrow>
+    </md>.
+  </p>
 
-    <p>
-      So if <m>y = 6x^2+11x-13</m>,
-      we can immediately compute <m>\yp = 12x+11</m>.
-    </p>
+  <p>
+    So if <m>y = 6x^2+11x-13</m>,
+    we can immediately compute <m>\yp = 12x+11</m>.
+  </p>
 
-    <p>
-      In this section
-      (and in some sections to follow)
-      we will learn some of what mathematicians have already discovered about the derivatives of certain functions and how derivatives interact with arithmetic operations.
-      We start with a theorem.
-    </p>
+  <p>
+    In this section
+    (and in some sections to follow)
+    we will learn some of what mathematicians have already discovered about the derivatives of certain functions and how derivatives interact with arithmetic operations.
+    We start with a theorem.
+  </p>
 
-    <theorem xml:id="thm_deriv_common">
-      <title>Derivatives of Common Functions</title>
-      <statement>
-        <p>
-          <ol cols="2">
-            <li xml:id="constant-derivative-rule">
-              <title>Constant Rule</title>
+  <theorem xml:id="thm_deriv_common">
+    <title>Derivatives of Common Functions</title>
+    <statement>
+      <p>
+        <ol cols="2">
+          <li xml:id="constant-derivative-rule">
+            <title>Constant Rule</title>
 
-                  <idx><h>derivative</h><h>Constant Rule</h></idx>
+                <idx><h>derivative</h><h>Constant Rule</h></idx>
 
-              <p>
-                <m>\lzoo{x}{c} = 0</m>, where <m>c</m> is a constant.
-              </p>
-            </li>
+            <p>
+              <m>\lzoo{x}{c} = 0</m>, where <m>c</m> is a constant.
+            </p>
+          </li>
 
-            <li xml:id="power-derivative-rule">
-              <title>Power Rule</title>
+          <li xml:id="power-derivative-rule">
+            <title>Power Rule</title>
 
-                  <idx><h>derivative</h><h>Power Rule</h></idx>
-                  <idx><h>Power Rule</h><h>differentiation</h></idx>
+                <idx><h>derivative</h><h>Power Rule</h></idx>
+                <idx><h>Power Rule</h><h>differentiation</h></idx>
 
-              <p>
-                <m>\lzoo{x}{x^n}= nx^{n-1}</m>,
-                where <m>n</m> is an integer, <m>n \gt 0</m>.
-              </p>
-            </li>
+            <p>
+              <m>\lzoo{x}{x^n}= nx^{n-1}</m>,
+              where <m>n</m> is an integer, <m>n \gt 0</m>.
+            </p>
+          </li>
 
-            <li>
-              
-              <p>
-                <m>\lzoo{x}{\sin(x)} = \cos(x)</m>
-              </p>
-            </li>
+          <li>
+            
+            <p>
+              <m>\lzoo{x}{\sin(x)} = \cos(x)</m>
+            </p>
+          </li>
 
-            <li>
-              <p>
-                <m>\lzoo{x}{\cos(x)} = {-\sin(x)}</m>
-              </p>
-            </li>
+          <li>
+            <p>
+              <m>\lzoo{x}{\cos(x)} = {-\sin(x)}</m>
+            </p>
+          </li>
 
-            <li>
-              <p>
-                <m>\lzoo{x}{e^x} = e^x</m>
-              </p>
-            </li>
+          <li>
+            <p>
+              <m>\lzoo{x}{e^x} = e^x</m>
+            </p>
+          </li>
 
-            <li>
-              <p>
-                <m>\lzoo{x}{\ln(x)} = \frac{1}{x}</m>, for <m>x \gt  0</m>.
-              </p>
-            </li>
-          </ol>
+          <li>
+            <p>
+              <m>\lzoo{x}{\ln(x)} = \frac{1}{x}</m>, for <m>x \gt  0</m>.
+            </p>
+          </li>
+        </ol>
 
-          <idx><h>derivative</h><h>basic rules</h></idx>
+        <idx><h>derivative</h><h>basic rules</h></idx>
 
-        </p>
-      </statement>
-    </theorem>
+      </p>
+    </statement>
+  </theorem>
 
-    <exercise component="proteus" label="APEX-PROTEUS-deriv-basic-1-v1">
-      <title>PROTEUS EXERCISE</title>
-      <statement>
-        <p>
-          Explain graphically why the derivative of a constant function should be zero.
-          Then, use the definition of the derivative to show why this must be true.
-        </p>
-      </statement>
-      <response />
-      
-    </exercise>
+  <exercise component="proteus" label="APEX-PROTEUS-deriv-basic-1-v1">
+    <title>PROTEUS EXERCISE</title>
+    <statement>
+      <p>
+        Explain graphically why the derivative of a constant function should be zero.
+        Then, use the definition of the derivative to show why this must be true.
+      </p>
+    </statement>
+    <response />
+    
+  </exercise>
 
-    <figure xml:id="vid_deriv_basic_rules" component="video" vshift="0">
-      <caption>Video explanation of <xref ref="thm_deriv_common"/></caption>
-      <video youtube="wPJ8-zKc1n0" label="vid_deriv_basic_rules"/>
-    </figure>
+  <figure xml:id="vid_deriv_basic_rules" component="video" vshift="0">
+    <caption>Video explanation of <xref ref="thm_deriv_common"/></caption>
+    <video youtube="wPJ8-zKc1n0" label="vid_deriv_basic_rules"/>
+  </figure>
 
-    <p>
-      This theorem starts by stating an intuitive fact:
-      constant functions have zero rate of change as they are <em>constant</em>.
-      Therefore their derivative is <m>0</m>
-      (they change at the rate of <m>0</m>).
-      The theorem then states some fairly amazing things.
-      The <xref ref="power-derivative-rule" text="title"/> states that the derivatives of Power Functions
-      (of the form <m>y=x^n</m>)
-      are very straightforward:
-      multiply by the power, then subtract <m>1</m> from the power.
-      We see something incredible about the function <m>y=e^x</m>:
-      it is its own derivative.
-      We also see a new connection between the sine and cosine functions.
-    </p>
+  <p>
+    This theorem starts by stating an intuitive fact:
+    constant functions have zero rate of change as they are <em>constant</em>.
+    Therefore their derivative is <m>0</m>
+    (they change at the rate of <m>0</m>).
+    The theorem then states some fairly amazing things.
+    The <xref ref="power-derivative-rule" text="title"/> states that the derivatives of Power Functions
+    (of the form <m>y=x^n</m>)
+    are very straightforward:
+    multiply by the power, then subtract <m>1</m> from the power.
+    We see something incredible about the function <m>y=e^x</m>:
+    it is its own derivative.
+    We also see a new connection between the sine and cosine functions.
+  </p>
 
-    <p>
-      One special case of the <xref ref="power-derivative-rule" text="title"/> is when <m>n=1</m>,
-      <ie/>, when <m>f(x) = x</m>.
-      What is <m>\fp(x)</m>?
-      According to the <xref ref="power-derivative-rule" text="title"/>,
-      <me>
-        \fp(x) = \lzoo{x}{x} = \lzoo{x}{x^1} = 1\cdot x^0 = 1
-      </me>.
-    </p>
+  <p>
+    One special case of the <xref ref="power-derivative-rule" text="title"/> is when <m>n=1</m>,
+    <ie/>, when <m>f(x) = x</m>.
+    What is <m>\fp(x)</m>?
+    According to the <xref ref="power-derivative-rule" text="title"/>,
+    <me>
+      \fp(x) = \lzoo{x}{x} = \lzoo{x}{x^1} = 1\cdot x^0 = 1
+    </me>.
+  </p>
 
-    <p>
-      In words, we are asking <q>At what rate does <m>f</m> change with respect to <m>x</m>?</q>
-      Since <m>f</m> <em>is</em> <m>x</m>,
-      we are asking <q>At what rate does <m>x</m> change with respect to <m>x</m>?</q> The answer is:
-      <m>1</m>.
-      They change at the same rate.
-      We can also interpret the derivative as the slope of the tangent line to the function at a point <m>(c,f(c))</m>.
-      Since <m>f(x)=x</m> is a linear function with constant slope <m>1</m>,
-      we can say that the derivative of <m>f(x)=x</m> is <m>\fp(x)=1</m>.
-    </p>
+  <p>
+    In words, we are asking <q>At what rate does <m>f</m> change with respect to <m>x</m>?</q>
+    Since <m>f</m> <em>is</em> <m>x</m>,
+    we are asking <q>At what rate does <m>x</m> change with respect to <m>x</m>?</q> The answer is:
+    <m>1</m>.
+    They change at the same rate.
+    We can also interpret the derivative as the slope of the tangent line to the function at a point <m>(c,f(c))</m>.
+    Since <m>f(x)=x</m> is a linear function with constant slope <m>1</m>,
+    we can say that the derivative of <m>f(x)=x</m> is <m>\fp(x)=1</m>.
+  </p>
 
-    <p xml:id="vidint-deriv_basic_rules_exp_func" component="video">
-      <xref ref="thm_deriv_common"/> states that the natural exponential function has a remarkable propery:
-      it is equal to its own derivative! The video in <xref ref="vid_deriv_basic_rules_exp_func"/> explains why this is the case.
-    </p>
+  <p xml:id="vidint-deriv_basic_rules_exp_func" component="video">
+    <xref ref="thm_deriv_common"/> states that the natural exponential function has a remarkable propery:
+    it is equal to its own derivative! The video in <xref ref="vid_deriv_basic_rules_exp_func"/> explains why this is the case.
+  </p>
 
-    <figure xml:id="vid_deriv_basic_rules_exp_func" component="video" vshift="0">
-      <caption>Determining the derivative of <m>f(x)=e^x</m></caption>
-      <video youtube="ipKTEdQFBjw" label="vid_deriv_basic_rules_exp_func"/>
-    </figure>
+  <figure xml:id="vid_deriv_basic_rules_exp_func" component="video" vshift="0">
+    <caption>Determining the derivative of <m>f(x)=e^x</m></caption>
+    <video youtube="ipKTEdQFBjw" label="vid_deriv_basic_rules_exp_func"/>
+  </figure>
 
 
-    <p>
-      Let's practice using this theorem.
-    </p>
+  <p>
+    Let's practice using this theorem.
+  </p>
 
-    <example xml:id="ex_deriv_rule1">
-      <title>Using common derivative rules to find, and use, derivatives</title>
-      <statement>
-        <p>
-          Let <m>f(x)=x^3</m>.
-          <ol>
-            <li>
-              <p>
-                Find <m>\fp(x)</m>.
-              </p>
-            </li>
-            <li xml:id="item-tangent-line">
-              <p>
-                Find the equation of the line tangent to the graph of <m>f</m> at <m>x=-1</m>.
-              </p>
-            </li>
-            <li>
-              <p>
-                Use the tangent line to approximate <m>(-1.1)^3</m>.
-              </p>
-            </li>
-            <li>
-              <p>
-                Sketch <m>f</m>,
-                <m>\fp</m> and the tangent line from <xref ref="item-tangent-line"/> on the same axis.
-              </p>
-            </li>
-          </ol>
-        </p>
-      </statement>
-      <solution>
-        <p>
-          <ol>
-            <li>
-              <p>
-                The <xref ref="power-derivative-rule" text="title"/> states that if <m>f(x) = x^3</m>,
-                then <m>\fp(x) = 3x^2</m>.
-              </p>
-            </li>
-            <li>
-              <p>
-                To find the equation of the line tangent to the graph of <m>f</m> at <m>x=-1</m>,
-                we need a point and the slope.
-                The point is <m>(-1,f(-1)) = (-1, -1)</m>.
-                The slope is <m>\fp(-1)= 3</m>.
-                Thus the tangent line has equation <m>y = 3(x-(-1))+(-1) = 3x+2</m>.
-              </p>
-            </li>
-            <li>
-              <p>
-                We can use the tangent line to approximate
-                <m>(-1.1)^3</m> since <m>-1.1</m> is close to <m>-1</m>.
-                We have
-                <me>
-                  (-1.1)^3 \approx 3(-1.1)+2 = -1.3
-                </me>.
-                We can easily find the actual value:
-                <m>(-1.1)^3 = -1.331</m>.
-              </p>
-            </li>
-            <li>
-              <p>
-                See <xref ref="fig_xcubedwithderiv"/>.
-              </p>
-            </li>
-          </ol>
-        </p>
+  <example xml:id="ex_deriv_rule1">
+    <title>Using common derivative rules to find, and use, derivatives</title>
+    <statement>
+      <p>
+        Let <m>f(x)=x^3</m>.
+        <ol>
+          <li>
+            <p>
+              Find <m>\fp(x)</m>.
+            </p>
+          </li>
+          <li xml:id="item-tangent-line">
+            <p>
+              Find the equation of the line tangent to the graph of <m>f</m> at <m>x=-1</m>.
+            </p>
+          </li>
+          <li>
+            <p>
+              Use the tangent line to approximate <m>(-1.1)^3</m>.
+            </p>
+          </li>
+          <li>
+            <p>
+              Sketch <m>f</m>,
+              <m>\fp</m> and the tangent line from <xref ref="item-tangent-line"/> on the same axis.
+            </p>
+          </li>
+        </ol>
+      </p>
+    </statement>
+    <solution>
+      <p>
+        <ol>
+          <li>
+            <p>
+              The <xref ref="power-derivative-rule" text="title"/> states that if <m>f(x) = x^3</m>,
+              then <m>\fp(x) = 3x^2</m>.
+            </p>
+          </li>
+          <li>
+            <p>
+              To find the equation of the line tangent to the graph of <m>f</m> at <m>x=-1</m>,
+              we need a point and the slope.
+              The point is <m>(-1,f(-1)) = (-1, -1)</m>.
+              The slope is <m>\fp(-1)= 3</m>.
+              Thus the tangent line has equation <m>y = 3(x-(-1))+(-1) = 3x+2</m>.
+            </p>
+          </li>
+          <li>
+            <p>
+              We can use the tangent line to approximate
+              <m>(-1.1)^3</m> since <m>-1.1</m> is close to <m>-1</m>.
+              We have
+              <me>
+                (-1.1)^3 \approx 3(-1.1)+2 = -1.3
+              </me>.
+              We can easily find the actual value:
+              <m>(-1.1)^3 = -1.331</m>.
+            </p>
+          </li>
+          <li>
+            <p>
+              See <xref ref="fig_xcubedwithderiv"/>.
+            </p>
+          </li>
+        </ol>
+      </p>
 
-        <figure xml:id="fig_xcubedwithderiv" vshift="-1">
-          <caption>A graph of <m>f(x) = x^3</m>, along with its derivative <m>\fp(x) = 3x^2</m> and its tangent line at <m>x=-1</m></caption>          <!-- START figures/fig_xcubedwithderiv.tex -->
-          <image width="47%">
+      <figure xml:id="fig_xcubedwithderiv" vshift="-1">
+        <caption>A graph of <m>f(x) = x^3</m>, along with its derivative <m>\fp(x) = 3x^2</m> and its tangent line at <m>x=-1</m></caption>          <!-- START figures/fig_xcubedwithderiv.tex -->
+        <image width="47%">
+          <shortdescription>
+            Graph of function x^3, its derivative and a tangent line drawn at point (-1,-1).
+          </shortdescription>
+          <description>
+            <p>
+              The <m>y</m> axis is drawn between <m>-4</m> and <m>4</m> and the <m>x</m> axis
+              is drawn between <m>-2</m> and <m>2</m>.
+              The graph of function <m>f(x)=x^3</m> is a curve that appears to conincide the
+              <m>x</m> axis from <m>x=-0.5</m> to <m>x=0.5</m>,
+              then it appears to increase to infinity from <m>x=0.5</m> in the first quadrant,
+              and curves downward from to infinity from <m>x=-0.5</m> in the third quadrant.
+            </p>
+            <p>
+              The derivative <m>\fp(x)</m> is a parabola opening upwards.
+              It intersects the function <m>f(x)</m> at the origin and increases to infinity on
+              either side of the positive <m>y</m> axis.
+            </p>
+            <p>
+              A tangent line <m>l(x)</m>is drawn on the function at point <m>(-1,-1)</m>.
+              It has a positive slope and and intersects the <m>x</m> axis at approximately
+              <m>x=-0.6</m> and the <m>y</m> axis at <m>y=2</m>.
+            </p>
+          </description>
+          <latex-image label="img_xcubedwithderiv">
+            \begin{tikzpicture}
+            \begin{axis}[
+            xmin=-2.1,
+            xmax=2.1,
+            ymin=-5.1,
+                  ymax=5.1,
+                  clip=false
+                ]
+                \addplot+[infinite,domain=-1.5:1.5] {x^3} node[below right] {$f(x)$};
+                \addplot+[infinite,domain=-1.2:1.2] {3*x^2} node[right] {$f'(x)$};
+                \addplot[tangentline,domain=-2:1] {3*(x+1)-1} node[above left] {$\ell(x)$};
+                \addplot[soliddot] coordinates {(-1,-1) (-1,3)};
+              \end{axis}
+            \end{tikzpicture}
+          </latex-image>
+        </image>
+        <!-- figures/fig_xcubedwithderiv.tex END -->
+      </figure>
+    </solution>
+    <solution component="video" vshift="5">
+      <title>Video solution</title>
+      <video width="98%" youtube="lyAEJSmSr-A" label="vid_deriv_basic_rules_ex" component="video"/>
+    </solution>
+  </example>
+
+  <exercise label="APEX-PROTEUS-deriv-basic-2-v1" component="proteus">
+    <title>PROTEUS EXERCISE</title>
+    <statement>
+      <p>
+        Associate each function <m>f(x)</m> on the left with every function <m>F(x)</m> on the right such that <m>F^\prime(x) = f(x)</m>.
+      </p>
+    </statement>
+    <feedback>
+      <p>
+        Did you encounter any cases where two functions had the same derivative?
+        How were these functions related?
+      </p>
+    </feedback>
+    <matching>
+      <premise ref="proteus-deriv-basic-1 proteus-deriv-basic-2"><m> x^2 - 1</m></premise>
+      <premise ref="proteus-deriv-basic-3"><m>5\cos(x) - 3\sin(x)</m></premise>
+      <premise ref="proteus-deriv-basic-7"><m>e^x - \frac{5}{x}</m></premise>
+      <premise ref="proteus-deriv-basic-9"><m>3e^x+\sin(x)</m></premise>
+<!--  -->
+      <response xml:id="proteus-deriv-basic-1" order="5"><m>\dfrac{x^3}{3}-x</m></response>
+      <response xml:id="proteus-deriv-basic-2" order="3"><m>\dfrac{x^3}{3}-x+3</m></response>
+      <response xml:id="proteus-deriv-basic-3" order="1"><m>5\sin(x) + 3\cos(x) + 4</m></response>
+      <response xml:id="proteus-deriv-basic-4" order="9"><m>5\sin(x) - 3\cos(x)</m></response>
+      <response xml:id="proteus-deriv-basic-5" order="7"><m>-5\ln(x) + e^x</m></response>
+      <response xml:id="proteus-deriv-basic-6" order="2"><m>e^x + 5\ln(x)</m> </response>
+      <response xml:id="proteus-deriv-basic-7" order="8"><m>\frac{x^3}{3}-x^2+x+8</m></response>
+      <response xml:id="proteus-deriv-basic-9" order="4"><m>3e^x-\cos(x)</m></response>
+      <response xml:id="proteus-deriv-basic-8" order="6"><m>3e^x+\cos(x)</m></response>
+    </matching>
+  </exercise>
+
+  <p>
+    <xref ref="thm_deriv_common"/> gives useful information,
+    but we will need much more.
+    For instance, using the theorem,
+    we can easily find the derivative of <m>y=x^3</m>,
+    but it does not tell how to compute the derivative of <m>y=2x^3</m>,
+    <m>y=x^3+\sin(x)</m> nor <m>y=x^3\sin(x)</m>.
+    The following theorem helps with the first two of these examples
+    (the third is answered in the next section).
+  </p>
+
+  <theorem xml:id="thm_deriv_prop">
+    <title>Properties of the Derivative</title>
+    <statement>
+      <p>
+        Let <m>f</m> and <m>g</m> be differentiable on an open interval <m>I</m> and let <m>c</m> be a real number.
+        Then:
+        <ol>
+          <li xml:id="sum-difference-derivative-rule">
+            <title>Sum/Difference Rule</title>
+            <p>
+              <me>
+                \lzoo{x}{f(x) \pm g(x)} \lzoo{x}{f(x)} \pm \lzoo{x}{g(x)} = \fp(x)\pm \gp(x)
+              </me>
+
+                <idx><h>derivative</h><h>Sum/Difference Rule</h></idx>
+                <idx><h>Sum/Difference Rule</h><h>of derivatives</h></idx>
+
+            </p>
+          </li>
+
+          <li xml:id="constant-multiple-derivative-rule">
+            <title>Constant Multiple Rule</title>
+            <p>
+              <me>
+                \lzoo{x}{c\cdot f(x)} = c\cdot\lzoo{x}{f(x)} = c\cdot\fp(x)
+              </me>.
+
+                <idx><h>derivative</h><h>Constant Multiple Rule</h></idx>
+                <idx><h>Constant Multiple Rule</h><h>of derivatives</h></idx>
+
+            </p>
+          </li>
+        </ol>
+      </p>
+    </statement>
+  </theorem>
+
+  <exercise component="proteus" label="APEX-PROTEUS-deriv-basic-3-v1">
+    <title>PROTEUS EXERCISE</title>
+    <statement>
+      <p>
+        In <xref ref="ex_deriv_rule1"/> above, we saw that <m>\fp(x) = 3x^2</m>,
+        where <m>f(x)=x^3</m>. Let <m>g(x)=x</m> and let <m>h(x)=x^2</m>.
+        Observe that <m>g(x)h(x)=f(x)</m>.
+      </p>
+
+      <p>
+        <xref ref="thm_deriv_prop"/> tells us that the derivative of a sum or difference
+        is the sum or difference of the derivatives.
+        Using <m>g(x)=x</m>, <m>h(x)=x^2</m>, and <m>f(x)=x^3</m>,
+        explain why there can't be a similar true statement about products.
+      </p>
+    </statement>
+    <response />
+    
+  </exercise>
+
+  <figure xml:id="vid_deriv_basic_rules_const_sum_rule" component="video" vshift="2">
+    <caption>Video presentation of <xref ref="thm_deriv_prop"/></caption>
+    <video youtube="Hr0sQcVhQ9A" label="vid_deriv_basic_rules_const_sum_rule"/>
+  </figure>
+
+  <p xml:id="vidint_deriv_basic_rules_const_sum_rule" component="video">
+    While we will be mainly focused on <em>using</em> these rules,
+    it can also be interesting to see where they come from.
+    Fortunately, it is not too difficult to establish these rules using the definition of the derivative.
+    The video in <xref ref="vid_deriv_basic_rules_proofs"/> shows why the sum rule is true.
+  </p>
+
+  <figure xml:id="vid_deriv_basic_rules_proofs" component="video" vshift="-3">
+    <caption>Proving the sum rule</caption>
+    <video youtube="nVVpyilxZTw" label="vid_deriv_basic_rules_proofs"/>
+  </figure>
+
+  <p>
+    <xref ref="thm_deriv_prop"/>
+    allows us to find the derivatives of a wide variety of functions.
+    It can be used in conjunction with the <xref ref="power-derivative-rule" text="title"/> to find the derivatives of any polynomial.
+    Recall in <xref ref="ex_deriv1"/> that we found,
+    using the limit definition, the derivative of <m>f(x) = 3x^2+5x-7</m>.
+    We can now find its derivative without expressly using limits:
+    <md>
+      <mrow>\lzoo{x}{3x^2+5x-7} \amp = 3\lzoo{x}{x^2} + 5\lzoo{x}{x} - \lzoo{x}{7}</mrow>
+      <mrow>\amp = 3\cdot 2x+5\cdot 1- 0</mrow>
+      <mrow>\amp = 6x+5</mrow>
+    </md>.
+  </p>
+
+  <p>
+    We were a bit pedantic here, showing every step.
+    Normally we would do all the arithmetic and steps in our head and readily find <m>\lzoo{x}{3x^2+5x+7}= 6x+5</m>.
+  </p>
+
+  <example xml:id="ex_der2">
+    <title>Using the tangent line to approximate a function value</title>
+    <statement>
+      <p>
+        Let <m>f(x) = \sin(x) + 2x+1</m>.
+        Approximate <m>f(3)</m> using an appropriate tangent line.
+      </p>
+    </statement>
+    <solution>
+      <p>
+        This problem is intentionally ambiguous;
+        we are to <em>approximate</em> using an
+        <em>appropriate</em> tangent line.
+        How good of an approximation are we seeking?
+        What does <q>appropriate</q> mean?
+      </p>
+
+      <p>
+        In the <q>real world,</q> people solving problems deal with these issues all time.
+        One must make a judgment using whatever seems reasonable.
+        In this example, the actual answer is <m>f(3) = \sin(3) + 7</m>,
+        where the real problem spot is <m>\sin(3)</m>.
+        What is <m>\sin(3)</m>?
+      </p>
+
+      <p>
+        Since <m>3</m> is close to <m>\pi</m>,
+        we can assume <m>\sin(3) \approx \sin(\pi) = 0</m>.
+        Thus one guess is <m>f(3) \approx 7</m>.
+        Can we do better?
+        Let's use a tangent line as instructed and examine the results;
+        it seems best to find the tangent line at <m>x=\pi</m>.
+      </p>
+
+      <p>
+        Using <xref ref="thm_deriv_common"/>
+        we find <m>\fp(x) = \cos(x) + 2</m>.
+        The slope of the tangent line is thus <m>\fp(\pi) = \cos(\pi) + 2 =1</m>.
+        Also, <m>f(\pi) = 2\pi+1 \approx 7.28</m>.
+        So the tangent line to the graph of <m>f</m> at <m>x=\pi</m> is <m>y=1(x-\pi)+ 2\pi+1 =x+\pi+1 \approx x+4.14</m>.
+        Evaluated at <m>x=3</m>, our tangent line gives <m>y=3+4.14 = 7.14</m>.
+        Using the tangent line,
+        our final approximation is that <m>f(3) \approx 7.14</m>.
+      </p>
+
+      <p>
+        Using a calculator,
+        we get an answer accurate to four places after the decimal:
+        <m>f(3) = 7.1411</m>.
+        Our initial guess was <m>7</m>;
+        our tangent line approximation was more accurate, at <m>7.14</m>.
+      </p>
+
+      <p>
+        The point is <em>not</em> <q>Here's a cool way to do some math without a calculator.</q> Sure,
+        that might be handy sometime,
+        but your phone could probably give you the answer.
+        Rather, the point is to say that tangent lines are a good way of approximating,
+        and many scientists,
+        engineers and mathematicians often face problems too hard to solve directly.
+        So they approximate.
+      </p>
+
+      <p>
+        The graphs in <xref ref="fig_sintangapprox"/>
+        shows the graph of the function <m>f(x)</m> along with the tangent line constructed at <m>x=\pi</m>.
+        The graph in <xref ref="fig_sintangapprox"/>
+        shows the same tangent line and function.
+        Once zoomed in,
+        you can barely distinguish the tangent line from the function.
+        This indicates that the tangent line is a good a approximation of the function so long as we are near the point of tangency.
+      </p>
+
+      <sidebyside widths="47% 47%" margins="0%">
+        <figure xml:id="fig_sintangapprox">
+          <caption>A graph of <m>f(x) = \sin(x)+2x+1</m> along with its tangent line approximation at <m>x=\pi</m></caption>
+          <image>
             <shortdescription>
-              Graph of function x^3, its derivative and a tangent line drawn at point (-1,-1).
+              Graph of the function for this example and its tangent at x=pi.
             </shortdescription>
             <description>
               <p>
-                The <m>y</m> axis is drawn between <m>-4</m> and <m>4</m> and the <m>x</m> axis
-                is drawn between <m>-2</m> and <m>2</m>.
-                The graph of function <m>f(x)=x^3</m> is a curve that appears to conincide the
-                <m>x</m> axis from <m>x=-0.5</m> to <m>x=0.5</m>,
-                then it appears to increase to infinity from <m>x=0.5</m> in the first quadrant,
-                and curves downward from to infinity from <m>x=-0.5</m> in the third quadrant.
+              The <m>y</m> axis is drawn from <m>-1</m> to <m>10</m> and <m>x</m> axis is drawn from <m>-1</m> to <m>5</m>.
+              The graph of <m>f(x)</m>is drawn in the first quadrant, the curve passes the
+              <m>y</m> axis at <m>y=1</m>, it increases until point <m>(5,10)</m>.
+              It has a slight undulation between <m>x=2</m> to <m>x=4</m>.
               </p>
               <p>
-                The derivative <m>\fp(x)</m> is a parabola opening upwards.
-                It intersects the function <m>f(x)</m> at the origin and increases to infinity on
-                either side of the positive <m>y</m> axis.
-              </p>
-              <p>
-                A tangent line <m>l(x)</m>is drawn on the function at point <m>(-1,-1)</m>.
-                It has a positive slope and and intersects the <m>x</m> axis at approximately
-                <m>x=-0.6</m> and the <m>y</m> axis at <m>y=2</m>.
-              </p>
+              A tangent line is drawn on the curve at approximately point <m>(3,7)</m> or <m>x=\pi</m>.
+            </p>
             </description>
-            <latex-image label="img_xcubedwithderiv">
+            <latex-image label="img_sintangapprox">
               \begin{tikzpicture}
               \begin{axis}[
-              xmin=-2.1,
-              xmax=2.1,
-              ymin=-5.1,
-                    ymax=5.1,
-                    clip=false
+              xmin=-1.1,
+                    xmax=5.1,
+                    ymin=-1,
+                    ymax=10,
                   ]
-                  \addplot+[infinite,domain=-1.5:1.5] {x^3} node[below right] {$f(x)$};
-                  \addplot+[infinite,domain=-1.2:1.2] {3*x^2} node[right] {$f'(x)$};
-                  \addplot[tangentline,domain=-2:1] {3*(x+1)-1} node[above left] {$\ell(x)$};
-                  \addplot[soliddot] coordinates {(-1,-1) (-1,3)};
+                  \addplot+[infinite,domain=-.5:5] {sin(deg(x))+2*x+1};
+                  \addplot[tangentline,domain=1:4.5] {x+4.14};
+                  \addplot[soliddot] coordinates {(3,7.1411) (3.14,7.28)};
+                  \draw (axis cs:0.5,1.2) node { $f(x)$};
+                  \draw (axis cs:0.5,5) node { $l(x)$};
                 \end{axis}
               \end{tikzpicture}
             </latex-image>
           </image>
           <!-- figures/fig_xcubedwithderiv.tex END -->
         </figure>
-      </solution>
-      <solution component="video" vshift="5">
-        <title>Video solution</title>
-        <video width="98%" youtube="lyAEJSmSr-A" label="vid_deriv_basic_rules_ex" component="video"/>
-      </solution>
-    </example>
 
-    <exercise label="APEX-PROTEUS-deriv-basic-2-v1" component="proteus">
-      <title>PROTEUS EXERCISE</title>
-      <statement>
-        <p>
-          Associate each function <m>f(x)</m> on the left with every function <m>F(x)</m> on the right such that <m>F^\prime(x) = f(x)</m>.
-        </p>
-      </statement>
-      <feedback>
-        <p>
-          Did you encounter any cases where two functions had the same derivative?
-          How were these functions related?
-        </p>
-      </feedback>
-      <matching>
-        <premise ref="proteus-deriv-basic-1 proteus-deriv-basic-2"><m> x^2 - 1</m></premise>
-        <premise ref="proteus-deriv-basic-3"><m>5\cos(x) - 3\sin(x)</m></premise>
-        <premise ref="proteus-deriv-basic-7"><m>e^x - \frac{5}{x}</m></premise>
-        <premise ref="proteus-deriv-basic-9"><m>3e^x+\sin(x)</m></premise>
-  <!--  -->
-        <response xml:id="proteus-deriv-basic-1" order="5"><m>\dfrac{x^3}{3}-x</m></response>
-        <response xml:id="proteus-deriv-basic-2" order="3"><m>\dfrac{x^3}{3}-x+3</m></response>
-        <response xml:id="proteus-deriv-basic-3" order="1"><m>5\sin(x) + 3\cos(x) + 4</m></response>
-        <response xml:id="proteus-deriv-basic-4" order="9"><m>5\sin(x) - 3\cos(x)</m></response>
-        <response xml:id="proteus-deriv-basic-5" order="7"><m>-5\ln(x) + e^x</m></response>
-        <response xml:id="proteus-deriv-basic-6" order="2"><m>e^x + 5\ln(x)</m> </response>
-        <response xml:id="proteus-deriv-basic-7" order="8"><m>\frac{x^3}{3}-x^2+x+8</m></response>
-        <response xml:id="proteus-deriv-basic-9" order="4"><m>3e^x-\cos(x)</m></response>
-        <response xml:id="proteus-deriv-basic-8" order="6"><m>3e^x+\cos(x)</m></response>
-      </matching>
-    </exercise>
-
-    <p>
-      <xref ref="thm_deriv_common"/> gives useful information,
-      but we will need much more.
-      For instance, using the theorem,
-      we can easily find the derivative of <m>y=x^3</m>,
-      but it does not tell how to compute the derivative of <m>y=2x^3</m>,
-      <m>y=x^3+\sin(x)</m> nor <m>y=x^3\sin(x)</m>.
-      The following theorem helps with the first two of these examples
-      (the third is answered in the next section).
-    </p>
-
-    <theorem xml:id="thm_deriv_prop">
-      <title>Properties of the Derivative</title>
-      <statement>
-        <p>
-          Let <m>f</m> and <m>g</m> be differentiable on an open interval <m>I</m> and let <m>c</m> be a real number.
-          Then:
-          <ol>
-            <li xml:id="sum-difference-derivative-rule">
-              <title>Sum/Difference Rule</title>
+        <figure xml:id="fig_sintangapproxzoom">
+          <caption>A graph of <m>f(x) = \sin(x)+2x+1</m> along with its tangent line approximation at <m>x=\pi</m>, zoomed in</caption>
+          <image>
+            <shortdescription>
+              Highly zoomed in view of the previous graph and its tangent line, near x=pi.
+            </shortdescription>
+            <description>
               <p>
-                <me>
-                  \lzoo{x}{f(x) \pm g(x)} \lzoo{x}{f(x)} \pm \lzoo{x}{g(x)} = \fp(x)\pm \gp(x)
-                </me>
-
-                  <idx><h>derivative</h><h>Sum/Difference Rule</h></idx>
-                  <idx><h>Sum/Difference Rule</h><h>of derivatives</h></idx>
-
-              </p>
-            </li>
-
-            <li xml:id="constant-multiple-derivative-rule">
-              <title>Constant Multiple Rule</title>
-              <p>
-                <me>
-                  \lzoo{x}{c\cdot f(x)} = c\cdot\lzoo{x}{f(x)} = c\cdot\fp(x)
-                </me>.
-
-                  <idx><h>derivative</h><h>Constant Multiple Rule</h></idx>
-                  <idx><h>Constant Multiple Rule</h><h>of derivatives</h></idx>
-
-              </p>
-            </li>
-          </ol>
-        </p>
-      </statement>
-    </theorem>
-
-    <exercise component="proteus" label="APEX-PROTEUS-deriv-basic-3-v1">
-      <title>PROTEUS EXERCISE</title>
-      <statement>
-        <p>
-          In <xref ref="ex_deriv_rule1"/> above, we saw that <m>\fp(x) = 3x^2</m>,
-          where <m>f(x)=x^3</m>. Let <m>g(x)=x</m> and let <m>h(x)=x^2</m>.
-          Observe that <m>g(x)h(x)=f(x)</m>.
-        </p>
-
-        <p>
-          <xref ref="thm_deriv_prop"/> tells us that the derivative of a sum or difference
-          is the sum or difference of the derivatives.
-          Using <m>g(x)=x</m>, <m>h(x)=x^2</m>, and <m>f(x)=x^3</m>,
-          explain why there can't be a similar true statement about products.
-        </p>
-      </statement>
-      <response />
-      
-    </exercise>
-
-    <figure xml:id="vid_deriv_basic_rules_const_sum_rule" component="video" vshift="2">
-      <caption>Video presentation of <xref ref="thm_deriv_prop"/></caption>
-      <video youtube="Hr0sQcVhQ9A" label="vid_deriv_basic_rules_const_sum_rule"/>
-    </figure>
-
-    <p xml:id="vidint_deriv_basic_rules_const_sum_rule" component="video">
-      While we will be mainly focused on <em>using</em> these rules,
-      it can also be interesting to see where they come from.
-      Fortunately, it is not too difficult to establish these rules using the definition of the derivative.
-      The video in <xref ref="vid_deriv_basic_rules_proofs"/> shows why the sum rule is true.
-    </p>
-
-    <figure xml:id="vid_deriv_basic_rules_proofs" component="video" vshift="-3">
-      <caption>Proving the sum rule</caption>
-      <video youtube="nVVpyilxZTw" label="vid_deriv_basic_rules_proofs"/>
-    </figure>
-
-    <p>
-      <xref ref="thm_deriv_prop"/>
-      allows us to find the derivatives of a wide variety of functions.
-      It can be used in conjunction with the <xref ref="power-derivative-rule" text="title"/> to find the derivatives of any polynomial.
-      Recall in <xref ref="ex_deriv1"/> that we found,
-      using the limit definition, the derivative of <m>f(x) = 3x^2+5x-7</m>.
-      We can now find its derivative without expressly using limits:
-      <md>
-        <mrow>\lzoo{x}{3x^2+5x-7} \amp = 3\lzoo{x}{x^2} + 5\lzoo{x}{x} - \lzoo{x}{7}</mrow>
-        <mrow>\amp = 3\cdot 2x+5\cdot 1- 0</mrow>
-        <mrow>\amp = 6x+5</mrow>
-      </md>.
-    </p>
-
-    <p>
-      We were a bit pedantic here, showing every step.
-      Normally we would do all the arithmetic and steps in our head and readily find <m>\lzoo{x}{3x^2+5x+7}= 6x+5</m>.
-    </p>
-
-    <example xml:id="ex_der2">
-      <title>Using the tangent line to approximate a function value</title>
-      <statement>
-        <p>
-          Let <m>f(x) = \sin(x) + 2x+1</m>.
-          Approximate <m>f(3)</m> using an appropriate tangent line.
-        </p>
-      </statement>
-      <solution>
-        <p>
-          This problem is intentionally ambiguous;
-          we are to <em>approximate</em> using an
-          <em>appropriate</em> tangent line.
-          How good of an approximation are we seeking?
-          What does <q>appropriate</q> mean?
-        </p>
-
-        <p>
-          In the <q>real world,</q> people solving problems deal with these issues all time.
-          One must make a judgment using whatever seems reasonable.
-          In this example, the actual answer is <m>f(3) = \sin(3) + 7</m>,
-          where the real problem spot is <m>\sin(3)</m>.
-          What is <m>\sin(3)</m>?
-        </p>
-
-        <p>
-          Since <m>3</m> is close to <m>\pi</m>,
-          we can assume <m>\sin(3) \approx \sin(\pi) = 0</m>.
-          Thus one guess is <m>f(3) \approx 7</m>.
-          Can we do better?
-          Let's use a tangent line as instructed and examine the results;
-          it seems best to find the tangent line at <m>x=\pi</m>.
-        </p>
-
-        <p>
-          Using <xref ref="thm_deriv_common"/>
-          we find <m>\fp(x) = \cos(x) + 2</m>.
-          The slope of the tangent line is thus <m>\fp(\pi) = \cos(\pi) + 2 =1</m>.
-          Also, <m>f(\pi) = 2\pi+1 \approx 7.28</m>.
-          So the tangent line to the graph of <m>f</m> at <m>x=\pi</m> is <m>y=1(x-\pi)+ 2\pi+1 =x+\pi+1 \approx x+4.14</m>.
-          Evaluated at <m>x=3</m>, our tangent line gives <m>y=3+4.14 = 7.14</m>.
-          Using the tangent line,
-          our final approximation is that <m>f(3) \approx 7.14</m>.
-        </p>
-
-        <p>
-          Using a calculator,
-          we get an answer accurate to four places after the decimal:
-          <m>f(3) = 7.1411</m>.
-          Our initial guess was <m>7</m>;
-          our tangent line approximation was more accurate, at <m>7.14</m>.
-        </p>
-
-        <p>
-          The point is <em>not</em> <q>Here's a cool way to do some math without a calculator.</q> Sure,
-          that might be handy sometime,
-          but your phone could probably give you the answer.
-          Rather, the point is to say that tangent lines are a good way of approximating,
-          and many scientists,
-          engineers and mathematicians often face problems too hard to solve directly.
-          So they approximate.
-        </p>
-
-        <p>
-          The graphs in <xref ref="fig_sintangapprox"/>
-          shows the graph of the function <m>f(x)</m> along with the tangent line constructed at <m>x=\pi</m>.
-          The graph in <xref ref="fig_sintangapprox"/>
-          shows the same tangent line and function.
-          Once zoomed in,
-          you can barely distinguish the tangent line from the function.
-          This indicates that the tangent line is a good a approximation of the function so long as we are near the point of tangency.
-        </p>
-
-        <sidebyside widths="47% 47%" margins="0%">
-          <figure xml:id="fig_sintangapprox">
-            <caption>A graph of <m>f(x) = \sin(x)+2x+1</m> along with its tangent line approximation at <m>x=\pi</m></caption>
-            <image>
-              <shortdescription>
-                Graph of the function for this example and its tangent at x=pi.
-              </shortdescription>
-              <description>
-                <p>
-                The <m>y</m> axis is drawn from <m>-1</m> to <m>10</m> and <m>x</m> axis is drawn from <m>-1</m> to <m>5</m>.
-                The graph of <m>f(x)</m>is drawn in the first quadrant, the curve passes the
-                <m>y</m> axis at <m>y=1</m>, it increases until point <m>(5,10)</m>.
-                It has a slight undulation between <m>x=2</m> to <m>x=4</m>.
-                </p>
-                <p>
-                A tangent line is drawn on the curve at approximately point <m>(3,7)</m> or <m>x=\pi</m>.
-              </p>
-              </description>
-              <latex-image label="img_sintangapprox">
-                \begin{tikzpicture}
-                \begin{axis}[
-                xmin=-1.1,
-                      xmax=5.1,
-                      ymin=-1,
-                      ymax=10,
-                    ]
-                    \addplot+[infinite,domain=-.5:5] {sin(deg(x))+2*x+1};
-                    \addplot[tangentline,domain=1:4.5] {x+4.14};
-                    \addplot[soliddot] coordinates {(3,7.1411) (3.14,7.28)};
-                    \draw (axis cs:0.5,1.2) node { $f(x)$};
-                    \draw (axis cs:0.5,5) node { $l(x)$};
+              The <m>y</m> axis is drawn from <m>6.8</m> to <m>7.4</m> and <m>x</m> axis
+              is drawn from <m>2.6</m> to <m>3.4</m>.
+              The graph of <m>f(x)</m> is drawn in the first quadrant, the curve and
+              its tangent line are aligned except near shifted origin around point <m>(2.6, 6.8)</m>
+              where they are slightly apart.
+            </p>
+          </description>
+          <latex-image label="img_sintangapproxzoom">
+            \begin{tikzpicture}
+            \begin{axis}[
+            ymin=6.7,
+            ymax=7.4,
+                    xmin=2.5,
+                    xmax=3.5,
+                    xdiscontinuity,
+                    ydiscontinuity
+                  ]
+                  \addplot+[infinite,domain=2.6:3.25] {sin(deg(x))+2*x+1};
+                  \addplot[tangentline,domain=2.6:3.25] {x+4.14};
+                  \addplot[soliddot] coordinates {(3,7.1411) (3.14,7.28)};
+                  %\draw (axis cs:0.5,1.2) node { $f(x)$};
+                  %\draw (axis cs:0.5,5) node { $l(x)$};
                   \end{axis}
-                \end{tikzpicture}
-              </latex-image>
-            </image>
-            <!-- figures/fig_xcubedwithderiv.tex END -->
-          </figure>
+              \end{tikzpicture}
+            </latex-image>
+          </image>
+          <!-- figures/fig_xcubedwithderiv.tex END -->
+        </figure>
+      </sidebyside>
+    </solution>
+    <solution component="video" vshift="6">
+      <title>Video solution</title>
+      <video width="98%" youtube="a0hsWtT74jM" label="vid_deriv_basic_rules_examples_1" component="video"/>
+    </solution>
+  </example>
 
-          <figure xml:id="fig_sintangapproxzoom">
-            <caption>A graph of <m>f(x) = \sin(x)+2x+1</m> along with its tangent line approximation at <m>x=\pi</m>, zoomed in</caption>
-            <image>
-              <shortdescription>
-                Highly zoomed in view of the previous graph and its tangent line, near x=pi.
-              </shortdescription>
-              <description>
-                <p>
-                The <m>y</m> axis is drawn from <m>6.8</m> to <m>7.4</m> and <m>x</m> axis
-                is drawn from <m>2.6</m> to <m>3.4</m>.
-                The graph of <m>f(x)</m> is drawn in the first quadrant, the curve and
-                its tangent line are aligned except near shifted origin around point <m>(2.6, 6.8)</m>
-                where they are slightly apart.
-              </p>
-            </description>
-            <latex-image label="img_sintangapproxzoom">
-              \begin{tikzpicture}
-              \begin{axis}[
-              ymin=6.7,
-              ymax=7.4,
-                      xmin=2.5,
-                      xmax=3.5,
-                      xdiscontinuity,
-                      ydiscontinuity
-                    ]
-                    \addplot+[infinite,domain=2.6:3.25] {sin(deg(x))+2*x+1};
-                    \addplot[tangentline,domain=2.6:3.25] {x+4.14};
-                    \addplot[soliddot] coordinates {(3,7.1411) (3.14,7.28)};
-                    %\draw (axis cs:0.5,1.2) node { $f(x)$};
-                    %\draw (axis cs:0.5,5) node { $l(x)$};
-                    \end{axis}
-                \end{tikzpicture}
-              </latex-image>
-            </image>
-            <!-- figures/fig_xcubedwithderiv.tex END -->
-          </figure>
-        </sidebyside>
-      </solution>
-      <solution component="video" vshift="6">
-        <title>Video solution</title>
-        <video width="98%" youtube="a0hsWtT74jM" label="vid_deriv_basic_rules_examples_1" component="video"/>
-      </solution>
-    </example>
-  </introduction>
-
-  <subsection>
+  <paragraphs>
     <title>Higher Order Derivatives</title>
     
     <p>
@@ -722,9 +720,9 @@
         <video width="98%" youtube="nF2-IrvHmqc" label="vid_deriv_basic_rules_examples_2" component="video"/>
       </solution>
     </example>
-  </subsection>
+  </paragraphs>
 
-  <subsection>
+  <paragraphs>
     <title>Interpreting Higher Order Derivatives</title>
     <p>
       What do higher order derivatives <em>mean</em>?
@@ -786,7 +784,7 @@
       The mathematical topic of <term>series</term>
       makes extensive use of higher order derivatives.
     </p>
-  </subsection>
+  </paragraphs>
 
   <exercises>
     <subexercises xml:id="TaC-deriv-basic">

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1554,7 +1554,6 @@
           <latex-image label="peer-continuity-img1">
             \begin{tikzpicture}
               \begin{axis}[
-                  minor xtick={0,0.1,...,1},
                   xmin=-4.5,
                   xmax=6.5,
                   ymin=-1.5,


### PR DESCRIPTION
An introduction shouldn't comprise 70% of a section. Put the bit on higher order derivatives into a `paragraphs` instead of a subsection.