### PR TITLE
Some image adjustments

### DIFF
--- a/ptx/sec_def_int.ptx
+++ b/ptx/sec_def_int.ptx
@@ -142,8 +142,8 @@
       \begin{tikzpicture}
       \begin{axis}[
       axis on top,
-      x label style={at={(axis description cs:0.85,0.3)},anchor=south},
-      y label style={at={(axis description cs:0,.85)},rotate=90,anchor=south},
+      x label style={at={(axis description cs:0.85,0.33)},anchor=south},
+      y label style={at={(axis description cs:0.05,.75)},rotate=90,anchor=south},
       xlabel={$t$ (s)},
       ylabel={$v$ (ft/s)},
       ytick={-2,5},

--- a/ptx/sec_differentials.ptx
+++ b/ptx/sec_differentials.ptx
@@ -528,7 +528,7 @@
       </p>
 
       <p>
-        <ol cols="3">
+        <ol cols="2">
           <li><p><m>y = \sin(x)</m></p></li>
 
           <li><p><m>y = e^x\left(x^2+2\right)</m></p></li>

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -969,7 +969,7 @@
           Find the point at which sales are decreasing at their greatest rate.
         </p>
         <pagebreak-latex/>
-        <figure xml:id="fig_conc3" vshift="2">
+        <figure xml:id="fig_conc3" vshift="1.5">
           <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3"/>, modeling the sale of a product over time</caption>
           <!-- START figures/fig_conc3.tex -->
           <image width="47%">
@@ -1031,7 +1031,7 @@
           so the decline in sales is <q>leveling off.</q>
         </p>
 
-        <figure xml:id="fig_conc3b" vshift="4">
+        <figure xml:id="fig_conc3b" vshift="2.5">
           <caption>A graph of <m>S(t)</m> in <xref ref="ex_conc3"/>, along with <m>S'(t)</m></caption>
           <!-- START figures/fig_conc3b.tex -->
           <image width="47%">
@@ -1085,7 +1085,7 @@
       as shown in <xref ref="fig_concavity5"/>.
     </p>
 
-    <figure xml:id="fig_concavity5" vshift="0">
+    <figure xml:id="fig_concavity5" vshift="-1">
       <caption>A graph of <m>f(x) = x^4</m>. Clearly <m>f</m> is always concave up, despite the fact that <m>\fpp(x) = 0</m> when <m>x=0</m>. In this example, the <em>possible</em> point of inflection <m>(0,0)</m> is not a point of inflection.</caption>
       <!-- START figures/fig_concavity5.tex -->
       <image width="47%">

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -991,7 +991,7 @@
         again demonstrating that <m>f</m> is increasing when <m>\fp\gt 0</m> and decreasing when <m>\fp\lt 0</m>.
       </p>
 
-      <figure xml:id="fig_incr2" vshift="-2">
+      <figure xml:id="fig_incr2" vshift="2">
         <caption>A graph of <m>f(x)</m> in <xref ref="ex_incr2"/>, showing where <m>f</m> is increasing and decreasing</caption>
         <!-- START figures/fig_incr2.tex -->
         <image width="47%">


### PR DESCRIPTION
A few small changes:
- One figure in Section 3.3 ran off the bottom of the page for me, so I shifted it up
- Enlarging the columns for those concavity graphs changed the page breaking in Section 3.4 (LaTeX seems to be ignoring the one that is manually inserted), and this resulted in some badly-placed figures on one page
- I noticed an example in 4.4 where the 3 column layout for the parts led to some bad line breaks. I reduced to two columns
- In 5.2 there was one image where the axis labels were colliding with other parts of the image, so I adjusted them

@APEXCalculus can you build the `latex-color-print-novideo` target and confirm that the changes to the image layout (esp. in Section 3.4) work for you? If it seems too crowded with the 4 images on Page 162 we can try a different page break.