### PR TITLE
fix duplicate ids across versions

### DIFF
--- a/ptx/sec_taylor_poly.ptx
+++ b/ptx/sec_taylor_poly.ptx
@@ -1132,7 +1132,7 @@
           We now set out to compute <m>p_9(x)</m>.
           We again need a table of the derivatives of
           <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m>.
-          A table of these values is given in <xref ref="fig_taypoly4a"/>.
+          A table of these values is given in <xref ref="fig_taypoly4a" component="taypoly-late"/><xref ref="fig_taypoly4a-early" component="taypoly-early"/>.
         </p>
 
         <figure xml:id="fig_taypoly4a" vshift="4" component="taypoly-late">
@@ -1181,7 +1181,7 @@
           </tabular>
         </figure>
 
-        <figure xml:id="fig_taypoly4a" vshift="0" component="taypoly-early">
+        <figure xml:id="fig_taypoly4a-early" vshift="0" component="taypoly-early">
           <caption>A table of the derivatives of <m>f(x)=\cos(x)</m> evaluated at <m>x=0</m></caption>
           <tabular>
             <row>
@@ -1259,7 +1259,7 @@
         </p>
 
         <p>
-          <xref ref="fig_taypoly4b"/>
+          <xref ref="fig_taypoly4b" component="taypoly-late"/><xref ref="fig_taypoly4b-early" component="taypoly-early"/>
           shows a graph of <m>y=p_8(x)</m> and <m>y=\cos(x)</m>.
           Note how well the two functions agree on about <m>(-\pi,\pi)</m>.
         </p>
@@ -1313,7 +1313,7 @@
           <!-- figures/fig_taypoly4.tex END -->
         </figure>
 
-        <figure xml:id="fig_taypoly4b" vshift="-3" component="taypoly-early">
+        <figure xml:id="fig_taypoly4b-early" vshift="-3" component="taypoly-early">
           <caption>A graph of <m>f(x)= \cos(x)</m> and its degree 8 Maclaurin
           polynomial</caption>
           <!-- START figures/fig_taypoly4.tex -->
@@ -1406,7 +1406,7 @@
             <li>
               <p>
                 We begin by evaluating the derivatives of <m>f</m> at <m>x=4</m>.
-                This is done in <xref ref="fig_taypoly5a"/>.
+                This is done in <xref ref="fig_taypoly5a" component="taypoly-late"/><xref ref="fig_taypoly5a-early" component="taypoly-early"/>.
               </p>
 
               <figure xml:id="fig_taypoly5a" vshift="0" component="taypoly-late">
@@ -1435,7 +1435,7 @@
                 </tabular>
               </figure>
 
-              <figure xml:id="fig_taypoly5a" vshift="-4.5" component="taypoly-early">
+              <figure xml:id="fig_taypoly5a-early" vshift="-4.5" component="taypoly-early">
                 <caption>A table of the derivatives of <m>f(x)=\sqrt{x}</m> evaluated at <m>x=4</m></caption>
                 <tabular>
                   <row>

--- a/ptx/sec_taylor_series.ptx
+++ b/ptx/sec_taylor_series.ptx
@@ -552,7 +552,7 @@
   </p>
 
   <p>
-    In <xref ref="idea_common_taylor"/>
+    <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>
     (on the following page)
     we give a table of the Taylor series of a number of common functions.
     We then give a theorem about the
@@ -565,7 +565,7 @@
   <p>
     Before we investigate combining functions,
     consider the Taylor series for the arctangent function
-    (see <xref ref="idea_common_taylor"/>).
+    (see <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>).
     Knowing that <m>\tan^{-1}(1) = \pi/4</m>,
     we can use this series to approximate the value of <m>\pi</m>:
     <md>
@@ -639,7 +639,7 @@
     </p>
   </insight>
 
-  <insight xml:id="idea_common_taylor" hstretch="375" hskip="87" component="taypoly-early">
+  <insight xml:id="idea_common_taylor-early" hstretch="375" hskip="87" component="taypoly-early">
     <title>Important Taylor Series Expansions</title>
     <tabular>
       <row>
@@ -752,13 +752,13 @@
     <statement>
       <p>
         Write out the first 3 terms of the Taylor Series for
-        <m>f(x) = e^x\cos(x)</m> using <xref ref="idea_common_taylor"/>
+        <m>f(x) = e^x\cos(x)</m> using <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>
         and <xref ref="thm_series_alg"/>.
       </p>
     </statement>
     <solution>
       <p>
-        <xref ref="idea_common_taylor"/> informs us that
+        <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/> informs us that
         <me>
           e^x = 1+x+\frac{x^2}{2!}+\frac{x^3}{3!}+\cdots \text{ and }  \cos(x) = 1-\frac{x^2}{2!}+\frac{x^4}{4!}+\cdots
         </me>.
@@ -800,7 +800,7 @@
 
 
   <figure xml:id="vid-seqseries-taylorseries-arctan" component="video" vshift="9">
-    <caption>Deriving the Taylor series for <m>\arctan(x)</m> in <xref ref="idea_common_taylor"/></caption>
+    <caption>Deriving the Taylor series for <m>\arctan(x)</m> in <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/></caption>
     <video youtube="v-y5IH796gY" label="vid-seqseries-taylorseries-arctan"/>
   </figure>
 
@@ -1094,7 +1094,7 @@
       </p>
 
       <p>
-        Using <xref ref="idea_common_taylor"/>
+        Using <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>
         and <xref ref="thm_series_alg"/>,
         we recognize <m>f(x) = e^{2x}</m>:
         <me>
@@ -1110,7 +1110,7 @@
 
   <p>
     Finding a pattern in the coefficients that match the series expansion of a known function,
-    such as those shown in <xref ref="idea_common_taylor"/>,
+    such as those shown in <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>,
     can be difficult.
     What if the coefficients in the previous example were given in their reduced form;
     how could we still recover the function <m>y=e^{2x}</m>?
@@ -1225,7 +1225,7 @@
       <exercisegroup cols="2" xml:id="exset-taylor-series-identify-pattern">
         <introduction>
           <p>
-            <xref ref="idea_common_taylor"/>
+            <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>
             gives the <m>n</m>th term of the Taylor series of common functions.
             In the following exercises, verify the formula given in the Key Idea by finding
             the first few terms of the Taylor series of the given function and identifying a pattern.
@@ -1358,7 +1358,7 @@
             find a formula for the <m>n</m>th term of the Taylor series of <m>f(x)</m>,
             centered at <m>c</m>,
             by finding the coefficients of the first few powers of <m>x</m> and looking for a pattern.
-            (The formulas for several of these are found in <xref ref="idea_common_taylor"/>;
+            (The formulas for several of these are found in <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>;
             show work verifying these formula.)
           </p>
         </introduction>
@@ -1526,7 +1526,7 @@
           <p>
             In the following exercises,
             show that the Taylor series for <m>f(x)</m>,
-            as given in <xref ref="idea_common_taylor"/>,
+            as given in <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>,
             is equal to <m>f(x)</m> by applying <xref ref="thm_function_series_equality"/>;
             that is, show <m>\lim\limits_{n\to\infty}R_n(x) =0</m>.
           </p>
@@ -1715,7 +1715,7 @@
         <introduction>
           <p>
             In the following exercises,
-            use the Taylor series given in <xref ref="idea_common_taylor"/> to verify the given identity.
+            use the Taylor series given in <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/> to verify the given identity.
           </p>
         </introduction>
 
@@ -1899,7 +1899,7 @@
         <introduction>
           <p>
             In the following exercises,
-            use the Taylor series given in <xref ref="idea_common_taylor"/>
+            use the Taylor series given in <xref ref="idea_common_taylor" component="taypoly-late"/><xref ref="idea_common_taylor-early" component="taypoly-early"/>
             to create the Taylor series of the given functions.
           </p>
         </introduction>


### PR DESCRIPTION
Because of the parallel versions used for "early" and "late" Taylor polynomials, there are a few figures that get duplicated, and along with them, their `xml:id`s.

This is usually not a problem, since once assembly runs, only one version is included. But there are a few CLI versions where it causes an error, including the one currently in use on Runestone.

This just modifies the `xml:id` for the versions in the "early" component to avoid the conflict in the first place.