### PR TITLE
Don't use tasks in a peer instruction question

### DIFF
--- a/ptx/sec_limit_analytically.ptx
+++ b/ptx/sec_limit_analytically.ptx
@@ -1423,20 +1423,18 @@
       </choices>
     </exercise>
 
-    <exercise label="peer-limit-analytic-3">
-      <introduction>
+    <exercise label="peer-limit-analytic-3a">
+      <statement>
         <p>
           Consider the function <m>f(x) = \dfrac{x^2+4x+3}{x^2-1}</m>.
         </p>
-      </introduction>
 
-      <task label="peer-limit-analytic-3a">
-        <statement>
-          <p>
-            A function <m>g(x)</m> such that <m>g(x)=f(x)</m>
-            for all <m>x\neq -1</m> is:
-          </p>
-        </statement>
+        <p>
+          A function <m>g(x)</m> such that <m>g(x)=f(x)</m>
+          for all <m>x\neq -1</m> is:
+        </p>
+      </statement>
+      <choices>
         <choice>
           <statement>
             <p>
@@ -1465,13 +1463,19 @@
             </p>
           </statement>
         </choice>
-      </task>
-      <task label="peer-limit-analytic-3b">
-        <statement>
-          <p>
-            The value of <m>\lim\limits_{x\to -1}f(x)</m> is:
-          </p>
-        </statement>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-analytic-3b">
+      <statement>
+        <p>
+          Consider again the function <m>f(x) = \dfrac{x^2+4x+3}{x^2-1}</m>.
+        </p>
+        <p>
+          The value of <m>\lim\limits_{x\to -1}f(x)</m> is:
+        </p>
+      </statement>
+      <choices>
         <choice>
           <statement>
             <p>
@@ -1507,7 +1511,7 @@
             </p>
           </statement>
         </choice>
-      </task>
+      </choices>
     </exercise>
     
     <exercise label="peer-limit-analytic-4">

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1691,123 +1691,126 @@
         </choice>
       </choices>
     </exercise>
-    <exercise label="peer-limit-continuity-5">
-      <introduction>
+    
+    <exercise label="peer-limit-continuity-5a">
+      <statement>
         <p>
-          Determine the type of discontinity each function has at the given point.
+          Determine the type of discontinity the function has at the given point:
         </p>
-      </introduction>
-      <task label="peer-limit-continuity-5a">
-        <statement>
-          <p>
-            <m>f(x) = \dfrac{\abs{x}}{x}</m>, at <m>x=0</m>
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                Removable
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                Jump
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                Infinite
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                No discontinuity
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
-      <task label="peer-limit-continuity-5b">
-        <statement>
-          <p>
-            <m>f(x) = \dfrac{\sin(x)}{x}</m>, at <m>x=0</m>
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                Removable
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                Jump
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                Infinite
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                No discontinuity
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
-      <task label="peer-limit-continuity-5c">
-        <statement>
-          <p>
-            <m>f(x) = \dfrac1x</m>, at <m>x=0</m>
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                Removable
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                Jump
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                Infinite
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                No discontinuity
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
+        <p>
+          <m>f(x) = \dfrac{\abs{x}}{x}</m>, at <m>x=0</m>
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              Removable
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Jump
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Infinite
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              No discontinuity
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+    <exercise label="peer-limit-continuity-5b">
+      <statement>
+        <p>
+          Determine the type of discontinity the function has at the given point:
+        </p>
+        <p>
+          <m>f(x) = \dfrac{\sin(x)}{x}</m>, at <m>x=0</m>
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              Removable
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Jump
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Infinite
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              No discontinuity
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+    <exercise label="peer-limit-continuity-5c">
+      <statement>
+        <p>
+          Determine the type of discontinity the function has at the given point:
+        </p>
+        <p>
+          <m>f(x) = \dfrac1x</m>, at <m>x=0</m>
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              Removable
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Jump
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              Infinite
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              No discontinuity
+            </p>
+          </statement>
+        </choice>
+      </choices>
     </exercise>
   </reading-questions>
 

--- a/ptx/sec_limit_infty.ptx
+++ b/ptx/sec_limit_infty.ptx
@@ -1344,91 +1344,91 @@
   </subsection>
 
   <reading-questions component="peer">
-    <exercise label="peer-limit-infinite-1">
-      <introduction>
+    
+    <exercise label="peer-limit-infinite-1a">
+      <statement>
         <p>
           Let <m>f(x) = \dfrac{(x+1)(x-4)}{(x+2)^2(x-2)}</m>.
         </p>
 
         <p>
-          Construct a sign diagram for <m>f(x)</m>,
-          and use it to answer the following questions.
+          Using a sign diagram for <m>f(x)</m>,
+          determine which of the following is true at <m>x=2</m>:
         </p>
-      </introduction>
-      <task label="peer-limit-infinite-1a">
-        <statement>
-          <p>
-            Which of the following is true at <m>x=2</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to 2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=\infty</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to 2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=\infty</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to 2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=-\infty</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to 2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=-\infty</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
-      <task label="peer-limit-infinite-1b">
-        <statement>
-          <p>
-            Which of the following is true at <m>x=-2</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to -2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=\infty</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to -2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=\infty</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to -2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=-\infty</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                <m>\lim\limits_{x\to -2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=-\infty</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to 2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=\infty</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to 2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=\infty</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to 2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=-\infty</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to 2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to 2^+}f(x)=-\infty</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-infinite-1b">
+      <statement>
+        <p>
+          Let <m>f(x) = \dfrac{(x+1)(x-4)}{(x+2)^2(x-2)}</m>.
+          (This is the same function as the previous problem.)
+        </p>
+        <p>
+          Using your sign diagram for <m>f(x)</m>,
+          determine which of the following is true at <m>x=-2</m>:
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to -2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=\infty</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to -2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=\infty</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to -2^-}f(x)=\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=-\infty</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>\lim\limits_{x\to -2^-}f(x)=-\infty</m> and <m>\lim\limits_{x\to -2^+}f(x)=-\infty</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
     </exercise>
     
     <exercise label="peer-limit-infinite-2">
@@ -1477,79 +1477,79 @@
       </choices>
     </exercise>
 
-    <exercise label="peer-limit-infinite-3">
-      <introduction>
+    <exercise label="peer-limit-infinite-3a">
+      <statement>
         <p>
           Let <m>f(x) = \dfrac{3x^2-4x}{4-5x+8x^2}</m>.
         </p>
-      </introduction>
-      <task label="peer-limit-infinite-3a">
-        <statement>
-          <p>
-            Which of the following is equal to <m>f(x)</m> when <m>x\neq 0</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                <m>\dfrac{3-4x}{4-5x+8}</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>\dfrac{3-4/x}{4-5x+8x^2}</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                <m>\dfrac{3-4/x}{8-5/x+4/x^2}</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
-      <task label="peer-limit-infinite-3b">
-        <statement>
-          <p>
-            What is the value of <m>\lim\limits_{x\to\infty}f(x)</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                <m>3/8</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>3/4</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>0</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>\infty</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
+        <p>
+          Which of the following is equal to <m>f(x)</m> when <m>x\neq 0</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>\dfrac{3-4x}{4-5x+8}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\dfrac{3-4/x}{4-5x+8x^2}</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>\dfrac{3-4/x}{8-5/x+4/x^2}</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+    <exercise label="peer-limit-infinite-3b">
+      <statement>
+        <p>
+          Let <m>f(x) = \dfrac{3x^2-4x}{4-5x+8x^2}</m>.
+          (This is the same function as the previous question.)
+        </p>
+        <p>
+          What is the value of <m>\lim\limits_{x\to\infty}f(x)</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>3/8</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>3/4</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>\infty</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
     </exercise>
 
     <exercise label="peer-limit-infinite-4">

--- a/ptx/sec_limit_intro.ptx
+++ b/ptx/sec_limit_intro.ptx
@@ -1525,8 +1525,8 @@
   </paragraphs>
 
   <reading-questions component="peer">
-    <exercise label="peer-limit-intro-1">
-      <introduction>
+    <exercise label="peer-limit-intro-1a">
+      <statement>
         <p>
           Suppose we have the following graph of a function <m>f</m>,
           but we can't see what is happening under the square:
@@ -1534,7 +1534,7 @@
 
         <image width="47%">
           <shortdescription>A downward-facing parabola, with one portion blocked by a square.</shortdescription>
-          <latex-image label="peer-limit-intro-img1">
+          <latex-image label="peer-limit-intro-img1a">
             \begin{tikzpicture}
               
                   \begin{axis}[
@@ -1554,82 +1554,108 @@
             \end{tikzpicture}
           </latex-image>
         </image>
-      </introduction>
-      <task label="peer-limit-intro1a">
-        <statement>
-          <p>
-            If you had to guess, when <m>x</m> is close to 2,
-            you would say that <m>f(x)</m> is close to:
-          </p>
-        </statement>
-        <choices>
-          <choice correct="no">
-            <statement>
-              <p>
-                <m>0</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="no">
-            <statement>
-              <p>
-                <m>1</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                <m>2</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="no">
-            <statement>
-              <p>
-                <m>3</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
-      <task label="peer-limit-intro1b">
-        <statement>
-          <p>
-            What can you say about <m>f(2)</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement correct="no">
-              <p>
-                <m>f(2)=2</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="no">
-            <statement>
-              <p>
-                <m>f(2)</m> is close to <m>2</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="no">
-            <statement>
-              <p>
-                <m>f(2)</m> is undefined
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                Nothing
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
+
+        <p>
+          If you had to guess, when <m>x</m> is close to 2,
+          you would say that <m>f(x)</m> is close to:
+        </p>
+      </statement>
+      <choices>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>3</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+    
+    <exercise label="peer-limit-intro1b">
+      <statement>
+        <p>
+          Suppose we have the following graph of a function <m>f</m>,
+          but we can't see what is happening under the square:
+        </p>
+
+        <image width="47%">
+          <shortdescription>A downward-facing parabola, with one portion blocked by a square.</shortdescription>
+          <latex-image label="peer-limit-intro-img1b">
+            \begin{tikzpicture}
+              
+                  \begin{axis}[
+                      ymin=-1,
+                      ymax=3,
+                      xmin=-1,
+                      xmax=4.3,
+                      axis equal,
+                    ]
+                    \addplot+ [leftarrow,domain=-0.9:1.98]{-0.5*x^2+x+2};
+                    \addplot [firstcurvestyle,rightarrow,domain=2.02:3.5]{-0.5*x^2+x+2};
+                    \addplot[squaremark] coordinates{(2,2)};
+                    %\addplot[hollowdot] coordinates{(2,2.6)};
+                    %\addplot[hollowdot] coordinates{(2,0.4)};
+                  \end{axis}
+                
+            \end{tikzpicture}
+          </latex-image>
+        </image>
+        
+        <p>
+          What can you say about <m>f(2)</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement correct="no">
+            <p>
+              <m>f(2)=2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>f(2)</m> is close to <m>2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="no">
+          <statement>
+            <p>
+              <m>f(2)</m> is undefined
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              Nothing
+            </p>
+          </statement>
+        </choice>
+      </choices>
     </exercise>
 
     <exercise label="peer-limit-intro-2">
@@ -1729,6 +1755,7 @@
         </choice>
       </choices>
     </exercise>
+    
     <exercise label="peer-limit-intro-4">
       <statement>
         <p>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -872,86 +872,86 @@
   </p>
 
   <reading-questions component="peer">
-    <exercise label="peer-limit-oneside-1">
-      <introduction>
+    <exercise label="peer-limit-oneside-1a">      
+      <statement>
         <p>
           Consider the function <m>f(x) = \begin{cases}2-x, \amp x\lt -1\\ 1+x^2, \amp -1\leq x\lt 2\\ \sin(\pi x),\amp x\geq 2\end{cases}</m>.
         </p>
-      </introduction>
-      <task label="peer-limit-oneside-1a">
-        <statement>
-          <p>
-            What is the value of <m>f(0)</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                <m>2</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>0</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>-1</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                <m>1</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
-      <task label="peer-limit-oneside-1b">
-        <statement>
-          <p>
-            What is the value of <m>f(2)</m>?
-          </p>
-        </statement>
-        <choices>
-          <choice>
-            <statement>
-              <p>
-                <m>2</m>
-              </p>
-            </statement>
-          </choice>
-          <choice correct="yes">
-            <statement>
-              <p>
-                <m>0</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>5</m>
-              </p>
-            </statement>
-          </choice>
-          <choice>
-            <statement>
-              <p>
-                <m>1</m>
-              </p>
-            </statement>
-          </choice>
-        </choices>
-      </task>
+        <p>
+          What is the value of <m>f(0)</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>-1</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>1</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
+    </exercise>
+
+    <exercise label="peer-limit-oneside-1b">
+      <statement>
+        <p>
+          Consider again the function <m>f(x) = \begin{cases}2-x, \amp x\lt -1\\ 1+x^2, \amp -1\leq x\lt 2\\ \sin(\pi x),\amp x\geq 2\end{cases}</m>.
+        </p>
+        <p>
+          What is the value of <m>f(2)</m>?
+        </p>
+      </statement>
+      <choices>
+        <choice>
+          <statement>
+            <p>
+              <m>2</m>
+            </p>
+          </statement>
+        </choice>
+        <choice correct="yes">
+          <statement>
+            <p>
+              <m>0</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>5</m>
+            </p>
+          </statement>
+        </choice>
+        <choice>
+          <statement>
+            <p>
+              <m>1</m>
+            </p>
+          </statement>
+        </choice>
+      </choices>
     </exercise>
 
     <exercise label="peer-limit-oneside-2">


### PR DESCRIPTION
This is a Runestone-only fix. Multi-part questions are a bad idea on Runestone (at least, if used for polling) since the introduction isn't visible, and in a polling question you don't have the option of viewing the full exercise in the book.