### PR TITLE
add missing = sign in theorem, and move proteus ex

### DIFF
--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -293,6 +293,54 @@
     </solution>
   </example>
 
+  <p>
+    <xref ref="thm_deriv_common"/> gives useful information,
+    but we will need much more.
+    For instance, using the theorem,
+    we can easily find the derivative of <m>y=x^3</m>,
+    but it does not tell how to compute the derivative of <m>y=2x^3</m>,
+    <m>y=x^3+\sin(x)</m> nor <m>y=x^3\sin(x)</m>.
+    The following theorem helps with the first two of these examples
+    (the third is answered in the next section).
+  </p>
+
+  <theorem xml:id="thm_deriv_prop">
+    <title>Properties of the Derivative</title>
+    <statement>
+      <p>
+        Let <m>f</m> and <m>g</m> be differentiable on an open interval <m>I</m> and let <m>c</m> be a real number.
+        Then:
+        <ol>
+          <li xml:id="sum-difference-derivative-rule">
+            <title>Sum/Difference Rule</title>
+            <p>
+              <me>
+                \lzoo{x}{f(x) \pm g(x)} =  \lzoo{x}{f(x)} \pm \lzoo{x}{g(x)} = \fp(x)\pm \gp(x)
+              </me>
+
+                <idx><h>derivative</h><h>Sum/Difference Rule</h></idx>
+                <idx><h>Sum/Difference Rule</h><h>of derivatives</h></idx>
+
+            </p>
+          </li>
+
+          <li xml:id="constant-multiple-derivative-rule">
+            <title>Constant Multiple Rule</title>
+            <p>
+              <me>
+                \lzoo{x}{c\cdot f(x)} = c\cdot\lzoo{x}{f(x)} = c\cdot\fp(x)
+              </me>.
+
+                <idx><h>derivative</h><h>Constant Multiple Rule</h></idx>
+                <idx><h>Constant Multiple Rule</h><h>of derivatives</h></idx>
+
+            </p>
+          </li>
+        </ol>
+      </p>
+    </statement>
+  </theorem>
+
   <exercise label="APEX-PROTEUS-deriv-basic-2-v1" component="proteus">
     <title>PROTEUS EXERCISE</title>
     <statement>
@@ -323,54 +371,6 @@
       <response xml:id="proteus-deriv-basic-8" order="6"><m>3e^x+\cos(x)</m></response>
     </matching>
   </exercise>
-
-  <p>
-    <xref ref="thm_deriv_common"/> gives useful information,
-    but we will need much more.
-    For instance, using the theorem,
-    we can easily find the derivative of <m>y=x^3</m>,
-    but it does not tell how to compute the derivative of <m>y=2x^3</m>,
-    <m>y=x^3+\sin(x)</m> nor <m>y=x^3\sin(x)</m>.
-    The following theorem helps with the first two of these examples
-    (the third is answered in the next section).
-  </p>
-
-  <theorem xml:id="thm_deriv_prop">
-    <title>Properties of the Derivative</title>
-    <statement>
-      <p>
-        Let <m>f</m> and <m>g</m> be differentiable on an open interval <m>I</m> and let <m>c</m> be a real number.
-        Then:
-        <ol>
-          <li xml:id="sum-difference-derivative-rule">
-            <title>Sum/Difference Rule</title>
-            <p>
-              <me>
-                \lzoo{x}{f(x) \pm g(x)} \lzoo{x}{f(x)} \pm \lzoo{x}{g(x)} = \fp(x)\pm \gp(x)
-              </me>
-
-                <idx><h>derivative</h><h>Sum/Difference Rule</h></idx>
-                <idx><h>Sum/Difference Rule</h><h>of derivatives</h></idx>
-
-            </p>
-          </li>
-
-          <li xml:id="constant-multiple-derivative-rule">
-            <title>Constant Multiple Rule</title>
-            <p>
-              <me>
-                \lzoo{x}{c\cdot f(x)} = c\cdot\lzoo{x}{f(x)} = c\cdot\fp(x)
-              </me>.
-
-                <idx><h>derivative</h><h>Constant Multiple Rule</h></idx>
-                <idx><h>Constant Multiple Rule</h><h>of derivatives</h></idx>
-
-            </p>
-          </li>
-        </ol>
-      </p>
-    </statement>
-  </theorem>
 
   <exercise component="proteus" label="APEX-PROTEUS-deriv-basic-3-v1">
     <title>PROTEUS EXERCISE</title>


### PR DESCRIPTION
Somehow we've been missing an equals sign in the sum/difference rule all this time...