### PR TITLE
Code fixes for webwork exercises

### DIFF
--- a/ptx/docinfo.ptx
+++ b/ptx/docinfo.ptx
@@ -20,8 +20,8 @@
     \newcommand\blank[2]{\,\colorbox{gray}{$\phantom{\rule{#1pt}{#2pt}}$}\,}
     \newcommand{\highlight}[1]{{\color{blue}{#1}}}
     \newcommand{\ds}{\displaystyle}
-    \newcommand{\fp}{f'}
-    \newcommand{\fpp}{f''}
+    \newcommand{\fp}{f\hskip.75pt '}
+    \newcommand{\fpp}{f\hskip.75pt ''}
 
     %  Leibniz notation
     %  Usage: \lz{y}{x}
@@ -62,11 +62,10 @@
     %Infinite Series with index starting n=1
     %Usage: \infser \frac{1}{n} or \infser[0] 0.5^n
     \newcommand{\infser}[1][1]{\sum_{n=#1}^\infty}
-
-    \newcommand{\Fp}{F\primeskip'}
-    \newcommand{\Fpp}{F\primeskip''}
-    \newcommand{\yp}{y\primeskip'}
-    \newcommand{\gp}{g\primeskip'}
+    \newcommand{\Fp}{F\hskip.75pt '}
+    \newcommand{\Fpp}{F\hskip.75pt ''}
+    \newcommand{\yp}{y\hskip.75pt '}
+    \newcommand{\gp}{g\hskip.75pt '}
     \newcommand{\dx}{\Delta x}
     \newcommand{\dy}{\Delta y}
     \newcommand{\ddz}{\Delta z}
@@ -107,7 +106,6 @@
     \newcommand{\zerooverzero}{\ds \raisebox{8pt}{\text{``\ }}\frac{0}{0}\raisebox{8pt}{\textit{ ''}}}
     \newcommand{\deriv}[2]{\myds\frac{d}{dx}\left(#1\right)=#2}
     \newcommand{\myint}[2]{\myds\int #1\, dx= {\ds #2}}
-    \newcommand{\primeskip}{\hskip.75pt}
     \newcommand{\abs}[1]{\left\lvert #1\right\rvert}
     \newcommand{\sech}{\operatorname{sech}}
     \newcommand{\csch}{\operatorname{csch}}

--- a/ptx/docinfo.ptx
+++ b/ptx/docinfo.ptx
@@ -103,9 +103,7 @@
     \newcommand{\R}{mathbb{R}}
     \newcommand{\mathN}{\mathbb{N}}
     \newcommand{\surfaceS}{\mathcal{S}}
-    \newcommand{\zerooverzero}{\ds \raisebox{8pt}{\text{``\ }}\frac{0}{0}\raisebox{8pt}{\textit{ ''}}}
-    \newcommand{\deriv}[2]{\myds\frac{d}{dx}\left(#1\right)=#2}
-    \newcommand{\myint}[2]{\myds\int #1\, dx= {\ds #2}}
+    \newcommand{\zerooverzero}{\displaystyle \raisebox{8pt}{\text{``\ }}\frac{0}{0}\raisebox{8pt}{\textit{ ''}}}
     \newcommand{\abs}[1]{\left\lvert #1\right\rvert}
     \newcommand{\sech}{\operatorname{sech}}
     \newcommand{\csch}{\operatorname{csch}}

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -3206,55 +3206,55 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
-              <sidebyside>
-                <tabular>
-                  <row bottom="medium">
-                    <cell>Iteration</cell>
-                    <cell>Interval</cell>
-                    <cell>Midpoint Sign</cell>
-                  </row>
-                  <row>
-                    <cell>1</cell>
-                    <cell><m><var name="$in[0]"/></m></cell>
-                    <cell><var name="$popup[0]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>2</cell>
-                    <cell><var name="$in[1]" width="20"/></cell>
-                    <cell><var name="$popup[1]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>3</cell>
-                    <cell><var name="$in[2]" width="20"/></cell>
-                    <cell><var name="$popup[2]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>4</cell>
-                    <cell><var name="$in[3]" width="20"/></cell>
-                    <cell><var name="$popup[3]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>5</cell>
-                    <cell><var name="$in[4]" width="20"/></cell>
-                    <cell><var name="$popup[4]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>6</cell>
-                    <cell><var name="$in[5]" width="20"/></cell>
-                    <cell><var name="$popup[5]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>7</cell>
-                    <cell><var name="$in[6]" width="20"/></cell>
-                    <cell><var name="$popup[6]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>8</cell>
-                    <cell><var name="$in[7]" width="20"/></cell>
-                    <cell></cell>
-                  </row>
-                </tabular>
-              </sidebyside>
+              
+              <tabular>
+                <row bottom="medium">
+                  <cell>Iteration</cell>
+                  <cell>Interval</cell>
+                  <cell>Midpoint Sign</cell>
+                </row>
+                <row>
+                  <cell>1</cell>
+                  <cell><m><var name="$in[0]"/></m></cell>
+                  <cell><var name="$popup[0]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>2</cell>
+                  <cell><var name="$in[1]" width="20"/></cell>
+                  <cell><var name="$popup[1]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>3</cell>
+                  <cell><var name="$in[2]" width="20"/></cell>
+                  <cell><var name="$popup[2]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>4</cell>
+                  <cell><var name="$in[3]" width="20"/></cell>
+                  <cell><var name="$popup[3]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>5</cell>
+                  <cell><var name="$in[4]" width="20"/></cell>
+                  <cell><var name="$popup[4]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>6</cell>
+                  <cell><var name="$in[5]" width="20"/></cell>
+                  <cell><var name="$popup[5]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>7</cell>
+                  <cell><var name="$in[6]" width="20"/></cell>
+                  <cell><var name="$popup[6]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>8</cell>
+                  <cell><var name="$in[7]" width="20"/></cell>
+                  <cell></cell>
+                </row>
+              </tabular>
+              
               <p>
                 <var name="$z" width="10"/>
               </p>
@@ -3292,55 +3292,55 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
-              <sidebyside>
-                <tabular>
-                  <row bottom="medium">
-                    <cell>Iteration</cell>
-                    <cell>Interval</cell>
-                    <cell>Midpoint Sign</cell>
-                  </row>
-                  <row>
-                    <cell>1</cell>
-                    <cell><m><var name="$in[0]"/></m></cell>
-                    <cell><var name="$popup[0]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>2</cell>
-                    <cell><var name="$in[1]" width="20"/></cell>
-                    <cell><var name="$popup[1]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>3</cell>
-                    <cell><var name="$in[2]" width="20"/></cell>
-                    <cell><var name="$popup[2]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>4</cell>
-                    <cell><var name="$in[3]" width="20"/></cell>
-                    <cell><var name="$popup[3]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>5</cell>
-                    <cell><var name="$in[4]" width="20"/></cell>
-                    <cell><var name="$popup[4]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>6</cell>
-                    <cell><var name="$in[5]" width="20"/></cell>
-                    <cell><var name="$popup[5]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>7</cell>
-                    <cell><var name="$in[6]" width="20"/></cell>
-                    <cell><var name="$popup[6]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>8</cell>
-                    <cell><var name="$in[7]" width="20"/></cell>
-                    <cell></cell>
-                  </row>
-                </tabular>
-              </sidebyside>
+              
+              <tabular>
+                <row bottom="medium">
+                  <cell>Iteration</cell>
+                  <cell>Interval</cell>
+                  <cell>Midpoint Sign</cell>
+                </row>
+                <row>
+                  <cell>1</cell>
+                  <cell><m><var name="$in[0]"/></m></cell>
+                  <cell><var name="$popup[0]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>2</cell>
+                  <cell><var name="$in[1]" width="20"/></cell>
+                  <cell><var name="$popup[1]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>3</cell>
+                  <cell><var name="$in[2]" width="20"/></cell>
+                  <cell><var name="$popup[2]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>4</cell>
+                  <cell><var name="$in[3]" width="20"/></cell>
+                  <cell><var name="$popup[3]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>5</cell>
+                  <cell><var name="$in[4]" width="20"/></cell>
+                  <cell><var name="$popup[4]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>6</cell>
+                  <cell><var name="$in[5]" width="20"/></cell>
+                  <cell><var name="$popup[5]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>7</cell>
+                  <cell><var name="$in[6]" width="20"/></cell>
+                  <cell><var name="$popup[6]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>8</cell>
+                  <cell><var name="$in[7]" width="20"/></cell>
+                  <cell></cell>
+                </row>
+              </tabular>
+              
               <p>
                 <var name="$z" width="10"/>
               </p>
@@ -3378,55 +3378,54 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
-              <sidebyside>
-                <tabular>
-                  <row bottom="medium">
-                    <cell>Iteration</cell>
-                    <cell>Interval</cell>
-                    <cell>Midpoint Sign</cell>
-                  </row>
-                  <row>
-                    <cell>1</cell>
-                    <cell><m><var name="$in[0]"/></m></cell>
-                    <cell><var name="$popup[0]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>2</cell>
-                    <cell><var name="$in[1]" width="20"/></cell>
-                    <cell><var name="$popup[1]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>3</cell>
-                    <cell><var name="$in[2]" width="20"/></cell>
-                    <cell><var name="$popup[2]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>4</cell>
-                    <cell><var name="$in[3]" width="20"/></cell>
-                    <cell><var name="$popup[3]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>5</cell>
-                    <cell><var name="$in[4]" width="20"/></cell>
-                    <cell><var name="$popup[4]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>6</cell>
-                    <cell><var name="$in[5]" width="20"/></cell>
-                    <cell><var name="$popup[5]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>7</cell>
-                    <cell><var name="$in[6]" width="20"/></cell>
-                    <cell><var name="$popup[6]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>8</cell>
-                    <cell><var name="$in[7]" width="20"/></cell>
-                    <cell></cell>
-                  </row>
-                </tabular>
-              </sidebyside>
+              
+              <tabular>
+                <row bottom="medium">
+                  <cell>Iteration</cell>
+                  <cell>Interval</cell>
+                  <cell>Midpoint Sign</cell>
+                </row>
+                <row>
+                  <cell>1</cell>
+                  <cell><m><var name="$in[0]"/></m></cell>
+                  <cell><var name="$popup[0]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>2</cell>
+                  <cell><var name="$in[1]" width="20"/></cell>
+                  <cell><var name="$popup[1]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>3</cell>
+                  <cell><var name="$in[2]" width="20"/></cell>
+                  <cell><var name="$popup[2]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>4</cell>
+                  <cell><var name="$in[3]" width="20"/></cell>
+                  <cell><var name="$popup[3]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>5</cell>
+                  <cell><var name="$in[4]" width="20"/></cell>
+                  <cell><var name="$popup[4]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>6</cell>
+                  <cell><var name="$in[5]" width="20"/></cell>
+                  <cell><var name="$popup[5]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>7</cell>
+                  <cell><var name="$in[6]" width="20"/></cell>
+                  <cell><var name="$popup[6]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>8</cell>
+                  <cell><var name="$in[7]" width="20"/></cell>
+                  <cell></cell>
+                </row>
+              </tabular>
               <p>
                 <var name="$z" width="10"/>
               </p>
@@ -3464,55 +3463,54 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
-              <sidebyside>
-                <tabular>
-                  <row bottom="medium">
-                    <cell>Iteration</cell>
-                    <cell>Interval</cell>
-                    <cell>Midpoint Sign</cell>
-                  </row>
-                  <row>
-                    <cell>1</cell>
-                    <cell><m><var name="$in[0]"/></m></cell>
-                    <cell><var name="$popup[0]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>2</cell>
-                    <cell><var name="$in[1]" width="20"/></cell>
-                    <cell><var name="$popup[1]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>3</cell>
-                    <cell><var name="$in[2]" width="20"/></cell>
-                    <cell><var name="$popup[2]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>4</cell>
-                    <cell><var name="$in[3]" width="20"/></cell>
-                    <cell><var name="$popup[3]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>5</cell>
-                    <cell><var name="$in[4]" width="20"/></cell>
-                    <cell><var name="$popup[4]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>6</cell>
-                    <cell><var name="$in[5]" width="20"/></cell>
-                    <cell><var name="$popup[5]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>7</cell>
-                    <cell><var name="$in[6]" width="20"/></cell>
-                    <cell><var name="$popup[6]" form="popup"/></cell>
-                  </row>
-                  <row>
-                    <cell>8</cell>
-                    <cell><var name="$in[7]" width="20"/></cell>
-                    <cell></cell>
-                  </row>
-                </tabular>
-              </sidebyside>
+              
+              <tabular>
+                <row bottom="medium">
+                  <cell>Iteration</cell>
+                  <cell>Interval</cell>
+                  <cell>Midpoint Sign</cell>
+                </row>
+                <row>
+                  <cell>1</cell>
+                  <cell><m><var name="$in[0]"/></m></cell>
+                  <cell><var name="$popup[0]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>2</cell>
+                  <cell><var name="$in[1]" width="20"/></cell>
+                  <cell><var name="$popup[1]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>3</cell>
+                  <cell><var name="$in[2]" width="20"/></cell>
+                  <cell><var name="$popup[2]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>4</cell>
+                  <cell><var name="$in[3]" width="20"/></cell>
+                  <cell><var name="$popup[3]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>5</cell>
+                  <cell><var name="$in[4]" width="20"/></cell>
+                  <cell><var name="$popup[4]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>6</cell>
+                  <cell><var name="$in[5]" width="20"/></cell>
+                  <cell><var name="$popup[5]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>7</cell>
+                  <cell><var name="$in[6]" width="20"/></cell>
+                  <cell><var name="$popup[6]" form="popup"/></cell>
+                </row>
+                <row>
+                  <cell>8</cell>
+                  <cell><var name="$in[7]" width="20"/></cell>
+                  <cell></cell>
+                </row>
+              </tabular>
               <p>
                 <var name="$z" width="10"/>
               </p>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -3196,7 +3196,7 @@
               $in[0]=Compute("[$l[0],$r[0]]");
               for my$i(1..7){$m[$i-1]=($l[$i-1]+$r[$i-1])/2;
                 ($l[$i],$r[$i])=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?($l[$i-1],$m[$i-1]):($m[$i-1],$r[$i-1]);
-                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'1',showInStatic=&gt;0):DropDown(['+','-'],'0',showInStatic=&gt;0);
+                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'0',showInStatic=&gt;0):DropDown(['+','-'],'1',showInStatic=&gt;0);
                 $in[$i]=Compute("[$l[$i],$r[$i]]");
               };
               $z=Real(($l[7]+$r[7])/2)-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.01);
@@ -3206,6 +3206,8 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
+
+              <instruction>If <m>f(m)\gt 0</m> at the midpoint <m>m</m>, put <m>+</m> for the midpoint sign. If <m>f(m)\lt 0</m>, put <m>-</m> for the midpoint sign.</instruction>
               
               <tabular>
                 <row bottom="medium">
@@ -3254,6 +3256,8 @@
                   <cell></cell>
                 </row>
               </tabular>
+
+              <instruction>Enter the solution to <m>f(x)=0</m>, accurate to two decimal places.</instruction>
               
               <p>
                 <var name="$z" width="10"/>
@@ -3282,7 +3286,7 @@
               $in[0]=Compute("[$l[0],$r[0]]");
               for my$i(1..7){$m[$i-1]=($l[$i-1]+$r[$i-1])/2;
                 ($l[$i],$r[$i])=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?($l[$i-1],$m[$i-1]):($m[$i-1],$r[$i-1]);
-                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'1',showInStatic=&gt;0):DropDown(['+','-'],'0',showInStatic=&gt;0);
+                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'0',showInStatic=&gt;0):DropDown(['+','-'],'1',showInStatic=&gt;0);
                 $in[$i]=Compute("[$l[$i],$r[$i]]");
               };
               $z=Real(($l[7]+$r[7])/2)-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.01);
@@ -3292,6 +3296,8 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
+
+              <instruction>If <m>f(m)\gt 0</m> at the midpoint <m>m</m>, put <m>+</m> for the midpoint sign. If <m>f(m)\lt 0</m>, put <m>-</m> for the midpoint sign.</instruction>
               
               <tabular>
                 <row bottom="medium">
@@ -3340,6 +3346,8 @@
                   <cell></cell>
                 </row>
               </tabular>
+
+              <instruction>Enter the solution to <m>f(x)=0</m>, accurate to two decimal places.</instruction>
               
               <p>
                 <var name="$z" width="10"/>
@@ -3368,7 +3376,7 @@
               $in[0]=Compute("[$l[0],$r[0]]");
               for my$i(1..7){$m[$i-1]=($l[$i-1]+$r[$i-1])/2;
                 ($l[$i],$r[$i])=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?($l[$i-1],$m[$i-1]):($m[$i-1],$r[$i-1]);
-                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'1',showInStatic=&gt;0):DropDown(['+','-'],'0',showInStatic=&gt;0);
+                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'0',showInStatic=&gt;0):DropDown(['+','-'],'1',showInStatic=&gt;0);
                 $in[$i]=Compute("[$l[$i],$r[$i]]");
               };
               $z=Real(($l[7]+$r[7])/2)-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.01);
@@ -3378,6 +3386,8 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
+
+              <instruction>If <m>f(m)\gt 0</m> at the midpoint <m>m</m>, put <m>+</m> for the midpoint sign. If <m>f(m)\lt 0</m>, put <m>-</m> for the midpoint sign.</instruction>
               
               <tabular>
                 <row bottom="medium">
@@ -3426,6 +3436,9 @@
                   <cell></cell>
                 </row>
               </tabular>
+
+              <instruction>Enter the solution to <m>f(x)=0</m>, accurate to two decimal places.</instruction>
+
               <p>
                 <var name="$z" width="10"/>
               </p>
@@ -3453,7 +3466,7 @@
               $in[0]=Compute("[$l[0],$r[0]]");
               for my$i(1..7){$m[$i-1]=($l[$i-1]+$r[$i-1])/2;
                 ($l[$i],$r[$i])=($f-&gt;eval(x=&gt;$m[$i-1])&lt;0)?($l[$i-1],$m[$i-1]):($m[$i-1],$r[$i-1]);
-                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'1',showInStatic=&gt;0):DropDown(['+','-'],'0',showInStatic=&gt;0);
+                $popup[$i-1]=($f-&gt;eval(x=&gt;$m[$i-1])&gt;0)?DropDown(['+','-'],'0',showInStatic=&gt;0):DropDown(['+','-'],'1',showInStatic=&gt;0);
                 $in[$i]=Compute("[$l[$i],$r[$i]]");
               };
               $z=Real(($l[7]+$r[7])/2)-&gt;with(tolType=&gt;'absolute',tolerance=&gt;0.01);
@@ -3463,6 +3476,8 @@
               <p>
                 <m>f(x)=<var name="$f"/></m> on the interval <m><var name="$in[0]"/></m>
               </p>
+
+              <instruction>If <m>f(m)\gt 0</m> at the midpoint <m>m</m>, put <m>+</m> for the midpoint sign. If <m>f(m)\lt 0</m>, put <m>-</m> for the midpoint sign.</instruction>
               
               <tabular>
                 <row bottom="medium">
@@ -3511,6 +3526,9 @@
                   <cell></cell>
                 </row>
               </tabular>
+
+              <instruction>Enter the solution to <m>f(x)=0</m>, accurate to two decimal places.</instruction>
+              
               <p>
                 <var name="$z" width="10"/>
               </p>

--- a/ptx/sec_limit_onesided.ptx
+++ b/ptx/sec_limit_onesided.ptx
@@ -2503,7 +2503,7 @@
             <task label="ex-limit-onesided-piecewise-evaluate-5a">
               <statement>
                 <p>
-                  <m>\lim\limits_{x\to <var name="$a"/>^-} f(x)</m>
+                  <m>\lim\limits_{x\to a^-} f(x)</m>
                 </p>
                 <p>
                   <var name="$L[0]" width="10"/>
@@ -2514,7 +2514,7 @@
             <task label="ex-limit-onesided-piecewise-evaluate-5b">
               <statement>
                 <p>
-                  <m>\lim\limits_{x\to <var name="$a"/>^+} f(x)</m>
+                  <m>\lim\limits_{x\to a^+} f(x)</m>
                 </p>
                 <p>
                   <var name="$L[1]" width="10"/>
@@ -2525,7 +2525,7 @@
             <task label="ex-limit-onesided-piecewise-evaluate-5c">
               <statement>
                 <p>
-                  <m>\lim\limits_{x\to <var name="$a"/>} f(x)</m>
+                  <m>\lim\limits_{x\to a} f(x)</m>
                 </p>
                 <p>
                   <var name="$L[2]" width="10"/>
@@ -2536,7 +2536,7 @@
             <task label="ex-limit-onesided-piecewise-evaluate-5d">
               <statement>
                 <p>
-                  <m>f(<var name="$a"/>)</m>
+                  <m>f(a)</m>
                 </p>
                 <p>
                   <var name="$L[3]" width="10"/>


### PR DESCRIPTION
A few housekeeping items:
- there were a few WW problems with a sidebyside that is now deprecated. these have been removed
- the bisection exercises had a programming error, and all the midpoint signs were flipped
- WeBWorK can process LaTeX macros, but not macros that depend on other macros, so I've removed the `\primeskip` command and hard-coded the spacing into the definition of macros like `\fp`, `\gp`, etc.