### PR TITLE
Fix sign error in cos version of normal line problem

### DIFF
--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1968,7 +1968,6 @@
               else {
                 $rm = Formula("1/$m");
                 $n= Formula("y=-$rm(x-pi/$a)+$k");
-                $t=Formula("y=$k") if ($m == 0);
               };
             </pg-code>
             <statement>

--- a/ptx/sec_deriv_basic_rules.ptx
+++ b/ptx/sec_deriv_basic_rules.ptx
@@ -1940,15 +1940,15 @@
               %trigrecip = (
                 'sin'=&gt;{
                   2=&gt;Formula("1"),
-                  3=&gt;Formula("2 sqrt(3)/3"),
+                  3=&gt;Formula("2*sqrt(3)/3"),
                   4=&gt;Formula("sqrt(2)"),
                   6=&gt;Formula("2"),
                 },
                 'cos'=&gt;{
                   2=&gt;Formula("DNE"),
                   3=&gt;Formula("2"),
-                  4=&gt;Formula("2 sqrt(2)"),
-                  6=&gt;Formula("2 sqrt(3)/3"),
+                  4=&gt;Formula("2*sqrt(2)"),
+                  6=&gt;Formula("2*sqrt(3)/3"),
                 },
               );
               %trigd = (
@@ -1966,8 +1966,7 @@
               if (($c eq 'sin') and ($a==2))
                 {$n= Formula("x=pi/$a");}
               else {
-                $rm = Formula("1/$b")*$trigrecip{$trigd{$c}}{$a};
-                $rm = Formula("1/-$b")-&gt;reduce*$trigrecip{$trigd{$c}}{$a} if ($c eq 'cos');
+                $rm = Formula("1/$m");
                 $n= Formula("y=-$rm(x-pi/$a)+$k");
                 $t=Formula("y=$k") if ($m == 0);
               };


### PR DESCRIPTION
This should fix the bug pointed out in #381.

@Alex-Jordan would you be willing to check my work before I merge this?
It is less elegant than before, but I've removed the bug, I think.

Since there was already logic to deal with the case m=0 (in which case the normal line is vertical), I just defined the slope for the normal line as -1/m. It means there are displayed answers with content like `-\left(-\frac{1}{\frac{4\sqrt{2}}{2}}\right)` but I'm willing to live with this if the correct answers are marked as such.