### PR TITLE
fix typo in theorem statement

### DIFF
--- a/ptx/sec_graph_mvt.ptx
+++ b/ptx/sec_graph_mvt.ptx
@@ -526,7 +526,7 @@
           </li>
           <li>
             <p>
-              If <m>\gp'(x)=h'(x)</m> for all <m>x</m> in <m>I</m>,
+              If <m>\gp(x)=h'(x)</m> for all <m>x</m> in <m>I</m>,
               then there is a constant <m>C</m> such that <m>g(x)=h(x)+C</m>
               for all <m>x</m> in <m>I</m>.
             </p>


### PR DESCRIPTION
The text currently says g''(x)=h'(x) instead of g'(x)=h'(x).

Not sure when that one crept in...