### PR TITLE
Create "playground" course for proteus

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -19,6 +19,9 @@
     <target name="runestone-proteus" format="html" source="apex.ptx" publication="publication-runestone-proteus.ptx" output-dir="../published/APEX-PROTEUS">
       <stringparams key="html.annotation" value="hypothesis"/>
     </target>
+    <target name="runestone-playground" format="html" source="apex.ptx" publication="publication-proteus-playground.ptx" output-dir="../published/APEXplayground">
+      <stringparams key="html.annotation" value="hypothesis"/>
+    </target>
     <target name="latex" format="latex" source="apex.ptx" publication="publication.ptx" xsl="apex-latex-style.xsl"/>
     <target name="latex-novideo" format="latex" source="apex.ptx" publication="publication-novid.ptx" xsl="apex-latex-style.xsl"/>
     <target name="latex-print" format="latex" source="apex.ptx" publication="publication-print.ptx" xsl="apex-latex-print-style.xsl"/>

--- a/ptx/apex.ptx
+++ b/ptx/apex.ptx
@@ -6,6 +6,7 @@
   <book xml:id="apex-calculus">
     <title>APEX Calculus</title>
     <subtitle component="proteus">PROTEUS version</subtitle>
+    <subtitle component="playground">PROTEUS Playground</subtitle>
     <frontmatter label="frontmatter">
       <bibinfo>
         <author>

--- a/ptx/docinfo.ptx
+++ b/ptx/docinfo.ptx
@@ -8,7 +8,8 @@
 
   <document-id edition="5" component="proteus">APEXPROTEUS</document-id>
   <document-id edition="5" component="main">APEX</document-id>
-
+  <document-id edition="5" component="playground">APEXplayground</document-id>
+  
   <blurb shelf="Mathematics">
     A traditional calculus textbook with many exercises and few proofs,
     covering calculus from limits to vector calculus.

--- a/publication/publication-proteus-playground.ptx
+++ b/publication/publication-proteus-playground.ptx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<publication>
+
+    <!-- Relative path, relative to "main" source file -->
+    <source>
+        <directories external="../assets" generated="../generated-assets"/>
+        <version include="playground color video taypoly-late video-late"/>
+    </source>
+
+    <webwork server="https://webwork-dev.uleth.ca" course="apex-main"/>
+
+    <common>
+      <tableofcontents level="2"/>
+      <exercise-divisional hint="no" answer="no" solution="no"/>
+      <exercise-reading hint="yes" answer="no" solution="no"/>
+    </common>
+    <!-- HTML-Specific Options -->
+    <html>
+        <platform host="runestone"/>
+        <calculator model="geogebra-graphing"/>
+        <index-page ref="apex-calculus"/>
+        <video privacy="yes"/>
+        <!-- baseurl should not have a trailing slash -->
+        <baseurl href="https://opentext.uleth.ca/apex-video"/>
+        <knowl example="no" exercise-inline="no"/>
+        <asymptote links="yes"/>
+        <exercises tabbed-tasks="inline"/>
+        <webwork divisional="dynamic" reading="dynamic"/>
+        <css theme="salem" palette="ice-fire"/>
+    </html>
+    
+</publication>


### PR DESCRIPTION
This just adds a different build target, for use on Runestone only, to support development of new PROTEUS questions.