### PR TITLE
10.3 intro is way too long. Add subsection

### DIFF
--- a/ptx/sec_par_calc.ptx
+++ b/ptx/sec_par_calc.ptx
@@ -19,6 +19,11 @@
       <video youtube="FIvX66HAaj8" label="vid-planecurves-parcalc-intro"/>
     </figure>
 
+  </introduction>
+
+  <subsection xml:id="subsec-parametric-tangent" label="subsec-param-tangent">
+    <title>Tangent lines to parametric curves</title>
+        
     <p>
       The slope of the tangent line is still <m>\frac{dy}{dx}</m>,
       and the Chain Rule allows us to calculate this in the context of parametric equations.
@@ -571,7 +576,7 @@
         </match>
       </cardsort>
     </exercise>
-  </introduction>
+  </subsection>
 
   <subsection>
     <title>Concavity</title>

--- a/ptx/sec_param_eqs.ptx
+++ b/ptx/sec_param_eqs.ptx
@@ -419,22 +419,22 @@
     </example>
 
     <exercise label="APEX-PROTEUS-param-eqs-1-v1" component="proteus">
-    <title>PROTEUS EXERCISE</title>
-    
-    <statement>
-      <p>
-        Two parametrizations are given:
-        <md>
-          x=\cos(t),\ y=\sin(t),\ 0\le t\le 2\pi
-        </md>
-        and
-        <md>
-          x=\cos(2t),\ y=\sin(2t),\ 0\le t\le \pi
-        </md>.
-      </p>
+      <title>PROTEUS EXERCISE</title>
+      
+      <statement>
+        <p>
+          Two parametrizations are given:
+          <md>
+            x=\cos(t),\ y=\sin(t),\ 0\le t\le 2\pi
+          </md>
+          and
+          <md>
+            x=\cos(2t),\ y=\sin(2t),\ 0\le t\le \pi
+          </md>.
+        </p>
 
-      <p>Which statement is true?</p>
-    </statement>
+        <p>Which statement is true?</p>
+      </statement>
       <choices>
         <choice correct="no">
            <statement><p>The second traces a larger circle.</p> </statement>


### PR DESCRIPTION
The "introduction in 10.3 ran all the way to the subsection on concavity. This isn't allowed -- nothing with a number (like an exercise) will work correctly.