### PR TITLE
2026 summer edits chpt12

### DIFF
--- a/ptx/sec_curvature.ptx
+++ b/ptx/sec_curvature.ptx
@@ -208,7 +208,7 @@
           We find it with <m>\vec r(2) = \la 1/5, 18/5\ra</m>.
         </p>
 
-        <figure xml:id="fig_vvfarc1" vshift="-2">
+        <figure xml:id="fig_vvfarc1" vshift="0">
           <caption>Graphing <m>\vec r</m> in <xref ref="ex_vvfarc1"/> with parameters <m>t</m> and <m>s</m></caption>
           <!-- START figures/fig_vvfarc1.tex -->
           <image width="47%">
@@ -687,7 +687,7 @@
       Being able to think of curvature in terms of the radius of a circle is very useful.
     </p>
 
-    <figure xml:id="fig_curvature_osculate" vshift="6">
+    <figure xml:id="fig_curvature_osculate" vshift="3">
       <caption>Illustrating the osculating circles for the curve seen in <xref ref="fig_curvature_intro"/></caption>
       <!-- START figures/fig_curvature_introc.tex -->
       <image width="47%">
@@ -757,7 +757,7 @@
           </md>.
         </p>
 
-        <figure xml:id="fig_curvature3" vshift="0">
+        <figure xml:id="fig_curvature3" vshift="1">
           <caption>Examining the curvature of <m>y=x^2</m></caption>
           <!-- START figures/fig_curvature3.tex -->
           <image width="47%">
@@ -834,26 +834,10 @@
           </md>
         </p>
 
-        <p>
-          While this is not a particularly <q>nice</q> formula,
-          it does explicitly tell us what the curvature is at a given <m>t</m> value.
-          To maximize <m>\kappa(t)</m>,
-          we should solve <m>\kappa'(t)=0</m> for <m>t</m>.
-          This is doable, but <em>very</em> time consuming.
-          Instead, consider the graph of
-          <m>\kappa(t)</m> as given in <xref ref="fig_curvature4a"/>.
-          We see that <m>\kappa</m> is maximized at two <m>t</m> values;
-          using a numerical solver, we find these values are <m>t\approx\pm 0.189</m>.
-          In <xref ref="fig_curvature4b_3D"/> we graph <m>\vrt</m> and indicate the points where curvature is maximized.
-        </p>
-
-        <figure xml:id="fig_curvature4">
-          <caption>Understanding the curvature of a curve in space</caption>
-          <sidebyside widths="47% 47%" margins="0%" valign="bottom">
-            <figure xml:id="fig_curvature4a">
-              <caption>The curvature of <m>\vec{r}(t)</m></caption>
+        <figure xml:id="fig_curvature4a" vshift="4">
+              <caption>The curvature of <m>\vec{r}(t)</m> in <xref ref="ex_curvature4"/></caption>
             <!-- START figures/fig_curvature4a.tex -->
-              <image>
+              <image width="47%">
                 <shortdescription>A plot of the curvature as a function of the parameter t.</shortdescription>
                 <description>
                   <p>
@@ -885,11 +869,11 @@
             <!-- figures/fig_curvature4a.tex END -->
             </figure>
 
-            <figure xml:id="fig_curvature4b_3D">
-              <caption>A plot of the curve <m>\vec{r}(t)=\la t, t^2, 2t^3\ra</m></caption>
+        <figure xml:id="fig_curvature4b_3D" vshift="-3">
+              <caption>A plot of the curve <m>\vec{r}(t)=\la t, t^2, 2t^3\ra</m> in <xref ref="ex_curvature4"/></caption>
 
               <!-- START figures/figcurvature4_3D.asy -->
-              <image>
+              <image width="47%">
                 <shortdescription>A plot of the vector-valued function in this example, with points of maximum curvature marked.</shortdescription>
                 <description>
                   <p>
@@ -950,9 +934,19 @@
               </image>
             <!-- figures/figcurvature4_3D.asy END -->
             </figure>
-          </sidebyside>
 
-        </figure>
+        <p>
+          While this is not a particularly <q>nice</q> formula,
+          it does explicitly tell us what the curvature is at a given <m>t</m> value.
+          To maximize <m>\kappa(t)</m>,
+          we should solve <m>\kappa'(t)=0</m> for <m>t</m>.
+          This is doable, but <em>very</em> time consuming.
+          Instead, consider the graph of
+          <m>\kappa(t)</m> as given in <xref ref="fig_curvature4a"/>.
+          We see that <m>\kappa</m> is maximized at two <m>t</m> values;
+          using a numerical solver, we find these values are <m>t\approx\pm 0.189</m>.
+          In <xref ref="fig_curvature4b_3D"/> we graph <m>\vrt</m> and indicate the points where curvature is maximized.
+        </p>
 
       </solution>
     </example>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -68,7 +68,7 @@
           since they are only length 1.)
         </p>
 
-        <figure xml:id="fig_tannorm1" vshift="-1">
+        <figure xml:id="fig_tannorm1" vshift="2">
           <caption>Plotting unit tangent vectors in <xref ref="ex_tannorm1"/></caption>
 
           <!-- START figures/figtannorm1_3D.asy -->
@@ -382,7 +382,7 @@
           These are sketched in <xref ref="fig_tannorm3"/>.
         </p>
 
-        <figure xml:id="fig_tannorm3" vshift="0">
+        <figure xml:id="fig_tannorm3" vshift="3">
           <caption>Plotting unit tangent and normal vectors in <xref ref="ex_tannorm3"/></caption>
 
           <!-- START figures/figtannorm3_3D.asy -->
@@ -447,17 +447,7 @@
       </solution>
     </example>
 
-    <aside vshift="-6">
-      <p>
-        There is one flaw in our definition of <m>\unitnormal(t)</m>:
-        it is possible that we could have <m>\unittangentprime(t)=0</m>!
-        Indeed, this is the case for any line of the form
-        <m>\vec{\ell}(t) = \vec{r}_0+t\vec{v}</m>.
-        For straight lines in the plane,
-        it is most common to orient the normal vector <m>90^\circ</m> counterclockwise from the tangent vector,
-        but for lines in three dimensions, there is no preferred choice of normal vector.
-      </p>
-    </aside>
+    
 
     <p>
       The previous example was once again
@@ -517,7 +507,7 @@
           we compute the unit tangent and normal vectors for <m>t=-1,0</m> and 1 and sketch them in <xref ref="fig_tannorm4"/>.
         </p>
 
-        <figure xml:id="fig_tannorm4" vshift="-5">
+        <figure xml:id="fig_tannorm4" vshift="0">
           <caption>Plotting unit tangent and normal vectors in <xref ref="ex_tannorm4"/></caption>
           <!-- START figures/fig_tannorm4.tex -->
           <image width="47%">
@@ -607,6 +597,18 @@
         </p>
       </statement>
     </theorem>
+
+    <p>
+        A brief consideration of this theorem may make one wonder: what if the graph of <m>\vec r</m> does 
+        not have a concave side? What if <m>\vec r</m> is a line?
+    </p> 
+    <p>   
+        This exposes a shortcoming in our definition of <m>\unitnormal(t)</m>, where
+        we require that <m>\unittangent(t)</m> be smooth, i.e., that <m>\unittangentprime(t) \neq \vec 0</m>,
+        a requirement that lines do not fulfill. One may still want to compute a normal vector for a given line, though. 
+        For straight lines in the <m>x,y</m> plane, it is most common to orient the normal vector <m>90^\circ</m> 
+        counterclockwise from the tangent vector. For lines in three dimensions, there is no preferred choice of normal vector.
+      </p>
   </subsection>
 
   <subsection>
@@ -802,7 +804,7 @@
           gives a graph of the path for reference.
         </p>
 
-        <figure xml:id="fig_tannorm6" vshift="0">
+        <figure xml:id="fig_tannorm6" vshift="2">
           <caption>Graphing <m>\vec r(t)</m> in <xref ref="ex_tannorm6"/></caption>
           <!-- START figures/fig_tannorm6.tex -->
           <image width="47%">
@@ -875,7 +877,7 @@
           which we plot in <xref ref="fig_tannorm7b"/>.
         </p>
 
-        <figure xml:id="fig_tannorm7b" vshift="-2">
+        <figure xml:id="fig_tannorm7b" vshift="0">
           <caption>Plotting the position of a thrown ball, with 1s increments shown</caption>
           <!-- START figures/fig_tannorm7b.tex -->
           <image width="47%">
@@ -1043,10 +1045,7 @@
             <statement>
               <p>
                 If <m>\unittangent(t)</m> is a unit tangent vector,
-                what is <m>\norm{\unittangent(t)}</m>?
-              </p>
-
-              <p>
+                what is <m>\norm{\unittangent(t)}</m>? 
                 <fillin answer="1" width="5"/>
               </p>
             </statement>
@@ -1072,10 +1071,7 @@
             <statement>
               <p>
                 If <m>\unitnormal(t)</m> is a unit normal vector,
-                what is <m>\unitnormal(t)\cdot \vrp(t)</m>?
-              </p>
-
-              <p>
+                what is <m>\unitnormal(t)\cdot \vrp(t)</m>? 
                 <fillin answer="0" width="5"/>
               </p>
             </statement>

--- a/ptx/sec_vvf.ptx
+++ b/ptx/sec_vvf.ptx
@@ -648,7 +648,7 @@
           <m>\vec r(t) = \vec p(t) + \vec c(t) = \la \cos(t) + t,-\sin(t) +1\ra</m>,
           which is graphed in <xref ref="fig_vvf4b"/>.
         </p>
-        <figure xml:id="fig_vvf4b" vshift="2">
+        <figure xml:id="fig_vvf4b" vshift="3">
           <caption>The cycloid in <xref ref="ex_vvf4"/></caption>
           <!-- START figures/fig_vvf4a.tex -->
           <image width="47%">
@@ -750,7 +750,7 @@
           The displacement of <m>\vec r(t)</m> on <m>[-1,1]</m> is thus <m>\vec d = \la 0,1\ra - \la 0,-1\ra = \la 0,2\ra</m>.
         </p>
 
-        <figure xml:id="fig_vvf5" vshift="-6">
+        <figure xml:id="fig_vvf5" vshift="2">
           <caption>Graphing the displacement of a position function in <xref ref="ex_vvf5"/></caption>
           <!-- START figures/fig_vvf5.tex -->
           <image width="47%">

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -341,13 +341,16 @@
 
     <aside vshift="3">
       <p>
-        Alternate notations for the derivative of <m>\vec r</m> include:
+        Two notes on <xref ref="def_vvf_derivative"/>:
+      </p>
+      <p>
+        First, alternate notations for the derivative of <m>\vec r</m> include:
         <md>
           \vrp(t) = \frac{d}{dt}\big(\,\vec r(t)\,\big) = \frac{d\vec r}{dt}
         </md>.
       </p>
       <p>
-        Using one-sided limits,
+        Second, using one-sided limits,
         we can define differentiability on closed intervals.
         We'll make use of this a few times in this chapter.
       </p>
@@ -364,10 +367,7 @@
       The following theorem verifies that this means we can compute derivatives component-wise as well,
       making the task not too difficult.
     </p>
-    <aside vshift="3">
-      
-    </aside>
-
+    
     <theorem xml:id="thm_vvf_deriv">
       <title>Derivatives of Vector-Valued Functions</title>
       <statement>

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -19,7 +19,7 @@
       The theorem following the definition shows that in practice,
       taking limits of vector-valued functions is no more difficult than taking limits of real-valued functions.
     </p>
-    <aside vshift="0">
+    <aside vshift="-2">
       <p>
         We can define one-sided limits in a manner very similar to <xref ref="def_vvf_limit"/>.
       </p>
@@ -339,7 +339,7 @@
       </statement>
     </definition>
 
-    <aside vshift="0">
+    <aside vshift="3">
       <p>
         Alternate notations for the derivative of <m>\vec r</m> include:
         <md>
@@ -992,7 +992,7 @@
                 <m>\vec u(t)</m> is 1 for all <m>t</m>.
               </p>
 
-              <figure xml:id="fig_vvfderiv2a" vshift="-3">
+              <figure xml:id="fig_vvfderiv2a" vshift="0">
                 <caption>Graphing <m>\vec r(t)</m> and <m>\vec u(t)</m> in <xref ref="ex_vvfderiv2"/></caption>
               <!-- START figures/fig_vvfderiv2a.tex -->
                 <image width="47%">
@@ -2312,7 +2312,7 @@
 
               <statement>
                 <p>
-                  <m>\displaystyle\int_0^{\pi} \la -\sin(t) ,\cos(t) \ra\,dt=</m><var name="$int" width="30"/>.
+                  <m>\displaystyle\int_0^{\pi} \la -\sin(t) ,\cos(t) \ra\,dt=</m><var name="$int" width="20"/>.
                 </p>
               </statement>
           </webwork>

--- a/ptx/sec_vvf_calc.ptx
+++ b/ptx/sec_vvf_calc.ptx
@@ -346,6 +346,11 @@
           \vrp(t) = \frac{d}{dt}\big(\,\vec r(t)\,\big) = \frac{d\vec r}{dt}
         </md>.
       </p>
+      <p>
+        Using one-sided limits,
+        we can define differentiability on closed intervals.
+        We'll make use of this a few times in this chapter.
+      </p>
     </aside>
     <p>
       If a vector-valued function has a derivative for all <m>c</m> in an open interval <m>I</m>,
@@ -359,12 +364,8 @@
       The following theorem verifies that this means we can compute derivatives component-wise as well,
       making the task not too difficult.
     </p>
-    <aside vshift="0">
-      <p>
-        Again, using one-sided limits,
-        we can define differentiability on closed intervals.
-        We'll make use of this a few times in this chapter.
-      </p>
+    <aside vshift="3">
+      
     </aside>
 
     <theorem xml:id="thm_vvf_deriv">
@@ -1070,7 +1071,7 @@
                 </md>
               </p>
 
-              <figure xml:id="fig_vvfderiv2b" vshift="-5">
+              <figure xml:id="fig_vvfderiv2b" vshift="2">
                 <caption>Graphing some of the derivatives of <m>\vec u(t)</m> in <xref ref="ex_vvfderiv2"/></caption>
               <!-- START figures/fig_vvfderiv2b.tex -->
                 <image width="47%">

--- a/ptx/sec_vvf_motion.ptx
+++ b/ptx/sec_vvf_motion.ptx
@@ -863,6 +863,8 @@
       </md>.
     </p>
 
+    <p xml:id="pagebreak-projectile-motion"></p>
+
     <insight xml:id="idea_projectile">
       <title>Projectile Motion</title>
       <p>

--- a/publication/publication-pdf.ptx
+++ b/publication/publication-pdf.ptx
@@ -47,6 +47,7 @@
       <insertions pagebreaks="exset-double-polar-special exset-cylindrical-spherical-setup exset-Greens-divergence exset-vectors-balance-forces"/>
       <!-- other page breaks -->
       <insertions pagebreaks="pagebreak-taylor-series pagebreak-iterated-int pagebreak-glossary"/>
+      <insertions pagebreaks="pagebreak-projectile-motion"/>
     </latex>
     <epub>
       <cover front="cover/cover.png"/>


### PR DESCRIPTION
This is mostly just vertical figure adjustment, but there are a few other changes.

Definition 12.2.8 had 2 asides that accompanied it. I have merged these into one aside. 

Within the Solution to Exercise 12.4.10, there was an aside that referred to a "flaw" in the definition of the unit normal vector `N` wherein `T'` could not be `\vec 0`; however, lines have this property! I moved the aside into text that follows Theorem 12.4.12 where it seems to fit better. I also changed the wording a little.