### PR TITLE
Ensure linked exercises agree

### DIFF
--- a/ptx/sec_IBP.ptx
+++ b/ptx/sec_IBP.ptx
@@ -1086,7 +1086,7 @@
         </exercise>
         <!-- Exercise 14 -->
         <exercise label="ex-int-by-parts-evaluate-10">
-          <webwork xml:id="webwork-ex-int-by-parts-evaluate-10">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-10" seed="1">
             <pg-code>
               ($m,$n) = random_subset(2,2..9);
               if($envir{problemSeed}==1){$m=2;$n=3};
@@ -1110,7 +1110,7 @@
         </exercise>
         <!-- Exercise 15 -->
         <exercise label="ex-int-by-parts-evaluate-11">
-          <webwork xml:id="webwork-ex-int-by-parts-evaluate-11">
+          <webwork xml:id="webwork-ex-int-by-parts-evaluate-11" seed="1">
             <pg-code>
               $m = random(2,9,1);
               if($envir{problemSeed}==1){$m=5;};
@@ -1604,7 +1604,7 @@
         </introduction>
         <!-- Exercise 41 -->
         <exercise label="ex-int-by-parts-definite-1">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-1">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-1" seed="1">
             <pg-code>
               $b = list_random('\pi/2','\pi','3\pi/2','2\pi');
               if($envir{problemSeed}==1){$b = '\pi';};
@@ -1624,7 +1624,7 @@
         </exercise>
         <!-- Exercise 42 -->
         <exercise label="ex-int-by-parts-definite-2">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-2">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-2" seed="1">
             <pg-code>
               ($a,$b) = num_sort(random_subset(2,-2,-1,1,2));
               if($envir{problemSeed}==1){$a=-1;$b=1;};
@@ -1644,7 +1644,7 @@
         </exercise>
         <!-- Exercise 43 -->
         <exercise label="ex-int-by-parts-definite-3">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-3">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-3" seed="1">
             <pg-code>
               $b = list_random('\pi/6','\pi/4','\pi/3','\pi/2');
               if($envir{problemSeed}==1){$b='\pi/4';};
@@ -1665,7 +1665,7 @@
         </exercise>
         <!-- Exercise 44 -->
         <exercise label="ex-int-by-parts-definite-4">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-4">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-4" seed="1">
             <pg-code>
               $b = list_random('\pi/6','\pi/4','\pi/3','\pi/2');
               if($envir{problemSeed}==1){$b='\pi/2';};
@@ -1689,7 +1689,7 @@
         </exercise>
         <!-- Exercise 45 -->
         <exercise label="ex-int-by-parts-definite-5">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-5">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-5" seed="1">
             <pg-code>
               $c = random(2,9,1);
               if($envir{problemSeed}==1){$c=2;};
@@ -1713,7 +1713,7 @@
         </exercise>
         <!-- Exercise 46 -->
         <exercise label="ex-int-by-parts-definite-6">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-6">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-6" seed="1">
             <pg-code>
               $a = 0;
               $b = 1;
@@ -1732,7 +1732,7 @@
         </exercise>
         <!-- Exercise 47 -->
         <exercise label="ex-int-by-parts-definite-7">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-7">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-7" seed="1">
             <pg-code>
               ($a,$b) = num_sort(random_subset(2,1..4));
               if($envir{problemSeed}==1){$a=1;$b=2};
@@ -1757,7 +1757,7 @@
         </exercise>
         <!-- Exercise 48 -->
         <exercise label="ex-int-by-parts-definite-8">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-8">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-8" seed="1">
             <pg-code>
               $b = list_random('\pi/2','\pi','3\pi/2','2\pi');
               if($envir{problemSeed}==1){$b='\pi'};
@@ -1781,7 +1781,7 @@
         </exercise>
         <!-- Exercise 49 -->
         <exercise label="ex-int-by-parts-definite-9">
-          <webwork xml:id="webwork-ex-int-by-parts-definite-9">
+          <webwork xml:id="webwork-ex-int-by-parts-definite-9" seed="1">
             <pg-code>
               $b = list_random('\pi/2','\pi','3\pi/2','2\pi');
               if($envir{problemSeed}==1){$b='\pi/2'};

--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -2333,7 +2333,7 @@
           <p>
             An implicitly defined function is given.
             Find <m>\lzn{2}{y}{x}</m>.
-            Note: these are the same functions used in Exercises <xref ref="exer_02_06_ex_09" text="local"/> through <xref ref="exer_02_06_ex_12" text="local"/>.
+            Note: these are the same functions used in <xref ref="exset-deriv-implicit-compute" text="custom">Exercises</xref>.
           </p>
         </introduction>
         <exercise label="ex-deriv-implicit-second-1">

--- a/ptx/sec_directional_derivative.ptx
+++ b/ptx/sec_directional_derivative.ptx
@@ -1398,7 +1398,7 @@
 
               <statement>
                 <p>
-                  Find <m>\nabla f</m>, where <m>f(x,y) = \sin(x)\cos(y)</m>.
+                  <m>f(x,y) = \sin(x)\cos(y)</m>.
                 </p>
 
                 <p>
@@ -1434,7 +1434,7 @@
 
               <statement>
                 <p>
-                  Find <m>\nabla f</m>, where <m>f(x,y) = -4x+3y</m>.
+                  <m>f(x,y) = -4x+3y</m>.
                 </p>
 
                 <p>
@@ -1470,7 +1470,7 @@
 
               <statement>
                 <p>
-                  Find <m>\nabla f</m>, where <m>f(x,y) = x^2y^3-2x</m>.
+                  <m>f(x,y) = x^2y^3-2x</m>.
                 </p>
 
                 <p>
@@ -1487,7 +1487,7 @@
           <p>
             A function <m>f(x,y)</m> and a point <m>P</m> are given.
             Find the directional derivative of <m>f</m> in the indicated directions.
-            Note: these are the same functions as in <xref first="x12_05_ex_07" last="x12_05_ex_22">Exercises</xref>.
+            Note: these are the same functions as in <xref first="x12_05_ex_07" last="x12_05_ex_22" text="local">Exercises</xref>.
           </p>
         </introduction>
 
@@ -1554,8 +1554,7 @@
 
               <introduction>
                 <p>
-                  Consider <m>f(x,y) = \sin(x)\cos(y)</m>,
-                  at <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>.
+                  <m>f(x,y) = \sin(x)\cos(y)</m>, <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>
                 </p>
               </introduction>
               <task label="ex-directional-derivative-compute-2a">
@@ -1590,7 +1589,7 @@
               </pg-code> -->
               <introduction>
                 <p>
-                  <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>.
+                  <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>
                 </p>
               </introduction>
               <task label="ex-directional-derivative-compute-3a">
@@ -1616,7 +1615,7 @@
               <task label="ex-directional-derivative-compute-3b">
                 <statement>
                   <p>
-                    In the direction toward the point <m>Q = (-2,-2)</m>.
+                    In the direction toward the point <m>Q = (-2,-2)</m>
                   </p>
                 </statement>
                 <answer>
@@ -1647,7 +1646,7 @@
 
               <introduction>
                 <p>
-                  Consider <m>f(x,y) = -4x+3y</m>, at <m>P = (5,2)</m>.
+                  <m>f(x,y) = -4x+3y</m>, <m>P = (5,2)</m>
                 </p>
               </introduction>
               <task label="ex-directional-derivative-compute-4a">
@@ -1735,7 +1734,7 @@
 
               <introduction>
                 <p>
-                  Consider <m>f(x,y) = x^2y^3-2x</m>, at <m>P = (1,1)</m>.
+                  <m>f(x,y) = x^2y^3-2x</m>, <m>P = (1,1)</m>
                 </p>
               </introduction>
 
@@ -1879,7 +1878,7 @@
               <introduction>
                 <p>
                   <m>f(x,y) = \sin(x)\cos(y)</m>,
-                  <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>:
+                  <m>P = \left(\frac{\pi}{4},\frac{\pi}{3}\right)</m>
                 </p>
               </introduction>
 
@@ -1936,7 +1935,7 @@
               </pg-code> -->
               <introduction>
                 <p>
-                  <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>.
+                  <m>\ds f(x,y) = \frac{1}{x^2+y^2+1}</m>, <m>P = (1,1)</m>
                 </p>
               </introduction>
 
@@ -2181,7 +2180,7 @@
 
               <introduction>
                 <p>
-                  Given <m>f(x,y) = x^2y^3-2x</m>, <m>P = (1,1)</m>:
+                  <m>f(x,y) = x^2y^3-2x</m>, <m>P = (1,1)</m>
                 </p>
               </introduction>
 
@@ -2303,7 +2302,7 @@
               <introduction>
                 <p>
                   <m>F(x,y,z) = \sin(x)\cos(y)e^z</m>,
-                  <m>\vec v = \la 2,2,1\ra</m>, <m>P = (0,0,0)</m>.
+                  <m>\vec v = \la 2,2,1\ra</m>, <m>P = (0,0,0)</m>
                 </p>
               </introduction>
 
@@ -2388,8 +2387,8 @@
 
               <introduction>
                 <p>
-                  Given <m>F(x,y,z) = \frac{2}{x^2+y^2+z^2}</m>,
-                  <m>\vec v = \la 1,1,-2\ra</m>, <m>P = (1,1,1)</m>:
+                  <m>F(x,y,z) = \frac{2}{x^2+y^2+z^2}</m>,
+                  <m>\vec v = \la 1,1,-2\ra</m>, <m>P = (1,1,1)</m>
                 </p>
               </introduction>
 

--- a/ptx/sec_dot_product.ptx
+++ b/ptx/sec_dot_product.ptx
@@ -2552,7 +2552,7 @@
 
               <statement>
                 <p>
-                  <m>\vec u = \la 1,2\ra</m>and <m>\vec v = \la -1,3\ra</m>.
+                  <m>\vec u = \la 1,2\ra</m> and <m>\vec v = \la -1,3\ra</m>.
                 </p>
 
                 <p component="web">

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -1539,7 +1539,7 @@
         </introduction>
 
         <exercise label="ex-graph-concavity-intervals-1">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-1">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-1" seed="1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -1597,7 +1597,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-2">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-2">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-2" seed="1">
             <pg-code>
               ($a,$b) = random_subset(2,-9..-1,1..9);
               if($envir{problemSeed}==1){$a=-5; $b=7};
@@ -1654,7 +1654,7 @@
           </webwork>
         </exercise>
 
-        <exercise label="ex-graph-concavity-intervals-3">
+        <exercise label="ex-graph-concavity-intervals-3" seed="1">
           <webwork xml:id="webwork-ex-graph-concavity-intervals-3">
             <pg-code>
               $s = random(1,9,1);
@@ -1714,7 +1714,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-4">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-4">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-4" seed="1">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = non_zero_random(-9,9,1);
@@ -1778,7 +1778,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-5">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-5">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-5" seed="1">
             <pg-code>
               $s = non_zero_random(-9,9,1);
               $k = ($s % 2 == 0) ? non_zero_random(2,8,2) : non_zero_random(1,9,2);
@@ -1846,7 +1846,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-6">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-6">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-6" seed="1">
             <pg-code>
               ($r,$s,$t) = random_subset(3,-5..-1,1..5);
               $k = list_random(-12,-8,-4,4,8,12);
@@ -1935,7 +1935,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-7">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-7">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-7" seed="1">
             <pg-code>
               $r = non_zero_random(-4,4,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -1998,7 +1998,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-8">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-8">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-8" seed="1">
             <pg-code>
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
@@ -2053,7 +2053,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-9">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-9">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-9" seed="1">
             <pg-code>
               $r = random(-9,9,1);
               $s = random(1,9,1);
@@ -2134,7 +2134,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-10">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-10">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-10" seed="1">
             <pg-code>
               ($r,$s) = num_sort(random_subset(2,-9..-1,1..9));
               if($envir{problemSeed}==1){$r=-1; $s = 1;};
@@ -2194,7 +2194,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-11">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-11">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-11" seed="1">
             <pg-code>
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
@@ -2249,7 +2249,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-12">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-12">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-12" seed="1">
             <pg-code>
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
@@ -2304,7 +2304,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-13">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-13">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-13" seed="1">
             <pg-code>
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
@@ -2359,7 +2359,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-intervals-14">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-14">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-14" seed="1">
             <pg-code>
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));
@@ -2421,12 +2421,12 @@
             Find the critical points of <m>f</m> and use the Second Derivative Test,
             when possible,
             to determine the relative extrema.
-            (Note: these are the same functions as in <xref ref="exercisegroup-concavity"/>.)
+            (Note: these are the same functions as in <xref ref="exercisegroup-concavity" text="custom">Exercises</xref>.)
           </p>
         </introduction>
 
         <exercise label="ex-graph-concavity-second-test-1">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-1">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-1" seed="1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -2484,7 +2484,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-2">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-2">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-2" seed="1">
             <pg-code>
               ($a,$b) = random_subset(2,-9..-1,1..9);
               if($envir{problemSeed}==1){$a=-5; $b=7};
@@ -2543,7 +2543,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-3">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-3">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-3" seed="1">
             <pg-code>
               $s = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -2620,7 +2620,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-4">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-4">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-4" seed="1">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = non_zero_random(-9,9,1);
@@ -2683,7 +2683,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-5">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-5">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-5" seed="1">
             <pg-code>
               $s = non_zero_random(-9,9,1);
               $k = ($s % 2 == 0) ? non_zero_random(2,8,2) : non_zero_random(1,9,2);
@@ -2750,7 +2750,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-6">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-6">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-6" seed="1">
             <pg-code>
               ($r,$s,$t) = random_subset(3,-5..-1,1..5);
               $k = list_random(-12,-8,-4,4,8,12);
@@ -2838,7 +2838,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-7">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-7">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-7" seed="1">
             <pg-code>
               $r = non_zero_random(-4,4,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -2900,7 +2900,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-8">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-8">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-8" seed="1">
             <pg-code>
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
@@ -2954,7 +2954,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-9">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-9">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-9" seed="1">
             <pg-code>
               $r = random(-9,9,1);
               $s = random(1,9,1);
@@ -3034,7 +3034,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-10">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-10">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-10" seed="1">
             <pg-code>
               ($r,$s) = num_sort(random_subset(2,-9..-1,1..9));
               if($envir{problemSeed}==1){$r=-1; $s = 1;};
@@ -3095,7 +3095,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-11">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-11">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-11" seed="1">
             <pg-code>
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
@@ -3149,7 +3149,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-12">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-12">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-12" seed="1">
             <pg-code>
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
@@ -3203,7 +3203,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-13">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-13">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-13" seed="1">
             <pg-code>
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
@@ -3257,7 +3257,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-second-test-14">
-          <webwork xml:id="webwork-ex-graph-concavity-second-test-14">
+          <webwork xml:id="webwork-ex-graph-concavity-second-test-14" seed="1">
             <pg-code>
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));

--- a/ptx/sec_graph_concavity.ptx
+++ b/ptx/sec_graph_concavity.ptx
@@ -1538,7 +1538,7 @@
           </p>
         </introduction>
 
-        <exercise label="ex-graph-concavity-intervals-1">
+        <exercise label="ex-graph-concavity-intervals-1" xml:id="ex-graph-concavity-intervals-first">
           <webwork xml:id="webwork-ex-graph-concavity-intervals-1" seed="1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
@@ -1654,8 +1654,8 @@
           </webwork>
         </exercise>
 
-        <exercise label="ex-graph-concavity-intervals-3" seed="1">
-          <webwork xml:id="webwork-ex-graph-concavity-intervals-3">
+        <exercise label="ex-graph-concavity-intervals-3">
+          <webwork xml:id="webwork-ex-graph-concavity-intervals-3" seed="1">
             <pg-code>
               $s = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -2358,7 +2358,7 @@
           </webwork>
         </exercise>
 
-        <exercise label="ex-graph-concavity-intervals-14">
+        <exercise label="ex-graph-concavity-intervals-14" xml:id="ex-graph-concavity-intervals-last">
           <webwork xml:id="webwork-ex-graph-concavity-intervals-14" seed="1">
             <pg-code>
               $f = Formula("e^(-x^2)");
@@ -2421,7 +2421,8 @@
             Find the critical points of <m>f</m> and use the Second Derivative Test,
             when possible,
             to determine the relative extrema.
-            (Note: these are the same functions as in <xref ref="exercisegroup-concavity" text="custom">Exercises</xref>.)
+            (Note: these are the same functions as in
+            <xref first="ex-graph-concavity-intervals-first" last="ex-graph-concavity-intervals-last" text="local">Exercises</xref>.)
           </p>
         </introduction>
 
@@ -3316,12 +3317,13 @@
           <p>
             A function <m>f(x)</m> is given.
             Find the <m>x</m> values where <m>\fp(x)</m> has a relative maximum or minimum.
-            (Note: these are the same functions as in <xref ref="exercisegroup-concavity"/>.)
+            (Note: these are the same functions as in 
+            <xref first="ex-graph-concavity-intervals-first" last="ex-graph-concavity-intervals-last" text="local">Exercises</xref>.)
           </p>
         </introduction>
 
         <exercise label="ex-graph-concavity-deriv-crit-1">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-1">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-1" seed="1">
             <pg-code>
               $r = non_zero_random(-9,9,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -3372,7 +3374,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-2">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-2">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-2" seed="1">
             <pg-code>
               ($a,$b) = random_subset(2,-9..-1,1..9);
               if($envir{problemSeed}==1){$a=-5; $b=7};
@@ -3424,7 +3426,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-3">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-3">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-3" seed="1">
             <pg-code>
               $s = random(1,9,1);
               $c = non_zero_random(-9,9,1);
@@ -3494,7 +3496,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-4">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-4">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-4" seed="1">
             <pg-code>
               $a = non_zero_random(-9,9,1);
               $b = non_zero_random(-9,9,1);
@@ -3551,7 +3553,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-5">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-5">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-5" seed="1">
             <pg-code>
               $s = non_zero_random(-9,9,1);
               $k = ($s % 2 == 0) ? non_zero_random(2,8,2) : non_zero_random(1,9,2);
@@ -3611,7 +3613,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-6">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-6">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-6" seed="1">
             <pg-code>
               ($r,$s,$t) = random_subset(3,-5..-1,1..5);
               $k = list_random(-12,-8,-4,4,8,12);
@@ -3693,7 +3695,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-7">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-7">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-7" seed="1">
             <pg-code>
               $r = non_zero_random(-4,4,1);
               if($envir{problemSeed}==1){$r=1;};
@@ -3748,7 +3750,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-8">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-8">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-8" seed="1">
             <pg-code>
               $f = Formula("sec(x)");
               $inflecs = List(Compute("none"));
@@ -3795,7 +3797,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-9">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-9">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-9" seed="1">
             <pg-code>
               $r = random(-9,9,1);
               $s = random(1,9,1);
@@ -3868,7 +3870,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-10">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-10">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-10" seed="1">
             <pg-code>
               ($r,$s) = num_sort(random_subset(2,-9..-1,1..9));
               if($envir{problemSeed}==1){$r=-1; $s = 1;};
@@ -3922,7 +3924,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-11">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-11">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-11" seed="1">
             <pg-code>
               $f = Formula("sin(x) + cos(x)");
               $inflecs = List(Compute("-pi/4"),Compute("3pi/4"));
@@ -3969,7 +3971,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-12">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-12">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-12" seed="1">
             <pg-code>
               $f = Formula("x^2e^x");
               $inflecs = List(Compute("-2+sqrt(2)"),Compute("-2-sqrt(2)"));
@@ -4016,7 +4018,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-13">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-13">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-13" seed="1">
             <pg-code>
               $f = Formula("x^2ln(x)");
               $inflecs = List(Compute("1/e^(3/2)"));
@@ -4063,7 +4065,7 @@
         </exercise>
 
         <exercise label="ex-graph-concavity-deriv-crit-14">
-          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-14">
+          <webwork xml:id="webwork-ex-graph-concavity-deriv-crit-14" seed="1">
             <pg-code>
               $f = Formula("e^(-x^2)");
               $inflecs = List(Compute("1/sqrt(2)"),Compute("-1/sqrt(2)"));

--- a/ptx/sec_graph_incr_decr.ptx
+++ b/ptx/sec_graph_incr_decr.ptx
@@ -422,7 +422,7 @@
     <statement>
       <p>
         Suppose a function <m>f</m> is increasing on <m>(0,1)</m>
-        and decreasingg on <m>(1,2)</m>.
+        and decreasing on <m>(1,2)</m>.
         What are two possible features that we might find on the graph of <m>f</m>
         at <m>x=1</m>? 
       </p>

--- a/ptx/sec_limit_continuity.ptx
+++ b/ptx/sec_limit_continuity.ptx
@@ -1716,48 +1716,6 @@
       </choices>
     </exercise>
 
-    <exercise label="peer-limit-continuity-4">
-      <statement>
-        <p>
-          <m>f</m> is not continuous at either <m>0</m> or <m>1</m>
-        </p>
-
-        <p>
-          For what value of <m>c</m> is <m>f</m> continuous at <m>2</m>?
-        </p>
-      </statement>
-      <choices>
-        <choice>
-          <statement>
-            <p>
-              <m>5/2</m>
-            </p>
-          </statement>
-        </choice>
-        <choice>
-          <statement>
-            <p>
-              <m>8/3</m>
-            </p>
-          </statement>
-        </choice>
-        <choice>
-          <statement>
-            <p>
-              <m>\sqrt{2}</m>
-            </p>
-          </statement>
-        </choice>
-        <choice>
-          <statement>
-            <p>
-              Not possible to solve for <m>c</m>
-            </p>
-          </statement>
-        </choice>
-      </choices>
-    </exercise>
-    
     <exercise label="peer-limit-continuity-5a">
       <statement>
         <p>

--- a/ptx/sec_multi_chain.ptx
+++ b/ptx/sec_multi_chain.ptx
@@ -1010,8 +1010,7 @@
 
               <statement>
                 <p>
-                  <m>z=x^2-y^2</m>, <m>x=t</m>,
-                  and <m>y=t^2-1</m>; <m>t=1</m>
+                  <m>z=x^2-y^2</m>, <m>x=t</m>, <m>y=t^2-1</m>; <m>t=1</m>
                 </p>
 
                 <instruction>
@@ -1083,7 +1082,7 @@
               <statement>
                 <p>
                   <m>z=\frac{x}{y^2+1}</m>, <m>x=\cos(t)</m>,
-                  and <m>y=\sin(t)</m>; <m>t=\pi/2</m>
+                  <m>y=\sin(t)</m>; <m>t=\pi/2</m>
                 </p>
                 <instruction>
                   Use the Multivariable Chain Rule to compute <m>\lz{z}{t}</m>.
@@ -1155,7 +1154,7 @@
               <statement>
                 <p>
                   <m>z=\cos(x) \sin(y)</m>, <m>x=\pi t</m>,
-                  and <m>y=2\pi t+\pi/2</m>; <m>t=3</m>
+                  <m>y=2\pi t+\pi/2</m>; <m>t=3</m>
                 </p>
 
                 <instruction>
@@ -1212,8 +1211,7 @@
 
               <statement>
                 <p>
-                  Given <m>z=x^2-y^2</m>, <m>x=t</m>, and <m>y=t^2-1</m>,
-                  at what values of <m>t</m> does <m>\lz{z}{t}=0</m>?
+                  <m>z=x^2-y^2</m>, <m>x=t</m>, <m>y=t^2-1</m>
                 </p>
 
                 <p>
@@ -1250,10 +1248,9 @@
 
               <statement>
                 <p>
-                  Given <m>z=\frac{x}{y^2+1}</m>,
-                  <m>x=\cos(t)</m>, and <m>y=\sin(t)</m>,
-                  at what values of <m>t</m> in
-                  <m>[0,2\pi)</m> does <m>\lz{z}{t}=0</m>?
+                  <m>z=\frac{x}{y^2+1}</m>,
+                  <m>x=\cos(t)</m>, <m>y=\sin(t)</m>;
+                  <m>t</m> in <m>[0,2\pi)</m>
                 </p>
 
                 <p>
@@ -1322,9 +1319,9 @@
 
               <statement>
                 <p>
-                  Given <m>z=\cos(x) \sin(y)</m>,
-                  <m>x=\pi t</m>, and <m>y=2\pi t+\pi/2</m>,
-                  at what values of <m>t</m> in <m>[0,2)</m> does <m>\lz{z}{t}=0</m>?
+                  <m>z=\cos(x) \sin(y)</m>,
+                  <m>x=\pi t</m>, <m>y=2\pi t+\pi/2</m>;
+                  <m>t</m> in <m>[0,2)</m>
                 </p>
 
                 <p>
@@ -1504,7 +1501,7 @@
               <statement>
                 <p>
                   <m>z=\cos\mathopen{}\left(\pi x+\frac{\pi}2y\right)\mathclose{}</m>,
-                  <m>x=st^2</m>, and <m>y=s^2t</m>; <m>s=1</m>, <m>t=0</m>
+                  <m>x=st^2</m>, <m>y=s^2t</m>; <m>s=1</m>, <m>t=0</m>
                 </p>
 
                 <instruction>
@@ -1569,7 +1566,7 @@
               <statement>
                 <p>
                   <m>z=x^2+y^2</m>, <m>x=s\cos(t)</m>,
-                  and <m>y=s\sin(t)</m>; <m>s=2</m>, <m>t=\pi/4</m>
+                  <m>y=s\sin(t)</m>; <m>s=2</m>, <m>t=\pi/4</m>
                 </p>
 
                 <instruction>
@@ -1635,7 +1632,7 @@
               <statement>
                 <p>
                   <m>z=e^{-(x^2+y^2)}</m>, <m>x=t</m>,
-                  and <m>y=st^2</m>, <m>s=1</m>, <m>t=1</m>
+                  <m>y=st^2</m>; <m>s=1</m>, <m>t=1</m>
                 </p>
 
                 <instruction>

--- a/ptx/sec_multi_tangent.ptx
+++ b/ptx/sec_multi_tangent.ptx
@@ -1621,7 +1621,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 3x-5y</m>, <m>\vec v = \la 1,1\ra</m>, <m>P=(4,2)</m>.
+                  <m>f(x,y) = 3x-5y</m>, <m>\vec v = \la 1,1\ra</m>, <m>P=(4,2)</m>
                 </p>
               </statement>
               <solution>
@@ -1752,7 +1752,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 2x^2y-4xy^2</m>, <m>P=(2,3)</m>.
+                  <m>f(x,y) = 2x^2y-4xy^2</m>, <m>P=(2,3)</m>
                 </p>
               </statement>
               <solution>
@@ -1838,7 +1838,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 3x-5y</m>, <m>P=(4,2)</m>.
+                  <m>f(x,y) = 3x-5y</m>, <m>P=(4,2)</m>
                 </p>
               </statement>
               <solution>
@@ -1934,7 +1934,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 2x^2y-4xy^2</m>, <m>P=(2,3)</m>.
+                  <m>f(x,y) = 2x^2y-4xy^2</m>, <m>P=(2,3)</m>
                 </p>
               </statement>
               <solution>
@@ -1952,7 +1952,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 3\cos(x) \sin(y)</m>, <m>P=(\pi/3, \pi/6)</m>.
+                  <m>f(x,y) = 3\cos(x) \sin(y)</m>, <m>P=(\pi/3, \pi/6)</m>
                 </p>
               </statement>
               <solution>
@@ -1969,7 +1969,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 3x-5y</m>, <m>P=(4,2)</m>.
+                  <m>f(x,y) = 3x-5y</m>, <m>P=(4,2)</m>
                 </p>
               </statement>
               <solution>
@@ -1986,7 +1986,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = x^2-2x-y^2+4y</m>, <m>P=(1,2)</m>.
+                  <m>f(x,y) = x^2-2x-y^2+4y</m>, <m>P=(1,2)</m>
                 </p>
               </statement>
               <solution>
@@ -2014,7 +2014,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 2x^2y-4xy^2</m>, <m>P=(2,3)</m>.
+                  <m>f(x,y) = 2x^2y-4xy^2</m>, <m>P=(2,3)</m>
                 </p>
               </statement>
               <solution>
@@ -2034,7 +2034,7 @@
 
               <statement>
                 <p>
-                  <m>f(x,y) = 3\cos(x) \sin(y)</m>, <m>P=(\pi/3, \pi/6)</m>.
+                  <m>f(x,y) = 3\cos(x) \sin(y)</m>, <m>P=(\pi/3, \pi/6)</m>
                 </p>
 
                 <instruction>
@@ -2053,7 +2053,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>f(x,y) = 3x-5y</m>, <m>P=(4,2)</m>.
+                  <m>f(x,y) = 3x-5y</m>, <m>P=(4,2)</m>
                 </p>
               </statement>
               <solution>

--- a/ptx/sec_tan_norm.ptx
+++ b/ptx/sec_tan_norm.ptx
@@ -1146,7 +1146,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>\vrt = \la 2t^2,t^2-t\ra</m>,<m>t=1</m>
+                  <m>\vrt = \la 2t^2,t^2-t\ra</m>, <m>t=1</m>
                 </p>
               </statement>
               <answer>
@@ -1170,7 +1170,7 @@
 
               <statement>
                 <p>
-                  <m>\vrt = \la t,\cos(t) \ra</m>, <m>t=\pi/4</m>.
+                  <m>\vrt = \la t,\cos(t) \ra</m>, <m>t=\pi/4</m>
                 </p>
                 <instruction>
                   Find <m>\unittangent(t)</m>.
@@ -1194,7 +1194,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>\vrt = \la \cos^3(t) ,\sin^3(t) \ra</m>,<m>t=\pi/4</m>
+                  <m>\vrt = \la \cos^3(t) ,\sin^3(t) \ra</m>, <m>t=\pi/4</m>
                 </p>
               </statement>
               <solution>
@@ -1221,7 +1221,7 @@
 
               <statement>
                 <p>
-                  <m>\vrt = \la \cos(t) , \sin(t) \ra</m>, <m>t=\pi</m>.
+                  <m>\vrt = \la \cos(t) , \sin(t) \ra</m>, <m>t=\pi</m>
                 </p>
                 <instruction>
                   Find <m>\unittangent(t)</m>.
@@ -1259,8 +1259,7 @@
 
               <statement>
                 <p>
-                  Find the vector equation of the line tangent to
-                  <m>\vrt = \la 2t^2,t^2-t \ra</m> at <m>t=1</m> using the unit tangent vector.
+                  <m>\vrt = \la 2t^2,t^2-t \ra</m>, <m>t=1</m>
                 </p>
 
                 <instruction>
@@ -1283,8 +1282,7 @@
 
               <statement>
                 <p>
-                  Find the vector equation of the line tangent to
-                  <m>\vrt = \la t,\cos(t) \ra</m> at <m>t=\pi/4</m> using the unit tangent vector.
+                  <m>\vrt = \la t,\cos(t) \ra</m>, at <m>t=\pi/4</m>
                 </p>
 
                 <instruction>
@@ -1303,7 +1301,7 @@
               </pg-code> -->
               <statement>
                 <p>
-                  <m>\vrt = \la \cos^3(t) ,\sin^3(t) \ra</m>,<m>t=\pi/4</m>
+                  <m>\vrt = \la \cos^3(t) ,\sin^3(t) \ra</m>, <m>t=\pi/4</m>
                 </p>
               </statement>
               <solution>
@@ -1330,8 +1328,7 @@
 
               <statement>
                 <p>
-                  Find the vector equation of the line tangent to
-                  <m>\vrt = \la \cos(t) ,\sin(t) \ra</m> at <m>t=\pi</m> using the unit tangent vector.
+                  <m>\vrt = \la \cos(t) ,\sin(t) \ra</m>, <m>t=\pi</m>
                 </p>
 
                 <instruction>

--- a/publication/publication-accelerated-web.ptx
+++ b/publication/publication-accelerated-web.ptx
@@ -28,6 +28,7 @@
         <asymptote links="yes"/>
         <webwork divisional="dynamic" reading="dynamic"/>
         <annotation platform="hypothesis"/>
+        <feedback href="https://github.com/APEXCalculus/APEXCalculusPTX/issues"/>
         <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     <!-- PDF-Specific Options -->

--- a/publication/publication-runestone.ptx
+++ b/publication/publication-runestone.ptx
@@ -30,6 +30,7 @@
         <webwork divisional="dynamic" reading="dynamic"/>
         <annotation platform="hypothesis"/>
         <css theme="salem" palette="ice-fire"/>
+        <feedback href="https://github.com/APEXCalculus/APEXCalculusPTX/issues"/>
     </html>
     
 </publication>

--- a/publication/publication-standard-web.ptx
+++ b/publication/publication-standard-web.ptx
@@ -28,6 +28,7 @@
         <asymptote links="yes"/>
         <webwork divisional="dynamic" reading="dynamic"/>
         <annotation platform="hypothesis"/>
+        <feedback href="https://github.com/APEXCalculus/APEXCalculusPTX/issues"/>
         <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     <!-- PDF-Specific Options -->

--- a/publication/publication-web-video.ptx
+++ b/publication/publication-web-video.ptx
@@ -27,6 +27,7 @@
         <knowl example="no"/>
         <asymptote links="yes"/>
         <webwork divisional="dynamic" reading="dynamic"/>
+        <feedback href="https://github.com/APEXCalculus/APEXCalculusPTX/issues"/>
         <!-- <css toc="crc" banner="crc" navbar="crc" shell="crc"/> -->
     </html>
     <!-- PDF-Specific Options -->

--- a/publication/publication-web.ptx
+++ b/publication/publication-web.ptx
@@ -27,6 +27,7 @@
         <knowl example="no"/>
         <asymptote links="yes"/>
         <webwork divisional="dynamic"/>
+        <feedback href="https://github.com/APEXCalculus/APEXCalculusPTX/issues"/>
     </html>
     <!-- PDF-Specific Options -->
     <latex print="no" sides="one">


### PR DESCRIPTION
The main change here: in a few sections (but most notably, Section 3.4, on concavity) we have some exercise groups that are dependent on each other.

Usually this is indicated by text like "Note: the functions in this exercise group are the same as the functions in Exercises 15-28."

However, in a couple of places this was no longer true, due to WeBWorK randomization. This ensures that the "static" versions of these questions (including the ones in print) do, indeed, use the same functions.

I've also made one change to the HTML: a "Feedback" button that links to our GitHub issues page. That way, if someone notices a problem like this, they have a way of reporting it.