### PR TITLE
Remove far too long introduction

### DIFF
--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -1,815 +1,815 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_planes" label="sec_planes">
   <title>Planes</title>
-  <p>
-    Any flat surface, such as a wall,
-    table top or stiff piece of cardboard can be thought of as representing part of a plane.
-    Consider a piece of cardboard with a point <m>P</m> marked on it.
-    One can take a nail and stick it into the cardboard at <m>P</m> such that the nail is perpendicular to the cardboard;
-    see <xref ref="fig_planes_intro"/>.
-  </p>
+    <p>
+      Any flat surface, such as a wall,
+      table top or stiff piece of cardboard can be thought of as representing part of a plane.
+      Consider a piece of cardboard with a point <m>P</m> marked on it.
+      One can take a nail and stick it into the cardboard at <m>P</m> such that the nail is perpendicular to the cardboard;
+      see <xref ref="fig_planes_intro"/>.
+    </p>
 
-  <figure xml:id="fig_planes_intro" vshift="0">
-    <caption>Illustrating defining a plane with a sheet of cardboard and a nail</caption>
+    <figure xml:id="fig_planes_intro" vshift="0">
+      <caption>Illustrating defining a plane with a sheet of cardboard and a nail</caption>
 
-    <!-- START figures/figplanes_intro_3D.asy -->
-    <image width="47%">
-      <shortdescription>A nail sticks into a flat, rectangular sheet of cardboard.</shortdescription>
-      <description>
+      <!-- START figures/figplanes_intro_3D.asy -->
+      <image width="47%">
+        <shortdescription>A nail sticks into a flat, rectangular sheet of cardboard.</shortdescription>
+        <description>
+          <p>
+            A flat, rectangular surface represents a sheet of cardboard.
+            The image of a nail is drawn sticking into the sheet, at a point <m>P</m>, which is marked.
+            The nail is standing upright, in a position perpendicular to the sheet of cardboard.
+          </p>
+        </description>
+        <asymptote label="img_planes_intro">
+
+
+
+          //ASY file for figlines3.asy in Chapter 10
+
+          size(200,200,IgnoreAspect);
+          //currentprojection=perspective(7,2,1);
+          currentprojection=orthographic((-4,27,7),(.012,-0.002,0.015),(0,0,0),.9);
+          defaultrender.merge=true;
+
+          // setup and draw the axes
+          real[] myxchoice={};
+          real[] myychoice={};
+          real[] myzchoice={};
+
+          pair xbounds=(-2,2);
+          pair ybounds=(-2,2);
+          pair zbounds=(-2,2);
+
+          xaxis3("",xbounds.x,xbounds.y,invisible,OutTicks(myxchoice),Arrow3(size=3mm));
+          yaxis3("",ybounds.x,ybounds.y,invisible,OutTicks(myychoice),Arrow3(size=3mm));
+          zaxis3("",zbounds.x,zbounds.y,invisible,OutTicks(myzchoice),Arrow3(size=3mm));
+
+          defaultpen(0.5mm);
+
+          real f(pair z) {return 0;}
+          surface s=surface(f,(-2,-2),(2,2),1,1);
+          pen p=bluepen+.3mm;
+          draw(s,surfacepen,meshpen=p,render(merge=true));
+
+          draw(scale(.1,.1,.2)*rotate(180,Y)*shift(-1Z)*unitcone,surfacepen=white);
+          draw(scale(.1,.1,.5)*shift(.4Z)*unitcylinder,surfacepen=white);
+          draw(scale(.15,.15,.05)*shift(14Z)*unitcylinder,surfacepen=white);
+
+          //real f(pair z) {return 0;}
+          //surface s=surface(f,(-2,-2),(2,2));
+          //draw(s,white,meshpen=p,render(merge=true));
+          draw(scale3(.15)*shift(4.7Z)*unitdisk,surfacepen=white);
+          draw(scale3(.15)*shift(5Z)*unitdisk,surfacepen=white);
+
+          draw(scale3(.05)*unitdisk);
+          label("$P$",(0,0,0),NW);
+
+          //draw((0,0,.9)--(0,0,0),gray+1mm,Arrow3(size=2mm));
+          //draw((0,0,.9)--(0,0,1),gray+1.2mm);
+
+        </asymptote>
+      </image>
+      <!-- figures/figplanes_intro_3D.asy END -->
+    </figure>
+
+    <p>
+      This nail provides a <q>handle</q> for the cardboard.
+      Moving the cardboard around moves <m>P</m> to different locations in space.
+      Tilting the nail
+      (but keeping <m>P</m> fixed)
+      tilts the cardboard.
+      Both moving and tilting the cardboard defines a different plane in space.
+      In fact, we can define a plane by: 1) the location of <m>P</m> in space,
+      and 2) the direction of the nail.
+    </p>
+
+    <figure xml:id="vid-vectors-planes-intro" component="video" vshift="-4">
+      <caption>Video inroduction to <xref ref="sec_planes"/></caption>
+      <video youtube="aP-fcbArvtA" label="vid-vectors-planes-intro"/>
+    </figure>
+
+    <p>
+      The previous section showed that one can define a line given a point on the line and the direction of the line
+      (usually given by a vector).
+      One can make a similar statement about planes:
+      we can define a plane in space given a point on the plane and the direction the plane <q>faces</q>
+      (using the description above,
+      the direction of the nail).
+      Once again, the direction information will be supplied by a vector,
+      called a <em>normal vector</em>,
+      that is orthogonal to the plane.
+          <idx><h>vectors</h><h>normal vector</h></idx>
+          <idx><h>normal vector</h></idx>
+          <idx><h>planes</h><h>normal vector</h></idx>
+    </p>
+
+    <p>
+      What exactly does <q>orthogonal to the plane</q> mean?
+      Choose any two points <m>P</m> and <m>Q</m> in the plane,
+      and consider the vector <m>\overrightarrow{PQ}</m>.
+      We say a vector <m>\vec n</m> is orthogonal to the plane if <m>\vec n</m> is perpendicular to <m>\overrightarrow{PQ}</m> for all choices of <m>P</m> and <m>Q</m>;
+      that is, if <m>\vec n\cdot \overrightarrow{PQ}=0</m> for all <m>P</m> and <m>Q</m>.
+    </p>
+
+    <p>
+      This gives us way of writing an equation describing the plane.
+      Let <m>P=(x_0,y_0,z_0)</m> be a point in the plane and let
+      <m>\vec n = \la a,b,c\ra</m> be a normal vector to the plane.
+      A point <m>Q = (x,y,z)</m> lies in the plane defined by <m>P</m> and <m>\vec n</m> if,
+      and only if, <m>\overrightarrow{PQ}</m> is orthogonal to <m>\vec n</m>.
+      Knowing <m>\overrightarrow{PQ} = \la x-x_0,y-y_0,z-z_0\ra</m>, consider:
+      <md>
+        <mrow>\overrightarrow{PQ}\cdot\vec n \amp = 0</mrow>
+        <mrow>\la x-x_0,y-y_0,z-z_0\ra\cdot \la a,b,c\ra \amp =0</mrow>
+        <mrow number="yes" xml:id="eq-plane-standard-form">a(x-x_0)+b(y-y_0)+c(z-z_0) \amp =0</mrow>
+      </md>.
+      <xref ref="eq-plane-standard-form">Equation</xref> defines an <em>implicit</em> function describing the plane. More algebra produces:
+      <md>
+        ax+by+cz = ax_0+by_0+cz_0
+      </md>.
+      The right hand side is just a number, so we replace it with <m>d</m>:
+      <md number="yes" xml:id="eq-plane-general-form">
+        ax+by+cz = d
+      </md>.
+      As long as <m>c\neq 0</m>, we can solve for <m>z</m>:
+      <md number="yes" xml:id="eq-plane-graph-form">
+        z = \frac1c(d-ax-by)
+      </md>.
+    </p>
+
+    <p>
+      <xref ref="eq-plane-graph-form">Equation</xref> is especially useful as many computer programs can graph functions in this form.
+      Equations <xref ref="eq-plane-standard-form"/> and <xref ref="eq-plane-general-form"/> have specific names,
+      given next.
+    </p>
+
+    <definition xml:id="def_planes">
+      <title>Equations of a Plane in Standard and General Forms</title>
+      <statement>
         <p>
-          A flat, rectangular surface represents a sheet of cardboard.
-          The image of a nail is drawn sticking into the sheet, at a point <m>P</m>, which is marked.
-          The nail is standing upright, in a position perpendicular to the sheet of cardboard.
+          The plane passing through the point <m>P=(x_0,y_0,z_0)</m> with normal vector
+          <m>\vec n=\la a,b,c\ra</m> can be described by an equation with
+          <term>standard form</term>
+          <md>
+            a(x-x_0)+b(y-y_0)+c(z-z_0) =0;
+          </md>
+          the equation's <term>general form</term>
+          is <idx><h>planes</h><h>equations of</h></idx>
+          <md>
+            ax+by+cz = d
+          </md>.
         </p>
-      </description>
-      <asymptote label="img_planes_intro">
-
-
-
-        //ASY file for figlines3.asy in Chapter 10
-
-        size(200,200,IgnoreAspect);
-        //currentprojection=perspective(7,2,1);
-        currentprojection=orthographic((-4,27,7),(.012,-0.002,0.015),(0,0,0),.9);
-        defaultrender.merge=true;
-
-        // setup and draw the axes
-        real[] myxchoice={};
-        real[] myychoice={};
-        real[] myzchoice={};
-
-        pair xbounds=(-2,2);
-        pair ybounds=(-2,2);
-        pair zbounds=(-2,2);
-
-        xaxis3("",xbounds.x,xbounds.y,invisible,OutTicks(myxchoice),Arrow3(size=3mm));
-        yaxis3("",ybounds.x,ybounds.y,invisible,OutTicks(myychoice),Arrow3(size=3mm));
-        zaxis3("",zbounds.x,zbounds.y,invisible,OutTicks(myzchoice),Arrow3(size=3mm));
-
-        defaultpen(0.5mm);
-
-        real f(pair z) {return 0;}
-        surface s=surface(f,(-2,-2),(2,2),1,1);
-        pen p=bluepen+.3mm;
-        draw(s,surfacepen,meshpen=p,render(merge=true));
-
-        draw(scale(.1,.1,.2)*rotate(180,Y)*shift(-1Z)*unitcone,surfacepen=white);
-        draw(scale(.1,.1,.5)*shift(.4Z)*unitcylinder,surfacepen=white);
-        draw(scale(.15,.15,.05)*shift(14Z)*unitcylinder,surfacepen=white);
-
-        //real f(pair z) {return 0;}
-        //surface s=surface(f,(-2,-2),(2,2));
-        //draw(s,white,meshpen=p,render(merge=true));
-        draw(scale3(.15)*shift(4.7Z)*unitdisk,surfacepen=white);
-        draw(scale3(.15)*shift(5Z)*unitdisk,surfacepen=white);
-
-        draw(scale3(.05)*unitdisk);
-        label("$P$",(0,0,0),NW);
-
-        //draw((0,0,.9)--(0,0,0),gray+1mm,Arrow3(size=2mm));
-        //draw((0,0,.9)--(0,0,1),gray+1.2mm);
-
-      </asymptote>
-    </image>
-    <!-- figures/figplanes_intro_3D.asy END -->
-  </figure>
-
-  <p>
-    This nail provides a <q>handle</q> for the cardboard.
-    Moving the cardboard around moves <m>P</m> to different locations in space.
-    Tilting the nail
-    (but keeping <m>P</m> fixed)
-    tilts the cardboard.
-    Both moving and tilting the cardboard defines a different plane in space.
-    In fact, we can define a plane by: 1) the location of <m>P</m> in space,
-    and 2) the direction of the nail.
-  </p>
-
-  <figure xml:id="vid-vectors-planes-intro" component="video" vshift="-4">
-    <caption>Video inroduction to <xref ref="sec_planes"/></caption>
-    <video youtube="aP-fcbArvtA" label="vid-vectors-planes-intro"/>
-  </figure>
-
-  <p>
-    The previous section showed that one can define a line given a point on the line and the direction of the line
-    (usually given by a vector).
-    One can make a similar statement about planes:
-    we can define a plane in space given a point on the plane and the direction the plane <q>faces</q>
-    (using the description above,
-    the direction of the nail).
-    Once again, the direction information will be supplied by a vector,
-    called a <em>normal vector</em>,
-    that is orthogonal to the plane.
-        <idx><h>vectors</h><h>normal vector</h></idx>
-        <idx><h>normal vector</h></idx>
-        <idx><h>planes</h><h>normal vector</h></idx>
-  </p>
-
-  <p>
-    What exactly does <q>orthogonal to the plane</q> mean?
-    Choose any two points <m>P</m> and <m>Q</m> in the plane,
-    and consider the vector <m>\overrightarrow{PQ}</m>.
-    We say a vector <m>\vec n</m> is orthogonal to the plane if <m>\vec n</m> is perpendicular to <m>\overrightarrow{PQ}</m> for all choices of <m>P</m> and <m>Q</m>;
-    that is, if <m>\vec n\cdot \overrightarrow{PQ}=0</m> for all <m>P</m> and <m>Q</m>.
-  </p>
-
-  <p>
-    This gives us way of writing an equation describing the plane.
-    Let <m>P=(x_0,y_0,z_0)</m> be a point in the plane and let
-    <m>\vec n = \la a,b,c\ra</m> be a normal vector to the plane.
-    A point <m>Q = (x,y,z)</m> lies in the plane defined by <m>P</m> and <m>\vec n</m> if,
-    and only if, <m>\overrightarrow{PQ}</m> is orthogonal to <m>\vec n</m>.
-    Knowing <m>\overrightarrow{PQ} = \la x-x_0,y-y_0,z-z_0\ra</m>, consider:
-    <md>
-      <mrow>\overrightarrow{PQ}\cdot\vec n \amp = 0</mrow>
-      <mrow>\la x-x_0,y-y_0,z-z_0\ra\cdot \la a,b,c\ra \amp =0</mrow>
-      <mrow number="yes" xml:id="eq-plane-standard-form">a(x-x_0)+b(y-y_0)+c(z-z_0) \amp =0</mrow>
-    </md>.
-    <xref ref="eq-plane-standard-form">Equation</xref> defines an <em>implicit</em> function describing the plane. More algebra produces:
-    <md>
-      ax+by+cz = ax_0+by_0+cz_0
-    </md>.
-    The right hand side is just a number, so we replace it with <m>d</m>:
-    <md number="yes" xml:id="eq-plane-general-form">
-      ax+by+cz = d
-    </md>.
-    As long as <m>c\neq 0</m>, we can solve for <m>z</m>:
-    <md number="yes" xml:id="eq-plane-graph-form">
-      z = \frac1c(d-ax-by)
-    </md>.
-  </p>
-
-  <p>
-    <xref ref="eq-plane-graph-form">Equation</xref> is especially useful as many computer programs can graph functions in this form.
-    Equations <xref ref="eq-plane-standard-form"/> and <xref ref="eq-plane-general-form"/> have specific names,
-    given next.
-  </p>
-
-  <definition xml:id="def_planes">
-    <title>Equations of a Plane in Standard and General Forms</title>
-    <statement>
-      <p>
-        The plane passing through the point <m>P=(x_0,y_0,z_0)</m> with normal vector
-        <m>\vec n=\la a,b,c\ra</m> can be described by an equation with
-        <term>standard form</term>
-        <md>
-          a(x-x_0)+b(y-y_0)+c(z-z_0) =0;
-        </md>
-        the equation's <term>general form</term>
-        is <idx><h>planes</h><h>equations of</h></idx>
-        <md>
-          ax+by+cz = d
-        </md>.
-      </p>
-    </statement>
-  </definition>
-
-  <exercise label="APEX-PROTEUS-sec-11_6-planes-1-v1" component="proteus">
-    <title>PROTEUS EXERCISE</title>
-    <statement>
-      <p>
-        Is it possible to define a plane using parametric equations?
-        If so, how many parameters are needed, and why?
-      </p>
-    </statement>
-    <response/>
-  </exercise>
-
-  <p>
-    A key to remember throughout this section is this:
-    to find the equation of a plane,
-    we need a point and a normal vector.
-    We will give several examples of finding the equation of a plane,
-    and in each one different types of information are given.
-    In each case,
-    we need to use the given information to find a point on the plane and a normal vector.
-  </p>
-
-  <example xml:id="ex_planes1">
-    <title>Finding the equation of a plane</title>
-    <statement>
-      <p>
-        Write the equation of the plane that passes through the points <m>P=(1,1,0)</m>,
-        <m>Q = (1,2,-1)</m> and <m>R = (0,1,2)</m> in standard form.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        We need a vector <m>\vec n</m> that is orthogonal to the plane.
-        Since <m>P</m>, <m>Q</m> and <m>R</m> are in the plane,
-        so are the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m>;
-        <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m> is orthogonal to <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> and hence the plane itself.
-      </p>
-
-      <p>
-        It is straightforward to compute <m>\vec n = \overrightarrow{PQ}\times\overrightarrow{PR} = \la 2,1,1\ra</m>.
-        We can use any point we wish in the plane
-        (any of <m>P</m>, <m>Q</m> or <m>R</m> will do)
-        and we arbitrarily choose <m>P</m>.
-        Following <xref ref="def_planes"/>,
-        the equation of the plane in standard form is
-        <md>
-          2(x-1) + (y-1)+z = 0
-        </md>.
-      </p>
-
-      <p>
-        The plane is sketched in <xref ref="fig_planes1"/>.
-      </p>
-
-      <figure xml:id="fig_planes1" vshift="2">
-        <caption>Sketching the plane in <xref ref="ex_planes1"/></caption>
-
-        <!-- START figures/figplanes1_3D.asy -->
-        <image width="47%">
-          <shortdescription>Three points P, Q, and R are plotted in space, along with the plane containing them.</shortdescription>
-          <description>
-            <p>
-              In a three-dimensional coordinate system, three points <m>P</m>, <m>Q</m>, and <m>R</m> are plotted.
-              Three vectors are drawn with their tails at <m>P</m>:
-              <m>\overrightarrow{PQ}</m>, <m>\overrightarrow{PR}</m>, and the cross product <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m>.
-              The plane containing <m>P</m>, <m>Q</m>, and <m>R</m> is also shown.
-              The vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> are parallel to the plane,
-              while their cross product is perpendicular to the plane.
-            </p>
-          </description>
-          <asymptote label="img_planes1">
-
-
-
-            //ASY file for figlines_dist2.asy in Chapter 10
-            //ASY file for figplanes1.asy in Chapter 10
-
-            //size(200,200,IgnoreAspect);
-            size(282,282,Aspect);
-            //currentprojection=perspective(7,2,1);
-            currentprojection=orthographic((1.92,19.3,4),(0,-0.015,0.06),(0,0,0),1);
-            defaultrender.merge=true;
-
-
-            // setup and draw the axes
-            real[] myxchoice={-4,4};
-            real[] myychoice={-4,4};
-            real[] myzchoice={-4,4};
-            defaultpen(0.5mm);
-            pair xbounds=(-3.5,3.5);
-            pair ybounds=(-4.5,4.5);
-            pair zbounds=(-4.5,6.5);
-
-            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0),S);
-            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-            //Draw the plane
-            triple f(pair t) {
-              return (t.x,t.y,-2*t.x-t.y+3);
-            }
-            surface s=surface(f,(-1,-2),(2,3),8,8,Spline);
-            pen p=apexmeshpen+.2mm;
-            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-            //Draw points P=(1,1,0), Q=(1,2,-1), R=(0,1,2)
-            dotfactor=3;
-            dot((1,1,0));label("$P$",(1,1,0),N);
-            dot((1,2,-1));label("$Q$",(1,2,-1),W);
-            dot((0,1,2));label("$R$",(0,1,2),W);
-            //Draw Vectors
-            draw((1,1,0)--(1,2,-1),bluepen,Arrow3(size=2mm));//PQ
-            draw((1,1,0)--(0,1,2),bluepen,Arrow3(size=2mm));//PR
-            draw((1,1,0)--(3,2,1),bluepen,Arrow3(size=2mm));//P to PQxPR
-            label("$\overrightarrow{PQ}\times \overrightarrow{PR}$",(3,2,1),N);
-
-            //test i,j,k moved to P
-            //draw((1,1,0)--(2,1,0),bluepen,Arrow3(size=2mm));//P by i
-            //draw((1,1,0)--(1,2,0),bluepen,Arrow3(size=2mm));//P by j
-            //draw((1,1,0)--(1,1,1),bluepen,Arrow3(size=2mm));//P by k
-
-            // Use lines L1 1+3t,2-t,t  and L2 -2+4t,3+t,5+2t
-            //draw P1 (t=0) and vector d1 at P1 (t=1)
-            //dotfactor=3;dot((1,2,0));label("$P_1$",(1,2,0),N);
-            //draw((1,2,0)--(4,1,1),redpen,Arrow3(size=2mm));
-            //label("$\vec{d}_1$",(4,1,1),N);
-            //draw P2 (t=-1.5) and vector d2 at P2 (t=-0.5)
-            //dotfactor=3;dot((-8,1.5,2));label("$P_2$",(-8,1.5,2),N);
-            //draw((-8,1.5,2)--(-4,2.5,4),redpen,Arrow3(size=2mm));
-            //label("$\vec{d}_2$",(-4,2.5,4),N);
-
-            //draw vector P1 to P2
-            //draw((1,2,0)--(-8,1.5,2),black,Arrow3(size=2mm));
-            //label("$\overrightarrow{P_1 P_2}$",(-3.5,1.75,1),W);
-
-            //draw the lines 1+3t,2-t,t  and -2+4t,3+t,5+2t
-            //draw((-5,4,-2)--(7,0,2),bluepen);//L1
-            //draw((-14,0,-1)--(2,4,7),bluepen);//L2
-
-          </asymptote>
-        </image>
-        <!-- figures/figplanes1_3D.asy END -->
-      </figure>
-    </solution>
-    <solution component="video" vshift="7">
-      <title>Video solution</title>
-      <video width="98%" youtube="oc77R0am1vk" label="vid-vectors-planes-3points" component="video"/>
-    </solution>
-  </example>
-
-  <p>
-    We have just demonstrated the fact that any three non-collinear points define a plane.
-    (This is why a three-legged stool does not <q>rock;</q>
-    it's three feet always lie in a plane.
-    A four-legged stool will rock unless all four feet lie in the same plane.)
-  </p>
-
-  <example xml:id="ex_planes2">
-    <title>Finding the equation of a plane</title>
-    <statement>
-      <p>
-        Verify that lines <m>\ell_1</m> and <m>\ell_2</m>,
-        whose parametric equations are given below, intersect,
-        then give the equation of the plane that contains these two lines in general form.
-        <md>
-          \ell_1: \begin{matrix} x\amp =\amp -5+2s \\ y\amp =\amp 1+s \\ z\amp =\amp -4+2s \end{matrix}  \qquad\qquad \ell_2: \begin{matrix} x \amp =\amp  2+3t\\ y\amp =\amp 1-2t \\ z\amp =\amp 1+t \end{matrix}
-        </md>
-      </p>
-    </statement>
-    <solution>
-      <p>
-        The lines clearly are not parallel.
-        If they do not intersect, they are skew,
-        meaning there is not a plane that contains them both.
-        If they do intersect, there is such a plane.
-      </p>
-
-      <p>
-        To find their point of intersection, we set the <m>x</m>,
-        <m>y</m> and <m>z</m> equations equal to each other and solve for <m>s</m> and <m>t</m>:
-        <md>
-          \begin{matrix} -5+2s \amp =\amp 2+3t \\ 1+s \amp =\amp  1-2t \\ -4+2s \amp =\amp  1+t \end{matrix}   \Rightarrow   s=2, t=-1
-        </md>.
-      </p>
-
-      <p>
-        When <m>s=2</m> and <m>t=-1</m>,
-        the lines intersect at the point <m>P= (-1,3,0)</m>.
-      </p>
-
-      <p>
-        Let <m>\vec d_1 = \la 2,1,2\ra</m> and
-        <m>\vec d_2=\la 3,-2,1\ra</m> be the directions of lines <m>\ell_1</m> and <m>\ell_2</m>,
-        respectively.
-        A normal vector to the plane containing these the two lines will also be orthogonal to <m>\vec d_1</m> and <m>\vec d_2</m>.
-        Thus we find a normal vector <m>\vec n</m> by computing <m>\vec n = \vec d_1 \times \vec d_2= \la 5,4-7\ra</m>.
-      </p>
-
-      <p>
-        We can pick any point in the plane with which to write our equation;
-        each line gives us infinite choices of points.
-        We choose <m>P</m>, the point of intersection.
-        We follow <xref ref="def_planes"/>
-        to write the plane's equation in general form:
-        <md>
-          <mrow>5(x+1) +4(y-3) -7z \amp = 0</mrow>
-          <mrow>5x + 5 + 4y-12 -7z \amp = 0</mrow>
-          <mrow>5x+4y-7z \amp = 7</mrow>
-        </md>.
-      </p>
-
-      <p>
-        The plane's equation in general form is <m>5x+4y-7z=7</m>;
-        it is sketched in <xref ref="fig_planes2"/>.
-      </p>
-
-      <figure xml:id="fig_planes2" vshift="2.5">
-        <caption>Sketching the plane in <xref ref="ex_planes2"/></caption>
-
-        <!-- START figures/figplanes2_3D.asy -->
-        <image width="47%">
-          <shortdescription>In three dimensions, two lines are plotted, intersecting at a point P, along with the plane containing both lines.</shortdescription>
-          <description>
-            <p>
-              Three-dimensional coordinate axes are shown, with the points <m>(5,0,0)</m>, <m>(0,5,0)</m>, and <m>(0,0,-5)</m> indicated for scale.
-              A point <m>P</m> is plotted in space. Two lines <m>\ell_1</m> and <m>\ell_2</m> are shown intersecting at this point.
-              The plane containing both lines is also plotted, along with a normal vector, located with its tail at <m>P</m>.
-            </p>
-          </description>
-          <asymptote label="img_planes2">
-
-
-
-            //ASY file for figplanes2.asy in Chapter 10
-
-            size(282,282,Aspect);
-            //size(200,200,IgnoreAspect);
-            //currentprojection=perspective(7,2,1);
-            currentprojection=orthographic((-16,18.6,6.76),(0.014,-0.015,0077),(0,0,0),.99);
-            defaultrender.merge=true;
-
-            // setup and draw the axes
-            real[] myxchoice={5};
-            real[] myychoice={5};
-            real[] myzchoice={-5};
-            defaultpen(0.5mm);
-            pair xbounds=(-4,6);
-            pair ybounds=(-1,6);
-            pair zbounds=(-6,5);
-
-            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-            //Draw the plane
-            triple f(pair t) {
-              return (t.x,t.y,(5/7)*t.x+(4/7)*t.y-1);
-            }
-            surface s=surface(f,(-5,-6),(5,6),8,8,Spline);
-            pen p=apexmeshpen+.1mm;
-            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-            //Draw points P=(-1,3,0)
-            dotfactor=3;dot((-1,3,0));label("$P$",(-1,3,0),E);
-
-            //Draw normal vector at P, n=(5,4,-7)
-            draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
-            label("$\vec{n}$",(4,7,-7),W);
-
-            //draw the lines -5+2t,1+t,-4+2t  and 2+3t,1-2t,1+t
-            draw((5,6,6)--(-5,1,-4),bluepen);label("$\ell_1$",(5,6,6),N);//L1
-            draw((5,-1,2)--(-4.9,5.6,-1.3),bluepen);label("$\ell_2$",(5,-1,2),N);//L2
-
-          </asymptote>
-        </image>
-        <!-- figures/figplanes2_3D.asy END -->
-      </figure>
-    </solution>
-  </example>
-
-  <example xml:id="ex_planes3">
-    <title>Finding the equation of a plane</title>
-    <statement>
-      <p>
-        Give the equation, in standard form,
-        of the plane that passes through the point
-        <m>P=(-1,0,1)</m> and is orthogonal to the line with vector equation <m>\vec \ell(t) = \la -1,0,1\ra + t\la 1,2,2\ra</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        As the plane is to be orthogonal to the line,
-        the plane must be orthogonal to the direction of the line given by <m>\vec d = \la 1,2,2\ra</m>.
-        We use this as our normal vector.
-        Thus the plane's equation, in standard form, is
-        <md>
-          (x+1) +2y+2(z-1)=0
-        </md>.
-      </p>
-
-      <p>
-        The line and plane are sketched in <xref ref="fig_planes3"/>.
-      </p>
-
-      <figure xml:id="fig_planes3" vshift="1">
-        <caption>The line and plane in <xref ref="ex_planes3"/></caption>
-
-        <!-- START figures/figplanes3_3D.asy -->
-        <image width="47%">
-          <shortdescription>A plane is plotted in a three-dimensional coordinate system, along with a line passing through it at a point P.</shortdescription>
-          <description>
-            <p>
-              A plane is plotted against a set of three-dimensional coordinate axes.
-              A line passes through the plane, intersecting it at a point <m>P</m>.
-              The line is perpendicular to the plane.
-            </p>
-          </description>
-          <asymptote label="img_planes3">
-
-
-
-            //ASY file for figplanes3.asy in Chapter 10
-
-            size(282,282,Aspect);
-            //size(200,200,IgnoreAspect);
-            //currentprojection=perspective(7,2,1);
-            currentprojection=orthographic(4,4,2);
-            defaultrender.merge=true;
-
-            // setup and draw the axes
-            real[] myxchoice={-3,3};
-            real[] myychoice={-3,3};
-            real[] myzchoice={-3,3};
-            defaultpen(0.5mm);
-            pair xbounds=(-4,4);
-            pair ybounds=(-4,4);
-            pair zbounds=(-4,4);
-
-            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-            //Draw the plane z=-(x+1)/2-y+1
-            triple f(pair t) {
-              return (t.x,t.y,(-1/2)*(t.x+1)-t.y+1);
-            }
-            surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
-            pen p=apexmeshpen+.1mm;
-            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-            //Draw points P=(-1,0,1)
-            dotfactor=3;dot((-1,0,1));label("$P$",(-1,0,1),N);
-
-            //draw the line -1+t,2t,1+2t
-            draw((1,4,5)--(-3,-4,-3),bluepen);//L t=2 to t=-2
-
-            //Draw normal vector at P, n=(1,2,2)
-            //draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
-            //label("$\vec{n}$",(4,7,-7),W);
-
-          </asymptote>
-        </image>
-        <!-- figures/figplanes3_3D.asy END -->
-      </figure>
-    </solution>
-    <solution component="video" vshift="-5">
-      <title>Video solution</title>
-      <video width="98%" youtube="2diP-H-QLoI" label="vid-vectors-planes-given-normal" component="video"/>
-    </solution>
-  </example>
-
-  <example xml:id="ex_planes4">
-    <title>Finding the intersection of two planes</title>
-    <statement>
-      <p>
-        Give the parametric equations of the line that is the intersection of the planes <m>p_1</m> and <m>p_2</m>, where:
-        <md>
-          <mrow>p_1: x-(y-2)+(z-1) =0</mrow>
-          <mrow>p_2: -2(x-2)+(y+1)+(z-3)=0</mrow>
-        </md>
-      </p>
-    </statement>
-    <solution>
-      <p>
-        To find an equation of a line,
-        we need a point on the line and the direction of the line.
-      </p>
-
-      <p>
-        We can find a point on the line by solving each equation of the planes for <m>z</m>:
-        <md>
-          <mrow>p_1: z = -x+y-1</mrow>
-          <mrow>p_2: z = 2x-y-2</mrow>
-        </md>
-      </p>
-
-      <p>
-        We can now set these two equations equal to each other (<ie/>, we are finding values of <m>x</m> and <m>y</m> where the planes have the same <m>z</m> value):
-        <md>
-          <mrow>-x+y-1 \amp = 2x-y-2</mrow>
-          <mrow>2y \amp = 3x-1</mrow>
-          <mrow>y \amp = \frac12(3x-1)</mrow>
-        </md>
-      </p>
-
-      <p>
-        We can choose any value for <m>x</m>;
-        we choose <m>x=1</m>.
-        This determines that <m>y=1</m>.
-        We can now use the equations of either plane to find <m>z</m>:
-        when <m>x=1</m> and <m>y=1</m>,
-        <m>z=-1</m> on both planes.
-        We have found a point <m>P</m> on the line: <m>P= (1,1,-1)</m>.
-      </p>
-
-      <p>
-        We now need the direction of the line.
-        Since the line lies in each plane,
-        its direction is orthogonal to a normal vector for each plane.
-        Considering the equations for <m>p_1</m> and <m>p_2</m>,
-        we can quickly determine their normal vectors.
-        For <m>p_1</m>,
-        <m>\vec n_1 = \la 1,-1,1\ra</m> and for <m>p_2</m>,
-        <m>\vec n_2 = \la -2,1,1\ra</m>.
-        A direction orthogonal to both of these directions is their cross product:
-        <m>\vec d = \vec n_1\times \vec n_2 = \la -2,-3,-1\ra</m>.
-      </p>
-
-      <p>
-        The parametric equations of the line through
-        <m>P=(1,1,-1)</m> in the direction of <m>d=\la -2,-3,-1\ra</m> is:
-        <md>
-          \ell:  x= -2t+1 y = -3t+1 z=-t-1
-        </md>.
-      </p>
-
-      <p>
-        The planes and line are graphed in <xref ref="fig_planes4"/>.
-      </p>
-
-      <figure xml:id="fig_planes4" vshift="0">
-        <caption>Graphing the planes and their line of intersection in <xref ref="ex_planes4"/></caption>
-
-        <!-- START figures/figplanes4_3D.asy -->
-        <image width="47%">
-          <shortdescription>Two planes are shown intersecting along a common line.</shortdescription>
-          <description>
-            <p>
-              Two planes are plotted in a three-dimensional coordinate system.
-              The planes intersect along a line, which is also plotted,
-              along with a point <m>P</m> that lies on the line, as well as on both planes.
-            </p>
-          </description>
-          <asymptote label="img_planes4">
-
-
-
-            //ASY file for figplanes43D.asy in Chapter 10
-
-            //size(282,282,Aspect);
-            size(200,200,IgnoreAspect);
-            //currentprojection=perspective(7,2,1);
-            currentprojection=orthographic(8,14.7,14);
-            defaultrender.merge=true;
-
-            // setup and draw the axes
-            real[] myxchoice={-2,2};
-            real[] myychoice={-2,2};
-            real[] myzchoice={-5};
-            defaultpen(0.5mm);
-            pair xbounds=(-3,3);
-            pair ybounds=(-3,3);
-            pair zbounds=(-6,2);
-
-            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-            //Draw the planes z=-x+y-1 and z=2x-y-2
-            triple f(pair t) {
-              return (t.x,t.y,-t.x+t.y-1);
-            }
-            surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
-            pen p=apexmeshpen;
-            draw(s,surfacepen,meshpen=p+.2mm,nolight,render(merge=true));
-            triple f(pair t) {
-              return (t.x,t.y,2*t.x-t.y-2);
-            }
-            surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
-            pen pp=apexmeshpen+.2mm;
-            //draw(s,rgb(1,.4,.7)+opacity(.7),meshpen=pp,nolight,render(merge=true)); // HOT PINK
-
-            pen q=redcurvepen+.1mm;
-            draw(s,surfacepen2,meshpen=q,nolight,render(merge=true)); // better red
-
-            //Draw point P=(1,1,-1)
-            dotfactor=3;dot((1,1,-1));label("$P$",(1,1,-1),N);
-
-            //draw the line 1-2t,1-3t,-1-t
-            draw((4,5.5,0.5)--(-2,-3.5,-2.5),bluepen);//L t=-1.5 to t=1.5
-
-          </asymptote>
-        </image>
-        <!-- figures/figplanes4_3D.asy END -->
-      </figure>
-      <!-- <figure xml:id="vid-vectors-planes-interection2" component="video" vshift="-5">
-        <caption>An alternative method for solving <xref ref="ex_planes4"/></caption>
-        <video width="98%" youtube="tthyDV7cjR8" label="vid-vectors-planes-interection2"/>
-      </figure> -->
-    </solution>
-    <solution component="video" vshift="5">
-      <title>Video solution</title>
-      <video width="98%" youtube="x2HB6huEEmQ" label="vid-vectors-planes-interect1" component="video"/>
-    </solution>
-  </example>
-
-  <example xml:id="ex_planes5">
-    <title>Finding the intersection of a plane and a line</title>
-    <statement>
-      <p>
-        Find the point of intersection, if any,
-        of the line <m>\ell(t) = \la 3,-3,-1\ra +t\la-1,2,1\ra</m> and the plane with equation in general form <m>2x+y+z=4</m>.
-      </p>
-    </statement>
-    <solution>
-      <p>
-        The equation of the plane shows that the vector
-        <m>\vec n = \la 2,1,1\ra</m> is a normal vector to the plane,
-        and the equation of the line shows that the line moves parallel to <m>\vec d = \la -1,2,1\ra</m>.
-        Since these are not orthogonal,
-        we know there is a point of intersection.
-        (If there were orthogonal,
-        it would mean that the plane and line were parallel to each other,
-        either never intersecting or the line was in the plane itself.)
-      </p>
-
-      <p>
-        To find the point of intersection,
-        we need to find a <m>t</m> value such that <m>\ell(t)</m> satisfies the equation of the plane.
-        Rewriting the equation of the line with parametric equations will help:
-        <md>
-          \ell(t) = \left\{\begin{aligned}x\amp = 3-t\\ y\amp =-3+2t\\ z\amp = -1+t \end{aligned} \right.
-        </md>.
-      </p>
-
-      <p>
-        Replacing <m>x</m>,
-        <m>y</m> and <m>z</m> in the equation of the plane with the expressions containing <m>t</m> found in the equation of the line allows us to determine a <m>t</m> value that indicates the point of intersection:
-        <md>
-          <mrow>2x+y+z \amp =4</mrow>
-          <mrow>2(3-t) + (-3+2t) + (-1+t) \amp = 4</mrow>
-          <mrow>t\amp =2</mrow>
-        </md>.
-      </p>
-
-      <p>
-        When <m>t=2</m>,
-        the point on the line satisfies the equation of the plane;
-        that point is <m>\ell(2) = \la 1,1,1\ra</m>.
-        Thus the point <m>(1,1,1)</m> is the point of intersection between the plane and the line,
-        illustrated in <xref ref="fig_planes5"/>.
-      </p>
-
-      <figure xml:id="fig_planes5" vshift="4">
-        <caption>Illustrating the intersection of a line and a plane in <xref ref="ex_planes5"/></caption>
-
-        <!-- START figures/figplanes5_3D.asy -->
-        <image width="47%">
-          <shortdescription>A line in three dimensions passes through a plane, intersecting it at a point.</shortdescription>
-          <description>
-            <p>
-              A plane is plotted against a three-dimensional coordinate system.
-              A line, labeled <m>\ell(t)</m>, is also plotted.
-              The line appears to be almost, but not quite, parallel to the plane.
-              It passes through the plane, intersecting it at a point that is plotted, but not labeled.
-            </p>
-          </description>
-          <asymptote label="img_planes5">
-
-
-
-            //ASY file for figplanes53D.asy in Chapter 10
-
-            //size(282,282,Aspect);
-            size(200,200,IgnoreAspect);
-            //currentprojection=perspective(7,2,1);
-            currentprojection=orthographic(5,4,2);
-            defaultrender.merge=true;
-
-            // setup and draw the axes
-            real[] myxchoice={-2,2};
-            real[] myychoice={-2,2};
-            real[] myzchoice={2};
-            defaultpen(0.5mm);
-            pair xbounds=(-3,4);
-            pair ybounds=(-3,4);
-            pair zbounds=(-2,7);
-
-            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-            //Draw the plane z=4-2x-y
-            triple f(pair t) {
-              return (t.x,t.y,4-2*t.x-t.y);
-            }
-            surface s=surface(f,(-2,-2),(3,3),8,8,Spline);
-            pen p=apexmeshpen+.2mm;
-            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-            //Draw point P=(1,1,1)
-            dotfactor=3;dot((1,1,1),redpen);//label("$P$",(1,1,1),N);
-
-            //draw the line 3-t,-3+2t,-1+t
-            draw((3,-3,-1)--(0,3,2),redpen);//L t=0 to t=3
-            label("$\ell(t)$",(3,-3,-1),N);
-
-          </asymptote>
-        </image>
-        <!-- figures/figplanes5_3D.asy END -->
-      </figure>
-    </solution>
-    <solution component="video" vshift="6">
-      <title>Video solution</title>
-      <video width="98%" youtube="DjuaixH0ayo" label="vid-vectors-planes-lineint" component="video"/>
-    </solution>
-  </example>
+      </statement>
+    </definition>
+
+    <exercise label="APEX-PROTEUS-sec-11_6-planes-1-v1" component="proteus">
+      <title>PROTEUS EXERCISE</title>
+      <statement>
+        <p>
+          Is it possible to define a plane using parametric equations?
+          If so, how many parameters are needed, and why?
+        </p>
+      </statement>
+      <response/>
+    </exercise>
+
+    <p>
+      A key to remember throughout this section is this:
+      to find the equation of a plane,
+      we need a point and a normal vector.
+      We will give several examples of finding the equation of a plane,
+      and in each one different types of information are given.
+      In each case,
+      we need to use the given information to find a point on the plane and a normal vector.
+    </p>
+
+    <example xml:id="ex_planes1">
+      <title>Finding the equation of a plane</title>
+      <statement>
+        <p>
+          Write the equation of the plane that passes through the points <m>P=(1,1,0)</m>,
+          <m>Q = (1,2,-1)</m> and <m>R = (0,1,2)</m> in standard form.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          We need a vector <m>\vec n</m> that is orthogonal to the plane.
+          Since <m>P</m>, <m>Q</m> and <m>R</m> are in the plane,
+          so are the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m>;
+          <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m> is orthogonal to <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> and hence the plane itself.
+        </p>
+
+        <p>
+          It is straightforward to compute <m>\vec n = \overrightarrow{PQ}\times\overrightarrow{PR} = \la 2,1,1\ra</m>.
+          We can use any point we wish in the plane
+          (any of <m>P</m>, <m>Q</m> or <m>R</m> will do)
+          and we arbitrarily choose <m>P</m>.
+          Following <xref ref="def_planes"/>,
+          the equation of the plane in standard form is
+          <md>
+            2(x-1) + (y-1)+z = 0
+          </md>.
+        </p>
+
+        <p>
+          The plane is sketched in <xref ref="fig_planes1"/>.
+        </p>
+
+        <figure xml:id="fig_planes1" vshift="2">
+          <caption>Sketching the plane in <xref ref="ex_planes1"/></caption>
+
+          <!-- START figures/figplanes1_3D.asy -->
+          <image width="47%">
+            <shortdescription>Three points P, Q, and R are plotted in space, along with the plane containing them.</shortdescription>
+            <description>
+              <p>
+                In a three-dimensional coordinate system, three points <m>P</m>, <m>Q</m>, and <m>R</m> are plotted.
+                Three vectors are drawn with their tails at <m>P</m>:
+                <m>\overrightarrow{PQ}</m>, <m>\overrightarrow{PR}</m>, and the cross product <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m>.
+                The plane containing <m>P</m>, <m>Q</m>, and <m>R</m> is also shown.
+                The vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> are parallel to the plane,
+                while their cross product is perpendicular to the plane.
+              </p>
+            </description>
+            <asymptote label="img_planes1">
+
+
+
+              //ASY file for figlines_dist2.asy in Chapter 10
+              //ASY file for figplanes1.asy in Chapter 10
+
+              //size(200,200,IgnoreAspect);
+              size(282,282,Aspect);
+              //currentprojection=perspective(7,2,1);
+              currentprojection=orthographic((1.92,19.3,4),(0,-0.015,0.06),(0,0,0),1);
+              defaultrender.merge=true;
+
+
+              // setup and draw the axes
+              real[] myxchoice={-4,4};
+              real[] myychoice={-4,4};
+              real[] myzchoice={-4,4};
+              defaultpen(0.5mm);
+              pair xbounds=(-3.5,3.5);
+              pair ybounds=(-4.5,4.5);
+              pair zbounds=(-4.5,6.5);
+
+              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0),S);
+              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+              //Draw the plane
+              triple f(pair t) {
+                return (t.x,t.y,-2*t.x-t.y+3);
+              }
+              surface s=surface(f,(-1,-2),(2,3),8,8,Spline);
+              pen p=apexmeshpen+.2mm;
+              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+              //Draw points P=(1,1,0), Q=(1,2,-1), R=(0,1,2)
+              dotfactor=3;
+              dot((1,1,0));label("$P$",(1,1,0),N);
+              dot((1,2,-1));label("$Q$",(1,2,-1),W);
+              dot((0,1,2));label("$R$",(0,1,2),W);
+              //Draw Vectors
+              draw((1,1,0)--(1,2,-1),bluepen,Arrow3(size=2mm));//PQ
+              draw((1,1,0)--(0,1,2),bluepen,Arrow3(size=2mm));//PR
+              draw((1,1,0)--(3,2,1),bluepen,Arrow3(size=2mm));//P to PQxPR
+              label("$\overrightarrow{PQ}\times \overrightarrow{PR}$",(3,2,1),N);
+
+              //test i,j,k moved to P
+              //draw((1,1,0)--(2,1,0),bluepen,Arrow3(size=2mm));//P by i
+              //draw((1,1,0)--(1,2,0),bluepen,Arrow3(size=2mm));//P by j
+              //draw((1,1,0)--(1,1,1),bluepen,Arrow3(size=2mm));//P by k
+
+              // Use lines L1 1+3t,2-t,t  and L2 -2+4t,3+t,5+2t
+              //draw P1 (t=0) and vector d1 at P1 (t=1)
+              //dotfactor=3;dot((1,2,0));label("$P_1$",(1,2,0),N);
+              //draw((1,2,0)--(4,1,1),redpen,Arrow3(size=2mm));
+              //label("$\vec{d}_1$",(4,1,1),N);
+              //draw P2 (t=-1.5) and vector d2 at P2 (t=-0.5)
+              //dotfactor=3;dot((-8,1.5,2));label("$P_2$",(-8,1.5,2),N);
+              //draw((-8,1.5,2)--(-4,2.5,4),redpen,Arrow3(size=2mm));
+              //label("$\vec{d}_2$",(-4,2.5,4),N);
+
+              //draw vector P1 to P2
+              //draw((1,2,0)--(-8,1.5,2),black,Arrow3(size=2mm));
+              //label("$\overrightarrow{P_1 P_2}$",(-3.5,1.75,1),W);
+
+              //draw the lines 1+3t,2-t,t  and -2+4t,3+t,5+2t
+              //draw((-5,4,-2)--(7,0,2),bluepen);//L1
+              //draw((-14,0,-1)--(2,4,7),bluepen);//L2
+
+            </asymptote>
+          </image>
+          <!-- figures/figplanes1_3D.asy END -->
+        </figure>
+      </solution>
+      <solution component="video" vshift="7">
+        <title>Video solution</title>
+        <video width="98%" youtube="oc77R0am1vk" label="vid-vectors-planes-3points" component="video"/>
+      </solution>
+    </example>
+
+    <p>
+      We have just demonstrated the fact that any three non-collinear points define a plane.
+      (This is why a three-legged stool does not <q>rock;</q>
+      it's three feet always lie in a plane.
+      A four-legged stool will rock unless all four feet lie in the same plane.)
+    </p>
+
+    <example xml:id="ex_planes2">
+      <title>Finding the equation of a plane</title>
+      <statement>
+        <p>
+          Verify that lines <m>\ell_1</m> and <m>\ell_2</m>,
+          whose parametric equations are given below, intersect,
+          then give the equation of the plane that contains these two lines in general form.
+          <md>
+            \ell_1: \begin{matrix} x\amp =\amp -5+2s \\ y\amp =\amp 1+s \\ z\amp =\amp -4+2s \end{matrix}  \qquad\qquad \ell_2: \begin{matrix} x \amp =\amp  2+3t\\ y\amp =\amp 1-2t \\ z\amp =\amp 1+t \end{matrix}
+          </md>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The lines clearly are not parallel.
+          If they do not intersect, they are skew,
+          meaning there is not a plane that contains them both.
+          If they do intersect, there is such a plane.
+        </p>
+
+        <p>
+          To find their point of intersection, we set the <m>x</m>,
+          <m>y</m> and <m>z</m> equations equal to each other and solve for <m>s</m> and <m>t</m>:
+          <md>
+            \begin{matrix} -5+2s \amp =\amp 2+3t \\ 1+s \amp =\amp  1-2t \\ -4+2s \amp =\amp  1+t \end{matrix}   \Rightarrow   s=2, t=-1
+          </md>.
+        </p>
+
+        <p>
+          When <m>s=2</m> and <m>t=-1</m>,
+          the lines intersect at the point <m>P= (-1,3,0)</m>.
+        </p>
+
+        <p>
+          Let <m>\vec d_1 = \la 2,1,2\ra</m> and
+          <m>\vec d_2=\la 3,-2,1\ra</m> be the directions of lines <m>\ell_1</m> and <m>\ell_2</m>,
+          respectively.
+          A normal vector to the plane containing these the two lines will also be orthogonal to <m>\vec d_1</m> and <m>\vec d_2</m>.
+          Thus we find a normal vector <m>\vec n</m> by computing <m>\vec n = \vec d_1 \times \vec d_2= \la 5,4-7\ra</m>.
+        </p>
+
+        <p>
+          We can pick any point in the plane with which to write our equation;
+          each line gives us infinite choices of points.
+          We choose <m>P</m>, the point of intersection.
+          We follow <xref ref="def_planes"/>
+          to write the plane's equation in general form:
+          <md>
+            <mrow>5(x+1) +4(y-3) -7z \amp = 0</mrow>
+            <mrow>5x + 5 + 4y-12 -7z \amp = 0</mrow>
+            <mrow>5x+4y-7z \amp = 7</mrow>
+          </md>.
+        </p>
+
+        <p>
+          The plane's equation in general form is <m>5x+4y-7z=7</m>;
+          it is sketched in <xref ref="fig_planes2"/>.
+        </p>
+
+        <figure xml:id="fig_planes2" vshift="2.5">
+          <caption>Sketching the plane in <xref ref="ex_planes2"/></caption>
+
+          <!-- START figures/figplanes2_3D.asy -->
+          <image width="47%">
+            <shortdescription>In three dimensions, two lines are plotted, intersecting at a point P, along with the plane containing both lines.</shortdescription>
+            <description>
+              <p>
+                Three-dimensional coordinate axes are shown, with the points <m>(5,0,0)</m>, <m>(0,5,0)</m>, and <m>(0,0,-5)</m> indicated for scale.
+                A point <m>P</m> is plotted in space. Two lines <m>\ell_1</m> and <m>\ell_2</m> are shown intersecting at this point.
+                The plane containing both lines is also plotted, along with a normal vector, located with its tail at <m>P</m>.
+              </p>
+            </description>
+            <asymptote label="img_planes2">
+
+
+
+              //ASY file for figplanes2.asy in Chapter 10
+
+              size(282,282,Aspect);
+              //size(200,200,IgnoreAspect);
+              //currentprojection=perspective(7,2,1);
+              currentprojection=orthographic((-16,18.6,6.76),(0.014,-0.015,0077),(0,0,0),.99);
+              defaultrender.merge=true;
+
+              // setup and draw the axes
+              real[] myxchoice={5};
+              real[] myychoice={5};
+              real[] myzchoice={-5};
+              defaultpen(0.5mm);
+              pair xbounds=(-4,6);
+              pair ybounds=(-1,6);
+              pair zbounds=(-6,5);
+
+              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+              //Draw the plane
+              triple f(pair t) {
+                return (t.x,t.y,(5/7)*t.x+(4/7)*t.y-1);
+              }
+              surface s=surface(f,(-5,-6),(5,6),8,8,Spline);
+              pen p=apexmeshpen+.1mm;
+              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+              //Draw points P=(-1,3,0)
+              dotfactor=3;dot((-1,3,0));label("$P$",(-1,3,0),E);
+
+              //Draw normal vector at P, n=(5,4,-7)
+              draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
+              label("$\vec{n}$",(4,7,-7),W);
+
+              //draw the lines -5+2t,1+t,-4+2t  and 2+3t,1-2t,1+t
+              draw((5,6,6)--(-5,1,-4),bluepen);label("$\ell_1$",(5,6,6),N);//L1
+              draw((5,-1,2)--(-4.9,5.6,-1.3),bluepen);label("$\ell_2$",(5,-1,2),N);//L2
+
+            </asymptote>
+          </image>
+          <!-- figures/figplanes2_3D.asy END -->
+        </figure>
+      </solution>
+    </example>
+
+    <example xml:id="ex_planes3">
+      <title>Finding the equation of a plane</title>
+      <statement>
+        <p>
+          Give the equation, in standard form,
+          of the plane that passes through the point
+          <m>P=(-1,0,1)</m> and is orthogonal to the line with vector equation <m>\vec \ell(t) = \la -1,0,1\ra + t\la 1,2,2\ra</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          As the plane is to be orthogonal to the line,
+          the plane must be orthogonal to the direction of the line given by <m>\vec d = \la 1,2,2\ra</m>.
+          We use this as our normal vector.
+          Thus the plane's equation, in standard form, is
+          <md>
+            (x+1) +2y+2(z-1)=0
+          </md>.
+        </p>
+
+        <p>
+          The line and plane are sketched in <xref ref="fig_planes3"/>.
+        </p>
+
+        <figure xml:id="fig_planes3" vshift="1">
+          <caption>The line and plane in <xref ref="ex_planes3"/></caption>
+
+          <!-- START figures/figplanes3_3D.asy -->
+          <image width="47%">
+            <shortdescription>A plane is plotted in a three-dimensional coordinate system, along with a line passing through it at a point P.</shortdescription>
+            <description>
+              <p>
+                A plane is plotted against a set of three-dimensional coordinate axes.
+                A line passes through the plane, intersecting it at a point <m>P</m>.
+                The line is perpendicular to the plane.
+              </p>
+            </description>
+            <asymptote label="img_planes3">
+
+
+
+              //ASY file for figplanes3.asy in Chapter 10
+
+              size(282,282,Aspect);
+              //size(200,200,IgnoreAspect);
+              //currentprojection=perspective(7,2,1);
+              currentprojection=orthographic(4,4,2);
+              defaultrender.merge=true;
+
+              // setup and draw the axes
+              real[] myxchoice={-3,3};
+              real[] myychoice={-3,3};
+              real[] myzchoice={-3,3};
+              defaultpen(0.5mm);
+              pair xbounds=(-4,4);
+              pair ybounds=(-4,4);
+              pair zbounds=(-4,4);
+
+              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+              //Draw the plane z=-(x+1)/2-y+1
+              triple f(pair t) {
+                return (t.x,t.y,(-1/2)*(t.x+1)-t.y+1);
+              }
+              surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
+              pen p=apexmeshpen+.1mm;
+              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+              //Draw points P=(-1,0,1)
+              dotfactor=3;dot((-1,0,1));label("$P$",(-1,0,1),N);
+
+              //draw the line -1+t,2t,1+2t
+              draw((1,4,5)--(-3,-4,-3),bluepen);//L t=2 to t=-2
+
+              //Draw normal vector at P, n=(1,2,2)
+              //draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
+              //label("$\vec{n}$",(4,7,-7),W);
+
+            </asymptote>
+          </image>
+          <!-- figures/figplanes3_3D.asy END -->
+        </figure>
+      </solution>
+      <solution component="video" vshift="-5">
+        <title>Video solution</title>
+        <video width="98%" youtube="2diP-H-QLoI" label="vid-vectors-planes-given-normal" component="video"/>
+      </solution>
+    </example>
+
+    <example xml:id="ex_planes4">
+      <title>Finding the intersection of two planes</title>
+      <statement>
+        <p>
+          Give the parametric equations of the line that is the intersection of the planes <m>p_1</m> and <m>p_2</m>, where:
+          <md>
+            <mrow>p_1: x-(y-2)+(z-1) =0</mrow>
+            <mrow>p_2: -2(x-2)+(y+1)+(z-3)=0</mrow>
+          </md>
+        </p>
+      </statement>
+      <solution>
+        <p>
+          To find an equation of a line,
+          we need a point on the line and the direction of the line.
+        </p>
+
+        <p>
+          We can find a point on the line by solving each equation of the planes for <m>z</m>:
+          <md>
+            <mrow>p_1: z = -x+y-1</mrow>
+            <mrow>p_2: z = 2x-y-2</mrow>
+          </md>
+        </p>
+
+        <p>
+          We can now set these two equations equal to each other (<ie/>, we are finding values of <m>x</m> and <m>y</m> where the planes have the same <m>z</m> value):
+          <md>
+            <mrow>-x+y-1 \amp = 2x-y-2</mrow>
+            <mrow>2y \amp = 3x-1</mrow>
+            <mrow>y \amp = \frac12(3x-1)</mrow>
+          </md>
+        </p>
+
+        <p>
+          We can choose any value for <m>x</m>;
+          we choose <m>x=1</m>.
+          This determines that <m>y=1</m>.
+          We can now use the equations of either plane to find <m>z</m>:
+          when <m>x=1</m> and <m>y=1</m>,
+          <m>z=-1</m> on both planes.
+          We have found a point <m>P</m> on the line: <m>P= (1,1,-1)</m>.
+        </p>
+
+        <p>
+          We now need the direction of the line.
+          Since the line lies in each plane,
+          its direction is orthogonal to a normal vector for each plane.
+          Considering the equations for <m>p_1</m> and <m>p_2</m>,
+          we can quickly determine their normal vectors.
+          For <m>p_1</m>,
+          <m>\vec n_1 = \la 1,-1,1\ra</m> and for <m>p_2</m>,
+          <m>\vec n_2 = \la -2,1,1\ra</m>.
+          A direction orthogonal to both of these directions is their cross product:
+          <m>\vec d = \vec n_1\times \vec n_2 = \la -2,-3,-1\ra</m>.
+        </p>
+
+        <p>
+          The parametric equations of the line through
+          <m>P=(1,1,-1)</m> in the direction of <m>d=\la -2,-3,-1\ra</m> is:
+          <md>
+            \ell:  x= -2t+1 y = -3t+1 z=-t-1
+          </md>.
+        </p>
+
+        <p>
+          The planes and line are graphed in <xref ref="fig_planes4"/>.
+        </p>
+
+        <figure xml:id="fig_planes4" vshift="0">
+          <caption>Graphing the planes and their line of intersection in <xref ref="ex_planes4"/></caption>
+
+          <!-- START figures/figplanes4_3D.asy -->
+          <image width="47%">
+            <shortdescription>Two planes are shown intersecting along a common line.</shortdescription>
+            <description>
+              <p>
+                Two planes are plotted in a three-dimensional coordinate system.
+                The planes intersect along a line, which is also plotted,
+                along with a point <m>P</m> that lies on the line, as well as on both planes.
+              </p>
+            </description>
+            <asymptote label="img_planes4">
+
+
+
+              //ASY file for figplanes43D.asy in Chapter 10
+
+              //size(282,282,Aspect);
+              size(200,200,IgnoreAspect);
+              //currentprojection=perspective(7,2,1);
+              currentprojection=orthographic(8,14.7,14);
+              defaultrender.merge=true;
+
+              // setup and draw the axes
+              real[] myxchoice={-2,2};
+              real[] myychoice={-2,2};
+              real[] myzchoice={-5};
+              defaultpen(0.5mm);
+              pair xbounds=(-3,3);
+              pair ybounds=(-3,3);
+              pair zbounds=(-6,2);
+
+              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+              //Draw the planes z=-x+y-1 and z=2x-y-2
+              triple f(pair t) {
+                return (t.x,t.y,-t.x+t.y-1);
+              }
+              surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
+              pen p=apexmeshpen;
+              draw(s,surfacepen,meshpen=p+.2mm,nolight,render(merge=true));
+              triple f(pair t) {
+                return (t.x,t.y,2*t.x-t.y-2);
+              }
+              surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
+              pen pp=apexmeshpen+.2mm;
+              //draw(s,rgb(1,.4,.7)+opacity(.7),meshpen=pp,nolight,render(merge=true)); // HOT PINK
+
+              pen q=redcurvepen+.1mm;
+              draw(s,surfacepen2,meshpen=q,nolight,render(merge=true)); // better red
+
+              //Draw point P=(1,1,-1)
+              dotfactor=3;dot((1,1,-1));label("$P$",(1,1,-1),N);
+
+              //draw the line 1-2t,1-3t,-1-t
+              draw((4,5.5,0.5)--(-2,-3.5,-2.5),bluepen);//L t=-1.5 to t=1.5
+
+            </asymptote>
+          </image>
+          <!-- figures/figplanes4_3D.asy END -->
+        </figure>
+        <!-- <figure xml:id="vid-vectors-planes-interection2" component="video" vshift="-5">
+          <caption>An alternative method for solving <xref ref="ex_planes4"/></caption>
+          <video width="98%" youtube="tthyDV7cjR8" label="vid-vectors-planes-interection2"/>
+        </figure> -->
+      </solution>
+      <solution component="video" vshift="5">
+        <title>Video solution</title>
+        <video width="98%" youtube="x2HB6huEEmQ" label="vid-vectors-planes-interect1" component="video"/>
+      </solution>
+    </example>
+
+    <example xml:id="ex_planes5">
+      <title>Finding the intersection of a plane and a line</title>
+      <statement>
+        <p>
+          Find the point of intersection, if any,
+          of the line <m>\ell(t) = \la 3,-3,-1\ra +t\la-1,2,1\ra</m> and the plane with equation in general form <m>2x+y+z=4</m>.
+        </p>
+      </statement>
+      <solution>
+        <p>
+          The equation of the plane shows that the vector
+          <m>\vec n = \la 2,1,1\ra</m> is a normal vector to the plane,
+          and the equation of the line shows that the line moves parallel to <m>\vec d = \la -1,2,1\ra</m>.
+          Since these are not orthogonal,
+          we know there is a point of intersection.
+          (If there were orthogonal,
+          it would mean that the plane and line were parallel to each other,
+          either never intersecting or the line was in the plane itself.)
+        </p>
+
+        <p>
+          To find the point of intersection,
+          we need to find a <m>t</m> value such that <m>\ell(t)</m> satisfies the equation of the plane.
+          Rewriting the equation of the line with parametric equations will help:
+          <md>
+            \ell(t) = \left\{\begin{aligned}x\amp = 3-t\\ y\amp =-3+2t\\ z\amp = -1+t \end{aligned} \right.
+          </md>.
+        </p>
+
+        <p>
+          Replacing <m>x</m>,
+          <m>y</m> and <m>z</m> in the equation of the plane with the expressions containing <m>t</m> found in the equation of the line allows us to determine a <m>t</m> value that indicates the point of intersection:
+          <md>
+            <mrow>2x+y+z \amp =4</mrow>
+            <mrow>2(3-t) + (-3+2t) + (-1+t) \amp = 4</mrow>
+            <mrow>t\amp =2</mrow>
+          </md>.
+        </p>
+
+        <p>
+          When <m>t=2</m>,
+          the point on the line satisfies the equation of the plane;
+          that point is <m>\ell(2) = \la 1,1,1\ra</m>.
+          Thus the point <m>(1,1,1)</m> is the point of intersection between the plane and the line,
+          illustrated in <xref ref="fig_planes5"/>.
+        </p>
+
+        <figure xml:id="fig_planes5" vshift="4">
+          <caption>Illustrating the intersection of a line and a plane in <xref ref="ex_planes5"/></caption>
+
+          <!-- START figures/figplanes5_3D.asy -->
+          <image width="47%">
+            <shortdescription>A line in three dimensions passes through a plane, intersecting it at a point.</shortdescription>
+            <description>
+              <p>
+                A plane is plotted against a three-dimensional coordinate system.
+                A line, labeled <m>\ell(t)</m>, is also plotted.
+                The line appears to be almost, but not quite, parallel to the plane.
+                It passes through the plane, intersecting it at a point that is plotted, but not labeled.
+              </p>
+            </description>
+            <asymptote label="img_planes5">
+
+
+
+              //ASY file for figplanes53D.asy in Chapter 10
+
+              //size(282,282,Aspect);
+              size(200,200,IgnoreAspect);
+              //currentprojection=perspective(7,2,1);
+              currentprojection=orthographic(5,4,2);
+              defaultrender.merge=true;
+
+              // setup and draw the axes
+              real[] myxchoice={-2,2};
+              real[] myychoice={-2,2};
+              real[] myzchoice={2};
+              defaultpen(0.5mm);
+              pair xbounds=(-3,4);
+              pair ybounds=(-3,4);
+              pair zbounds=(-2,7);
+
+              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+              //Draw the plane z=4-2x-y
+              triple f(pair t) {
+                return (t.x,t.y,4-2*t.x-t.y);
+              }
+              surface s=surface(f,(-2,-2),(3,3),8,8,Spline);
+              pen p=apexmeshpen+.2mm;
+              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+              //Draw point P=(1,1,1)
+              dotfactor=3;dot((1,1,1),redpen);//label("$P$",(1,1,1),N);
+
+              //draw the line 3-t,-3+2t,-1+t
+              draw((3,-3,-1)--(0,3,2),redpen);//L t=0 to t=3
+              label("$\ell(t)$",(3,-3,-1),N);
+
+            </asymptote>
+          </image>
+          <!-- figures/figplanes5_3D.asy END -->
+        </figure>
+      </solution>
+      <solution component="video" vshift="6">
+        <title>Video solution</title>
+        <video width="98%" youtube="DjuaixH0ayo" label="vid-vectors-planes-lineint" component="video"/>
+      </solution>
+    </example>
 
   <paragraphs xml:id="subsec_planes_distances">
     <title>Distances</title>

--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -1,819 +1,817 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xml:id="sec_planes" label="sec_planes">
   <title>Planes</title>
-  <introduction>
-    <p>
-      Any flat surface, such as a wall,
-      table top or stiff piece of cardboard can be thought of as representing part of a plane.
-      Consider a piece of cardboard with a point <m>P</m> marked on it.
-      One can take a nail and stick it into the cardboard at <m>P</m> such that the nail is perpendicular to the cardboard;
-      see <xref ref="fig_planes_intro"/>.
-    </p>
+  <p>
+    Any flat surface, such as a wall,
+    table top or stiff piece of cardboard can be thought of as representing part of a plane.
+    Consider a piece of cardboard with a point <m>P</m> marked on it.
+    One can take a nail and stick it into the cardboard at <m>P</m> such that the nail is perpendicular to the cardboard;
+    see <xref ref="fig_planes_intro"/>.
+  </p>
 
-    <figure xml:id="fig_planes_intro" vshift="0">
-      <caption>Illustrating defining a plane with a sheet of cardboard and a nail</caption>
+  <figure xml:id="fig_planes_intro" vshift="0">
+    <caption>Illustrating defining a plane with a sheet of cardboard and a nail</caption>
 
-      <!-- START figures/figplanes_intro_3D.asy -->
-      <image width="47%">
-        <shortdescription>A nail sticks into a flat, rectangular sheet of cardboard.</shortdescription>
-        <description>
-          <p>
-            A flat, rectangular surface represents a sheet of cardboard.
-            The image of a nail is drawn sticking into the sheet, at a point <m>P</m>, which is marked.
-            The nail is standing upright, in a position perpendicular to the sheet of cardboard.
-          </p>
-        </description>
-        <asymptote label="img_planes_intro">
-
-
-
-          //ASY file for figlines3.asy in Chapter 10
-
-          size(200,200,IgnoreAspect);
-          //currentprojection=perspective(7,2,1);
-          currentprojection=orthographic((-4,27,7),(.012,-0.002,0.015),(0,0,0),.9);
-          defaultrender.merge=true;
-
-          // setup and draw the axes
-          real[] myxchoice={};
-          real[] myychoice={};
-          real[] myzchoice={};
-
-          pair xbounds=(-2,2);
-          pair ybounds=(-2,2);
-          pair zbounds=(-2,2);
-
-          xaxis3("",xbounds.x,xbounds.y,invisible,OutTicks(myxchoice),Arrow3(size=3mm));
-          yaxis3("",ybounds.x,ybounds.y,invisible,OutTicks(myychoice),Arrow3(size=3mm));
-          zaxis3("",zbounds.x,zbounds.y,invisible,OutTicks(myzchoice),Arrow3(size=3mm));
-
-          defaultpen(0.5mm);
-
-          real f(pair z) {return 0;}
-          surface s=surface(f,(-2,-2),(2,2),1,1);
-          pen p=bluepen+.3mm;
-          draw(s,surfacepen,meshpen=p,render(merge=true));
-
-          draw(scale(.1,.1,.2)*rotate(180,Y)*shift(-1Z)*unitcone,surfacepen=white);
-          draw(scale(.1,.1,.5)*shift(.4Z)*unitcylinder,surfacepen=white);
-          draw(scale(.15,.15,.05)*shift(14Z)*unitcylinder,surfacepen=white);
-
-          //real f(pair z) {return 0;}
-          //surface s=surface(f,(-2,-2),(2,2));
-          //draw(s,white,meshpen=p,render(merge=true));
-          draw(scale3(.15)*shift(4.7Z)*unitdisk,surfacepen=white);
-          draw(scale3(.15)*shift(5Z)*unitdisk,surfacepen=white);
-
-          draw(scale3(.05)*unitdisk);
-          label("$P$",(0,0,0),NW);
-
-          //draw((0,0,.9)--(0,0,0),gray+1mm,Arrow3(size=2mm));
-          //draw((0,0,.9)--(0,0,1),gray+1.2mm);
-
-        </asymptote>
-      </image>
-      <!-- figures/figplanes_intro_3D.asy END -->
-    </figure>
-
-    <p>
-      This nail provides a <q>handle</q> for the cardboard.
-      Moving the cardboard around moves <m>P</m> to different locations in space.
-      Tilting the nail
-      (but keeping <m>P</m> fixed)
-      tilts the cardboard.
-      Both moving and tilting the cardboard defines a different plane in space.
-      In fact, we can define a plane by: 1) the location of <m>P</m> in space,
-      and 2) the direction of the nail.
-    </p>
-
-    <figure xml:id="vid-vectors-planes-intro" component="video" vshift="-4">
-      <caption>Video inroduction to <xref ref="sec_planes"/></caption>
-      <video youtube="aP-fcbArvtA" label="vid-vectors-planes-intro"/>
-    </figure>
-
-    <p>
-      The previous section showed that one can define a line given a point on the line and the direction of the line
-      (usually given by a vector).
-      One can make a similar statement about planes:
-      we can define a plane in space given a point on the plane and the direction the plane <q>faces</q>
-      (using the description above,
-      the direction of the nail).
-      Once again, the direction information will be supplied by a vector,
-      called a <em>normal vector</em>,
-      that is orthogonal to the plane.
-          <idx><h>vectors</h><h>normal vector</h></idx>
-          <idx><h>normal vector</h></idx>
-          <idx><h>planes</h><h>normal vector</h></idx>
-    </p>
-
-    <p>
-      What exactly does <q>orthogonal to the plane</q> mean?
-      Choose any two points <m>P</m> and <m>Q</m> in the plane,
-      and consider the vector <m>\overrightarrow{PQ}</m>.
-      We say a vector <m>\vec n</m> is orthogonal to the plane if <m>\vec n</m> is perpendicular to <m>\overrightarrow{PQ}</m> for all choices of <m>P</m> and <m>Q</m>;
-      that is, if <m>\vec n\cdot \overrightarrow{PQ}=0</m> for all <m>P</m> and <m>Q</m>.
-    </p>
-
-    <p>
-      This gives us way of writing an equation describing the plane.
-      Let <m>P=(x_0,y_0,z_0)</m> be a point in the plane and let
-      <m>\vec n = \la a,b,c\ra</m> be a normal vector to the plane.
-      A point <m>Q = (x,y,z)</m> lies in the plane defined by <m>P</m> and <m>\vec n</m> if,
-      and only if, <m>\overrightarrow{PQ}</m> is orthogonal to <m>\vec n</m>.
-      Knowing <m>\overrightarrow{PQ} = \la x-x_0,y-y_0,z-z_0\ra</m>, consider:
-      <md>
-        <mrow>\overrightarrow{PQ}\cdot\vec n \amp = 0</mrow>
-        <mrow>\la x-x_0,y-y_0,z-z_0\ra\cdot \la a,b,c\ra \amp =0</mrow>
-        <mrow number="yes" xml:id="eq-plane-standard-form">a(x-x_0)+b(y-y_0)+c(z-z_0) \amp =0</mrow>
-      </md>.
-      <xref ref="eq-plane-standard-form">Equation</xref> defines an <em>implicit</em> function describing the plane. More algebra produces:
-      <md>
-        ax+by+cz = ax_0+by_0+cz_0
-      </md>.
-      The right hand side is just a number, so we replace it with <m>d</m>:
-      <md number="yes" xml:id="eq-plane-general-form">
-        ax+by+cz = d
-      </md>.
-      As long as <m>c\neq 0</m>, we can solve for <m>z</m>:
-      <md number="yes" xml:id="eq-plane-graph-form">
-        z = \frac1c(d-ax-by)
-      </md>.
-    </p>
-
-    <p>
-      <xref ref="eq-plane-graph-form">Equation</xref> is especially useful as many computer programs can graph functions in this form.
-      Equations <xref ref="eq-plane-standard-form"/> and <xref ref="eq-plane-general-form"/> have specific names,
-      given next.
-    </p>
-
-    <definition xml:id="def_planes">
-      <title>Equations of a Plane in Standard and General Forms</title>
-      <statement>
+    <!-- START figures/figplanes_intro_3D.asy -->
+    <image width="47%">
+      <shortdescription>A nail sticks into a flat, rectangular sheet of cardboard.</shortdescription>
+      <description>
         <p>
-          The plane passing through the point <m>P=(x_0,y_0,z_0)</m> with normal vector
-          <m>\vec n=\la a,b,c\ra</m> can be described by an equation with
-          <term>standard form</term>
-          <md>
-            a(x-x_0)+b(y-y_0)+c(z-z_0) =0;
-          </md>
-          the equation's <term>general form</term>
-          is <idx><h>planes</h><h>equations of</h></idx>
-          <md>
-            ax+by+cz = d
-          </md>.
+          A flat, rectangular surface represents a sheet of cardboard.
+          The image of a nail is drawn sticking into the sheet, at a point <m>P</m>, which is marked.
+          The nail is standing upright, in a position perpendicular to the sheet of cardboard.
         </p>
-      </statement>
-    </definition>
-
-    <exercise label="APEX-PROTEUS-sec-11_6-planes-1-v1" component="proteus">
-      <title>PROTEUS EXERCISE</title>
-      <statement>
-        <p>
-          Is it possible to define a plane using parametric equations?
-          If so, how many parameters are needed, and why?
-        </p>
-      </statement>
-      <response/>
-    </exercise>
-
-    <p>
-      A key to remember throughout this section is this:
-      to find the equation of a plane,
-      we need a point and a normal vector.
-      We will give several examples of finding the equation of a plane,
-      and in each one different types of information are given.
-      In each case,
-      we need to use the given information to find a point on the plane and a normal vector.
-    </p>
-
-    <example xml:id="ex_planes1">
-      <title>Finding the equation of a plane</title>
-      <statement>
-        <p>
-          Write the equation of the plane that passes through the points <m>P=(1,1,0)</m>,
-          <m>Q = (1,2,-1)</m> and <m>R = (0,1,2)</m> in standard form.
-        </p>
-      </statement>
-      <solution>
-        <p>
-          We need a vector <m>\vec n</m> that is orthogonal to the plane.
-          Since <m>P</m>, <m>Q</m> and <m>R</m> are in the plane,
-          so are the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m>;
-          <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m> is orthogonal to <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> and hence the plane itself.
-        </p>
-
-        <p>
-          It is straightforward to compute <m>\vec n = \overrightarrow{PQ}\times\overrightarrow{PR} = \la 2,1,1\ra</m>.
-          We can use any point we wish in the plane
-          (any of <m>P</m>, <m>Q</m> or <m>R</m> will do)
-          and we arbitrarily choose <m>P</m>.
-          Following <xref ref="def_planes"/>,
-          the equation of the plane in standard form is
-          <md>
-            2(x-1) + (y-1)+z = 0
-          </md>.
-        </p>
-
-        <p>
-          The plane is sketched in <xref ref="fig_planes1"/>.
-        </p>
-
-        <figure xml:id="fig_planes1" vshift="2">
-          <caption>Sketching the plane in <xref ref="ex_planes1"/></caption>
-
-          <!-- START figures/figplanes1_3D.asy -->
-          <image width="47%">
-            <shortdescription>Three points P, Q, and R are plotted in space, along with the plane containing them.</shortdescription>
-            <description>
-              <p>
-                In a three-dimensional coordinate system, three points <m>P</m>, <m>Q</m>, and <m>R</m> are plotted.
-                Three vectors are drawn with their tails at <m>P</m>:
-                <m>\overrightarrow{PQ}</m>, <m>\overrightarrow{PR}</m>, and the cross product <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m>.
-                The plane containing <m>P</m>, <m>Q</m>, and <m>R</m> is also shown.
-                The vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> are parallel to the plane,
-                while their cross product is perpendicular to the plane.
-              </p>
-            </description>
-            <asymptote label="img_planes1">
-
-
-
-              //ASY file for figlines_dist2.asy in Chapter 10
-              //ASY file for figplanes1.asy in Chapter 10
-
-              //size(200,200,IgnoreAspect);
-              size(282,282,Aspect);
-              //currentprojection=perspective(7,2,1);
-              currentprojection=orthographic((1.92,19.3,4),(0,-0.015,0.06),(0,0,0),1);
-              defaultrender.merge=true;
-
-
-              // setup and draw the axes
-              real[] myxchoice={-4,4};
-              real[] myychoice={-4,4};
-              real[] myzchoice={-4,4};
-              defaultpen(0.5mm);
-              pair xbounds=(-3.5,3.5);
-              pair ybounds=(-4.5,4.5);
-              pair zbounds=(-4.5,6.5);
-
-              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0),S);
-              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-              //Draw the plane
-              triple f(pair t) {
-                return (t.x,t.y,-2*t.x-t.y+3);
-              }
-              surface s=surface(f,(-1,-2),(2,3),8,8,Spline);
-              pen p=apexmeshpen+.2mm;
-              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-              //Draw points P=(1,1,0), Q=(1,2,-1), R=(0,1,2)
-              dotfactor=3;
-              dot((1,1,0));label("$P$",(1,1,0),N);
-              dot((1,2,-1));label("$Q$",(1,2,-1),W);
-              dot((0,1,2));label("$R$",(0,1,2),W);
-              //Draw Vectors
-              draw((1,1,0)--(1,2,-1),bluepen,Arrow3(size=2mm));//PQ
-              draw((1,1,0)--(0,1,2),bluepen,Arrow3(size=2mm));//PR
-              draw((1,1,0)--(3,2,1),bluepen,Arrow3(size=2mm));//P to PQxPR
-              label("$\overrightarrow{PQ}\times \overrightarrow{PR}$",(3,2,1),N);
-
-              //test i,j,k moved to P
-              //draw((1,1,0)--(2,1,0),bluepen,Arrow3(size=2mm));//P by i
-              //draw((1,1,0)--(1,2,0),bluepen,Arrow3(size=2mm));//P by j
-              //draw((1,1,0)--(1,1,1),bluepen,Arrow3(size=2mm));//P by k
-
-              // Use lines L1 1+3t,2-t,t  and L2 -2+4t,3+t,5+2t
-              //draw P1 (t=0) and vector d1 at P1 (t=1)
-              //dotfactor=3;dot((1,2,0));label("$P_1$",(1,2,0),N);
-              //draw((1,2,0)--(4,1,1),redpen,Arrow3(size=2mm));
-              //label("$\vec{d}_1$",(4,1,1),N);
-              //draw P2 (t=-1.5) and vector d2 at P2 (t=-0.5)
-              //dotfactor=3;dot((-8,1.5,2));label("$P_2$",(-8,1.5,2),N);
-              //draw((-8,1.5,2)--(-4,2.5,4),redpen,Arrow3(size=2mm));
-              //label("$\vec{d}_2$",(-4,2.5,4),N);
-
-              //draw vector P1 to P2
-              //draw((1,2,0)--(-8,1.5,2),black,Arrow3(size=2mm));
-              //label("$\overrightarrow{P_1 P_2}$",(-3.5,1.75,1),W);
-
-              //draw the lines 1+3t,2-t,t  and -2+4t,3+t,5+2t
-              //draw((-5,4,-2)--(7,0,2),bluepen);//L1
-              //draw((-14,0,-1)--(2,4,7),bluepen);//L2
-
-            </asymptote>
-          </image>
-          <!-- figures/figplanes1_3D.asy END -->
-        </figure>
-      </solution>
-      <solution component="video" vshift="7">
-        <title>Video solution</title>
-        <video width="98%" youtube="oc77R0am1vk" label="vid-vectors-planes-3points" component="video"/>
-      </solution>
-    </example>
-
-    <p>
-      We have just demonstrated the fact that any three non-collinear points define a plane.
-      (This is why a three-legged stool does not <q>rock;</q>
-      it's three feet always lie in a plane.
-      A four-legged stool will rock unless all four feet lie in the same plane.)
-    </p>
-
-    <example xml:id="ex_planes2">
-      <title>Finding the equation of a plane</title>
-      <statement>
-        <p>
-          Verify that lines <m>\ell_1</m> and <m>\ell_2</m>,
-          whose parametric equations are given below, intersect,
-          then give the equation of the plane that contains these two lines in general form.
-          <md>
-            \ell_1: \begin{matrix} x\amp =\amp -5+2s \\ y\amp =\amp 1+s \\ z\amp =\amp -4+2s \end{matrix}  \qquad\qquad \ell_2: \begin{matrix} x \amp =\amp  2+3t\\ y\amp =\amp 1-2t \\ z\amp =\amp 1+t \end{matrix}
-          </md>
-        </p>
-      </statement>
-      <solution>
-        <p>
-          The lines clearly are not parallel.
-          If they do not intersect, they are skew,
-          meaning there is not a plane that contains them both.
-          If they do intersect, there is such a plane.
-        </p>
-
-        <p>
-          To find their point of intersection, we set the <m>x</m>,
-          <m>y</m> and <m>z</m> equations equal to each other and solve for <m>s</m> and <m>t</m>:
-          <md>
-            \begin{matrix} -5+2s \amp =\amp 2+3t \\ 1+s \amp =\amp  1-2t \\ -4+2s \amp =\amp  1+t \end{matrix}   \Rightarrow   s=2, t=-1
-          </md>.
-        </p>
-
-        <p>
-          When <m>s=2</m> and <m>t=-1</m>,
-          the lines intersect at the point <m>P= (-1,3,0)</m>.
-        </p>
-
-        <p>
-          Let <m>\vec d_1 = \la 2,1,2\ra</m> and
-          <m>\vec d_2=\la 3,-2,1\ra</m> be the directions of lines <m>\ell_1</m> and <m>\ell_2</m>,
-          respectively.
-          A normal vector to the plane containing these the two lines will also be orthogonal to <m>\vec d_1</m> and <m>\vec d_2</m>.
-          Thus we find a normal vector <m>\vec n</m> by computing <m>\vec n = \vec d_1 \times \vec d_2= \la 5,4-7\ra</m>.
-        </p>
-
-        <p>
-          We can pick any point in the plane with which to write our equation;
-          each line gives us infinite choices of points.
-          We choose <m>P</m>, the point of intersection.
-          We follow <xref ref="def_planes"/>
-          to write the plane's equation in general form:
-          <md>
-            <mrow>5(x+1) +4(y-3) -7z \amp = 0</mrow>
-            <mrow>5x + 5 + 4y-12 -7z \amp = 0</mrow>
-            <mrow>5x+4y-7z \amp = 7</mrow>
-          </md>.
-        </p>
-
-        <p>
-          The plane's equation in general form is <m>5x+4y-7z=7</m>;
-          it is sketched in <xref ref="fig_planes2"/>.
-        </p>
-
-        <figure xml:id="fig_planes2" vshift="2.5">
-          <caption>Sketching the plane in <xref ref="ex_planes2"/></caption>
-
-          <!-- START figures/figplanes2_3D.asy -->
-          <image width="47%">
-            <shortdescription>In three dimensions, two lines are plotted, intersecting at a point P, along with the plane containing both lines.</shortdescription>
-            <description>
-              <p>
-                Three-dimensional coordinate axes are shown, with the points <m>(5,0,0)</m>, <m>(0,5,0)</m>, and <m>(0,0,-5)</m> indicated for scale.
-                A point <m>P</m> is plotted in space. Two lines <m>\ell_1</m> and <m>\ell_2</m> are shown intersecting at this point.
-                The plane containing both lines is also plotted, along with a normal vector, located with its tail at <m>P</m>.
-              </p>
-            </description>
-            <asymptote label="img_planes2">
-
-
-
-              //ASY file for figplanes2.asy in Chapter 10
-
-              size(282,282,Aspect);
-              //size(200,200,IgnoreAspect);
-              //currentprojection=perspective(7,2,1);
-              currentprojection=orthographic((-16,18.6,6.76),(0.014,-0.015,0077),(0,0,0),.99);
-              defaultrender.merge=true;
-
-              // setup and draw the axes
-              real[] myxchoice={5};
-              real[] myychoice={5};
-              real[] myzchoice={-5};
-              defaultpen(0.5mm);
-              pair xbounds=(-4,6);
-              pair ybounds=(-1,6);
-              pair zbounds=(-6,5);
-
-              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-              //Draw the plane
-              triple f(pair t) {
-                return (t.x,t.y,(5/7)*t.x+(4/7)*t.y-1);
-              }
-              surface s=surface(f,(-5,-6),(5,6),8,8,Spline);
-              pen p=apexmeshpen+.1mm;
-              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-              //Draw points P=(-1,3,0)
-              dotfactor=3;dot((-1,3,0));label("$P$",(-1,3,0),E);
-
-              //Draw normal vector at P, n=(5,4,-7)
-              draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
-              label("$\vec{n}$",(4,7,-7),W);
-
-              //draw the lines -5+2t,1+t,-4+2t  and 2+3t,1-2t,1+t
-              draw((5,6,6)--(-5,1,-4),bluepen);label("$\ell_1$",(5,6,6),N);//L1
-              draw((5,-1,2)--(-4.9,5.6,-1.3),bluepen);label("$\ell_2$",(5,-1,2),N);//L2
-
-            </asymptote>
-          </image>
-          <!-- figures/figplanes2_3D.asy END -->
-        </figure>
-      </solution>
-    </example>
-
-    <example xml:id="ex_planes3">
-      <title>Finding the equation of a plane</title>
-      <statement>
-        <p>
-          Give the equation, in standard form,
-          of the plane that passes through the point
-          <m>P=(-1,0,1)</m> and is orthogonal to the line with vector equation <m>\vec \ell(t) = \la -1,0,1\ra + t\la 1,2,2\ra</m>.
-        </p>
-      </statement>
-      <solution>
-        <p>
-          As the plane is to be orthogonal to the line,
-          the plane must be orthogonal to the direction of the line given by <m>\vec d = \la 1,2,2\ra</m>.
-          We use this as our normal vector.
-          Thus the plane's equation, in standard form, is
-          <md>
-            (x+1) +2y+2(z-1)=0
-          </md>.
-        </p>
-
-        <p>
-          The line and plane are sketched in <xref ref="fig_planes3"/>.
-        </p>
-
-        <figure xml:id="fig_planes3" vshift="1">
-          <caption>The line and plane in <xref ref="ex_planes3"/></caption>
-
-          <!-- START figures/figplanes3_3D.asy -->
-          <image width="47%">
-            <shortdescription>A plane is plotted in a three-dimensional coordinate system, along with a line passing through it at a point P.</shortdescription>
-            <description>
-              <p>
-                A plane is plotted against a set of three-dimensional coordinate axes.
-                A line passes through the plane, intersecting it at a point <m>P</m>.
-                The line is perpendicular to the plane.
-              </p>
-            </description>
-            <asymptote label="img_planes3">
-
-
-
-              //ASY file for figplanes3.asy in Chapter 10
-
-              size(282,282,Aspect);
-              //size(200,200,IgnoreAspect);
-              //currentprojection=perspective(7,2,1);
-              currentprojection=orthographic(4,4,2);
-              defaultrender.merge=true;
-
-              // setup and draw the axes
-              real[] myxchoice={-3,3};
-              real[] myychoice={-3,3};
-              real[] myzchoice={-3,3};
-              defaultpen(0.5mm);
-              pair xbounds=(-4,4);
-              pair ybounds=(-4,4);
-              pair zbounds=(-4,4);
-
-              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-              //Draw the plane z=-(x+1)/2-y+1
-              triple f(pair t) {
-                return (t.x,t.y,(-1/2)*(t.x+1)-t.y+1);
-              }
-              surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
-              pen p=apexmeshpen+.1mm;
-              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-              //Draw points P=(-1,0,1)
-              dotfactor=3;dot((-1,0,1));label("$P$",(-1,0,1),N);
-
-              //draw the line -1+t,2t,1+2t
-              draw((1,4,5)--(-3,-4,-3),bluepen);//L t=2 to t=-2
-
-              //Draw normal vector at P, n=(1,2,2)
-              //draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
-              //label("$\vec{n}$",(4,7,-7),W);
-
-            </asymptote>
-          </image>
-          <!-- figures/figplanes3_3D.asy END -->
-        </figure>
-      </solution>
-      <solution component="video" vshift="-5">
-        <title>Video solution</title>
-        <video width="98%" youtube="2diP-H-QLoI" label="vid-vectors-planes-given-normal" component="video"/>
-      </solution>
-    </example>
-
-    <example xml:id="ex_planes4">
-      <title>Finding the intersection of two planes</title>
-      <statement>
-        <p>
-          Give the parametric equations of the line that is the intersection of the planes <m>p_1</m> and <m>p_2</m>, where:
-          <md>
-            <mrow>p_1: x-(y-2)+(z-1) =0</mrow>
-            <mrow>p_2: -2(x-2)+(y+1)+(z-3)=0</mrow>
-          </md>
-        </p>
-      </statement>
-      <solution>
-        <p>
-          To find an equation of a line,
-          we need a point on the line and the direction of the line.
-        </p>
-
-        <p>
-          We can find a point on the line by solving each equation of the planes for <m>z</m>:
-          <md>
-            <mrow>p_1: z = -x+y-1</mrow>
-            <mrow>p_2: z = 2x-y-2</mrow>
-          </md>
-        </p>
-
-        <p>
-          We can now set these two equations equal to each other (<ie/>, we are finding values of <m>x</m> and <m>y</m> where the planes have the same <m>z</m> value):
-          <md>
-            <mrow>-x+y-1 \amp = 2x-y-2</mrow>
-            <mrow>2y \amp = 3x-1</mrow>
-            <mrow>y \amp = \frac12(3x-1)</mrow>
-          </md>
-        </p>
-
-        <p>
-          We can choose any value for <m>x</m>;
-          we choose <m>x=1</m>.
-          This determines that <m>y=1</m>.
-          We can now use the equations of either plane to find <m>z</m>:
-          when <m>x=1</m> and <m>y=1</m>,
-          <m>z=-1</m> on both planes.
-          We have found a point <m>P</m> on the line: <m>P= (1,1,-1)</m>.
-        </p>
-
-        <p>
-          We now need the direction of the line.
-          Since the line lies in each plane,
-          its direction is orthogonal to a normal vector for each plane.
-          Considering the equations for <m>p_1</m> and <m>p_2</m>,
-          we can quickly determine their normal vectors.
-          For <m>p_1</m>,
-          <m>\vec n_1 = \la 1,-1,1\ra</m> and for <m>p_2</m>,
-          <m>\vec n_2 = \la -2,1,1\ra</m>.
-          A direction orthogonal to both of these directions is their cross product:
-          <m>\vec d = \vec n_1\times \vec n_2 = \la -2,-3,-1\ra</m>.
-        </p>
-
-        <p>
-          The parametric equations of the line through
-          <m>P=(1,1,-1)</m> in the direction of <m>d=\la -2,-3,-1\ra</m> is:
-          <md>
-            \ell:  x= -2t+1 y = -3t+1 z=-t-1
-          </md>.
-        </p>
-
-        <p>
-          The planes and line are graphed in <xref ref="fig_planes4"/>.
-        </p>
-
-        <figure xml:id="fig_planes4" vshift="0">
-          <caption>Graphing the planes and their line of intersection in <xref ref="ex_planes4"/></caption>
-
-          <!-- START figures/figplanes4_3D.asy -->
-          <image width="47%">
-            <shortdescription>Two planes are shown intersecting along a common line.</shortdescription>
-            <description>
-              <p>
-                Two planes are plotted in a three-dimensional coordinate system.
-                The planes intersect along a line, which is also plotted,
-                along with a point <m>P</m> that lies on the line, as well as on both planes.
-              </p>
-            </description>
-            <asymptote label="img_planes4">
-
-
-
-              //ASY file for figplanes43D.asy in Chapter 10
-
-              //size(282,282,Aspect);
-              size(200,200,IgnoreAspect);
-              //currentprojection=perspective(7,2,1);
-              currentprojection=orthographic(8,14.7,14);
-              defaultrender.merge=true;
-
-              // setup and draw the axes
-              real[] myxchoice={-2,2};
-              real[] myychoice={-2,2};
-              real[] myzchoice={-5};
-              defaultpen(0.5mm);
-              pair xbounds=(-3,3);
-              pair ybounds=(-3,3);
-              pair zbounds=(-6,2);
-
-              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-              //Draw the planes z=-x+y-1 and z=2x-y-2
-              triple f(pair t) {
-                return (t.x,t.y,-t.x+t.y-1);
-              }
-              surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
-              pen p=apexmeshpen;
-              draw(s,surfacepen,meshpen=p+.2mm,nolight,render(merge=true));
-              triple f(pair t) {
-                return (t.x,t.y,2*t.x-t.y-2);
-              }
-              surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
-              pen pp=apexmeshpen+.2mm;
-              //draw(s,rgb(1,.4,.7)+opacity(.7),meshpen=pp,nolight,render(merge=true)); // HOT PINK
-
-              pen q=redcurvepen+.1mm;
-              draw(s,surfacepen2,meshpen=q,nolight,render(merge=true)); // better red
-
-              //Draw point P=(1,1,-1)
-              dotfactor=3;dot((1,1,-1));label("$P$",(1,1,-1),N);
-
-              //draw the line 1-2t,1-3t,-1-t
-              draw((4,5.5,0.5)--(-2,-3.5,-2.5),bluepen);//L t=-1.5 to t=1.5
-
-            </asymptote>
-          </image>
-          <!-- figures/figplanes4_3D.asy END -->
-        </figure>
-        <!-- <figure xml:id="vid-vectors-planes-interection2" component="video" vshift="-5">
-          <caption>An alternative method for solving <xref ref="ex_planes4"/></caption>
-          <video width="98%" youtube="tthyDV7cjR8" label="vid-vectors-planes-interection2"/>
-        </figure> -->
-      </solution>
-      <solution component="video" vshift="5">
-        <title>Video solution</title>
-        <video width="98%" youtube="x2HB6huEEmQ" label="vid-vectors-planes-interect1" component="video"/>
-      </solution>
-    </example>
-
-    <example xml:id="ex_planes5">
-      <title>Finding the intersection of a plane and a line</title>
-      <statement>
-        <p>
-          Find the point of intersection, if any,
-          of the line <m>\ell(t) = \la 3,-3,-1\ra +t\la-1,2,1\ra</m> and the plane with equation in general form <m>2x+y+z=4</m>.
-        </p>
-      </statement>
-      <solution>
-        <p>
-          The equation of the plane shows that the vector
-          <m>\vec n = \la 2,1,1\ra</m> is a normal vector to the plane,
-          and the equation of the line shows that the line moves parallel to <m>\vec d = \la -1,2,1\ra</m>.
-          Since these are not orthogonal,
-          we know there is a point of intersection.
-          (If there were orthogonal,
-          it would mean that the plane and line were parallel to each other,
-          either never intersecting or the line was in the plane itself.)
-        </p>
-
-        <p>
-          To find the point of intersection,
-          we need to find a <m>t</m> value such that <m>\ell(t)</m> satisfies the equation of the plane.
-          Rewriting the equation of the line with parametric equations will help:
-          <md>
-            \ell(t) = \left\{\begin{aligned}x\amp = 3-t\\ y\amp =-3+2t\\ z\amp = -1+t \end{aligned} \right.
-          </md>.
-        </p>
-
-        <p>
-          Replacing <m>x</m>,
-          <m>y</m> and <m>z</m> in the equation of the plane with the expressions containing <m>t</m> found in the equation of the line allows us to determine a <m>t</m> value that indicates the point of intersection:
-          <md>
-            <mrow>2x+y+z \amp =4</mrow>
-            <mrow>2(3-t) + (-3+2t) + (-1+t) \amp = 4</mrow>
-            <mrow>t\amp =2</mrow>
-          </md>.
-        </p>
-
-        <p>
-          When <m>t=2</m>,
-          the point on the line satisfies the equation of the plane;
-          that point is <m>\ell(2) = \la 1,1,1\ra</m>.
-          Thus the point <m>(1,1,1)</m> is the point of intersection between the plane and the line,
-          illustrated in <xref ref="fig_planes5"/>.
-        </p>
-
-        <figure xml:id="fig_planes5" vshift="4">
-          <caption>Illustrating the intersection of a line and a plane in <xref ref="ex_planes5"/></caption>
-
-          <!-- START figures/figplanes5_3D.asy -->
-          <image width="47%">
-            <shortdescription>A line in three dimensions passes through a plane, intersecting it at a point.</shortdescription>
-            <description>
-              <p>
-                A plane is plotted against a three-dimensional coordinate system.
-                A line, labeled <m>\ell(t)</m>, is also plotted.
-                The line appears to be almost, but not quite, parallel to the plane.
-                It passes through the plane, intersecting it at a point that is plotted, but not labeled.
-              </p>
-            </description>
-            <asymptote label="img_planes5">
-
-
-
-              //ASY file for figplanes53D.asy in Chapter 10
-
-              //size(282,282,Aspect);
-              size(200,200,IgnoreAspect);
-              //currentprojection=perspective(7,2,1);
-              currentprojection=orthographic(5,4,2);
-              defaultrender.merge=true;
-
-              // setup and draw the axes
-              real[] myxchoice={-2,2};
-              real[] myychoice={-2,2};
-              real[] myzchoice={2};
-              defaultpen(0.5mm);
-              pair xbounds=(-3,4);
-              pair ybounds=(-3,4);
-              pair zbounds=(-2,7);
-
-              xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
-              yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
-              zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
-
-              label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
-              label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
-              label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
-
-              //Draw the plane z=4-2x-y
-              triple f(pair t) {
-                return (t.x,t.y,4-2*t.x-t.y);
-              }
-              surface s=surface(f,(-2,-2),(3,3),8,8,Spline);
-              pen p=apexmeshpen+.2mm;
-              draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
-
-              //Draw point P=(1,1,1)
-              dotfactor=3;dot((1,1,1),redpen);//label("$P$",(1,1,1),N);
-
-              //draw the line 3-t,-3+2t,-1+t
-              draw((3,-3,-1)--(0,3,2),redpen);//L t=0 to t=3
-              label("$\ell(t)$",(3,-3,-1),N);
-
-            </asymptote>
-          </image>
-          <!-- figures/figplanes5_3D.asy END -->
-        </figure>
-      </solution>
-      <solution component="video" vshift="6">
-        <title>Video solution</title>
-        <video width="98%" youtube="DjuaixH0ayo" label="vid-vectors-planes-lineint" component="video"/>
-      </solution>
-    </example>
-  </introduction>
-
-  <subsection xml:id="subsec_planes_distances">
+      </description>
+      <asymptote label="img_planes_intro">
+
+
+
+        //ASY file for figlines3.asy in Chapter 10
+
+        size(200,200,IgnoreAspect);
+        //currentprojection=perspective(7,2,1);
+        currentprojection=orthographic((-4,27,7),(.012,-0.002,0.015),(0,0,0),.9);
+        defaultrender.merge=true;
+
+        // setup and draw the axes
+        real[] myxchoice={};
+        real[] myychoice={};
+        real[] myzchoice={};
+
+        pair xbounds=(-2,2);
+        pair ybounds=(-2,2);
+        pair zbounds=(-2,2);
+
+        xaxis3("",xbounds.x,xbounds.y,invisible,OutTicks(myxchoice),Arrow3(size=3mm));
+        yaxis3("",ybounds.x,ybounds.y,invisible,OutTicks(myychoice),Arrow3(size=3mm));
+        zaxis3("",zbounds.x,zbounds.y,invisible,OutTicks(myzchoice),Arrow3(size=3mm));
+
+        defaultpen(0.5mm);
+
+        real f(pair z) {return 0;}
+        surface s=surface(f,(-2,-2),(2,2),1,1);
+        pen p=bluepen+.3mm;
+        draw(s,surfacepen,meshpen=p,render(merge=true));
+
+        draw(scale(.1,.1,.2)*rotate(180,Y)*shift(-1Z)*unitcone,surfacepen=white);
+        draw(scale(.1,.1,.5)*shift(.4Z)*unitcylinder,surfacepen=white);
+        draw(scale(.15,.15,.05)*shift(14Z)*unitcylinder,surfacepen=white);
+
+        //real f(pair z) {return 0;}
+        //surface s=surface(f,(-2,-2),(2,2));
+        //draw(s,white,meshpen=p,render(merge=true));
+        draw(scale3(.15)*shift(4.7Z)*unitdisk,surfacepen=white);
+        draw(scale3(.15)*shift(5Z)*unitdisk,surfacepen=white);
+
+        draw(scale3(.05)*unitdisk);
+        label("$P$",(0,0,0),NW);
+
+        //draw((0,0,.9)--(0,0,0),gray+1mm,Arrow3(size=2mm));
+        //draw((0,0,.9)--(0,0,1),gray+1.2mm);
+
+      </asymptote>
+    </image>
+    <!-- figures/figplanes_intro_3D.asy END -->
+  </figure>
+
+  <p>
+    This nail provides a <q>handle</q> for the cardboard.
+    Moving the cardboard around moves <m>P</m> to different locations in space.
+    Tilting the nail
+    (but keeping <m>P</m> fixed)
+    tilts the cardboard.
+    Both moving and tilting the cardboard defines a different plane in space.
+    In fact, we can define a plane by: 1) the location of <m>P</m> in space,
+    and 2) the direction of the nail.
+  </p>
+
+  <figure xml:id="vid-vectors-planes-intro" component="video" vshift="-4">
+    <caption>Video inroduction to <xref ref="sec_planes"/></caption>
+    <video youtube="aP-fcbArvtA" label="vid-vectors-planes-intro"/>
+  </figure>
+
+  <p>
+    The previous section showed that one can define a line given a point on the line and the direction of the line
+    (usually given by a vector).
+    One can make a similar statement about planes:
+    we can define a plane in space given a point on the plane and the direction the plane <q>faces</q>
+    (using the description above,
+    the direction of the nail).
+    Once again, the direction information will be supplied by a vector,
+    called a <em>normal vector</em>,
+    that is orthogonal to the plane.
+        <idx><h>vectors</h><h>normal vector</h></idx>
+        <idx><h>normal vector</h></idx>
+        <idx><h>planes</h><h>normal vector</h></idx>
+  </p>
+
+  <p>
+    What exactly does <q>orthogonal to the plane</q> mean?
+    Choose any two points <m>P</m> and <m>Q</m> in the plane,
+    and consider the vector <m>\overrightarrow{PQ}</m>.
+    We say a vector <m>\vec n</m> is orthogonal to the plane if <m>\vec n</m> is perpendicular to <m>\overrightarrow{PQ}</m> for all choices of <m>P</m> and <m>Q</m>;
+    that is, if <m>\vec n\cdot \overrightarrow{PQ}=0</m> for all <m>P</m> and <m>Q</m>.
+  </p>
+
+  <p>
+    This gives us way of writing an equation describing the plane.
+    Let <m>P=(x_0,y_0,z_0)</m> be a point in the plane and let
+    <m>\vec n = \la a,b,c\ra</m> be a normal vector to the plane.
+    A point <m>Q = (x,y,z)</m> lies in the plane defined by <m>P</m> and <m>\vec n</m> if,
+    and only if, <m>\overrightarrow{PQ}</m> is orthogonal to <m>\vec n</m>.
+    Knowing <m>\overrightarrow{PQ} = \la x-x_0,y-y_0,z-z_0\ra</m>, consider:
+    <md>
+      <mrow>\overrightarrow{PQ}\cdot\vec n \amp = 0</mrow>
+      <mrow>\la x-x_0,y-y_0,z-z_0\ra\cdot \la a,b,c\ra \amp =0</mrow>
+      <mrow number="yes" xml:id="eq-plane-standard-form">a(x-x_0)+b(y-y_0)+c(z-z_0) \amp =0</mrow>
+    </md>.
+    <xref ref="eq-plane-standard-form">Equation</xref> defines an <em>implicit</em> function describing the plane. More algebra produces:
+    <md>
+      ax+by+cz = ax_0+by_0+cz_0
+    </md>.
+    The right hand side is just a number, so we replace it with <m>d</m>:
+    <md number="yes" xml:id="eq-plane-general-form">
+      ax+by+cz = d
+    </md>.
+    As long as <m>c\neq 0</m>, we can solve for <m>z</m>:
+    <md number="yes" xml:id="eq-plane-graph-form">
+      z = \frac1c(d-ax-by)
+    </md>.
+  </p>
+
+  <p>
+    <xref ref="eq-plane-graph-form">Equation</xref> is especially useful as many computer programs can graph functions in this form.
+    Equations <xref ref="eq-plane-standard-form"/> and <xref ref="eq-plane-general-form"/> have specific names,
+    given next.
+  </p>
+
+  <definition xml:id="def_planes">
+    <title>Equations of a Plane in Standard and General Forms</title>
+    <statement>
+      <p>
+        The plane passing through the point <m>P=(x_0,y_0,z_0)</m> with normal vector
+        <m>\vec n=\la a,b,c\ra</m> can be described by an equation with
+        <term>standard form</term>
+        <md>
+          a(x-x_0)+b(y-y_0)+c(z-z_0) =0;
+        </md>
+        the equation's <term>general form</term>
+        is <idx><h>planes</h><h>equations of</h></idx>
+        <md>
+          ax+by+cz = d
+        </md>.
+      </p>
+    </statement>
+  </definition>
+
+  <exercise label="APEX-PROTEUS-sec-11_6-planes-1-v1" component="proteus">
+    <title>PROTEUS EXERCISE</title>
+    <statement>
+      <p>
+        Is it possible to define a plane using parametric equations?
+        If so, how many parameters are needed, and why?
+      </p>
+    </statement>
+    <response/>
+  </exercise>
+
+  <p>
+    A key to remember throughout this section is this:
+    to find the equation of a plane,
+    we need a point and a normal vector.
+    We will give several examples of finding the equation of a plane,
+    and in each one different types of information are given.
+    In each case,
+    we need to use the given information to find a point on the plane and a normal vector.
+  </p>
+
+  <example xml:id="ex_planes1">
+    <title>Finding the equation of a plane</title>
+    <statement>
+      <p>
+        Write the equation of the plane that passes through the points <m>P=(1,1,0)</m>,
+        <m>Q = (1,2,-1)</m> and <m>R = (0,1,2)</m> in standard form.
+      </p>
+    </statement>
+    <solution>
+      <p>
+        We need a vector <m>\vec n</m> that is orthogonal to the plane.
+        Since <m>P</m>, <m>Q</m> and <m>R</m> are in the plane,
+        so are the vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m>;
+        <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m> is orthogonal to <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> and hence the plane itself.
+      </p>
+
+      <p>
+        It is straightforward to compute <m>\vec n = \overrightarrow{PQ}\times\overrightarrow{PR} = \la 2,1,1\ra</m>.
+        We can use any point we wish in the plane
+        (any of <m>P</m>, <m>Q</m> or <m>R</m> will do)
+        and we arbitrarily choose <m>P</m>.
+        Following <xref ref="def_planes"/>,
+        the equation of the plane in standard form is
+        <md>
+          2(x-1) + (y-1)+z = 0
+        </md>.
+      </p>
+
+      <p>
+        The plane is sketched in <xref ref="fig_planes1"/>.
+      </p>
+
+      <figure xml:id="fig_planes1" vshift="2">
+        <caption>Sketching the plane in <xref ref="ex_planes1"/></caption>
+
+        <!-- START figures/figplanes1_3D.asy -->
+        <image width="47%">
+          <shortdescription>Three points P, Q, and R are plotted in space, along with the plane containing them.</shortdescription>
+          <description>
+            <p>
+              In a three-dimensional coordinate system, three points <m>P</m>, <m>Q</m>, and <m>R</m> are plotted.
+              Three vectors are drawn with their tails at <m>P</m>:
+              <m>\overrightarrow{PQ}</m>, <m>\overrightarrow{PR}</m>, and the cross product <m>\overrightarrow{PQ}\times\overrightarrow{PR}</m>.
+              The plane containing <m>P</m>, <m>Q</m>, and <m>R</m> is also shown.
+              The vectors <m>\overrightarrow{PQ}</m> and <m>\overrightarrow{PR}</m> are parallel to the plane,
+              while their cross product is perpendicular to the plane.
+            </p>
+          </description>
+          <asymptote label="img_planes1">
+
+
+
+            //ASY file for figlines_dist2.asy in Chapter 10
+            //ASY file for figplanes1.asy in Chapter 10
+
+            //size(200,200,IgnoreAspect);
+            size(282,282,Aspect);
+            //currentprojection=perspective(7,2,1);
+            currentprojection=orthographic((1.92,19.3,4),(0,-0.015,0.06),(0,0,0),1);
+            defaultrender.merge=true;
+
+
+            // setup and draw the axes
+            real[] myxchoice={-4,4};
+            real[] myychoice={-4,4};
+            real[] myzchoice={-4,4};
+            defaultpen(0.5mm);
+            pair xbounds=(-3.5,3.5);
+            pair ybounds=(-4.5,4.5);
+            pair zbounds=(-4.5,6.5);
+
+            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0),S);
+            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+            //Draw the plane
+            triple f(pair t) {
+              return (t.x,t.y,-2*t.x-t.y+3);
+            }
+            surface s=surface(f,(-1,-2),(2,3),8,8,Spline);
+            pen p=apexmeshpen+.2mm;
+            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+            //Draw points P=(1,1,0), Q=(1,2,-1), R=(0,1,2)
+            dotfactor=3;
+            dot((1,1,0));label("$P$",(1,1,0),N);
+            dot((1,2,-1));label("$Q$",(1,2,-1),W);
+            dot((0,1,2));label("$R$",(0,1,2),W);
+            //Draw Vectors
+            draw((1,1,0)--(1,2,-1),bluepen,Arrow3(size=2mm));//PQ
+            draw((1,1,0)--(0,1,2),bluepen,Arrow3(size=2mm));//PR
+            draw((1,1,0)--(3,2,1),bluepen,Arrow3(size=2mm));//P to PQxPR
+            label("$\overrightarrow{PQ}\times \overrightarrow{PR}$",(3,2,1),N);
+
+            //test i,j,k moved to P
+            //draw((1,1,0)--(2,1,0),bluepen,Arrow3(size=2mm));//P by i
+            //draw((1,1,0)--(1,2,0),bluepen,Arrow3(size=2mm));//P by j
+            //draw((1,1,0)--(1,1,1),bluepen,Arrow3(size=2mm));//P by k
+
+            // Use lines L1 1+3t,2-t,t  and L2 -2+4t,3+t,5+2t
+            //draw P1 (t=0) and vector d1 at P1 (t=1)
+            //dotfactor=3;dot((1,2,0));label("$P_1$",(1,2,0),N);
+            //draw((1,2,0)--(4,1,1),redpen,Arrow3(size=2mm));
+            //label("$\vec{d}_1$",(4,1,1),N);
+            //draw P2 (t=-1.5) and vector d2 at P2 (t=-0.5)
+            //dotfactor=3;dot((-8,1.5,2));label("$P_2$",(-8,1.5,2),N);
+            //draw((-8,1.5,2)--(-4,2.5,4),redpen,Arrow3(size=2mm));
+            //label("$\vec{d}_2$",(-4,2.5,4),N);
+
+            //draw vector P1 to P2
+            //draw((1,2,0)--(-8,1.5,2),black,Arrow3(size=2mm));
+            //label("$\overrightarrow{P_1 P_2}$",(-3.5,1.75,1),W);
+
+            //draw the lines 1+3t,2-t,t  and -2+4t,3+t,5+2t
+            //draw((-5,4,-2)--(7,0,2),bluepen);//L1
+            //draw((-14,0,-1)--(2,4,7),bluepen);//L2
+
+          </asymptote>
+        </image>
+        <!-- figures/figplanes1_3D.asy END -->
+      </figure>
+    </solution>
+    <solution component="video" vshift="7">
+      <title>Video solution</title>
+      <video width="98%" youtube="oc77R0am1vk" label="vid-vectors-planes-3points" component="video"/>
+    </solution>
+  </example>
+
+  <p>
+    We have just demonstrated the fact that any three non-collinear points define a plane.
+    (This is why a three-legged stool does not <q>rock;</q>
+    it's three feet always lie in a plane.
+    A four-legged stool will rock unless all four feet lie in the same plane.)
+  </p>
+
+  <example xml:id="ex_planes2">
+    <title>Finding the equation of a plane</title>
+    <statement>
+      <p>
+        Verify that lines <m>\ell_1</m> and <m>\ell_2</m>,
+        whose parametric equations are given below, intersect,
+        then give the equation of the plane that contains these two lines in general form.
+        <md>
+          \ell_1: \begin{matrix} x\amp =\amp -5+2s \\ y\amp =\amp 1+s \\ z\amp =\amp -4+2s \end{matrix}  \qquad\qquad \ell_2: \begin{matrix} x \amp =\amp  2+3t\\ y\amp =\amp 1-2t \\ z\amp =\amp 1+t \end{matrix}
+        </md>
+      </p>
+    </statement>
+    <solution>
+      <p>
+        The lines clearly are not parallel.
+        If they do not intersect, they are skew,
+        meaning there is not a plane that contains them both.
+        If they do intersect, there is such a plane.
+      </p>
+
+      <p>
+        To find their point of intersection, we set the <m>x</m>,
+        <m>y</m> and <m>z</m> equations equal to each other and solve for <m>s</m> and <m>t</m>:
+        <md>
+          \begin{matrix} -5+2s \amp =\amp 2+3t \\ 1+s \amp =\amp  1-2t \\ -4+2s \amp =\amp  1+t \end{matrix}   \Rightarrow   s=2, t=-1
+        </md>.
+      </p>
+
+      <p>
+        When <m>s=2</m> and <m>t=-1</m>,
+        the lines intersect at the point <m>P= (-1,3,0)</m>.
+      </p>
+
+      <p>
+        Let <m>\vec d_1 = \la 2,1,2\ra</m> and
+        <m>\vec d_2=\la 3,-2,1\ra</m> be the directions of lines <m>\ell_1</m> and <m>\ell_2</m>,
+        respectively.
+        A normal vector to the plane containing these the two lines will also be orthogonal to <m>\vec d_1</m> and <m>\vec d_2</m>.
+        Thus we find a normal vector <m>\vec n</m> by computing <m>\vec n = \vec d_1 \times \vec d_2= \la 5,4-7\ra</m>.
+      </p>
+
+      <p>
+        We can pick any point in the plane with which to write our equation;
+        each line gives us infinite choices of points.
+        We choose <m>P</m>, the point of intersection.
+        We follow <xref ref="def_planes"/>
+        to write the plane's equation in general form:
+        <md>
+          <mrow>5(x+1) +4(y-3) -7z \amp = 0</mrow>
+          <mrow>5x + 5 + 4y-12 -7z \amp = 0</mrow>
+          <mrow>5x+4y-7z \amp = 7</mrow>
+        </md>.
+      </p>
+
+      <p>
+        The plane's equation in general form is <m>5x+4y-7z=7</m>;
+        it is sketched in <xref ref="fig_planes2"/>.
+      </p>
+
+      <figure xml:id="fig_planes2" vshift="2.5">
+        <caption>Sketching the plane in <xref ref="ex_planes2"/></caption>
+
+        <!-- START figures/figplanes2_3D.asy -->
+        <image width="47%">
+          <shortdescription>In three dimensions, two lines are plotted, intersecting at a point P, along with the plane containing both lines.</shortdescription>
+          <description>
+            <p>
+              Three-dimensional coordinate axes are shown, with the points <m>(5,0,0)</m>, <m>(0,5,0)</m>, and <m>(0,0,-5)</m> indicated for scale.
+              A point <m>P</m> is plotted in space. Two lines <m>\ell_1</m> and <m>\ell_2</m> are shown intersecting at this point.
+              The plane containing both lines is also plotted, along with a normal vector, located with its tail at <m>P</m>.
+            </p>
+          </description>
+          <asymptote label="img_planes2">
+
+
+
+            //ASY file for figplanes2.asy in Chapter 10
+
+            size(282,282,Aspect);
+            //size(200,200,IgnoreAspect);
+            //currentprojection=perspective(7,2,1);
+            currentprojection=orthographic((-16,18.6,6.76),(0.014,-0.015,0077),(0,0,0),.99);
+            defaultrender.merge=true;
+
+            // setup and draw the axes
+            real[] myxchoice={5};
+            real[] myychoice={5};
+            real[] myzchoice={-5};
+            defaultpen(0.5mm);
+            pair xbounds=(-4,6);
+            pair ybounds=(-1,6);
+            pair zbounds=(-6,5);
+
+            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+            //Draw the plane
+            triple f(pair t) {
+              return (t.x,t.y,(5/7)*t.x+(4/7)*t.y-1);
+            }
+            surface s=surface(f,(-5,-6),(5,6),8,8,Spline);
+            pen p=apexmeshpen+.1mm;
+            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+            //Draw points P=(-1,3,0)
+            dotfactor=3;dot((-1,3,0));label("$P$",(-1,3,0),E);
+
+            //Draw normal vector at P, n=(5,4,-7)
+            draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
+            label("$\vec{n}$",(4,7,-7),W);
+
+            //draw the lines -5+2t,1+t,-4+2t  and 2+3t,1-2t,1+t
+            draw((5,6,6)--(-5,1,-4),bluepen);label("$\ell_1$",(5,6,6),N);//L1
+            draw((5,-1,2)--(-4.9,5.6,-1.3),bluepen);label("$\ell_2$",(5,-1,2),N);//L2
+
+          </asymptote>
+        </image>
+        <!-- figures/figplanes2_3D.asy END -->
+      </figure>
+    </solution>
+  </example>
+
+  <example xml:id="ex_planes3">
+    <title>Finding the equation of a plane</title>
+    <statement>
+      <p>
+        Give the equation, in standard form,
+        of the plane that passes through the point
+        <m>P=(-1,0,1)</m> and is orthogonal to the line with vector equation <m>\vec \ell(t) = \la -1,0,1\ra + t\la 1,2,2\ra</m>.
+      </p>
+    </statement>
+    <solution>
+      <p>
+        As the plane is to be orthogonal to the line,
+        the plane must be orthogonal to the direction of the line given by <m>\vec d = \la 1,2,2\ra</m>.
+        We use this as our normal vector.
+        Thus the plane's equation, in standard form, is
+        <md>
+          (x+1) +2y+2(z-1)=0
+        </md>.
+      </p>
+
+      <p>
+        The line and plane are sketched in <xref ref="fig_planes3"/>.
+      </p>
+
+      <figure xml:id="fig_planes3" vshift="1">
+        <caption>The line and plane in <xref ref="ex_planes3"/></caption>
+
+        <!-- START figures/figplanes3_3D.asy -->
+        <image width="47%">
+          <shortdescription>A plane is plotted in a three-dimensional coordinate system, along with a line passing through it at a point P.</shortdescription>
+          <description>
+            <p>
+              A plane is plotted against a set of three-dimensional coordinate axes.
+              A line passes through the plane, intersecting it at a point <m>P</m>.
+              The line is perpendicular to the plane.
+            </p>
+          </description>
+          <asymptote label="img_planes3">
+
+
+
+            //ASY file for figplanes3.asy in Chapter 10
+
+            size(282,282,Aspect);
+            //size(200,200,IgnoreAspect);
+            //currentprojection=perspective(7,2,1);
+            currentprojection=orthographic(4,4,2);
+            defaultrender.merge=true;
+
+            // setup and draw the axes
+            real[] myxchoice={-3,3};
+            real[] myychoice={-3,3};
+            real[] myzchoice={-3,3};
+            defaultpen(0.5mm);
+            pair xbounds=(-4,4);
+            pair ybounds=(-4,4);
+            pair zbounds=(-4,4);
+
+            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+            //Draw the plane z=-(x+1)/2-y+1
+            triple f(pair t) {
+              return (t.x,t.y,(-1/2)*(t.x+1)-t.y+1);
+            }
+            surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
+            pen p=apexmeshpen+.1mm;
+            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+            //Draw points P=(-1,0,1)
+            dotfactor=3;dot((-1,0,1));label("$P$",(-1,0,1),N);
+
+            //draw the line -1+t,2t,1+2t
+            draw((1,4,5)--(-3,-4,-3),bluepen);//L t=2 to t=-2
+
+            //Draw normal vector at P, n=(1,2,2)
+            //draw((-1,3,0)--(4,7,-7),black,Arrow3(size=2mm));//n at P
+            //label("$\vec{n}$",(4,7,-7),W);
+
+          </asymptote>
+        </image>
+        <!-- figures/figplanes3_3D.asy END -->
+      </figure>
+    </solution>
+    <solution component="video" vshift="-5">
+      <title>Video solution</title>
+      <video width="98%" youtube="2diP-H-QLoI" label="vid-vectors-planes-given-normal" component="video"/>
+    </solution>
+  </example>
+
+  <example xml:id="ex_planes4">
+    <title>Finding the intersection of two planes</title>
+    <statement>
+      <p>
+        Give the parametric equations of the line that is the intersection of the planes <m>p_1</m> and <m>p_2</m>, where:
+        <md>
+          <mrow>p_1: x-(y-2)+(z-1) =0</mrow>
+          <mrow>p_2: -2(x-2)+(y+1)+(z-3)=0</mrow>
+        </md>
+      </p>
+    </statement>
+    <solution>
+      <p>
+        To find an equation of a line,
+        we need a point on the line and the direction of the line.
+      </p>
+
+      <p>
+        We can find a point on the line by solving each equation of the planes for <m>z</m>:
+        <md>
+          <mrow>p_1: z = -x+y-1</mrow>
+          <mrow>p_2: z = 2x-y-2</mrow>
+        </md>
+      </p>
+
+      <p>
+        We can now set these two equations equal to each other (<ie/>, we are finding values of <m>x</m> and <m>y</m> where the planes have the same <m>z</m> value):
+        <md>
+          <mrow>-x+y-1 \amp = 2x-y-2</mrow>
+          <mrow>2y \amp = 3x-1</mrow>
+          <mrow>y \amp = \frac12(3x-1)</mrow>
+        </md>
+      </p>
+
+      <p>
+        We can choose any value for <m>x</m>;
+        we choose <m>x=1</m>.
+        This determines that <m>y=1</m>.
+        We can now use the equations of either plane to find <m>z</m>:
+        when <m>x=1</m> and <m>y=1</m>,
+        <m>z=-1</m> on both planes.
+        We have found a point <m>P</m> on the line: <m>P= (1,1,-1)</m>.
+      </p>
+
+      <p>
+        We now need the direction of the line.
+        Since the line lies in each plane,
+        its direction is orthogonal to a normal vector for each plane.
+        Considering the equations for <m>p_1</m> and <m>p_2</m>,
+        we can quickly determine their normal vectors.
+        For <m>p_1</m>,
+        <m>\vec n_1 = \la 1,-1,1\ra</m> and for <m>p_2</m>,
+        <m>\vec n_2 = \la -2,1,1\ra</m>.
+        A direction orthogonal to both of these directions is their cross product:
+        <m>\vec d = \vec n_1\times \vec n_2 = \la -2,-3,-1\ra</m>.
+      </p>
+
+      <p>
+        The parametric equations of the line through
+        <m>P=(1,1,-1)</m> in the direction of <m>d=\la -2,-3,-1\ra</m> is:
+        <md>
+          \ell:  x= -2t+1 y = -3t+1 z=-t-1
+        </md>.
+      </p>
+
+      <p>
+        The planes and line are graphed in <xref ref="fig_planes4"/>.
+      </p>
+
+      <figure xml:id="fig_planes4" vshift="0">
+        <caption>Graphing the planes and their line of intersection in <xref ref="ex_planes4"/></caption>
+
+        <!-- START figures/figplanes4_3D.asy -->
+        <image width="47%">
+          <shortdescription>Two planes are shown intersecting along a common line.</shortdescription>
+          <description>
+            <p>
+              Two planes are plotted in a three-dimensional coordinate system.
+              The planes intersect along a line, which is also plotted,
+              along with a point <m>P</m> that lies on the line, as well as on both planes.
+            </p>
+          </description>
+          <asymptote label="img_planes4">
+
+
+
+            //ASY file for figplanes43D.asy in Chapter 10
+
+            //size(282,282,Aspect);
+            size(200,200,IgnoreAspect);
+            //currentprojection=perspective(7,2,1);
+            currentprojection=orthographic(8,14.7,14);
+            defaultrender.merge=true;
+
+            // setup and draw the axes
+            real[] myxchoice={-2,2};
+            real[] myychoice={-2,2};
+            real[] myzchoice={-5};
+            defaultpen(0.5mm);
+            pair xbounds=(-3,3);
+            pair ybounds=(-3,3);
+            pair zbounds=(-6,2);
+
+            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+            //Draw the planes z=-x+y-1 and z=2x-y-2
+            triple f(pair t) {
+              return (t.x,t.y,-t.x+t.y-1);
+            }
+            surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
+            pen p=apexmeshpen;
+            draw(s,surfacepen,meshpen=p+.2mm,nolight,render(merge=true));
+            triple f(pair t) {
+              return (t.x,t.y,2*t.x-t.y-2);
+            }
+            surface s=surface(f,(-3,-3),(3,3),8,8,Spline);
+            pen pp=apexmeshpen+.2mm;
+            //draw(s,rgb(1,.4,.7)+opacity(.7),meshpen=pp,nolight,render(merge=true)); // HOT PINK
+
+            pen q=redcurvepen+.1mm;
+            draw(s,surfacepen2,meshpen=q,nolight,render(merge=true)); // better red
+
+            //Draw point P=(1,1,-1)
+            dotfactor=3;dot((1,1,-1));label("$P$",(1,1,-1),N);
+
+            //draw the line 1-2t,1-3t,-1-t
+            draw((4,5.5,0.5)--(-2,-3.5,-2.5),bluepen);//L t=-1.5 to t=1.5
+
+          </asymptote>
+        </image>
+        <!-- figures/figplanes4_3D.asy END -->
+      </figure>
+      <!-- <figure xml:id="vid-vectors-planes-interection2" component="video" vshift="-5">
+        <caption>An alternative method for solving <xref ref="ex_planes4"/></caption>
+        <video width="98%" youtube="tthyDV7cjR8" label="vid-vectors-planes-interection2"/>
+      </figure> -->
+    </solution>
+    <solution component="video" vshift="5">
+      <title>Video solution</title>
+      <video width="98%" youtube="x2HB6huEEmQ" label="vid-vectors-planes-interect1" component="video"/>
+    </solution>
+  </example>
+
+  <example xml:id="ex_planes5">
+    <title>Finding the intersection of a plane and a line</title>
+    <statement>
+      <p>
+        Find the point of intersection, if any,
+        of the line <m>\ell(t) = \la 3,-3,-1\ra +t\la-1,2,1\ra</m> and the plane with equation in general form <m>2x+y+z=4</m>.
+      </p>
+    </statement>
+    <solution>
+      <p>
+        The equation of the plane shows that the vector
+        <m>\vec n = \la 2,1,1\ra</m> is a normal vector to the plane,
+        and the equation of the line shows that the line moves parallel to <m>\vec d = \la -1,2,1\ra</m>.
+        Since these are not orthogonal,
+        we know there is a point of intersection.
+        (If there were orthogonal,
+        it would mean that the plane and line were parallel to each other,
+        either never intersecting or the line was in the plane itself.)
+      </p>
+
+      <p>
+        To find the point of intersection,
+        we need to find a <m>t</m> value such that <m>\ell(t)</m> satisfies the equation of the plane.
+        Rewriting the equation of the line with parametric equations will help:
+        <md>
+          \ell(t) = \left\{\begin{aligned}x\amp = 3-t\\ y\amp =-3+2t\\ z\amp = -1+t \end{aligned} \right.
+        </md>.
+      </p>
+
+      <p>
+        Replacing <m>x</m>,
+        <m>y</m> and <m>z</m> in the equation of the plane with the expressions containing <m>t</m> found in the equation of the line allows us to determine a <m>t</m> value that indicates the point of intersection:
+        <md>
+          <mrow>2x+y+z \amp =4</mrow>
+          <mrow>2(3-t) + (-3+2t) + (-1+t) \amp = 4</mrow>
+          <mrow>t\amp =2</mrow>
+        </md>.
+      </p>
+
+      <p>
+        When <m>t=2</m>,
+        the point on the line satisfies the equation of the plane;
+        that point is <m>\ell(2) = \la 1,1,1\ra</m>.
+        Thus the point <m>(1,1,1)</m> is the point of intersection between the plane and the line,
+        illustrated in <xref ref="fig_planes5"/>.
+      </p>
+
+      <figure xml:id="fig_planes5" vshift="4">
+        <caption>Illustrating the intersection of a line and a plane in <xref ref="ex_planes5"/></caption>
+
+        <!-- START figures/figplanes5_3D.asy -->
+        <image width="47%">
+          <shortdescription>A line in three dimensions passes through a plane, intersecting it at a point.</shortdescription>
+          <description>
+            <p>
+              A plane is plotted against a three-dimensional coordinate system.
+              A line, labeled <m>\ell(t)</m>, is also plotted.
+              The line appears to be almost, but not quite, parallel to the plane.
+              It passes through the plane, intersecting it at a point that is plotted, but not labeled.
+            </p>
+          </description>
+          <asymptote label="img_planes5">
+
+
+
+            //ASY file for figplanes53D.asy in Chapter 10
+
+            //size(282,282,Aspect);
+            size(200,200,IgnoreAspect);
+            //currentprojection=perspective(7,2,1);
+            currentprojection=orthographic(5,4,2);
+            defaultrender.merge=true;
+
+            // setup and draw the axes
+            real[] myxchoice={-2,2};
+            real[] myychoice={-2,2};
+            real[] myzchoice={2};
+            defaultpen(0.5mm);
+            pair xbounds=(-3,4);
+            pair ybounds=(-3,4);
+            pair zbounds=(-2,7);
+
+            xaxis3("",xbounds.x,xbounds.y,black,OutTicks(myxchoice),Arrow3(size=3mm));
+            yaxis3("",ybounds.x,ybounds.y,black,OutTicks(myychoice),Arrow3(size=3mm));
+            zaxis3("",zbounds.x,zbounds.y,black,OutTicks(myzchoice),Arrow3(size=3mm));
+
+            label("$x$",(xbounds.y+0.05*(xbounds.y-xbounds.x),0,0));
+            label("$y$",(0,ybounds.y+0.05*(ybounds.y-ybounds.x),0));
+            label("$z$",(0,0,zbounds.y+0.05*(zbounds.y-zbounds.x)));
+
+            //Draw the plane z=4-2x-y
+            triple f(pair t) {
+              return (t.x,t.y,4-2*t.x-t.y);
+            }
+            surface s=surface(f,(-2,-2),(3,3),8,8,Spline);
+            pen p=apexmeshpen+.2mm;
+            draw(s,surfacepen,meshpen=p,nolight,render(merge=true));
+
+            //Draw point P=(1,1,1)
+            dotfactor=3;dot((1,1,1),redpen);//label("$P$",(1,1,1),N);
+
+            //draw the line 3-t,-3+2t,-1+t
+            draw((3,-3,-1)--(0,3,2),redpen);//L t=0 to t=3
+            label("$\ell(t)$",(3,-3,-1),N);
+
+          </asymptote>
+        </image>
+        <!-- figures/figplanes5_3D.asy END -->
+      </figure>
+    </solution>
+    <solution component="video" vshift="6">
+      <title>Video solution</title>
+      <video width="98%" youtube="DjuaixH0ayo" label="vid-vectors-planes-lineint" component="video"/>
+    </solution>
+  </example>
+
+  <paragraphs xml:id="subsec_planes_distances">
     <title>Distances</title>
     <p>
       Just as it was useful to find distances between points and lines in the previous section,
@@ -1015,7 +1013,7 @@
       but simple to apply to planes.
       By approximating a surface with millions of small planes one can more readily model the needed behavior.
     </p>
-  </subsection>
+  </paragraphs>
 
   <exercises>
     <subexercises xml:id="TaC-vectors-planes">


### PR DESCRIPTION
`sec_planes` has an `<introduction>` that is about 70% of the section.
This causes problems with numbering, etc.

I've removed the introduction, and the 'subsection' on distances is now a 'paragraphs'.