### PR TITLE
remove xref from video caption

### DIFF
--- a/ptx/sec_planes.ptx
+++ b/ptx/sec_planes.ptx
@@ -906,7 +906,7 @@
     </p>
 
     <figure xml:id="vid-vectors-planes-distance" component="video" vshift="0">
-      <caption>Video introduction to <xref ref="subsec_planes_distances"/></caption>
+      <caption>Introducing distance problems involving planes</caption>
       <video youtube="DT4JMy5Ak54" label="vid-vectors-planes-distance"/>
     </figure>
 


### PR DESCRIPTION
Since the segment on distance problems involving planes is now `paragraphs` and not `subsection`, the caption of the video introducing the content shouldn't have an xref.