### PR TITLE
remove redundant sidebyside

### DIFF
--- a/ptx/sec_disk.ptx
+++ b/ptx/sec_disk.ptx
@@ -698,13 +698,13 @@
 			<p>
 				Consider the region bounded by <m>y = x^2</m> and <m>y = 1</m> for <m>0 \le x \le 1</m>.
 			</p>
-			<sidebyside width="50%">
-				<image>
-					<latex-image>
-						<xi:include href="tikz-figs/tikz-washer-x.tex" parse="text" />
-					</latex-image>
-				</image>
-			</sidebyside>
+  
+      <image width="50%">
+        <latex-image>
+          <xi:include href="tikz-figs/tikz-washer-x.tex" parse="text" />
+        </latex-image>
+      </image>
+		
 			<p>
 				Match each inner and outer radius pair with the axis of rotation that they correspond to in the Washer Method.
 			</p>


### PR DESCRIPTION
There is a proteus question with a single-panel sidebyside, which is no longer allowed. Removing it as redundant.